### PR TITLE
Epic 5: implement CLI contracts and posture regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ Wrkr is the deterministic See-layer CLI in the See -> Prove -> Control model.
 
 ## Status
 
-Epics 1-4 are implemented.
+Epics 1-5 are implemented.
 
 - Epic 1: source acquisition contracts (`init`, `scan`, source manifests, incremental diff state)
 - Epic 2: deterministic detector engine (Claude/Cursor/Codex/Copilot, MCP, skills, CI/headless autonomy, dependencies, secrets, compiled actions) and YAML-backed policy evaluation (`WRKR-001`..`WRKR-015`)
 - Epic 3: deterministic inventory aggregation + repo exposure summaries, identity lifecycle manifest/chain updates, ranked risk reporting, posture profiles, and posture score outputs
 - Epic 4: signed proof record emission (`scan_finding`, `risk_assessment`, `approval`, lifecycle transitions), proof chain verification, and compliance evidence bundle generation
+- Epic 5: CLI contract hardening (`--json`, `--quiet`, `--explain`), report PDF output, manifest generation, and posture regression baseline/drift checks
 
 ## Quick Start
 
@@ -30,6 +31,7 @@ wrkr scan --path ./local-repos --profile standard --json
 
 # Risk report and inventory export views.
 wrkr report --top 5 --json
+wrkr report --pdf --json
 wrkr export --format inventory --json
 
 # Identity lifecycle commands.
@@ -37,7 +39,11 @@ wrkr identity list --json
 wrkr identity show <agent_id> --json
 wrkr identity approve <agent_id> --approver @maria --scope read-only --expires 90d --json
 wrkr lifecycle --org acme --json
+wrkr manifest generate --json
 wrkr score --json
+wrkr score --explain
+wrkr regress init --baseline ./.wrkr/last-scan.json --json
+wrkr regress run --baseline ./.wrkr/wrkr-regress-baseline.json --json
 wrkr verify --chain --json
 wrkr evidence --frameworks eu-ai-act,soc2 --json
 

--- a/core/cli/manifest.go
+++ b/core/cli/manifest.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Clyra-AI/wrkr/core/manifest"
+	"github.com/Clyra-AI/wrkr/core/manifestgen"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+func runManifest(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 {
+		return emitError(stderr, wantsJSONOutput(args), "invalid_input", "manifest subcommand is required", exitInvalidInput)
+	}
+
+	switch args[0] {
+	case "generate":
+		return runManifestGenerate(args[1:], stdout, stderr)
+	default:
+		return emitError(stderr, wantsJSONOutput(args), "invalid_input", "unsupported manifest subcommand", exitInvalidInput)
+	}
+}
+
+func runManifestGenerate(args []string, stdout io.Writer, stderr io.Writer) int {
+	jsonRequested := wantsJSONOutput(args)
+	fs := flag.NewFlagSet("manifest generate", flag.ContinueOnError)
+	if jsonRequested {
+		fs.SetOutput(io.Discard)
+	} else {
+		fs.SetOutput(stderr)
+	}
+
+	jsonOut := fs.Bool("json", false, "emit machine-readable output")
+	statePathFlag := fs.String("state", "", "state file path override")
+	outputPath := fs.String("output", "", "manifest output path override")
+
+	if err := fs.Parse(args); err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
+	}
+	if fs.NArg() != 0 {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", "manifest generate does not accept positional arguments", exitInvalidInput)
+	}
+
+	statePath := state.ResolvePath(*statePathFlag)
+	snapshot, err := state.Load(statePath)
+	if err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	generated, err := manifestgen.GenerateUnderReview(snapshot, now)
+	if err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
+
+	path := strings.TrimSpace(*outputPath)
+	if path == "" {
+		path = manifest.ResolvePath(statePath)
+	}
+	if err := manifest.Save(path, generated); err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
+
+	resolvedPath := filepath.Clean(path)
+	if *jsonOut {
+		_ = json.NewEncoder(stdout).Encode(map[string]any{
+			"status":         "ok",
+			"manifest_path":  resolvedPath,
+			"identity_count": len(generated.Identities),
+		})
+		return exitSuccess
+	}
+	_, _ = fmt.Fprintf(stdout, "wrkr manifest generated %s (%d identities)\n", resolvedPath, len(generated.Identities))
+	return exitSuccess
+}

--- a/core/cli/regress.go
+++ b/core/cli/regress.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Clyra-AI/wrkr/core/regress"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+func runRegress(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 {
+		return emitError(stderr, wantsJSONOutput(args), "invalid_input", "regress subcommand is required", exitInvalidInput)
+	}
+
+	switch args[0] {
+	case "init":
+		return runRegressInit(args[1:], stdout, stderr)
+	case "run":
+		return runRegressRun(args[1:], stdout, stderr)
+	default:
+		return emitError(stderr, wantsJSONOutput(args), "invalid_input", "unsupported regress subcommand", exitInvalidInput)
+	}
+}
+
+func runRegressInit(args []string, stdout io.Writer, stderr io.Writer) int {
+	jsonRequested := wantsJSONOutput(args)
+	fs := flag.NewFlagSet("regress init", flag.ContinueOnError)
+	if jsonRequested {
+		fs.SetOutput(io.Discard)
+	} else {
+		fs.SetOutput(stderr)
+	}
+
+	jsonOut := fs.Bool("json", false, "emit machine-readable output")
+	baselineScanPath := fs.String("baseline", "", "state snapshot path used to initialize baseline")
+	outputPath := fs.String("output", "", "baseline artifact output path")
+
+	if err := fs.Parse(args); err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
+	}
+	if fs.NArg() != 0 {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", "regress init does not accept positional arguments", exitInvalidInput)
+	}
+
+	scanPath := state.ResolvePath(strings.TrimSpace(*baselineScanPath))
+	snapshot, err := state.Load(scanPath)
+	if err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
+
+	baseline := regress.BuildBaseline(snapshot, time.Now().UTC().Truncate(time.Second))
+	targetPath := strings.TrimSpace(*outputPath)
+	if targetPath == "" {
+		targetPath = defaultBaselinePath(scanPath)
+	}
+	if err := regress.SaveBaseline(targetPath, baseline); err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
+
+	resolvedPath := filepath.Clean(targetPath)
+	if *jsonOut {
+		_ = json.NewEncoder(stdout).Encode(map[string]any{
+			"status":        "ok",
+			"baseline_path": resolvedPath,
+			"tool_count":    len(baseline.Tools),
+		})
+		return exitSuccess
+	}
+	_, _ = fmt.Fprintf(stdout, "wrkr regress baseline initialized %s (%d tools)\n", resolvedPath, len(baseline.Tools))
+	return exitSuccess
+}
+
+func runRegressRun(args []string, stdout io.Writer, stderr io.Writer) int {
+	jsonRequested := wantsJSONOutput(args)
+	fs := flag.NewFlagSet("regress run", flag.ContinueOnError)
+	if jsonRequested {
+		fs.SetOutput(io.Discard)
+	} else {
+		fs.SetOutput(stderr)
+	}
+
+	jsonOut := fs.Bool("json", false, "emit machine-readable output")
+	baselinePath := fs.String("baseline", "", "baseline artifact path")
+	statePathFlag := fs.String("state", "", "state file path override")
+
+	if err := fs.Parse(args); err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
+	}
+	if fs.NArg() != 0 {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", "regress run does not accept positional arguments", exitInvalidInput)
+	}
+	if strings.TrimSpace(*baselinePath) == "" {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", "--baseline is required", exitInvalidInput)
+	}
+
+	baseline, err := regress.LoadBaseline(strings.TrimSpace(*baselinePath))
+	if err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
+	snapshot, err := state.Load(state.ResolvePath(*statePathFlag))
+	if err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
+
+	result := regress.Compare(baseline, snapshot)
+	result.BaselinePath = filepath.Clean(strings.TrimSpace(*baselinePath))
+	if *jsonOut {
+		_ = json.NewEncoder(stdout).Encode(result)
+	} else if result.Drift {
+		_, _ = fmt.Fprintf(stdout, "wrkr regress drift detected (%d reasons)\n", result.ReasonCount)
+	} else {
+		_, _ = fmt.Fprintln(stdout, "wrkr regress no drift")
+	}
+
+	if result.Drift {
+		return exitRegressionDrift
+	}
+	return exitSuccess
+}
+
+func defaultBaselinePath(scanPath string) string {
+	return filepath.Join(filepath.Dir(scanPath), "wrkr-regress-baseline.json")
+}

--- a/core/cli/report.go
+++ b/core/cli/report.go
@@ -5,9 +5,12 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/risk"
 	"github.com/Clyra-AI/wrkr/core/state"
 )
@@ -23,6 +26,8 @@ func runReport(args []string, stdout io.Writer, stderr io.Writer) int {
 
 	jsonOut := fs.Bool("json", false, "emit machine-readable output")
 	explain := fs.Bool("explain", false, "emit rationale")
+	pdf := fs.Bool("pdf", false, "write a one-page PDF summary")
+	pdfPath := fs.String("pdf-path", "wrkr-report.pdf", "pdf output path")
 	topN := fs.Int("top", 5, "number of top findings")
 	statePathFlag := fs.String("state", "", "state file path override")
 
@@ -41,10 +46,27 @@ func runReport(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	top := selectTopFindings(*report, *topN)
+	totalTools, typeBreakdown := inventorySummary(snapshot.Inventory)
+	complianceGapCount := profileGapCount(snapshot)
 	payload := map[string]any{
-		"status":       "ok",
-		"generated_at": report.GeneratedAt,
-		"top_findings": top,
+		"status":               "ok",
+		"generated_at":         report.GeneratedAt,
+		"top_findings":         top,
+		"total_tools":          totalTools,
+		"tool_type_breakdown":  typeBreakdown,
+		"compliance_gap_count": complianceGapCount,
+	}
+
+	if *pdf {
+		resolvedPDFPath := strings.TrimSpace(*pdfPath)
+		if resolvedPDFPath == "" {
+			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", "--pdf-path must not be empty", exitInvalidInput)
+		}
+		lines := buildPDFSummaryLines(report.GeneratedAt, totalTools, typeBreakdown, complianceGapCount, top)
+		if err := writeReportPDF(resolvedPDFPath, lines); err != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+		}
+		payload["pdf_path"] = filepath.Clean(resolvedPDFPath)
 	}
 
 	if *jsonOut {
@@ -52,11 +74,18 @@ func runReport(args []string, stdout io.Writer, stderr io.Writer) int {
 		return exitSuccess
 	}
 	if *explain {
-		_, _ = fmt.Fprintf(stdout, "wrkr report top=%d\n", len(top))
+		_, _ = fmt.Fprintf(stdout, "wrkr report top=%d tools=%d compliance_gaps=%d\n", len(top), totalTools, complianceGapCount)
 		for idx, item := range top {
 			reasons := strings.Join(item.Reasons, ", ")
 			_, _ = fmt.Fprintf(stdout, "%d. %.2f %s [%s] %s\n", idx+1, item.Score, item.Finding.FindingType, item.Finding.Location, reasons)
 		}
+		if *pdf {
+			_, _ = fmt.Fprintf(stdout, "pdf: %s\n", filepath.Clean(strings.TrimSpace(*pdfPath)))
+		}
+		return exitSuccess
+	}
+	if *pdf {
+		_, _ = fmt.Fprintf(stdout, "wrkr report complete (pdf=%s)\n", filepath.Clean(strings.TrimSpace(*pdfPath)))
 		return exitSuccess
 	}
 	_, _ = fmt.Fprintln(stdout, "wrkr report complete")
@@ -78,4 +107,54 @@ func selectTopFindings(report risk.Report, requested int) []risk.ScoredFinding {
 		requested = len(source)
 	}
 	return append([]risk.ScoredFinding(nil), source[:requested]...)
+}
+
+func inventorySummary(inv *agginventory.Inventory) (int, []map[string]any) {
+	if inv == nil {
+		return 0, []map[string]any{}
+	}
+	byType := map[string]int{}
+	for _, tool := range inv.Tools {
+		byType[tool.ToolType]++
+	}
+	keys := make([]string, 0, len(byType))
+	for toolType := range byType {
+		keys = append(keys, toolType)
+	}
+	sort.Strings(keys)
+	breakdown := make([]map[string]any, 0, len(keys))
+	for _, toolType := range keys {
+		breakdown = append(breakdown, map[string]any{
+			"tool_type": toolType,
+			"count":     byType[toolType],
+		})
+	}
+	return len(inv.Tools), breakdown
+}
+
+func profileGapCount(snapshot state.Snapshot) int {
+	if snapshot.Profile == nil {
+		return 0
+	}
+	return len(snapshot.Profile.Fails)
+}
+
+func buildPDFSummaryLines(generatedAt string, totalTools int, typeBreakdown []map[string]any, complianceGapCount int, top []risk.ScoredFinding) []string {
+	lines := []string{
+		"Wrkr Board Summary",
+		fmt.Sprintf("Generated: %s", generatedAt),
+		fmt.Sprintf("Total AI tools: %d", totalTools),
+		"Tool breakdown:",
+	}
+	for _, item := range typeBreakdown {
+		toolType, _ := item["tool_type"].(string)
+		count, _ := item["count"].(int)
+		lines = append(lines, fmt.Sprintf("- %s: %d", toolType, count))
+	}
+	lines = append(lines, fmt.Sprintf("Compliance gaps: %d", complianceGapCount))
+	lines = append(lines, "Top risks:")
+	for idx, item := range top {
+		lines = append(lines, fmt.Sprintf("%d) %.2f %s %s", idx+1, item.Score, item.Finding.FindingType, item.Finding.Location))
+	}
+	return lines
 }

--- a/core/cli/report_contract_test.go
+++ b/core/cli/report_contract_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReportPDFDeterministicForFixedState(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	pdfPath := filepath.Join(tmp, "report.pdf")
+	snapshot := map[string]any{
+		"version": "v1",
+		"inventory": map[string]any{
+			"tools": []any{
+				map[string]any{"tool_type": "cursor"},
+				map[string]any{"tool_type": "mcp"},
+				map[string]any{"tool_type": "mcp"},
+			},
+		},
+		"profile": map[string]any{
+			"failing_rules": []any{"WRKR-001", "WRKR-002"},
+		},
+		"risk_report": map[string]any{
+			"generated_at": "2026-02-20T12:00:00Z",
+			"top_findings": []any{
+				map[string]any{
+					"risk_score": 9.1,
+					"finding": map[string]any{
+						"finding_type": "policy_violation",
+						"location":     "WRKR-001",
+					},
+				},
+			},
+			"ranked_findings": []any{
+				map[string]any{
+					"risk_score": 9.1,
+					"finding": map[string]any{
+						"finding_type": "policy_violation",
+						"location":     "WRKR-001",
+					},
+				},
+			},
+		},
+	}
+	payload, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("marshal state payload: %v", err)
+	}
+	if err := os.WriteFile(statePath, append(payload, '\n'), 0o600); err != nil {
+		t.Fatalf("write state payload: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := Run([]string{"report", "--pdf", "--pdf-path", pdfPath, "--state", statePath, "--json"}, &out, &errOut); code != 0 {
+		t.Fatalf("report --pdf failed: %d %s", code, errOut.String())
+	}
+	first, err := os.ReadFile(pdfPath)
+	if err != nil {
+		t.Fatalf("read first pdf: %v", err)
+	}
+
+	out.Reset()
+	errOut.Reset()
+	if code := Run([]string{"report", "--pdf", "--pdf-path", pdfPath, "--state", statePath, "--json"}, &out, &errOut); code != 0 {
+		t.Fatalf("report --pdf second run failed: %d %s", code, errOut.String())
+	}
+	second, err := os.ReadFile(pdfPath)
+	if err != nil {
+		t.Fatalf("read second pdf: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatal("expected deterministic report pdf bytes for fixed state")
+	}
+}

--- a/core/cli/report_pdf.go
+++ b/core/cli/report_pdf.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func writeReportPDF(path string, lines []string) error {
+	cleanPath := filepath.Clean(strings.TrimSpace(path))
+	if err := os.MkdirAll(filepath.Dir(cleanPath), 0o750); err != nil {
+		return fmt.Errorf("mkdir report pdf dir: %w", err)
+	}
+	payload := renderSimplePDF(lines)
+	if err := os.WriteFile(cleanPath, payload, 0o600); err != nil {
+		return fmt.Errorf("write report pdf: %w", err)
+	}
+	return nil
+}
+
+func renderSimplePDF(lines []string) []byte {
+	content := bytes.Buffer{}
+	content.WriteString("BT\n/F1 12 Tf\n50 770 Td\n")
+	for i, line := range lines {
+		if i > 0 {
+			content.WriteString("0 -16 Td\n")
+		}
+		content.WriteString("(")
+		content.WriteString(escapePDFLine(line))
+		content.WriteString(") Tj\n")
+	}
+	content.WriteString("ET\n")
+
+	stream := content.String()
+	objects := []string{
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+		"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+		fmt.Sprintf("<< /Length %d >>\nstream\n%sendstream", len(stream), stream),
+	}
+
+	out := bytes.Buffer{}
+	out.WriteString("%PDF-1.4\n")
+	offsets := make([]int, len(objects)+1)
+	for i, object := range objects {
+		offsets[i+1] = out.Len()
+		_, _ = fmt.Fprintf(&out, "%d 0 obj\n%s\nendobj\n", i+1, object)
+	}
+
+	xrefOffset := out.Len()
+	_, _ = fmt.Fprintf(&out, "xref\n0 %d\n", len(objects)+1)
+	out.WriteString("0000000000 65535 f \n")
+	for i := 1; i <= len(objects); i++ {
+		_, _ = fmt.Fprintf(&out, "%010d 00000 n \n", offsets[i])
+	}
+	_, _ = fmt.Fprintf(&out, "trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", len(objects)+1, xrefOffset)
+	return out.Bytes()
+}
+
+func escapePDFLine(in string) string {
+	normalized := strings.ReplaceAll(in, "\n", " ")
+	normalized = strings.TrimSpace(normalized)
+	if len(normalized) > 110 {
+		normalized = normalized[:110]
+	}
+	normalized = strings.ReplaceAll(normalized, "\\", "\\\\")
+	normalized = strings.ReplaceAll(normalized, "(", "\\(")
+	normalized = strings.ReplaceAll(normalized, ")", "\\)")
+	return normalized
+}

--- a/core/manifestgen/generate.go
+++ b/core/manifestgen/generate.go
@@ -1,0 +1,119 @@
+package manifestgen
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/identity"
+	"github.com/Clyra-AI/wrkr/core/manifest"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+func GenerateUnderReview(snapshot state.Snapshot, generatedAt time.Time) (manifest.Manifest, error) {
+	now := generatedAt.UTC().Truncate(time.Second)
+	if now.IsZero() {
+		now = time.Now().UTC().Truncate(time.Second)
+	}
+
+	records := recordsFromSnapshot(snapshot, now)
+	if len(records) == 0 {
+		return manifest.Manifest{}, fmt.Errorf("state snapshot does not contain discoverable identities")
+	}
+
+	return manifest.Manifest{
+		Version:    manifest.Version,
+		UpdatedAt:  now.Format(time.RFC3339),
+		Identities: records,
+	}, nil
+}
+
+func recordsFromSnapshot(snapshot state.Snapshot, now time.Time) []manifest.IdentityRecord {
+	if len(snapshot.Identities) > 0 {
+		out := make([]manifest.IdentityRecord, 0, len(snapshot.Identities))
+		for _, record := range snapshot.Identities {
+			item := record
+			item.Status = identity.StateUnderReview
+			item.Approval = manifest.Approval{}
+			item.ApprovalState = "missing"
+			item.Present = true
+			item.FirstSeen = fallbackTimestamp(item.FirstSeen, now)
+			item.LastSeen = now.Format(time.RFC3339)
+			out = append(out, item)
+		}
+		sortRecords(out)
+		return out
+	}
+
+	if snapshot.Inventory == nil {
+		return nil
+	}
+	return recordsFromInventory(*snapshot.Inventory, now)
+}
+
+func recordsFromInventory(inv agginventory.Inventory, now time.Time) []manifest.IdentityRecord {
+	out := make([]manifest.IdentityRecord, 0)
+	seen := map[string]struct{}{}
+	for _, tool := range inv.Tools {
+		locations := append([]agginventory.ToolLocation(nil), tool.Locations...)
+		sort.Slice(locations, func(i, j int) bool {
+			if locations[i].Repo != locations[j].Repo {
+				return locations[i].Repo < locations[j].Repo
+			}
+			return locations[i].Location < locations[j].Location
+		})
+		for _, location := range locations {
+			agentID := strings.TrimSpace(tool.AgentID)
+			toolID := strings.TrimSpace(tool.ToolID)
+			if agentID == "" {
+				toolID = identity.ToolID(tool.ToolType, location.Location)
+				agentID = identity.AgentID(toolID, tool.Org)
+			}
+			if _, exists := seen[agentID]; exists {
+				continue
+			}
+			seen[agentID] = struct{}{}
+			out = append(out, manifest.IdentityRecord{
+				AgentID:       agentID,
+				ToolID:        toolID,
+				ToolType:      tool.ToolType,
+				Org:           tool.Org,
+				Repo:          location.Repo,
+				Location:      location.Location,
+				Status:        identity.StateUnderReview,
+				Approval:      manifest.Approval{},
+				ApprovalState: "missing",
+				FirstSeen:     now.Format(time.RFC3339),
+				LastSeen:      now.Format(time.RFC3339),
+				Present:       true,
+				DataClass:     tool.DataClass,
+				EndpointClass: tool.EndpointClass,
+				AutonomyLevel: tool.AutonomyLevel,
+				RiskScore:     tool.RiskScore,
+			})
+		}
+	}
+	sortRecords(out)
+	return out
+}
+
+func fallbackTimestamp(value string, now time.Time) string {
+	if strings.TrimSpace(value) != "" {
+		return value
+	}
+	return now.Format(time.RFC3339)
+}
+
+func sortRecords(items []manifest.IdentityRecord) {
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].AgentID != items[j].AgentID {
+			return items[i].AgentID < items[j].AgentID
+		}
+		if items[i].Repo != items[j].Repo {
+			return items[i].Repo < items[j].Repo
+		}
+		return items[i].Location < items[j].Location
+	})
+}

--- a/core/manifestgen/generate_test.go
+++ b/core/manifestgen/generate_test.go
@@ -1,0 +1,106 @@
+package manifestgen
+
+import (
+	"testing"
+	"time"
+
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/manifest"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+func TestGenerateUnderReviewFromSnapshotIdentities(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 2, 21, 12, 0, 0, 0, time.UTC)
+	snapshot := state.Snapshot{
+		Identities: []manifest.IdentityRecord{
+			{
+				AgentID:       "wrkr:mcp-aa:acme",
+				ToolID:        "mcp-aa",
+				ToolType:      "mcp",
+				Org:           "acme",
+				Repo:          "acme/backend",
+				Location:      ".mcp.json",
+				Status:        "active",
+				ApprovalState: "valid",
+				Approval: manifest.Approval{
+					Approver: "@maria",
+					Scope:    "read-only",
+				},
+				FirstSeen: "2026-01-01T00:00:00Z",
+				LastSeen:  "2026-02-20T00:00:00Z",
+				Present:   true,
+			},
+		},
+	}
+
+	generated, err := GenerateUnderReview(snapshot, now)
+	if err != nil {
+		t.Fatalf("generate under-review manifest: %v", err)
+	}
+	if len(generated.Identities) != 1 {
+		t.Fatalf("expected one identity, got %d", len(generated.Identities))
+	}
+	record := generated.Identities[0]
+	if record.Status != "under_review" {
+		t.Fatalf("expected under_review status, got %q", record.Status)
+	}
+	if record.ApprovalState != "missing" {
+		t.Fatalf("expected missing approval state, got %q", record.ApprovalState)
+	}
+	if record.Approval.Approver != "" || record.Approval.Scope != "" {
+		t.Fatalf("expected approval to be cleared, got %+v", record.Approval)
+	}
+	if record.LastSeen != "2026-02-21T12:00:00Z" {
+		t.Fatalf("unexpected last_seen: %q", record.LastSeen)
+	}
+}
+
+func TestGenerateUnderReviewFallsBackToInventory(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 2, 21, 12, 0, 0, 0, time.UTC)
+	snapshot := state.Snapshot{
+		Inventory: &agginventory.Inventory{
+			Tools: []agginventory.Tool{
+				{
+					ToolID:        "cursor-aa",
+					AgentID:       "wrkr:cursor-aa:acme",
+					ToolType:      "cursor",
+					Org:           "acme",
+					DataClass:     "code",
+					EndpointClass: "workspace",
+					AutonomyLevel: "interactive",
+					RiskScore:     6.5,
+					Locations: []agginventory.ToolLocation{
+						{Repo: "acme/backend", Location: ".cursorrules"},
+					},
+				},
+			},
+		},
+	}
+
+	generated, err := GenerateUnderReview(snapshot, now)
+	if err != nil {
+		t.Fatalf("generate under-review manifest: %v", err)
+	}
+	if len(generated.Identities) != 1 {
+		t.Fatalf("expected one identity, got %d", len(generated.Identities))
+	}
+	record := generated.Identities[0]
+	if record.AgentID != "wrkr:cursor-aa:acme" {
+		t.Fatalf("unexpected agent id %q", record.AgentID)
+	}
+	if record.Status != "under_review" {
+		t.Fatalf("expected under_review status, got %q", record.Status)
+	}
+}
+
+func TestGenerateUnderReviewRequiresIdentityData(t *testing.T) {
+	t.Parallel()
+
+	if _, err := GenerateUnderReview(state.Snapshot{}, time.Date(2026, 2, 21, 12, 0, 0, 0, time.UTC)); err == nil {
+		t.Fatal("expected error when state has no identities or inventory")
+	}
+}

--- a/core/regress/regress.go
+++ b/core/regress/regress.go
@@ -1,0 +1,321 @@
+package regress
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Clyra-AI/wrkr/core/identity"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+const BaselineVersion = "v1"
+
+const (
+	ReasonNewUnapprovedTool     = "new_unapproved_tool"
+	ReasonRevokedToolReappeared = "revoked_tool_reappeared"
+	ReasonPermissionExpansion   = "unapproved_permission_expansion"
+	defaultApprovalState        = "missing"
+	defaultLifecycleState       = identity.StateUnderReview
+)
+
+type Baseline struct {
+	Version     string      `json:"version"`
+	GeneratedAt string      `json:"generated_at"`
+	Tools       []ToolState `json:"tools"`
+}
+
+type ToolState struct {
+	AgentID        string   `json:"agent_id"`
+	ToolID         string   `json:"tool_id"`
+	Org            string   `json:"org"`
+	Status         string   `json:"status"`
+	ApprovalStatus string   `json:"approval_status"`
+	Present        bool     `json:"present"`
+	Permissions    []string `json:"permissions"`
+}
+
+type Reason struct {
+	Code             string   `json:"code"`
+	AgentID          string   `json:"agent_id"`
+	ToolID           string   `json:"tool_id"`
+	Org              string   `json:"org"`
+	Message          string   `json:"message"`
+	AddedPermissions []string `json:"added_permissions,omitempty"`
+}
+
+type Result struct {
+	Status       string   `json:"status"`
+	Drift        bool     `json:"drift_detected"`
+	ReasonCount  int      `json:"reason_count"`
+	Reasons      []Reason `json:"reasons"`
+	BaselinePath string   `json:"baseline_path,omitempty"`
+}
+
+func BuildBaseline(snapshot state.Snapshot, generatedAt time.Time) Baseline {
+	now := generatedAt.UTC().Truncate(time.Second)
+	if now.IsZero() {
+		now = time.Now().UTC().Truncate(time.Second)
+	}
+	tools := SnapshotTools(snapshot)
+	return Baseline{
+		Version:     BaselineVersion,
+		GeneratedAt: now.Format(time.RFC3339),
+		Tools:       tools,
+	}
+}
+
+func SnapshotTools(snapshot state.Snapshot) []ToolState {
+	byAgent := map[string]*ToolState{}
+	for _, item := range snapshot.Identities {
+		agentID := strings.TrimSpace(item.AgentID)
+		if agentID == "" {
+			continue
+		}
+		tool := &ToolState{
+			AgentID:        agentID,
+			ToolID:         strings.TrimSpace(item.ToolID),
+			Org:            fallback(item.Org, "local"),
+			Status:         fallback(item.Status, defaultLifecycleState),
+			ApprovalStatus: fallback(item.ApprovalState, defaultApprovalState),
+			Present:        item.Present,
+			Permissions:    []string{},
+		}
+		byAgent[agentID] = tool
+	}
+
+	for _, finding := range snapshot.Findings {
+		org := fallback(finding.Org, "local")
+		toolID := identity.ToolID(finding.ToolType, finding.Location)
+		agentID := identity.AgentID(toolID, org)
+		item, exists := byAgent[agentID]
+		if !exists {
+			item = &ToolState{
+				AgentID:        agentID,
+				ToolID:         toolID,
+				Org:            org,
+				Status:         defaultLifecycleState,
+				ApprovalStatus: defaultApprovalState,
+				Present:        true,
+				Permissions:    []string{},
+			}
+			byAgent[agentID] = item
+		}
+		if strings.TrimSpace(item.ToolID) == "" {
+			item.ToolID = toolID
+		}
+		item.Present = true
+		item.Permissions = append(item.Permissions, finding.Permissions...)
+	}
+
+	out := make([]ToolState, 0, len(byAgent))
+	for _, item := range byAgent {
+		item.Permissions = dedupeSortedPermissions(item.Permissions)
+		out = append(out, *item)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].AgentID != out[j].AgentID {
+			return out[i].AgentID < out[j].AgentID
+		}
+		if out[i].ToolID != out[j].ToolID {
+			return out[i].ToolID < out[j].ToolID
+		}
+		return out[i].Org < out[j].Org
+	})
+	return out
+}
+
+func SaveBaseline(path string, baseline Baseline) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("baseline path is required")
+	}
+	baseline.Version = BaselineVersion
+	sort.Slice(baseline.Tools, func(i, j int) bool {
+		if baseline.Tools[i].AgentID != baseline.Tools[j].AgentID {
+			return baseline.Tools[i].AgentID < baseline.Tools[j].AgentID
+		}
+		return baseline.Tools[i].ToolID < baseline.Tools[j].ToolID
+	})
+	for i := range baseline.Tools {
+		baseline.Tools[i].Permissions = dedupeSortedPermissions(baseline.Tools[i].Permissions)
+	}
+
+	payload, err := json.MarshalIndent(baseline, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal baseline: %w", err)
+	}
+	payload = append(payload, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("mkdir baseline dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "regress-baseline-*.json")
+	if err != nil {
+		return fmt.Errorf("create baseline temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+	if _, err := tmp.Write(payload); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write baseline temp: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod baseline temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close baseline temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("commit baseline: %w", err)
+	}
+	return nil
+}
+
+func LoadBaseline(path string) (Baseline, error) {
+	payload, err := os.ReadFile(path) // #nosec G304 -- caller provides explicit local baseline path.
+	if err != nil {
+		return Baseline{}, fmt.Errorf("read baseline: %w", err)
+	}
+	var baseline Baseline
+	if err := json.Unmarshal(payload, &baseline); err != nil {
+		return Baseline{}, fmt.Errorf("parse baseline: %w", err)
+	}
+	if strings.TrimSpace(baseline.Version) == "" {
+		baseline.Version = BaselineVersion
+	}
+	sort.Slice(baseline.Tools, func(i, j int) bool {
+		if baseline.Tools[i].AgentID != baseline.Tools[j].AgentID {
+			return baseline.Tools[i].AgentID < baseline.Tools[j].AgentID
+		}
+		return baseline.Tools[i].ToolID < baseline.Tools[j].ToolID
+	})
+	for i := range baseline.Tools {
+		baseline.Tools[i].Permissions = dedupeSortedPermissions(baseline.Tools[i].Permissions)
+	}
+	return baseline, nil
+}
+
+func Compare(baseline Baseline, current state.Snapshot) Result {
+	currentTools := SnapshotTools(current)
+	baseByAgent := map[string]ToolState{}
+	for _, item := range baseline.Tools {
+		item.Permissions = dedupeSortedPermissions(item.Permissions)
+		baseByAgent[item.AgentID] = item
+	}
+	reasons := make([]Reason, 0)
+
+	for _, currentTool := range currentTools {
+		baseTool, exists := baseByAgent[currentTool.AgentID]
+		if !exists {
+			if currentTool.Present && !isApproved(currentTool) {
+				reasons = append(reasons, Reason{
+					Code:    ReasonNewUnapprovedTool,
+					AgentID: currentTool.AgentID,
+					ToolID:  currentTool.ToolID,
+					Org:     currentTool.Org,
+					Message: "detected tool not present in approved baseline",
+				})
+			}
+			continue
+		}
+
+		if strings.TrimSpace(baseTool.Status) == identity.StateRevoked && currentTool.Present {
+			reasons = append(reasons, Reason{
+				Code:    ReasonRevokedToolReappeared,
+				AgentID: currentTool.AgentID,
+				ToolID:  currentTool.ToolID,
+				Org:     currentTool.Org,
+				Message: "revoked tool reappeared in current scan",
+			})
+		}
+
+		added := permissionDelta(baseTool.Permissions, currentTool.Permissions)
+		if len(added) > 0 && !isApproved(currentTool) {
+			reasons = append(reasons, Reason{
+				Code:             ReasonPermissionExpansion,
+				AgentID:          currentTool.AgentID,
+				ToolID:           currentTool.ToolID,
+				Org:              currentTool.Org,
+				Message:          "tool permissions expanded without approval",
+				AddedPermissions: added,
+			})
+		}
+	}
+
+	sort.Slice(reasons, func(i, j int) bool {
+		if reasons[i].Code != reasons[j].Code {
+			return reasons[i].Code < reasons[j].Code
+		}
+		if reasons[i].AgentID != reasons[j].AgentID {
+			return reasons[i].AgentID < reasons[j].AgentID
+		}
+		return reasons[i].ToolID < reasons[j].ToolID
+	})
+
+	drift := len(reasons) > 0
+	status := "ok"
+	if drift {
+		status = "drift"
+	}
+	return Result{
+		Status:      status,
+		Drift:       drift,
+		ReasonCount: len(reasons),
+		Reasons:     reasons,
+	}
+}
+
+func dedupeSortedPermissions(values []string) []string {
+	set := map[string]struct{}{}
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		set[trimmed] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func permissionDelta(base, current []string) []string {
+	baseSet := map[string]struct{}{}
+	for _, value := range base {
+		baseSet[value] = struct{}{}
+	}
+	added := make([]string, 0)
+	for _, value := range current {
+		if _, exists := baseSet[value]; exists {
+			continue
+		}
+		added = append(added, value)
+	}
+	return dedupeSortedPermissions(added)
+}
+
+func isApproved(tool ToolState) bool {
+	approval := strings.TrimSpace(tool.ApprovalStatus)
+	status := strings.TrimSpace(tool.Status)
+	if approval == "valid" {
+		return true
+	}
+	return status == identity.StateApproved || status == identity.StateActive
+}
+
+func fallback(value, fallbackValue string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallbackValue
+	}
+	return value
+}

--- a/core/regress/regress_test.go
+++ b/core/regress/regress_test.go
@@ -1,0 +1,275 @@
+package regress
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Clyra-AI/wrkr/core/identity"
+	"github.com/Clyra-AI/wrkr/core/manifest"
+	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+func TestBuildBaselineAndLoadRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	snapshot := state.Snapshot{
+		Findings: []model.Finding{
+			{
+				FindingType: "source_discovery",
+				ToolType:    "source_repo",
+				Location:    "acme/backend",
+				Org:         "acme",
+				Permissions: []string{"repo.contents.read"},
+			},
+		},
+		Identities: []manifest.IdentityRecord{
+			{
+				AgentID:       identity.AgentID(identity.ToolID("source_repo", "acme/backend"), "acme"),
+				ToolID:        identity.ToolID("source_repo", "acme/backend"),
+				Org:           "acme",
+				Status:        identity.StateActive,
+				ApprovalState: "valid",
+				Present:       true,
+			},
+		},
+	}
+
+	baseline := BuildBaseline(snapshot, time.Date(2026, 2, 21, 12, 0, 0, 0, time.UTC))
+	if baseline.Version != BaselineVersion {
+		t.Fatalf("unexpected baseline version %q", baseline.Version)
+	}
+	if len(baseline.Tools) != 1 {
+		t.Fatalf("expected one tool in baseline, got %d", len(baseline.Tools))
+	}
+	if baseline.Tools[0].Permissions[0] != "repo.contents.read" {
+		t.Fatalf("unexpected permissions: %v", baseline.Tools[0].Permissions)
+	}
+
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	if err := SaveBaseline(path, baseline); err != nil {
+		t.Fatalf("save baseline: %v", err)
+	}
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read first baseline write: %v", err)
+	}
+	if err := SaveBaseline(path, baseline); err != nil {
+		t.Fatalf("save baseline second write: %v", err)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read second baseline write: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("baseline output must be byte stable")
+	}
+
+	loaded, err := LoadBaseline(path)
+	if err != nil {
+		t.Fatalf("load baseline: %v", err)
+	}
+	if len(loaded.Tools) != 1 {
+		t.Fatalf("expected one loaded tool, got %d", len(loaded.Tools))
+	}
+}
+
+func TestCompareFlagsNewUnapprovedTool(t *testing.T) {
+	t.Parallel()
+
+	current := state.Snapshot{
+		Findings: []model.Finding{
+			{
+				FindingType: "source_discovery",
+				ToolType:    "source_repo",
+				Location:    "acme/new-repo",
+				Org:         "acme",
+				Permissions: []string{"repo.contents.read"},
+			},
+		},
+	}
+	result := Compare(Baseline{Version: BaselineVersion, Tools: []ToolState{}}, current)
+	if !result.Drift {
+		t.Fatal("expected drift for new unapproved tool")
+	}
+	if result.ReasonCount != 1 {
+		t.Fatalf("expected one reason, got %d", result.ReasonCount)
+	}
+	if result.Reasons[0].Code != ReasonNewUnapprovedTool {
+		t.Fatalf("unexpected reason code %q", result.Reasons[0].Code)
+	}
+}
+
+func TestCompareFlagsRevokedToolReappearance(t *testing.T) {
+	t.Parallel()
+
+	toolID := identity.ToolID("source_repo", "acme/backend")
+	agentID := identity.AgentID(toolID, "acme")
+	baseline := Baseline{
+		Version: BaselineVersion,
+		Tools: []ToolState{
+			{
+				AgentID:        agentID,
+				ToolID:         toolID,
+				Org:            "acme",
+				Status:         identity.StateRevoked,
+				ApprovalStatus: "revoked",
+				Present:        false,
+			},
+		},
+	}
+	current := state.Snapshot{
+		Findings: []model.Finding{
+			{
+				FindingType: "source_discovery",
+				ToolType:    "source_repo",
+				Location:    "acme/backend",
+				Org:         "acme",
+				Permissions: []string{"repo.contents.read"},
+			},
+		},
+	}
+	result := Compare(baseline, current)
+	if !result.Drift {
+		t.Fatal("expected drift for revoked tool reappearance")
+	}
+	found := false
+	for _, reason := range result.Reasons {
+		if reason.Code == ReasonRevokedToolReappeared {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected revoked reappearance reason, got %v", result.Reasons)
+	}
+}
+
+func TestCompareFlagsUnapprovedPermissionExpansion(t *testing.T) {
+	t.Parallel()
+
+	toolID := identity.ToolID("source_repo", "acme/backend")
+	agentID := identity.AgentID(toolID, "acme")
+	baseline := Baseline{
+		Version: BaselineVersion,
+		Tools: []ToolState{
+			{
+				AgentID:        agentID,
+				ToolID:         toolID,
+				Org:            "acme",
+				Status:         identity.StateUnderReview,
+				ApprovalStatus: "missing",
+				Present:        true,
+				Permissions:    []string{"repo.contents.read"},
+			},
+		},
+	}
+	current := state.Snapshot{
+		Findings: []model.Finding{
+			{
+				FindingType: "source_discovery",
+				ToolType:    "source_repo",
+				Location:    "acme/backend",
+				Org:         "acme",
+				Permissions: []string{"repo.contents.read", "repo.actions.write"},
+			},
+		},
+		Identities: []manifest.IdentityRecord{
+			{
+				AgentID:       agentID,
+				ToolID:        toolID,
+				Org:           "acme",
+				Status:        identity.StateUnderReview,
+				ApprovalState: "missing",
+				Present:       true,
+			},
+		},
+	}
+	result := Compare(baseline, current)
+	if !result.Drift {
+		t.Fatal("expected drift for unapproved permission expansion")
+	}
+	found := false
+	for _, reason := range result.Reasons {
+		if reason.Code == ReasonPermissionExpansion {
+			found = true
+			if len(reason.AddedPermissions) != 1 || reason.AddedPermissions[0] != "repo.actions.write" {
+				t.Fatalf("unexpected added permissions: %v", reason.AddedPermissions)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected permission expansion reason, got %v", result.Reasons)
+	}
+}
+
+func TestCompareAllowsApprovedPermissionExpansion(t *testing.T) {
+	t.Parallel()
+
+	toolID := identity.ToolID("source_repo", "acme/backend")
+	agentID := identity.AgentID(toolID, "acme")
+	baseline := Baseline{
+		Version: BaselineVersion,
+		Tools: []ToolState{
+			{
+				AgentID:        agentID,
+				ToolID:         toolID,
+				Org:            "acme",
+				Status:         identity.StateActive,
+				ApprovalStatus: "valid",
+				Present:        true,
+				Permissions:    []string{"repo.contents.read"},
+			},
+		},
+	}
+	current := state.Snapshot{
+		Findings: []model.Finding{
+			{
+				FindingType: "source_discovery",
+				ToolType:    "source_repo",
+				Location:    "acme/backend",
+				Org:         "acme",
+				Permissions: []string{"repo.contents.read", "repo.actions.write"},
+			},
+		},
+		Identities: []manifest.IdentityRecord{
+			{
+				AgentID:       agentID,
+				ToolID:        toolID,
+				Org:           "acme",
+				Status:        identity.StateActive,
+				ApprovalState: "valid",
+				Present:       true,
+			},
+		},
+	}
+	result := Compare(baseline, current)
+	if result.Drift {
+		t.Fatalf("expected no drift for approved permission expansion, got %v", result.Reasons)
+	}
+}
+
+func TestCompareDeterministicForSameInput(t *testing.T) {
+	t.Parallel()
+
+	current := state.Snapshot{
+		Findings: []model.Finding{
+			{
+				FindingType: "source_discovery",
+				ToolType:    "source_repo",
+				Location:    "acme/backend",
+				Org:         "acme",
+				Permissions: []string{"repo.contents.read"},
+			},
+		},
+	}
+	baseline := BuildBaseline(current, time.Date(2026, 2, 21, 12, 0, 0, 0, time.UTC))
+	first := Compare(baseline, current)
+	second := Compare(baseline, current)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("compare must be deterministic\nfirst=%+v\nsecond=%+v", first, second)
+	}
+}

--- a/internal/e2e/cli_contract/cli_contract_e2e_test.go
+++ b/internal/e2e/cli_contract/cli_contract_e2e_test.go
@@ -1,0 +1,74 @@
+package clicontracte2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/cli"
+)
+
+func TestE2EScanQuietJSONRemainsMachineReadable(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	reposPath := filepath.Join(tmp, "repos")
+	statePath := filepath.Join(tmp, "state.json")
+	if err := os.MkdirAll(filepath.Join(reposPath, "alpha"), 0o755); err != nil {
+		t.Fatalf("mkdir repo fixture: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := cli.Run([]string{"scan", "--path", reposPath, "--quiet", "--json", "--state", statePath}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("scan failed: %d (%s)", code, errOut.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse scan payload: %v", err)
+	}
+	if payload["status"] != "ok" {
+		t.Fatalf("unexpected scan payload: %v", payload)
+	}
+}
+
+func TestE2ECLIParseErrorsRemainJSONForFlagOrderingVariants(t *testing.T) {
+	t.Parallel()
+
+	cases := [][]string{
+		{"--json", "--bad-flag"},
+		{"--bad-flag", "--json"},
+	}
+
+	for _, args := range cases {
+		args := args
+		t.Run(args[0], func(t *testing.T) {
+			t.Parallel()
+
+			var out bytes.Buffer
+			var errOut bytes.Buffer
+			code := cli.Run(args, &out, &errOut)
+			if code != 6 {
+				t.Fatalf("expected exit 6, got %d for args=%v", code, args)
+			}
+			if out.Len() != 0 {
+				t.Fatalf("expected no stdout on parse error, got %q", out.String())
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(errOut.Bytes(), &payload); err != nil {
+				t.Fatalf("expected JSON error output, got %q (%v)", errOut.String(), err)
+			}
+			errObj, ok := payload["error"].(map[string]any)
+			if !ok {
+				t.Fatalf("missing error payload: %v", payload)
+			}
+			if errObj["code"] != "invalid_input" {
+				t.Fatalf("unexpected error code: %v", errObj["code"])
+			}
+		})
+	}
+}

--- a/internal/e2e/regress/regress_e2e_test.go
+++ b/internal/e2e/regress/regress_e2e_test.go
@@ -1,0 +1,72 @@
+package regresse2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/cli"
+)
+
+func TestE2ERegressInitAndRunDetectsDrift(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	baselinePath := filepath.Join(tmp, "baseline.json")
+	reposPath := filepath.Join(tmp, "repos")
+	if err := os.MkdirAll(filepath.Join(reposPath, "alpha"), 0o755); err != nil {
+		t.Fatalf("mkdir alpha fixture: %v", err)
+	}
+
+	var scanOut bytes.Buffer
+	var scanErr bytes.Buffer
+	if code := cli.Run([]string{"scan", "--path", reposPath, "--state", statePath, "--json"}, &scanOut, &scanErr); code != 0 {
+		t.Fatalf("initial scan failed: %d (%s)", code, scanErr.String())
+	}
+
+	var initOut bytes.Buffer
+	var initErr bytes.Buffer
+	if code := cli.Run([]string{"regress", "init", "--baseline", statePath, "--output", baselinePath, "--json"}, &initOut, &initErr); code != 0 {
+		t.Fatalf("regress init failed: %d (%s)", code, initErr.String())
+	}
+
+	var runOut bytes.Buffer
+	var runErr bytes.Buffer
+	if code := cli.Run([]string{"regress", "run", "--baseline", baselinePath, "--state", statePath, "--json"}, &runOut, &runErr); code != 0 {
+		t.Fatalf("expected clean regress run, got %d (%s)", code, runErr.String())
+	}
+	var runPayload map[string]any
+	if err := json.Unmarshal(runOut.Bytes(), &runPayload); err != nil {
+		t.Fatalf("parse regress run payload: %v", err)
+	}
+	if runPayload["drift_detected"] != false {
+		t.Fatalf("expected no drift, got %v", runPayload)
+	}
+
+	if err := os.MkdirAll(filepath.Join(reposPath, "beta"), 0o755); err != nil {
+		t.Fatalf("mkdir beta fixture: %v", err)
+	}
+	scanOut.Reset()
+	scanErr.Reset()
+	if code := cli.Run([]string{"scan", "--path", reposPath, "--state", statePath, "--json"}, &scanOut, &scanErr); code != 0 {
+		t.Fatalf("second scan failed: %d (%s)", code, scanErr.String())
+	}
+
+	runOut.Reset()
+	runErr.Reset()
+	if code := cli.Run([]string{"regress", "run", "--baseline", baselinePath, "--state", statePath, "--json"}, &runOut, &runErr); code != 5 {
+		t.Fatalf("expected drift exit 5, got %d (%s)", code, runErr.String())
+	}
+	if runErr.Len() != 0 {
+		t.Fatalf("expected drift JSON on stdout only, got stderr=%q", runErr.String())
+	}
+	if err := json.Unmarshal(runOut.Bytes(), &runPayload); err != nil {
+		t.Fatalf("parse regress drift payload: %v", err)
+	}
+	if runPayload["drift_detected"] != true {
+		t.Fatalf("expected drift detected payload, got %v", runPayload)
+	}
+}

--- a/internal/e2e/score/score_e2e_test.go
+++ b/internal/e2e/score/score_e2e_test.go
@@ -1,0 +1,53 @@
+package scoree2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/cli"
+)
+
+func TestE2EScoreJSONAndExplainContracts(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	reposPath := filepath.Join(tmp, "repos")
+	if err := os.MkdirAll(filepath.Join(reposPath, "alpha"), 0o755); err != nil {
+		t.Fatalf("mkdir repo fixture: %v", err)
+	}
+
+	var scanOut bytes.Buffer
+	var scanErr bytes.Buffer
+	if code := cli.Run([]string{"scan", "--path", reposPath, "--state", statePath, "--json"}, &scanOut, &scanErr); code != 0 {
+		t.Fatalf("scan failed: %d (%s)", code, scanErr.String())
+	}
+
+	var scoreOut bytes.Buffer
+	var scoreErr bytes.Buffer
+	if code := cli.Run([]string{"score", "--state", statePath, "--json"}, &scoreOut, &scoreErr); code != 0 {
+		t.Fatalf("score --json failed: %d (%s)", code, scoreErr.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(scoreOut.Bytes(), &payload); err != nil {
+		t.Fatalf("parse score payload: %v", err)
+	}
+	for _, key := range []string{"score", "grade", "breakdown", "weighted_breakdown", "weights", "trend_delta"} {
+		if _, present := payload[key]; !present {
+			t.Fatalf("missing score key %q in %v", key, payload)
+		}
+	}
+
+	scoreOut.Reset()
+	scoreErr.Reset()
+	if code := cli.Run([]string{"score", "--state", statePath, "--explain"}, &scoreOut, &scoreErr); code != 0 {
+		t.Fatalf("score --explain failed: %d (%s)", code, scoreErr.String())
+	}
+	if !strings.Contains(scoreOut.String(), "wrkr score") {
+		t.Fatalf("expected explain output, got %q", scoreOut.String())
+	}
+}

--- a/schemas/v1/README.md
+++ b/schemas/v1/README.md
@@ -1,3 +1,6 @@
 # Wrkr Schemas v1
 
 This directory contains versioned JSON/YAML schemas for Wrkr runtime and artifact contracts.
+
+- `cli/`: shared CLI success/error envelope contracts.
+- `regress/`: posture regression baseline and drift-result contracts.

--- a/schemas/v1/cli/command-envelope.schema.json
+++ b/schemas/v1/cli/command-envelope.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wrkr.dev/schemas/v1/cli/command-envelope.schema.json",
+  "title": "Wrkr CLI Envelope",
+  "description": "Shared machine-readable success/error envelope for root-level CLI contracts.",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "const": "ok"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    {
+      "type": "object",
+      "required": ["error"],
+      "properties": {
+        "error": {
+          "type": "object",
+          "required": ["code", "message", "exit_code"],
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "exit_code": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/schemas/v1/regress/regress-baseline.schema.json
+++ b/schemas/v1/regress/regress-baseline.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wrkr.dev/schemas/v1/regress/regress-baseline.schema.json",
+  "title": "Wrkr Regress Baseline",
+  "type": "object",
+  "required": ["version", "generated_at", "tools"],
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "tools": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "agent_id",
+          "tool_id",
+          "org",
+          "status",
+          "approval_status",
+          "present",
+          "permissions"
+        ],
+        "properties": {
+          "agent_id": {
+            "type": "string"
+          },
+          "tool_id": {
+            "type": "string"
+          },
+          "org": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["discovered", "under_review", "approved", "active", "deprecated", "revoked"]
+          },
+          "approval_status": {
+            "type": "string"
+          },
+          "present": {
+            "type": "boolean"
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/v1/regress/regress-result.schema.json
+++ b/schemas/v1/regress/regress-result.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wrkr.dev/schemas/v1/regress/regress-result.schema.json",
+  "title": "Wrkr Regress Result",
+  "type": "object",
+  "required": ["status", "drift_detected", "reason_count", "reasons"],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["ok", "drift"]
+    },
+    "drift_detected": {
+      "type": "boolean"
+    },
+    "reason_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "baseline_path": {
+      "type": "string"
+    },
+    "reasons": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["code", "agent_id", "tool_id", "org", "message"],
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "new_unapproved_tool",
+              "revoked_tool_reappeared",
+              "unapproved_permission_expansion"
+            ]
+          },
+          "agent_id": {
+            "type": "string"
+          },
+          "tool_id": {
+            "type": "string"
+          },
+          "org": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "added_permissions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/testinfra/contracts/story5_contracts_test.go
+++ b/testinfra/contracts/story5_contracts_test.go
@@ -1,0 +1,150 @@
+package contracts
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/cli"
+)
+
+func TestStory5SchemasPresent(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	required := []string{
+		"schemas/v1/cli/command-envelope.schema.json",
+		"schemas/v1/regress/regress-baseline.schema.json",
+		"schemas/v1/regress/regress-result.schema.json",
+	}
+	for _, rel := range required {
+		if _, err := os.Stat(filepath.Join(repoRoot, rel)); err != nil {
+			t.Fatalf("expected schema %s: %v", rel, err)
+		}
+	}
+}
+
+func TestRootInvalidFlagOrderingJSONContract(t *testing.T) {
+	t.Parallel()
+
+	cases := [][]string{
+		{"--json", "--bad-flag"},
+		{"--bad-flag", "--json"},
+	}
+	for _, args := range cases {
+		args := args
+		t.Run(args[0], func(t *testing.T) {
+			t.Parallel()
+
+			var out bytes.Buffer
+			var errOut bytes.Buffer
+			code := cli.Run(args, &out, &errOut)
+			if code != 6 {
+				t.Fatalf("expected exit 6, got %d for args=%v", code, args)
+			}
+			if out.Len() != 0 {
+				t.Fatalf("expected no stdout, got %q", out.String())
+			}
+
+			var payload map[string]any
+			if err := json.Unmarshal(errOut.Bytes(), &payload); err != nil {
+				t.Fatalf("parse JSON error envelope: %v (%q)", err, errOut.String())
+			}
+			errObj, ok := payload["error"].(map[string]any)
+			if !ok {
+				t.Fatalf("missing error object: %v", payload)
+			}
+			if errObj["code"] != "invalid_input" {
+				t.Fatalf("unexpected error code: %v", errObj["code"])
+			}
+			if errObj["exit_code"] != float64(6) {
+				t.Fatalf("unexpected error exit code: %v", errObj["exit_code"])
+			}
+		})
+	}
+}
+
+func TestUnsupportedCommandExitCodeContract(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := cli.Run([]string{"not-a-command", "--json"}, &out, &errOut)
+	if code != 6 {
+		t.Fatalf("expected exit 6, got %d", code)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected no stdout, got %q", out.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(errOut.Bytes(), &payload); err != nil {
+		t.Fatalf("parse JSON error envelope: %v (%q)", err, errOut.String())
+	}
+	errObj, ok := payload["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing error object: %v", payload)
+	}
+	if errObj["code"] != "invalid_input" {
+		t.Fatalf("unexpected error code: %v", errObj["code"])
+	}
+	if errObj["exit_code"] != float64(6) {
+		t.Fatalf("unexpected error exit code: %v", errObj["exit_code"])
+	}
+}
+
+func TestRegressDriftExitCodeContract(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	baselinePath := filepath.Join(tmp, "baseline.json")
+	reposPath := filepath.Join(tmp, "repos")
+	if err := os.MkdirAll(filepath.Join(reposPath, "alpha"), 0o755); err != nil {
+		t.Fatalf("mkdir alpha fixture: %v", err)
+	}
+
+	var scanOut bytes.Buffer
+	var scanErr bytes.Buffer
+	if code := cli.Run([]string{"scan", "--path", reposPath, "--state", statePath, "--json"}, &scanOut, &scanErr); code != 0 {
+		t.Fatalf("scan failed: %d (%s)", code, scanErr.String())
+	}
+
+	var initOut bytes.Buffer
+	var initErr bytes.Buffer
+	if code := cli.Run([]string{"regress", "init", "--baseline", statePath, "--output", baselinePath, "--json"}, &initOut, &initErr); code != 0 {
+		t.Fatalf("regress init failed: %d (%s)", code, initErr.String())
+	}
+
+	if err := os.MkdirAll(filepath.Join(reposPath, "beta"), 0o755); err != nil {
+		t.Fatalf("mkdir beta fixture: %v", err)
+	}
+	scanOut.Reset()
+	scanErr.Reset()
+	if code := cli.Run([]string{"scan", "--path", reposPath, "--state", statePath, "--json"}, &scanOut, &scanErr); code != 0 {
+		t.Fatalf("second scan failed: %d (%s)", code, scanErr.String())
+	}
+
+	var runOut bytes.Buffer
+	var runErr bytes.Buffer
+	code := cli.Run([]string{"regress", "run", "--baseline", baselinePath, "--state", statePath, "--json"}, &runOut, &runErr)
+	if code != 5 {
+		t.Fatalf("expected drift exit 5, got %d (%s)", code, runErr.String())
+	}
+	if runErr.Len() != 0 {
+		t.Fatalf("expected JSON drift payload on stdout only, got stderr=%q", runErr.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(runOut.Bytes(), &payload); err != nil {
+		t.Fatalf("parse regress payload: %v", err)
+	}
+	if payload["status"] != "drift" {
+		t.Fatalf("expected status=drift, got %v", payload["status"])
+	}
+	if payload["drift_detected"] != true {
+		t.Fatalf("expected drift_detected=true, got %v", payload["drift_detected"])
+	}
+}


### PR DESCRIPTION
## Problem
PLAN_v1 Epic 5 required missing CLI surface contracts and regression control paths:
- root-level contract hardening for `--json`, `--quiet`, `--explain` and parse-error envelopes
- command flow coverage for `manifest generate` and `report --pdf`
- deterministic posture regression baseline/run commands with exit `5` drift semantics
- stronger score command CLI contracts and dedicated Epic 5 contract/e2e wiring

## Changes
- Hardened root contract handling and added ordering/unknown-command/help tests.
- Implemented deterministic report PDF output (`wrkr report --pdf`) and manifest generation command (`wrkr manifest generate`).
- Added `core/regress` plus `wrkr regress init/run` with deterministic drift reason codes:
  - `new_unapproved_tool`
  - `revoked_tool_reappeared`
  - `unapproved_permission_expansion`
- Extended `wrkr score` with explicit `--quiet` and `--explain` behavior.
- Added Epic 5 schemas for CLI envelope and regress baseline/result contracts.
- Added Tier 3/E2E and Tier 9 contract tests for new Epic 5 surfaces.
- Updated README/schema docs for new user-visible CLI contracts.

## Validation
- `make prepush-full`
- `go test ./core/cli ./core/manifestgen ./core/regress ./internal/e2e/cli_contract ./internal/e2e/regress ./internal/e2e/score ./testinfra/contracts -count=1`
- command anchor: `.tmp/wrkr scan --path <tmp> --state <tmp>/state.json --json`
- command checks in temp workspace:
  - `wrkr report --pdf --json`
  - `wrkr manifest generate --json`
  - `wrkr regress init ... --json`
  - `wrkr regress run ... --json` (clean and drift exit `5` paths)
  - `wrkr evidence ... --output <non-managed>` (exit `8` fail-closed)
