### PR TITLE
hygiene: block tracked wrkr local state artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ venv/
 
 # Local analysis scratch
 .tmp/
+.wrkr/
 *.sarif
 /wrkr
 /wrkr.exe

--- a/scripts/check_repo_hygiene.sh
+++ b/scripts/check_repo_hygiene.sh
@@ -35,3 +35,10 @@ for plan_doc in "product/PLAN_v1.md" "product/wrkr.md" "product/dev_guides.md" "
     exit 3
   fi
 done
+
+tracked_wrkr_state="$(git ls-files -- '.wrkr/*')"
+if [[ -n "${tracked_wrkr_state}" ]]; then
+  echo "transient wrkr local state must not be tracked:" >&2
+  echo "${tracked_wrkr_state}" >&2
+  exit 3
+fi


### PR DESCRIPTION
## Summary
- add `.wrkr/` to `.gitignore` so local scan state is excluded by default
- add repo hygiene script guard to fail when any `.wrkr/*` path is tracked
- add hygiene test coverage to enforce that transient wrkr local state is never tracked

## Validation
- `go run ./cmd/wrkr scan --path . --json`
- `make prepush-full`
