### PR TITLE
ci: add pull-requests read permission for paths-filter

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
   security-events: write
 
 concurrency:


### PR DESCRIPTION
## Problem
`dorny/paths-filter@v3` in the PR workflow requires `pull-requests: read` on `pull_request` events to fetch changed files. Without this permission, the required `fast-lane` check can fail due to API permission errors.

## Changes
- Updated `/Users/davidahmann/Projects/wrkr/.github/workflows/pr.yml` workflow permissions to include:
  - `pull-requests: read`

## Validation
- `go run ./cmd/wrkr scan --json`
- `make prepush-full`
