### PR TITLE
skills: tighten PR comment triage and merge loop safety

### DIFF
--- a/.agents/skills/adhoc-implement/SKILL.md
+++ b/.agents/skills/adhoc-implement/SKILL.md
@@ -97,6 +97,8 @@ When collecting evidence or emitting machine-readable status, use `wrkr` command
 - deterministic allow/block/require_approval fixtures
 - fail-closed undecidable-path tests
 - reason-code stability checks
+- regression input-boundary tests (`policy_check`/`policy_violation`/`parse_error` must not become tracked tools)
+- lifecycle preservation tests (`present=false` identities must not be rewritten to `present=true` by generation flows)
 - filesystem boundary tests for user-supplied output paths (`non-empty + non-managed => fail`)
 - ownership marker trust tests (`marker must be regular file`; reject symlink/directory)
 

--- a/.agents/skills/backlog-implement/SKILL.md
+++ b/.agents/skills/backlog-implement/SKILL.md
@@ -132,6 +132,8 @@ Rules:
 - Deterministic allow/block/require_approval fixture tests
 - Fail-closed undecidable-path tests
 - Stable reason-code tests
+- Regression input-boundary tests (`policy_check`/`policy_violation`/`parse_error` must not become tracked tools)
+- Lifecycle preservation tests (`present=false` identities must not be rewritten to `present=true` by generation flows)
 - Filesystem boundary tests for user-supplied output paths (`non-empty + non-managed => fail`)
 - Ownership marker trust tests (`marker must be regular file`; reject symlink/directory)
 

--- a/.agents/skills/backlog-plan/SKILL.md
+++ b/.agents/skills/backlog-plan/SKILL.md
@@ -70,6 +70,8 @@ If these are missing, stop and output a gap note instead of inventing details.
 - Add deterministic allow/block/require_approval fixture tests.
 - Add fail-closed tests for evaluator-missing or undecidable paths.
 - Add reason code stability checks.
+- Add regression input-boundary tests (`policy_check`/`policy_violation`/`parse_error` must not become tracked tools).
+- Add lifecycle preservation tests (`present=false` identities must not be rewritten to `present=true` by generation flows).
 - For stories that clean/reset output paths, require `non-empty + non-managed => fail` tests.
 - Require marker trust tests (`marker must be regular file`; reject symlink/directory).
 
@@ -132,6 +134,7 @@ Story template (required fields):
 - Optional when needed:
 - `Dependencies:`
 - `Risks:`
+- `Semantic invariants:` (required for stories touching identity/lifecycle/manifest/regress)
 
 ## Quality Gate for Output
 

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -43,6 +43,8 @@ Execute this workflow for: "review the codebase", "audit repo health", "run a fu
    - Integrity verification weakening
    - False-green test/CI paths
    - Portability/toolchain/path assumptions
+   - Finding-class boundary leaks (non-tool findings entering identity/regress tool state)
+   - Lifecycle-state clobbering (`present=false` or removed identities rewritten as present)
    - Schema/CLI contract drift
    - Docs/examples that do not match real behavior
 4. Verify findings with concrete evidence (file refs, commands, test output).
@@ -70,6 +72,8 @@ Execute this workflow for: "review the codebase", "audit repo health", "run a fu
 
 - Findings are primary output; summaries stay brief.
 - Treat recursive cleanup/delete on caller-selected paths with weak ownership gating as at least `P1`.
+- Treat finding-boundary leaks that can cause false drift/exit `5` as at least `P1`.
+- Treat lifecycle-state clobbering that reintroduces removed identities as at least `P2`.
 - Do not report style nits unless they cause runtime/contract risk.
 - Do not claim tests/commands were run if they were not.
 - Separate facts from inference.

--- a/.agents/skills/initial-plan/SKILL.md
+++ b/.agents/skills/initial-plan/SKILL.md
@@ -115,6 +115,7 @@ Story template (required fields):
 - `Test requirements:`
 - `Matrix wiring:`
 - `Acceptance criteria:`
+- `Semantic invariants:` (required for stories touching identity/lifecycle/manifest/regress)
 - Optional when needed:
 - `Dependencies:`
 - `Risks:`
@@ -141,6 +142,8 @@ For every story, derive required checks from `product/dev_guides.md` by work typ
 - Add deterministic fixture tests for allow/block/risk ranking behavior.
 - Add fail-closed tests for undecidable/ambiguous high-risk paths.
 - Add reason-code stability and ranking determinism checks.
+- Add regression input-boundary tests (`policy_check`/`policy_violation`/`parse_error` must not become tracked tools).
+- Add lifecycle preservation tests (`present=false` identities must not be rewritten to `present=true` by generation flows).
 - For stories that clean/reset output paths, add `non-empty + non-managed => fail` tests.
 - Add marker trust tests (`marker must be regular file`; reject symlink/directory).
 
@@ -216,6 +219,7 @@ Before finalizing, verify:
 - every story has concrete repo paths and executable commands
 - acceptance criteria are deterministic and objectively testable
 - test requirements match `dev_guides.md` tier expectations
+- identity/lifecycle/manifest/regress stories include explicit semantic invariants
 - matrix wiring exists for every story
 - sequence is dependency-aware and executable end-to-end
 - plan respects Wrkr boundaries (See product only; no Axym/Gait feature scope creep)

--- a/.agents/skills/pr-comments/SKILL.md
+++ b/.agents/skills/pr-comments/SKILL.md
@@ -63,9 +63,13 @@ Prioritize comments that affect:
 5. Security/privacy controls (signing, secrets handling, unsafe interlocks).
 6. Cross-platform/CI portability issues.
 7. Docs drift where behavior has changed.
+8. Semantic boundary leaks between finding classes and identity/regression state.
+9. Lifecycle-state preservation (for example absent identities being rewritten as present).
 
 Severity guidance:
 - Treat marker-name-only ownership checks before recursive delete/cleanup on user-supplied paths as at least `P1` until proven safe.
+- Treat finding-boundary leaks that can trigger false regression drift as at least `P1` until proven safe.
+- Treat lifecycle-preservation violations (`present=false` overwritten/reintroduced) as at least `P2`.
 
 Deprioritize or reject:
 


### PR DESCRIPTION
## Problem
Recent bot findings exposed a process gap: unresolved PR comments were not explicitly triaged and fixed before merge, and one documented loop omitted explicit commit steps after comment-driven fixes.

## Changes
- Updated `commit-push` skill to require unresolved-thread fetch against latest PR head SHA.
- Added explicit triage policy (`implement/defer/reject`) and tightened auto-fix criteria.
- Added missing `git add -A` + `git commit` in pre-merge comment-fix loop.
- Clarified fixes must be applied on the same working branch already used by the PR head.
- Updated adjacent implementation/review/plan skills to require comment triage awareness and avoid policy-only drift regressions.

## Validation
- `make prepush-full` (pass)
- CodeQL run included via prepush-full (pass)
