### PR TITLE
hotfix: remove custom main CodeQL job conflicting with default setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,33 +53,3 @@ jobs:
           make test-integration
           make test-e2e
           make test-contracts
-
-  codeql:
-    name: codeql
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.25.7'
-          check-latest: false
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: go
-
-      - name: Build
-        run: |
-          mkdir -p .tmp
-          go build -o .tmp/wrkr ./cmd/wrkr
-
-      - name: Analyze
-        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Problem
Post-merge main CI failed in `main` workflow `codeql` job with:
`CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled`.

## Root Cause
The repository has default CodeQL setup enabled, while `.github/workflows/main.yml` also ran an advanced CodeQL analysis job. This double-configuration causes SARIF processing failure.

## Changes
- Removed the custom `codeql` job from `.github/workflows/main.yml`.
- Kept the rest of the `main` workflow (core matrix + acceptance) intact.

## Validation
- `actionlint -color`
- `make prepush-full`
