### PR TITLE
evidence: honor env signing keys in fail-closed path

### DIFF
--- a/core/evidence/evidence.go
+++ b/core/evidence/evidence.go
@@ -155,11 +155,13 @@ func Build(in BuildInput) (BuildResult, error) {
 	}
 
 	signingKeyPath := proofemit.SigningKeyPath(resolvedStatePath)
-	if _, err := os.Stat(signingKeyPath); err != nil {
-		if os.IsNotExist(err) {
-			return BuildResult{}, fmt.Errorf("load signing material: signing key file does not exist: %s", signingKeyPath)
+	if !proofemit.HasEnvSigningKey() {
+		if _, err := os.Stat(signingKeyPath); err != nil {
+			if os.IsNotExist(err) {
+				return BuildResult{}, fmt.Errorf("load signing material: signing key file does not exist: %s", signingKeyPath)
+			}
+			return BuildResult{}, fmt.Errorf("load signing material: stat signing key file: %w", err)
 		}
-		return BuildResult{}, fmt.Errorf("load signing material: stat signing key file: %w", err)
 	}
 	signingMaterial, signingErr := proofemit.LoadSigningMaterial(resolvedStatePath)
 	if signingErr != nil {

--- a/core/proofemit/signing.go
+++ b/core/proofemit/signing.go
@@ -12,6 +12,10 @@ import (
 	proof "github.com/Clyra-AI/proof"
 )
 
+const envProofPrivateKey = "WRKR_PROOF_PRIVATE_KEY_B64"
+const envProofPublicKey = "WRKR_PROOF_PUBLIC_KEY_B64"
+const envProofKeyID = "WRKR_PROOF_KEY_ID"
+
 type keyFile struct {
 	KeyID      string `json:"key_id"`
 	PublicKey  string `json:"public_key"`
@@ -26,15 +30,19 @@ func keyPath(statePath string) string {
 	return filepath.Join(dir, "proof-signing-key.json")
 }
 
+func HasEnvSigningKey() bool {
+	return strings.TrimSpace(os.Getenv(envProofPrivateKey)) != ""
+}
+
 func loadSigningKey(statePath string) (proof.SigningKey, error) {
 	path := keyPath(statePath)
-	if value := strings.TrimSpace(os.Getenv("WRKR_PROOF_PRIVATE_KEY_B64")); value != "" {
+	if value := strings.TrimSpace(os.Getenv(envProofPrivateKey)); value != "" {
 		privateKey, err := decodePrivateKey(value)
 		if err != nil {
-			return proof.SigningKey{}, fmt.Errorf("decode WRKR_PROOF_PRIVATE_KEY_B64: %w", err)
+			return proof.SigningKey{}, fmt.Errorf("decode %s: %w", envProofPrivateKey, err)
 		}
 		publicKey := privateKey.Public().(ed25519.PublicKey)
-		keyID := strings.TrimSpace(os.Getenv("WRKR_PROOF_KEY_ID"))
+		keyID := strings.TrimSpace(os.Getenv(envProofKeyID))
 		return proof.SigningKey{Private: privateKey, Public: publicKey, KeyID: keyID}, nil
 	}
 
@@ -85,12 +93,12 @@ func loadSigningKey(statePath string) (proof.SigningKey, error) {
 }
 
 func loadPublicKey(statePath string) (proof.PublicKey, error) {
-	if value := strings.TrimSpace(os.Getenv("WRKR_PROOF_PUBLIC_KEY_B64")); value != "" {
+	if value := strings.TrimSpace(os.Getenv(envProofPublicKey)); value != "" {
 		publicKey, err := decodePublicKey(value)
 		if err != nil {
-			return proof.PublicKey{}, fmt.Errorf("decode WRKR_PROOF_PUBLIC_KEY_B64: %w", err)
+			return proof.PublicKey{}, fmt.Errorf("decode %s: %w", envProofPublicKey, err)
 		}
-		keyID := strings.TrimSpace(os.Getenv("WRKR_PROOF_KEY_ID"))
+		keyID := strings.TrimSpace(os.Getenv(envProofKeyID))
 		return proof.PublicKey{Public: publicKey, KeyID: keyID}, nil
 	}
 


### PR DESCRIPTION
## Problem
`wrkr evidence` recently added a pre-check requiring `proof-signing-key.json` before loading signing material. That blocked valid fileless signing setups that intentionally provide key material via `WRKR_PROOF_PRIVATE_KEY_B64` (for example CI and ephemeral runners).

## Changes
- Kept fail-closed behavior for missing signing material, but made it source-aware:
  - if env signing key is present, skip file existence gate
  - otherwise require local key file and fail when missing
- Added `proofemit.HasEnvSigningKey()` and centralized env var names in `core/proofemit/signing.go`
- Added regression test in `core/evidence/evidence_test.go`:
  - evidence build succeeds with env signing key when key file is absent
- Retained existing failure test for missing key when neither env nor file is present.

## Validation
- `go test ./core/evidence ./core/proofemit -count=1`
- `make prepush-full`
- `./.tmp/wrkr scan --path scenarios/wrkr/scan-mixed-org/repos --state .tmp/ship-readiness-state.json --json > .tmp/ship-readiness-scan.json`
- `./.tmp/wrkr verify --chain --state .tmp/ship-readiness-state.json --json > .tmp/ship-readiness-verify.json`
