### PR TITLE
safety: harden evidence fail-closed boundaries

### DIFF
--- a/.agents/skills/adhoc-implement/SKILL.md
+++ b/.agents/skills/adhoc-implement/SKILL.md
@@ -97,6 +97,8 @@ When collecting evidence or emitting machine-readable status, use `wrkr` command
 - deterministic allow/block/require_approval fixtures
 - fail-closed undecidable-path tests
 - reason-code stability checks
+- filesystem boundary tests for user-supplied output paths (`non-empty + non-managed => fail`)
+- ownership marker trust tests (`marker must be regular file`; reject symlink/directory)
 
 4. Determinism/hash/sign/pack changes:
 - byte-stability repeat-run tests
@@ -147,6 +149,7 @@ No story is complete if any required lane is skipped or failing.
 
 - Preserve determinism, offline-first defaults, fail-closed enforcement, schema stability, and exit-code stability.
 - Never weaken unapproved posture => regression failure behavior.
+- Do not allow recursive cleanup on user-supplied paths without explicit ownership validation tests.
 - No destructive git operations unless explicitly requested.
 - No silent skips of required tests/checks.
 - Keep changes tightly scoped to active story.

--- a/.agents/skills/adhoc-plan/SKILL.md
+++ b/.agents/skills/adhoc-plan/SKILL.md
@@ -86,6 +86,8 @@ Use `wrkr` commands with `--json` whenever the plan needs machine-readable evide
 - deterministic allow/block/require_approval fixtures
 - fail-closed undecidable-path tests
 - reason-code stability checks
+- For stories that clean/reset output paths, require `non-empty + non-managed => fail` tests
+- Require marker trust tests (`marker must be regular file`; reject symlink/directory)
 
 4. Determinism/hash/sign/packaging changes:
 - byte-stability repeat-run tests

--- a/.agents/skills/app-audit/SKILL.md
+++ b/.agents/skills/app-audit/SKILL.md
@@ -27,6 +27,8 @@ Execute this workflow when asked to perform app review, release readiness, archi
    - sync vs async behavior and failure handling
 7. Compare stated product intent vs implemented behavior.
 8. Assess security posture and fail-closed guarantees.
+   - explicitly test filesystem mutation boundaries on user-supplied output paths
+   - confirm cleanup/reset flows reject non-managed dirs and reject marker symlink/directory types
 9. Assess market wedge sharpness for existing personas only.
 10. Produce final go/no-go verdict with minimum blocker set.
 

--- a/.agents/skills/backlog-implement/SKILL.md
+++ b/.agents/skills/backlog-implement/SKILL.md
@@ -132,6 +132,8 @@ Rules:
 - Deterministic allow/block/require_approval fixture tests
 - Fail-closed undecidable-path tests
 - Stable reason-code tests
+- Filesystem boundary tests for user-supplied output paths (`non-empty + non-managed => fail`)
+- Ownership marker trust tests (`marker must be regular file`; reject symlink/directory)
 
 4. Determinism/hash/sign/packaging changes:
 - Repeat-run byte-stability tests
@@ -185,6 +187,7 @@ If story is internal-only and behavior is unchanged, do not force doc churn.
 
 - Preserve non-negotiables: determinism, offline-first, fail-closed, schema stability, stable exit codes.
 - Never weaken unapproved posture => regression failure paths.
+- Do not allow recursive cleanup on user-supplied paths without explicit ownership validation tests.
 - No destructive git operations unless explicitly requested.
 - No auto-commit or auto-push.
 - Keep changes story-scoped; no unrelated refactors.

--- a/.agents/skills/backlog-plan/SKILL.md
+++ b/.agents/skills/backlog-plan/SKILL.md
@@ -70,6 +70,8 @@ If these are missing, stop and output a gap note instead of inventing details.
 - Add deterministic allow/block/require_approval fixture tests.
 - Add fail-closed tests for evaluator-missing or undecidable paths.
 - Add reason code stability checks.
+- For stories that clean/reset output paths, require `non-empty + non-managed => fail` tests.
+- Require marker trust tests (`marker must be regular file`; reject symlink/directory).
 
 4. Determinism, hashing, signing, packaging:
 - Add byte-stability tests for repeated runs with identical input.

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -38,6 +38,7 @@ Execute this workflow for: "review the codebase", "audit repo health", "run a fu
 2. Run baseline validation where feasible (lint/build/tests) and record gaps if not run.
 3. Review each subsystem for:
    - Safety/control bypasses
+   - Destructive filesystem operations on user-supplied paths without trusted ownership checks (regular-file marker validation, no marker-name-only trust)
    - Determinism or reproducibility breaks
    - Integrity verification weakening
    - False-green test/CI paths
@@ -68,6 +69,7 @@ Execute this workflow for: "review the codebase", "audit repo health", "run a fu
 ## Review Rules
 
 - Findings are primary output; summaries stay brief.
+- Treat recursive cleanup/delete on caller-selected paths with weak ownership gating as at least `P1`.
 - Do not report style nits unless they cause runtime/contract risk.
 - Do not claim tests/commands were run if they were not.
 - Separate facts from inference.

--- a/.agents/skills/initial-plan/SKILL.md
+++ b/.agents/skills/initial-plan/SKILL.md
@@ -141,6 +141,8 @@ For every story, derive required checks from `product/dev_guides.md` by work typ
 - Add deterministic fixture tests for allow/block/risk ranking behavior.
 - Add fail-closed tests for undecidable/ambiguous high-risk paths.
 - Add reason-code stability and ranking determinism checks.
+- For stories that clean/reset output paths, add `non-empty + non-managed => fail` tests.
+- Add marker trust tests (`marker must be regular file`; reject symlink/directory).
 
 5. Runtime/state/concurrency:
 - Add atomic write/checkpoint/lock contention tests.

--- a/.agents/skills/pr-comments/SKILL.md
+++ b/.agents/skills/pr-comments/SKILL.md
@@ -57,11 +57,15 @@ If `pr_numbers` is missing, stop and report blocker.
 Prioritize comments that affect:
 
 1. Fail-closed behavior and enforcement boundaries.
-2. Determinism (verify/diff/replay/pack reproducibility).
-3. Schema and CLI contract stability (`--json`, exit codes, compatibility).
-4. Security/privacy controls (signing, secrets handling, unsafe interlocks).
-5. Cross-platform/CI portability issues.
-6. Docs drift where behavior has changed.
+2. Destructive filesystem cleanup on user-supplied paths with weak ownership validation.
+3. Determinism (verify/diff/replay/pack reproducibility).
+4. Schema and CLI contract stability (`--json`, exit codes, compatibility).
+5. Security/privacy controls (signing, secrets handling, unsafe interlocks).
+6. Cross-platform/CI portability issues.
+7. Docs drift where behavior has changed.
+
+Severity guidance:
+- Treat marker-name-only ownership checks before recursive delete/cleanup on user-supplied paths as at least `P1` until proven safe.
 
 Deprioritize or reject:
 

--- a/core/proofemit/proofemit.go
+++ b/core/proofemit/proofemit.go
@@ -33,6 +33,10 @@ func ChainPath(statePath string) string {
 	return filepath.Join(dir, "proof-chain.json")
 }
 
+func SigningKeyPath(statePath string) string {
+	return keyPath(statePath)
+}
+
 func LoadChain(path string) (*proof.Chain, error) {
 	payload, err := os.ReadFile(path) // #nosec G304 -- path is an explicit local proof chain location controlled by CLI state configuration.
 	if err != nil {


### PR DESCRIPTION
## Problem
`wrkr evidence` had multiple fail-open and filesystem-boundary risks in the evidence path:
- output cleanup trust depended on weak/accidental marker ownership conditions
- manifest hashing accepted non-regular file entries
- evidence generation could proceed with incomplete snapshot sections
- missing signing key could silently regenerate key material instead of hard failing
- review/process docs needed explicit anti-pattern guidance from these regressions

## Changes
- Hardened evidence output-dir controls in `/core/evidence/evidence.go`:
  - reject symlink output directories
  - require trusted marker to be a regular file with exact expected content before cleanup
  - keep cleanup scoped to wrkr-managed outputs only
- Hardened manifest building to reject non-regular files (including symlinks)
- Added fail-closed snapshot validation for required sections (`inventory`, `risk_report`, `profile`, `posture_score`)
- Added fail-closed signing material guard: evidence build now errors when signing key file is missing
- Added `SigningKeyPath` helper in `/core/proofemit/proofemit.go` for deterministic key-path checks
- Expanded evidence tests for:
  - marker directory/symlink/invalid-content rejection
  - symlink output-dir rejection
  - symlink manifest-entry rejection
  - missing proof chain / missing scan evidence / missing signing key
  - missing required snapshot sections
- Updated affected skills under `.agents/skills/` and `product/PLAN_v1.md` (epics 5+) with explicit fail-closed ownership and filesystem-safety expectations.

## Validation
- `make prepush-full`
- `./.tmp/wrkr scan --path scenarios/wrkr/scan-mixed-org/repos --state .tmp/ship-readiness-state.json --json`
