### PR TITLE
ci: initialize CodeQL in nightly risk lane

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Setup CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+
       - name: Run prepush full
         run: make prepush-full
 


### PR DESCRIPTION
## Problem
Nightly run `22211871264` failed in `risk-lane` because `make prepush-full` invokes `scripts/run_codeql.sh`, but the GitHub runner did not have `codeql` on PATH:
- `codeql CLI not found`
- `make: *** [Makefile:60: codeql] Error 7`

## Change
- add `github/codeql-action/init@v3` to `.github/workflows/nightly.yml` before `Run prepush full`
- initialize CodeQL for `go` so the existing `make prepush-full` contract can run unchanged

## Validation
- `go run ./cmd/wrkr scan --path . --json`
- `make prepush-full`
- reviewed failing run logs: `https://github.com/Clyra-AI/wrkr/actions/runs/22211871264`
