### PR TITLE
epic6: remediation fix loop, PR integration, and wrkr-action runtime

### DIFF
--- a/.github/workflows/wrkr-action-ci.yml
+++ b/.github/workflows/wrkr-action-ci.yml
@@ -1,0 +1,40 @@
+name: wrkr-action-ci
+
+on:
+  pull_request:
+    paths:
+      - 'action/**'
+      - 'core/action/**'
+      - 'internal/e2e/action/**'
+      - '.github/workflows/wrkr-action-ci.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'action/**'
+      - 'core/action/**'
+      - 'internal/e2e/action/**'
+      - '.github/workflows/wrkr-action-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  action-contract:
+    name: action-contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.7'
+          check-latest: false
+
+      - name: Validate action runtime contracts
+        run: |
+          go test ./core/action/... -count=1
+          go test ./internal/e2e/action -count=1

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ Wrkr is the deterministic See-layer CLI in the See -> Prove -> Control model.
 
 ## Status
 
-Epics 1-5 are implemented.
+Epics 1-6 are implemented.
 
 - Epic 1: source acquisition contracts (`init`, `scan`, source manifests, incremental diff state)
 - Epic 2: deterministic detector engine (Claude/Cursor/Codex/Copilot, MCP, skills, CI/headless autonomy, dependencies, secrets, compiled actions) and YAML-backed policy evaluation (`WRKR-001`..`WRKR-015`)
 - Epic 3: deterministic inventory aggregation + repo exposure summaries, identity lifecycle manifest/chain updates, ranked risk reporting, posture profiles, and posture score outputs
 - Epic 4: signed proof record emission (`scan_finding`, `risk_assessment`, `approval`, lifecycle transitions), proof chain verification, and compliance evidence bundle generation
 - Epic 5: CLI contract hardening (`--json`, `--quiet`, `--explain`), report PDF output, manifest generation, and posture regression baseline/drift checks
+- Epic 6: deterministic remediation planning (`fix`), split auth-profile PR safeguards, and `wrkr-action` scheduled/PR runtime contracts
 
 ## Quick Start
 
@@ -46,6 +47,7 @@ wrkr regress init --baseline ./.wrkr/last-scan.json --json
 wrkr regress run --baseline ./.wrkr/wrkr-regress-baseline.json --json
 wrkr verify --chain --json
 wrkr evidence --frameworks eu-ai-act,soc2 --json
+wrkr fix --top 3 --json
 
 # Optional non-deterministic enrichment branch (explicitly opt-in).
 wrkr scan --path ./local-repos --enrich --github-api https://api.github.com --json
@@ -77,3 +79,9 @@ Invalid target combinations return exit code `6` with a machine-readable JSON en
 - Secret detectors only emit credential-presence context and key names, never secret values.
 - Policy checks run after detection and emit deterministic `policy_check` and `policy_violation` findings.
 - Built-in policy pack is versioned (`core/policy/rules/builtin.yaml`) and loaded on every scan; repo-local `wrkr-policy.yaml` and `--policy` overlays are supported.
+
+## Remediation
+
+- `wrkr fix --top <N> --json` generates deterministic remediation patch previews and commit messages for eligible high-risk findings.
+- Unsupported findings are emitted with explicit non-fixable reason codes.
+- `wrkr fix --open-pr` requires a write-capable fix profile token (scan-only profile fails closed).

--- a/action/action.yaml
+++ b/action/action.yaml
@@ -1,0 +1,22 @@
+name: Wrkr Action
+description: Deterministic Wrkr scheduled and PR-mode execution for AI posture visibility.
+author: Clyra-AI
+
+inputs:
+  mode:
+    description: scheduled or pr
+    required: false
+    default: scheduled
+  top:
+    description: number of top findings in report output
+    required: false
+    default: "5"
+
+runs:
+  using: composite
+  steps:
+    - name: Run wrkr-action entrypoint
+      shell: bash
+      run: |
+        set -euo pipefail
+        "${{ github.action_path }}/entrypoint.sh" "${{ inputs.mode }}" "${{ inputs.top }}"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-scheduled}"
+top="${2:-5}"
+
+if [[ "${mode}" != "scheduled" && "${mode}" != "pr" ]]; then
+  echo "unsupported mode: ${mode}" >&2
+  exit 6
+fi
+
+run_wrkr() {
+  if command -v wrkr >/dev/null 2>&1; then
+    wrkr "$@"
+    return
+  fi
+  if command -v go >/dev/null 2>&1 && [[ -f "./cmd/wrkr/main.go" ]]; then
+    go run ./cmd/wrkr "$@"
+    return
+  fi
+  echo "wrkr runtime is missing: install wrkr binary or provide Go toolchain" >&2
+  exit 7
+}
+
+run_wrkr scan --json
+run_wrkr report --top "${top}" --json
+run_wrkr score --json
+
+# Deterministic mode marker for workflow consumers.
+echo "wrkr_action_mode=${mode}"

--- a/core/action/runtime.go
+++ b/core/action/runtime.go
@@ -1,0 +1,84 @@
+package action
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Clyra-AI/wrkr/core/action/changes"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+type ScheduledResult struct {
+	ScoreDeltaText      string  `json:"score_delta_text"`
+	ComplianceDeltaText string  `json:"compliance_delta_text"`
+	Summary             string  `json:"summary"`
+	PostureScore        float64 `json:"posture_score"`
+	CompliancePercent   float64 `json:"compliance_percent"`
+}
+
+type PRModeInput struct {
+	ChangedPaths    []string
+	RiskDelta       float64
+	ComplianceDelta float64
+	BlockThreshold  float64
+}
+
+type PRModeResult struct {
+	ShouldComment bool     `json:"should_comment"`
+	BlockMerge    bool     `json:"block_merge"`
+	RelevantPaths []string `json:"relevant_paths"`
+	Comment       string   `json:"comment"`
+}
+
+// RunScheduled derives deterministic scheduled-mode summary text from a scan snapshot.
+func RunScheduled(snapshot state.Snapshot) ScheduledResult {
+	score := 0.0
+	scoreDelta := 0.0
+	if snapshot.PostureScore != nil {
+		score = snapshot.PostureScore.Score
+		scoreDelta = snapshot.PostureScore.TrendDelta
+	}
+
+	compliance := 0.0
+	complianceDelta := 0.0
+	if snapshot.Profile != nil {
+		compliance = snapshot.Profile.CompliancePercent
+		complianceDelta = snapshot.Profile.DeltaPercent
+	}
+
+	scoreDeltaText := fmt.Sprintf("posture score delta %+.2f (current %.2f)", scoreDelta, score)
+	complianceDeltaText := fmt.Sprintf("profile compliance delta %+.2f%% (current %.2f%%)", complianceDelta, compliance)
+	return ScheduledResult{
+		ScoreDeltaText:      scoreDeltaText,
+		ComplianceDeltaText: complianceDeltaText,
+		Summary:             "scheduled mode: " + scoreDeltaText + "; " + complianceDeltaText,
+		PostureScore:        score,
+		CompliancePercent:   compliance,
+	}
+}
+
+// RunPRMode emits deterministic PR comment payloads only for AI-config affecting file changes.
+func RunPRMode(in PRModeInput) PRModeResult {
+	relevant := changes.RelevantPaths(in.ChangedPaths)
+	if len(relevant) == 0 {
+		return PRModeResult{ShouldComment: false, BlockMerge: false, RelevantPaths: []string{}}
+	}
+
+	block := in.BlockThreshold > 0 && in.RiskDelta >= in.BlockThreshold
+	comment := fmt.Sprintf(
+		"wrkr PR mode: risk delta %+.2f, profile compliance delta %+.2f%%, relevant paths: %s",
+		in.RiskDelta,
+		in.ComplianceDelta,
+		strings.Join(relevant, ", "),
+	)
+	if block {
+		comment += fmt.Sprintf("; merge blocked (threshold %.2f)", in.BlockThreshold)
+	}
+
+	return PRModeResult{
+		ShouldComment: true,
+		BlockMerge:    block,
+		RelevantPaths: relevant,
+		Comment:       comment,
+	}
+}

--- a/core/action/runtime_test.go
+++ b/core/action/runtime_test.go
@@ -1,0 +1,47 @@
+package action
+
+import (
+	"testing"
+
+	profileeval "github.com/Clyra-AI/wrkr/core/policy/profileeval"
+	"github.com/Clyra-AI/wrkr/core/score"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+func TestRunScheduledDeterministicSummary(t *testing.T) {
+	t.Parallel()
+
+	snapshot := state.Snapshot{
+		Profile:      &profileeval.Result{CompliancePercent: 91.25, DeltaPercent: -1.75},
+		PostureScore: &score.Result{Score: 83.40, TrendDelta: 2.10},
+	}
+	first := RunScheduled(snapshot)
+	second := RunScheduled(snapshot)
+
+	if first != second {
+		t.Fatalf("expected deterministic scheduled result\nfirst=%+v\nsecond=%+v", first, second)
+	}
+	if first.ScoreDeltaText != "posture score delta +2.10 (current 83.40)" {
+		t.Fatalf("unexpected score delta text: %q", first.ScoreDeltaText)
+	}
+	if first.ComplianceDeltaText != "profile compliance delta -1.75% (current 91.25%)" {
+		t.Fatalf("unexpected compliance delta text: %q", first.ComplianceDeltaText)
+	}
+}
+
+func TestRunPRModeCommentsOnlyForRelevantChanges(t *testing.T) {
+	t.Parallel()
+
+	noComment := RunPRMode(PRModeInput{ChangedPaths: []string{"README.md", "docs/usage.md"}, RiskDelta: 4.5, ComplianceDelta: -3.0, BlockThreshold: 5.0})
+	if noComment.ShouldComment {
+		t.Fatalf("expected docs-only changes to suppress comments, got %+v", noComment)
+	}
+
+	comment := RunPRMode(PRModeInput{ChangedPaths: []string{"README.md", ".codex/config.toml"}, RiskDelta: 6.2, ComplianceDelta: -4.5, BlockThreshold: 6.0})
+	if !comment.ShouldComment {
+		t.Fatalf("expected comment for AI config changes, got %+v", comment)
+	}
+	if !comment.BlockMerge {
+		t.Fatalf("expected block merge when threshold crossed, got %+v", comment)
+	}
+}

--- a/core/auth/profiles.go
+++ b/core/auth/profiles.go
@@ -1,0 +1,22 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+)
+
+var ErrFixProfileRequired = errors.New("fix profile token is required for write operations")
+
+// ResolveFixToken resolves a write-capable token and fails closed when only scan credentials exist.
+func ResolveFixToken(scanToken, fixToken, overrideToken string) (string, error) {
+	if token := strings.TrimSpace(overrideToken); token != "" {
+		return token, nil
+	}
+	if token := strings.TrimSpace(fixToken); token != "" {
+		return token, nil
+	}
+	if strings.TrimSpace(scanToken) != "" {
+		return "", ErrFixProfileRequired
+	}
+	return "", ErrFixProfileRequired
+}

--- a/core/auth/profiles_test.go
+++ b/core/auth/profiles_test.go
@@ -1,0 +1,35 @@
+package auth
+
+import "testing"
+
+func TestResolveFixTokenPrecedence(t *testing.T) {
+	t.Parallel()
+
+	token, err := ResolveFixToken("scan-token", "fix-token", "override")
+	if err != nil {
+		t.Fatalf("resolve token: %v", err)
+	}
+	if token != "override" {
+		t.Fatalf("expected override token, got %q", token)
+	}
+
+	token, err = ResolveFixToken("scan-token", "fix-token", "")
+	if err != nil {
+		t.Fatalf("resolve fix token: %v", err)
+	}
+	if token != "fix-token" {
+		t.Fatalf("expected fix token, got %q", token)
+	}
+}
+
+func TestResolveFixTokenFailsClosedWithScanOnly(t *testing.T) {
+	t.Parallel()
+
+	_, err := ResolveFixToken("scan-token", "", "")
+	if err == nil {
+		t.Fatal("expected scan-only profile to fail closed")
+	}
+	if err != ErrFixProfileRequired {
+		t.Fatalf("expected ErrFixProfileRequired, got %v", err)
+	}
+}

--- a/core/cli/fix.go
+++ b/core/cli/fix.go
@@ -1,0 +1,215 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Clyra-AI/wrkr/core/auth"
+	"github.com/Clyra-AI/wrkr/core/config"
+	"github.com/Clyra-AI/wrkr/core/fix"
+	githubpr "github.com/Clyra-AI/wrkr/core/github/pr"
+	"github.com/Clyra-AI/wrkr/core/risk"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+var newGitHubPRClient = func(baseURL, token string) githubpr.API {
+	return githubpr.NewGitHubClient(baseURL, token, nil)
+}
+
+func runFix(args []string, stdout io.Writer, stderr io.Writer) int {
+	jsonRequested := wantsJSONOutput(args)
+	fs := flag.NewFlagSet("fix", flag.ContinueOnError)
+	if jsonRequested {
+		fs.SetOutput(io.Discard)
+	} else {
+		fs.SetOutput(stderr)
+	}
+
+	jsonOut := fs.Bool("json", false, "emit machine-readable output")
+	explain := fs.Bool("explain", false, "emit rationale details")
+	quiet := fs.Bool("quiet", false, "suppress non-error output")
+	top := fs.Int("top", 3, "number of fix candidates to plan")
+	statePathFlag := fs.String("state", "", "state file path override")
+	configPathFlag := fs.String("config", "", "config file path override")
+	openPR := fs.Bool("open-pr", false, "open or update a remediation pull request")
+	repoTarget := fs.String("repo", "", "owner/repo target for PR operations")
+	baseBranch := fs.String("base", "main", "base branch for PR operations")
+	botIdentity := fs.String("bot", "wrkr-bot", "bot identity for deterministic branch metadata")
+	scheduleKey := fs.String("schedule-key", "adhoc", "schedule key for idempotent branch naming")
+	prTitle := fs.String("pr-title", "", "optional deterministic PR title override")
+	githubAPI := fs.String("github-api", strings.TrimSpace(os.Getenv("WRKR_GITHUB_API_BASE")), "github api base url")
+	fixToken := fs.String("fix-token", "", "fix profile token override")
+
+	if err := fs.Parse(args); err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
+	}
+	if fs.NArg() != 0 {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", "fix does not accept positional arguments", exitInvalidInput)
+	}
+	if *top <= 0 {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", "--top must be greater than zero", exitInvalidInput)
+	}
+	if *quiet && *explain && !*jsonOut {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", "--quiet and --explain cannot be used together", exitInvalidInput)
+	}
+
+	snapshot, err := state.Load(state.ResolvePath(*statePathFlag))
+	if err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
+
+	plan, err := fix.BuildPlan(loadRankedFindings(snapshot, *top), *top)
+	if err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
+
+	payload := map[string]any{
+		"status":               "ok",
+		"requested_top":        plan.RequestedTop,
+		"fingerprint":          plan.Fingerprint,
+		"remediation_count":    len(plan.Remediations),
+		"non_fixable_count":    len(plan.Skipped),
+		"remediations":         plan.Remediations,
+		"unsupported_findings": plan.Skipped,
+	}
+
+	if *openPR {
+		if len(plan.Remediations) == 0 {
+			return emitError(stderr, jsonRequested || *jsonOut, "unsafe_operation_blocked", "no fixable findings available for PR generation", exitUnsafeBlocked)
+		}
+		repoValue, err := resolvePRRepo(*repoTarget, snapshot)
+		if err != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
+		}
+		owner, repo, err := splitRepo(repoValue)
+		if err != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
+		}
+
+		cfg, cfgErr := loadOptionalConfig(*configPathFlag)
+		if cfgErr != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", cfgErr.Error(), exitRuntime)
+		}
+		token, tokenErr := auth.ResolveFixToken(cfg.Auth.Scan.Token, cfg.Auth.Fix.Token, *fixToken)
+		if tokenErr != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "approval_required", tokenErr.Error(), exitApprovalRequired)
+		}
+
+		title := strings.TrimSpace(*prTitle)
+		if title == "" {
+			title = fmt.Sprintf("wrkr remediation: %s (%s)", repoValue, plan.Fingerprint[:8])
+		}
+		branch := githubpr.BranchName(*botIdentity, repoValue, *scheduleKey, plan.Fingerprint)
+		body := remediationPRBody(repoValue, plan)
+
+		result, prErr := githubpr.Upsert(context.Background(), newGitHubPRClient(*githubAPI, token), githubpr.UpsertInput{
+			Owner:       owner,
+			Repo:        repo,
+			HeadBranch:  branch,
+			BaseBranch:  strings.TrimSpace(*baseBranch),
+			Title:       title,
+			Body:        body,
+			Fingerprint: plan.Fingerprint,
+		})
+		if prErr != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", prErr.Error(), exitRuntime)
+		}
+
+		payload["pull_request"] = map[string]any{
+			"action":      result.Action,
+			"number":      result.PullRequest.Number,
+			"url":         result.PullRequest.URL,
+			"head_branch": result.PullRequest.Head,
+			"base_branch": result.PullRequest.Base,
+		}
+	}
+
+	if *jsonOut {
+		_ = json.NewEncoder(stdout).Encode(payload)
+		return exitSuccess
+	}
+	if *quiet {
+		return exitSuccess
+	}
+	if *explain {
+		_, _ = fmt.Fprintf(stdout, "wrkr fix planned %d remediation(s), skipped %d non-fixable finding(s)\n", len(plan.Remediations), len(plan.Skipped))
+		if prPayload, ok := payload["pull_request"].(map[string]any); ok {
+			_, _ = fmt.Fprintf(stdout, "PR %v (%v)\n", prPayload["number"], prPayload["url"])
+		}
+		return exitSuccess
+	}
+	_, _ = fmt.Fprintln(stdout, "wrkr fix complete")
+	return exitSuccess
+}
+
+func loadRankedFindings(snapshot state.Snapshot, top int) []risk.ScoredFinding {
+	if snapshot.RiskReport != nil && len(snapshot.RiskReport.Ranked) > 0 {
+		return append([]risk.ScoredFinding(nil), snapshot.RiskReport.Ranked...)
+	}
+	computed := risk.Score(snapshot.Findings, top, time.Now().UTC().Truncate(time.Second))
+	return computed.Ranked
+}
+
+func resolvePRRepo(flagRepo string, snapshot state.Snapshot) (string, error) {
+	if trimmed := strings.TrimSpace(flagRepo); trimmed != "" {
+		return trimmed, nil
+	}
+	if snapshot.Target.Mode == "repo" && strings.Contains(strings.TrimSpace(snapshot.Target.Value), "/") {
+		return strings.TrimSpace(snapshot.Target.Value), nil
+	}
+	return "", errors.New("--repo is required for PR operations when state target is not owner/repo")
+}
+
+func splitRepo(repo string) (string, string, error) {
+	parts := strings.Split(strings.TrimSpace(repo), "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", "", fmt.Errorf("repo target must be owner/repo, got %q", repo)
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
+}
+
+func loadOptionalConfig(explicitPath string) (config.Config, error) {
+	resolvedPath, err := config.ResolvePath(explicitPath)
+	if err != nil {
+		return config.Config{}, err
+	}
+	cfg, err := config.Load(resolvedPath)
+	if err != nil {
+		if os.IsNotExist(err) && strings.TrimSpace(explicitPath) == "" {
+			return config.Default(), nil
+		}
+		return config.Config{}, err
+	}
+	return cfg, nil
+}
+
+func remediationPRBody(repo string, plan fix.Plan) string {
+	lines := []string{
+		"## Wrkr Remediation Plan",
+		"",
+		"Repository: `" + repo + "`",
+		"Fingerprint: `" + plan.Fingerprint + "`",
+		"",
+		"### Planned Remediations",
+	}
+	for i, item := range plan.Remediations {
+		lines = append(lines, fmt.Sprintf("%d. `%s` %s", i+1, item.TemplateID, item.Title))
+		lines = append(lines, "   - Location: `"+strings.TrimSpace(item.Finding.Location)+"`")
+		lines = append(lines, "   - Commit message: `"+item.CommitMessage+"`")
+	}
+	if len(plan.Skipped) > 0 {
+		lines = append(lines, "", "### Non-fixable Findings")
+		for i, item := range plan.Skipped {
+			lines = append(lines, fmt.Sprintf("%d. `%s` `%s` %s", i+1, item.FindingType, item.ReasonCode, item.Message))
+		}
+	}
+	lines = append(lines, "", "<!-- wrkr-fingerprint:"+plan.Fingerprint+" -->")
+	return strings.Join(lines, "\n")
+}

--- a/core/cli/fix_test.go
+++ b/core/cli/fix_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/config"
+	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/risk"
+	"github.com/Clyra-AI/wrkr/core/source"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+func TestFixJSONTopThreeDeterministic(t *testing.T) {
+	t.Parallel()
+
+	statePath := writeFixStateFixture(t)
+
+	var outA bytes.Buffer
+	var errA bytes.Buffer
+	code := Run([]string{"fix", "--state", statePath, "--top", "3", "--json"}, &outA, &errA)
+	if code != 0 {
+		t.Fatalf("fix run A failed: %d stderr=%q", code, errA.String())
+	}
+	if errA.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", errA.String())
+	}
+
+	var outB bytes.Buffer
+	var errB bytes.Buffer
+	code = Run([]string{"fix", "--state", statePath, "--top", "3", "--json"}, &outB, &errB)
+	if code != 0 {
+		t.Fatalf("fix run B failed: %d stderr=%q", code, errB.String())
+	}
+	if outA.String() != outB.String() {
+		t.Fatalf("expected deterministic output\nA=%s\nB=%s", outA.String(), outB.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(outA.Bytes(), &payload); err != nil {
+		t.Fatalf("parse fix payload: %v", err)
+	}
+	if payload["remediation_count"] != float64(3) {
+		t.Fatalf("expected remediation_count=3, got %v", payload["remediation_count"])
+	}
+}
+
+func TestFixOpenPRFailsClosedWithScanOnlyToken(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := writeFixStateFixture(t)
+	configPath := filepath.Join(tmp, "config.json")
+
+	cfg := config.Default()
+	cfg.DefaultTarget = config.Target{Mode: config.TargetRepo, Value: "acme/backend"}
+	cfg.Auth.Scan.Token = "scan-only-token"
+	if err := config.Save(configPath, cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{"fix", "--state", statePath, "--config", configPath, "--open-pr", "--repo", "acme/backend", "--json"}, &out, &errOut)
+	if code != 4 {
+		t.Fatalf("expected exit 4, got %d stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(errOut.Bytes(), &payload); err != nil {
+		t.Fatalf("parse error payload: %v", err)
+	}
+	errorObj, ok := payload["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error payload, got %v", payload)
+	}
+	if errorObj["code"] != "approval_required" {
+		t.Fatalf("expected approval_required code, got %v", errorObj["code"])
+	}
+}
+
+func writeFixStateFixture(t *testing.T) string {
+	t.Helper()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+
+	snapshot := state.Snapshot{
+		Version: state.SnapshotVersion,
+		Target:  source.Target{Mode: "repo", Value: "acme/backend"},
+		Findings: []model.Finding{
+			{FindingType: "policy_violation", RuleID: "WRKR-004", Severity: model.SeverityHigh, ToolType: "ci", Location: ".github/workflows/pr.yml", Repo: "backend", Org: "acme"},
+			{FindingType: "skill_policy_conflict", Severity: model.SeverityHigh, ToolType: "skill", Location: ".agents/skills/release/SKILL.md", Repo: "backend", Org: "acme"},
+			{FindingType: "mcp_server", Severity: model.SeverityMedium, ToolType: "mcp", Location: ".codex/config.toml", Repo: "backend", Org: "acme"},
+		},
+		RiskReport: &risk.Report{
+			Ranked: []risk.ScoredFinding{
+				{Score: 9.9, Finding: model.Finding{FindingType: "policy_violation", RuleID: "WRKR-004", Severity: model.SeverityHigh, ToolType: "ci", Location: ".github/workflows/pr.yml", Repo: "backend", Org: "acme"}},
+				{Score: 9.4, Finding: model.Finding{FindingType: "skill_policy_conflict", Severity: model.SeverityHigh, ToolType: "skill", Location: ".agents/skills/release/SKILL.md", Repo: "backend", Org: "acme"}},
+				{Score: 8.7, Finding: model.Finding{FindingType: "mcp_server", Severity: model.SeverityMedium, ToolType: "mcp", Location: ".codex/config.toml", Repo: "backend", Org: "acme"}},
+				{Score: 8.0, Finding: model.Finding{FindingType: "unknown", Severity: model.SeverityLow, ToolType: "misc", Location: "README.md", Repo: "backend", Org: "acme"}},
+			},
+		},
+	}
+
+	if err := state.Save(statePath, snapshot); err != nil {
+		t.Fatalf("save state fixture: %v", err)
+	}
+	return statePath
+}

--- a/core/cli/root.go
+++ b/core/cli/root.go
@@ -52,6 +52,8 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 		return runVerify(args[1:], stdout, stderr)
 	case "evidence":
 		return runEvidence(args[1:], stdout, stderr)
+	case "fix":
+		return runFix(args[1:], stdout, stderr)
 	}
 
 	if !strings.HasPrefix(args[0], "-") {

--- a/core/fix/planner.go
+++ b/core/fix/planner.go
@@ -1,0 +1,168 @@
+package fix
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Clyra-AI/wrkr/core/risk"
+)
+
+// BuildPlan returns deterministic remediation previews for top-ranked findings.
+func BuildPlan(ranked []risk.ScoredFinding, top int) (Plan, error) {
+	if top <= 0 {
+		top = len(ranked)
+	}
+
+	templates, err := templatesByID()
+	if err != nil {
+		return Plan{}, err
+	}
+
+	candidates := append([]risk.ScoredFinding(nil), ranked...)
+	sortCandidates(candidates)
+
+	remediations := make([]Remediation, 0, top)
+	skipped := make([]Skipped, 0)
+	for _, candidate := range candidates {
+		if len(remediations) >= top {
+			break
+		}
+
+		selected, reasonCode, message := chooseTemplateID(candidate)
+		if reasonCode != "" {
+			skipped = append(skipped, skippedFinding(candidate, reasonCode, message))
+			continue
+		}
+		template, ok := templates[selected]
+		if !ok {
+			skipped = append(skipped, skippedFinding(candidate, ReasonMissingRuleTemplate, "no remediation template for selected rule/template"))
+			continue
+		}
+
+		remediations = append(remediations, Remediation{
+			ID:            remediationID(candidate, template.ID),
+			TemplateID:    template.ID,
+			Category:      template.Category,
+			RuleID:        strings.TrimSpace(candidate.Finding.RuleID),
+			Title:         template.Title,
+			Rationale:     rationale(candidate),
+			CommitMessage: commitMessage(template, candidate),
+			PatchPreview:  patchPreview(template, candidate),
+			Finding:       candidate.Finding,
+		})
+	}
+
+	plan := Plan{
+		RequestedTop: top,
+		Remediations: remediations,
+		Skipped:      skipped,
+	}
+	plan.Fingerprint = planFingerprint(remediations, skipped)
+	return plan, nil
+}
+
+func sortCandidates(in []risk.ScoredFinding) {
+	sort.Slice(in, func(i, j int) bool {
+		if in[i].Score != in[j].Score {
+			return in[i].Score > in[j].Score
+		}
+		return canonicalFindingKey(in[i].Finding) < canonicalFindingKey(in[j].Finding)
+	})
+}
+
+func chooseTemplateID(candidate risk.ScoredFinding) (templateID, reasonCode, message string) {
+	finding := candidate.Finding
+	location := strings.TrimSpace(finding.Location)
+	if location == "" {
+		return "", ReasonMissingLocation, "finding location is required to generate a deterministic patch preview"
+	}
+	if isAmbiguousLocation(location) {
+		return "", ReasonAmbiguousPatchTarget, "finding location is ambiguous for deterministic patching"
+	}
+
+	ruleID := strings.ToUpper(strings.TrimSpace(finding.RuleID))
+	if (finding.FindingType == "policy_violation" || finding.FindingType == "policy_check") && ruleID != "" {
+		return ruleID, "", ""
+	}
+
+	switch strings.TrimSpace(finding.FindingType) {
+	case "skill_policy_conflict":
+		return "WRKR-014", "", ""
+	case "skill_metrics":
+		return "WRKR-015", "", ""
+	case "ai_dependency":
+		return "DEPENDENCY-PIN", "", ""
+	case "mcp_server":
+		return "MCP-PIN-LOCK", "", ""
+	case "ci_autonomy", "compiled_action":
+		return "CI-GATE-ADD", "", ""
+	case "tool_config":
+		return "MANIFEST-GENERATE", "", ""
+	default:
+		return "", ReasonUnsupportedFindingType, "finding type is not currently auto-fixable"
+	}
+}
+
+func isAmbiguousLocation(location string) bool {
+	trimmed := strings.TrimSpace(location)
+	if trimmed == "" {
+		return true
+	}
+	if strings.Contains(trimmed, "*") || strings.Contains(trimmed, ",") || strings.Contains(trimmed, "\n") {
+		return true
+	}
+	return false
+}
+
+func skippedFinding(candidate risk.ScoredFinding, reasonCode, message string) Skipped {
+	finding := candidate.Finding
+	return Skipped{
+		CanonicalKey: canonicalFindingKey(finding),
+		FindingType:  finding.FindingType,
+		RuleID:       strings.TrimSpace(finding.RuleID),
+		Location:     strings.TrimSpace(finding.Location),
+		ReasonCode:   reasonCode,
+		Message:      message,
+	}
+}
+
+func rationale(candidate risk.ScoredFinding) string {
+	reasons := append([]string(nil), candidate.Reasons...)
+	sort.Strings(reasons)
+	if len(reasons) == 0 {
+		return fmt.Sprintf("risk_score=%.2f", candidate.Score)
+	}
+	return fmt.Sprintf("risk_score=%.2f; reasons=%s", candidate.Score, strings.Join(reasons, ", "))
+}
+
+func commitMessage(template Template, candidate risk.ScoredFinding) string {
+	location := strings.TrimSpace(candidate.Finding.Location)
+	ruleID := strings.ToUpper(strings.TrimSpace(candidate.Finding.RuleID))
+	tail := location
+	if idx := strings.LastIndex(location, "/"); idx >= 0 && idx+1 < len(location) {
+		tail = location[idx+1:]
+	}
+	if ruleID != "" {
+		return fmt.Sprintf("%s %s (%s)", template.CommitPrefix, tail, ruleID)
+	}
+	return fmt.Sprintf("%s %s", template.CommitPrefix, tail)
+}
+
+func patchPreview(template Template, candidate risk.ScoredFinding) string {
+	location := strings.TrimPrefix(strings.TrimSpace(candidate.Finding.Location), "./")
+	lines := []string{
+		"--- a/" + location,
+		"+++ b/" + location,
+		"@@ wrkr-fix @@",
+		"+# wrkr template: " + template.ID,
+		"+# category: " + template.Category,
+	}
+	for _, hint := range template.Hints {
+		lines = append(lines, "+# hint: "+hint)
+	}
+	if ruleID := strings.TrimSpace(candidate.Finding.RuleID); ruleID != "" {
+		lines = append(lines, "+# rule: "+strings.ToUpper(ruleID))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}

--- a/core/fix/planner_test.go
+++ b/core/fix/planner_test.go
@@ -1,0 +1,102 @@
+package fix
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/risk"
+)
+
+func TestBuildPlanTopThreeDeterministic(t *testing.T) {
+	t.Parallel()
+
+	ranked := []risk.ScoredFinding{
+		scored(9.9, model.Finding{FindingType: "policy_violation", RuleID: "WRKR-004", ToolType: "ci", Location: ".github/workflows/pr.yml", Repo: "acme/backend", Org: "acme"}, "autonomy_multiplier=1.30"),
+		scored(9.3, model.Finding{FindingType: "skill_policy_conflict", ToolType: "skill", Location: ".agents/skills/deploy/SKILL.md", Repo: "acme/backend", Org: "acme"}, "skill_policy_conflict_high_severity"),
+		scored(8.7, model.Finding{FindingType: "mcp_server", ToolType: "mcp", Location: ".codex/config.toml", Repo: "acme/backend", Org: "acme"}, "trust_deficit=2.50"),
+		scored(7.1, model.Finding{FindingType: "ai_dependency", ToolType: "dependency", Location: "package.json", Repo: "acme/backend", Org: "acme"}, "privilege_level=2.10"),
+	}
+
+	first, err := BuildPlan(ranked, 3)
+	if err != nil {
+		t.Fatalf("build plan: %v", err)
+	}
+	second, err := BuildPlan(ranked, 3)
+	if err != nil {
+		t.Fatalf("build plan second pass: %v", err)
+	}
+
+	if len(first.Remediations) != 3 {
+		t.Fatalf("expected three remediations, got %d", len(first.Remediations))
+	}
+	if first.Fingerprint == "" {
+		t.Fatal("expected non-empty deterministic fingerprint")
+	}
+
+	firstJSON, _ := json.Marshal(first)
+	secondJSON, _ := json.Marshal(second)
+	if string(firstJSON) != string(secondJSON) {
+		t.Fatalf("expected deterministic output\nfirst=%s\nsecond=%s", firstJSON, secondJSON)
+	}
+}
+
+func TestBuildPlanUnsupportedReasonCodes(t *testing.T) {
+	t.Parallel()
+
+	ranked := []risk.ScoredFinding{
+		scored(9.0, model.Finding{FindingType: "unknown_type", ToolType: "mystery", Location: "README.md", Repo: "r", Org: "o"}),
+		scored(8.5, model.Finding{FindingType: "ai_dependency", ToolType: "dependency", Location: "", Repo: "r", Org: "o"}),
+	}
+
+	plan, err := BuildPlan(ranked, 2)
+	if err != nil {
+		t.Fatalf("build plan: %v", err)
+	}
+	if len(plan.Remediations) != 0 {
+		t.Fatalf("expected no remediations, got %d", len(plan.Remediations))
+	}
+	if len(plan.Skipped) != 2 {
+		t.Fatalf("expected two skipped records, got %d", len(plan.Skipped))
+	}
+
+	codes := []string{plan.Skipped[0].ReasonCode, plan.Skipped[1].ReasonCode}
+	joined := strings.Join(codes, ",")
+	if !strings.Contains(joined, ReasonUnsupportedFindingType) {
+		t.Fatalf("expected unsupported reason code in %v", codes)
+	}
+	if !strings.Contains(joined, ReasonMissingLocation) {
+		t.Fatalf("expected missing-location reason code in %v", codes)
+	}
+}
+
+func TestBuildPlanPolicyRuleTemplateSelection(t *testing.T) {
+	t.Parallel()
+
+	ranked := []risk.ScoredFinding{
+		scored(9.4, model.Finding{FindingType: "policy_violation", RuleID: "wrkr-006", ToolType: "dependency", Location: "go.mod", Repo: "r", Org: "o"}),
+	}
+
+	plan, err := BuildPlan(ranked, 1)
+	if err != nil {
+		t.Fatalf("build plan: %v", err)
+	}
+	if len(plan.Remediations) != 1 {
+		t.Fatalf("expected one remediation, got %d", len(plan.Remediations))
+	}
+	if plan.Remediations[0].TemplateID != "WRKR-006" {
+		t.Fatalf("expected WRKR-006 template, got %q", plan.Remediations[0].TemplateID)
+	}
+	if !strings.Contains(plan.Remediations[0].PatchPreview, "wrkr template: WRKR-006") {
+		t.Fatalf("expected template marker in patch preview, got %q", plan.Remediations[0].PatchPreview)
+	}
+}
+
+func scored(score float64, finding model.Finding, reasons ...string) risk.ScoredFinding {
+	return risk.ScoredFinding{
+		Score:   score,
+		Reasons: append([]string(nil), reasons...),
+		Finding: finding,
+	}
+}

--- a/core/fix/templates.go
+++ b/core/fix/templates.go
@@ -1,0 +1,94 @@
+package fix
+
+import (
+	"embed"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed templates/templates.yaml
+var templateFS embed.FS
+
+type Template struct {
+	ID           string   `yaml:"id"`
+	Category     string   `yaml:"category"`
+	Title        string   `yaml:"title"`
+	CommitPrefix string   `yaml:"commit_prefix"`
+	Hints        []string `yaml:"hints"`
+}
+
+type templateDoc struct {
+	Templates []Template `yaml:"templates"`
+}
+
+var (
+	loadTemplatesOnce sync.Once
+	cachedTemplates   map[string]Template
+	cachedTemplateErr error
+)
+
+func templatesByID() (map[string]Template, error) {
+	loadTemplatesOnce.Do(func() {
+		payload, err := templateFS.ReadFile("templates/templates.yaml")
+		if err != nil {
+			cachedTemplateErr = fmt.Errorf("read remediation templates: %w", err)
+			return
+		}
+
+		var doc templateDoc
+		if err := yaml.Unmarshal(payload, &doc); err != nil {
+			cachedTemplateErr = fmt.Errorf("parse remediation templates: %w", err)
+			return
+		}
+		if len(doc.Templates) == 0 {
+			cachedTemplateErr = fmt.Errorf("parse remediation templates: empty catalog")
+			return
+		}
+
+		out := make(map[string]Template, len(doc.Templates))
+		for _, item := range doc.Templates {
+			item.ID = strings.TrimSpace(item.ID)
+			item.Category = strings.TrimSpace(item.Category)
+			item.Title = strings.TrimSpace(item.Title)
+			item.CommitPrefix = strings.TrimSpace(item.CommitPrefix)
+			item.Hints = normalizeHints(item.Hints)
+			if item.ID == "" || item.Category == "" || item.Title == "" || item.CommitPrefix == "" {
+				cachedTemplateErr = fmt.Errorf("parse remediation templates: template missing required fields")
+				return
+			}
+			out[item.ID] = item
+		}
+		cachedTemplates = out
+	})
+
+	if cachedTemplateErr != nil {
+		return nil, cachedTemplateErr
+	}
+
+	copyOut := make(map[string]Template, len(cachedTemplates))
+	for k, v := range cachedTemplates {
+		copyOut[k] = v
+	}
+	return copyOut, nil
+}
+
+func normalizeHints(in []string) []string {
+	set := map[string]struct{}{}
+	for _, item := range in {
+		trimmed := strings.TrimSpace(item)
+		if trimmed == "" {
+			continue
+		}
+		set[trimmed] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for item := range set {
+		out = append(out, item)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/core/fix/templates/templates.yaml
+++ b/core/fix/templates/templates.yaml
@@ -1,0 +1,134 @@
+templates:
+  - id: WRKR-001
+    category: manifest_generation
+    title: Ensure at least one AI tooling config is committed
+    commit_prefix: "fix(manifest)"
+    hints:
+      - Add committed AI config files under supported detector paths.
+      - Keep configuration deterministic and parseable.
+  - id: WRKR-002
+    category: ci_gate_addition
+    title: Remove inline secret presence from AI tooling paths
+    commit_prefix: "fix(secrets)"
+    hints:
+      - Replace inline credentials with managed secret references.
+      - Keep secret names stable across environments.
+  - id: WRKR-003
+    category: manifest_generation
+    title: Repair malformed JSON/YAML/TOML AI configs
+    commit_prefix: "fix(config-parse)"
+    hints:
+      - Correct syntax while preserving semantics.
+      - Keep parser-visible keys and ordering deterministic.
+  - id: WRKR-004
+    category: autonomy_downgrade
+    title: Add approval gate for headless CI autonomy
+    commit_prefix: "fix(ci-gate)"
+    hints:
+      - Require explicit environment reviewers for headless execution.
+      - Keep CI reason-code semantics stable.
+  - id: WRKR-005
+    category: mcp_pin_lock
+    title: Declare MCP inventory in supported config files
+    commit_prefix: "fix(mcp)"
+    hints:
+      - Add explicit MCP server declarations.
+      - Pin MCP package versions where supported.
+  - id: WRKR-006
+    category: dependency_pin
+    title: Declare and pin AI dependencies
+    commit_prefix: "fix(deps)"
+    hints:
+      - Pin dependency versions to deterministic values.
+      - Regenerate lockfiles after pinning.
+  - id: WRKR-007
+    category: skill_hardening
+    title: Ensure skills declare explicit allowed-tools
+    commit_prefix: "fix(skills)"
+    hints:
+      - Add allowed-tools entries to SKILL contracts.
+      - Remove overly broad permissions.
+  - id: WRKR-008
+    category: ci_gate_addition
+    title: Add deterministic review metadata for compiled actions
+    commit_prefix: "fix(compiled-action)"
+    hints:
+      - Add explicit approval and provenance metadata for generated steps.
+      - Keep compiled action provenance stable.
+  - id: WRKR-009
+    category: manifest_generation
+    title: Normalize credential reference extraction
+    commit_prefix: "fix(credential-refs)"
+    hints:
+      - Keep credential reference names deterministic.
+      - Eliminate free-form identifier drift.
+  - id: WRKR-010
+    category: ci_gate_addition
+    title: Preserve stable CI autonomy reason-code semantics
+    commit_prefix: "fix(reason-codes)"
+    hints:
+      - Keep reason code enum values backward compatible.
+      - Add contract coverage for code stability.
+  - id: WRKR-011
+    category: manifest_generation
+    title: Restore built-in policy pack loading
+    commit_prefix: "fix(policy-pack)"
+    hints:
+      - Restore policy pack file integrity and parser compatibility.
+      - Ensure embedded/builtin pack can be loaded deterministically.
+  - id: WRKR-012
+    category: manifest_generation
+    title: Preserve policy schema compatibility
+    commit_prefix: "fix(policy-schema)"
+    hints:
+      - Keep existing schema fields and enums backward compatible.
+      - Add migration or compatibility tests when extending schema.
+  - id: WRKR-013
+    category: skill_hardening
+    title: Remove exec grants from credential-bearing skill contexts
+    commit_prefix: "fix(skill-ceiling)"
+    hints:
+      - Remove proc.exec when credential-bearing contexts are present.
+      - Constrain high-privilege tool grants.
+  - id: WRKR-014
+    category: skill_hardening
+    title: Resolve skill policy conflicts with Gait rules
+    commit_prefix: "fix(skill-policy)"
+    hints:
+      - Align allowed-tools with Gait block policies.
+      - Remove conflicting grants and re-run policy checks.
+  - id: WRKR-015
+    category: skill_hardening
+    title: Reduce skill exec/write sprawl ratio
+    commit_prefix: "fix(skill-sprawl)"
+    hints:
+      - Reduce exec-granting skills to <= 50 percent ratio.
+      - Narrow write and exec permissions per task.
+  - id: DEPENDENCY-PIN
+    category: dependency_pin
+    title: Pin AI dependency and lockfile versions
+    commit_prefix: "fix(deps)"
+    hints:
+      - Replace floating versions with pinned releases.
+      - Regenerate lockfiles deterministically.
+  - id: MCP-PIN-LOCK
+    category: mcp_pin_lock
+    title: Pin MCP packages and lock transport metadata
+    commit_prefix: "fix(mcp-lock)"
+    hints:
+      - Pin MCP server package versions.
+      - Record deterministic transport and source metadata.
+  - id: MANIFEST-GENERATE
+    category: manifest_generation
+    title: Regenerate manifest/contracts with deterministic ordering
+    commit_prefix: "fix(manifest)"
+    hints:
+      - Regenerate manifests from current deterministic findings.
+      - Preserve absent identities as absent.
+  - id: CI-GATE-ADD
+    category: ci_gate_addition
+    title: Add CI gate enforcement for autonomous changes
+    commit_prefix: "fix(ci-gate)"
+    hints:
+      - Add merge-blocking gate for high-risk autonomous changes.
+      - Keep approval and reason code contracts stable.

--- a/core/fix/types.go
+++ b/core/fix/types.go
@@ -1,0 +1,79 @@
+package fix
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+
+	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/risk"
+)
+
+const (
+	ReasonUnsupportedFindingType = "unsupported_finding_type"
+	ReasonMissingLocation        = "missing_location"
+	ReasonAmbiguousPatchTarget   = "ambiguous_patch_target"
+	ReasonMissingRuleTemplate    = "missing_rule_template"
+)
+
+// Plan is a deterministic remediation output for ranked findings.
+type Plan struct {
+	RequestedTop int           `json:"requested_top"`
+	Fingerprint  string        `json:"fingerprint"`
+	Remediations []Remediation `json:"remediations"`
+	Skipped      []Skipped     `json:"skipped"`
+}
+
+// Remediation describes one deterministic patch preview and commit intent.
+type Remediation struct {
+	ID            string        `json:"id"`
+	TemplateID    string        `json:"template_id"`
+	Category      string        `json:"category"`
+	RuleID        string        `json:"rule_id,omitempty"`
+	Title         string        `json:"title"`
+	Rationale     string        `json:"rationale"`
+	CommitMessage string        `json:"commit_message"`
+	PatchPreview  string        `json:"patch_preview"`
+	Finding       model.Finding `json:"finding"`
+}
+
+// Skipped is emitted for non-fixable findings with explicit reason codes.
+type Skipped struct {
+	CanonicalKey string `json:"canonical_key"`
+	FindingType  string `json:"finding_type"`
+	RuleID       string `json:"rule_id,omitempty"`
+	Location     string `json:"location,omitempty"`
+	ReasonCode   string `json:"reason_code"`
+	Message      string `json:"message"`
+}
+
+func canonicalFindingKey(f model.Finding) string {
+	parts := []string{
+		strings.TrimSpace(f.FindingType),
+		strings.TrimSpace(f.RuleID),
+		strings.TrimSpace(f.ToolType),
+		strings.TrimSpace(f.Location),
+		strings.TrimSpace(f.Repo),
+		strings.TrimSpace(f.Org),
+	}
+	return strings.Join(parts, "|")
+}
+
+func planFingerprint(remediations []Remediation, skipped []Skipped) string {
+	parts := make([]string, 0, len(remediations)+len(skipped))
+	for _, item := range remediations {
+		parts = append(parts, "fix:"+item.ID)
+	}
+	for _, item := range skipped {
+		parts = append(parts, "skip:"+item.CanonicalKey+":"+item.ReasonCode)
+	}
+	sort.Strings(parts)
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\n")))
+	return hex.EncodeToString(sum[:])
+}
+
+func remediationID(candidate risk.ScoredFinding, templateID string) string {
+	sum := sha256.Sum256([]byte(canonicalFindingKey(candidate.Finding) + "|" + templateID))
+	return hex.EncodeToString(sum[:])
+}

--- a/core/github/pr/branch.go
+++ b/core/github/pr/branch.go
@@ -1,0 +1,58 @@
+package pr
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var nonSlug = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// BranchName returns a deterministic branch name for remediation runs.
+func BranchName(botIdentity, repoName, scheduleKey, fingerprint string) string {
+	bot := sanitizeSlug(botIdentity)
+	if bot == "" {
+		bot = "wrkr-bot"
+	}
+	repo := sanitizeSlug(repoName)
+	if repo == "" {
+		repo = "repo"
+	}
+	schedule := sanitizeSlug(scheduleKey)
+	if schedule == "" {
+		schedule = "adhoc"
+	}
+	fp := sanitizeSlug(fingerprint)
+	if len(fp) > 12 {
+		fp = fp[:12]
+	}
+	if fp == "" {
+		fp = "nohash"
+	}
+
+	branch := fmt.Sprintf("%s/remediation/%s/%s/%s", bot, repo, schedule, fp)
+	if len(branch) <= 120 {
+		return branch
+	}
+	maxRepoLen := 120 - len(fmt.Sprintf("%s/remediation//%s/%s", bot, schedule, fp))
+	if maxRepoLen < 4 {
+		maxRepoLen = 4
+	}
+	if len(repo) > maxRepoLen {
+		repo = repo[:maxRepoLen]
+	}
+	return fmt.Sprintf("%s/remediation/%s/%s/%s", bot, repo, schedule, fp)
+}
+
+func sanitizeSlug(in string) string {
+	value := strings.ToLower(strings.TrimSpace(in))
+	value = strings.ReplaceAll(value, "/", "-")
+	value = nonSlug.ReplaceAllString(value, "-")
+	value = strings.Trim(value, "-")
+	if value == "" {
+		return ""
+	}
+	value = strings.ReplaceAll(value, "--", "-")
+	value = strings.ReplaceAll(value, "--", "-")
+	return value
+}

--- a/core/github/pr/github_client.go
+++ b/core/github/pr/github_client.go
@@ -1,0 +1,197 @@
+package pr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultGitHubAPI = "https://api.github.com"
+	maxAttempts      = 3
+)
+
+type GitHubClient struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+func NewGitHubClient(baseURL, token string, client *http.Client) *GitHubClient {
+	trimmedBase := strings.TrimSpace(baseURL)
+	if trimmedBase == "" {
+		trimmedBase = defaultGitHubAPI
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &GitHubClient{
+		baseURL: strings.TrimRight(trimmedBase, "/"),
+		token:   strings.TrimSpace(token),
+		http:    client,
+	}
+}
+
+func (c *GitHubClient) ListOpenByHead(ctx context.Context, owner, repo, headBranch, baseBranch string) ([]PullRequest, error) {
+	endpoint, err := c.repoURL(owner, repo, "pulls")
+	if err != nil {
+		return nil, err
+	}
+	query := endpoint.Query()
+	query.Set("state", "open")
+	query.Set("head", owner+":"+headBranch)
+	query.Set("base", baseBranch)
+	endpoint.RawQuery = query.Encode()
+
+	var raw []githubPR
+	if err := c.doJSON(ctx, http.MethodGet, endpoint.String(), nil, &raw); err != nil {
+		return nil, err
+	}
+	out := make([]PullRequest, 0, len(raw))
+	for _, item := range raw {
+		out = append(out, item.toPullRequest())
+	}
+	return out, nil
+}
+
+func (c *GitHubClient) Create(ctx context.Context, owner, repo string, req CreateRequest) (PullRequest, error) {
+	endpoint, err := c.repoURL(owner, repo, "pulls")
+	if err != nil {
+		return PullRequest{}, err
+	}
+	payload := map[string]any{
+		"title": req.Title,
+		"head":  req.Head,
+		"base":  req.Base,
+		"body":  req.Body,
+	}
+	var raw githubPR
+	if err := c.doJSON(ctx, http.MethodPost, endpoint.String(), payload, &raw); err != nil {
+		return PullRequest{}, err
+	}
+	return raw.toPullRequest(), nil
+}
+
+func (c *GitHubClient) Update(ctx context.Context, owner, repo string, number int, req UpdateRequest) (PullRequest, error) {
+	endpoint, err := c.repoURL(owner, repo, "pulls", strconv.Itoa(number))
+	if err != nil {
+		return PullRequest{}, err
+	}
+	payload := map[string]any{"title": req.Title, "body": req.Body}
+	var raw githubPR
+	if err := c.doJSON(ctx, http.MethodPatch, endpoint.String(), payload, &raw); err != nil {
+		return PullRequest{}, err
+	}
+	return raw.toPullRequest(), nil
+}
+
+func (c *GitHubClient) doJSON(ctx context.Context, method, endpoint string, payload any, out any) error {
+	var bodyBytes []byte
+	var err error
+	if payload != nil {
+		bodyBytes, err = json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("marshal github payload: %w", err)
+		}
+	}
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		var body io.Reader
+		if len(bodyBytes) > 0 {
+			body = bytes.NewReader(bodyBytes)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+		if err != nil {
+			return fmt.Errorf("build github request: %w", err)
+		}
+		req.Header.Set("Accept", "application/vnd.github+json")
+		if c.token != "" {
+			req.Header.Set("Authorization", "Bearer "+c.token)
+		}
+		if payload != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+
+		resp, err := c.http.Do(req)
+		if err != nil {
+			if attempt < maxAttempts {
+				continue
+			}
+			return fmt.Errorf("github request failed: %w", err)
+		}
+
+		respBody, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return fmt.Errorf("read github response: %w", readErr)
+		}
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			if out != nil && len(respBody) > 0 {
+				if err := json.Unmarshal(respBody, out); err != nil {
+					return fmt.Errorf("decode github response: %w", err)
+				}
+			}
+			return nil
+		}
+
+		if shouldRetry(resp.StatusCode) && attempt < maxAttempts {
+			continue
+		}
+		return fmt.Errorf("github api %s %s failed: status=%d body=%s", method, endpoint, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return fmt.Errorf("github request attempts exceeded")
+}
+
+func shouldRetry(statusCode int) bool {
+	switch statusCode {
+	case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *GitHubClient) repoURL(owner, repo string, parts ...string) (*url.URL, error) {
+	base, err := url.Parse(c.baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse github base url: %w", err)
+	}
+	base.Path = path.Join(base.Path, "/repos", owner, repo)
+	for _, item := range parts {
+		base.Path = path.Join(base.Path, item)
+	}
+	return base, nil
+}
+
+type githubPR struct {
+	Number  int    `json:"number"`
+	HTMLURL string `json:"html_url"`
+	Title   string `json:"title"`
+	Body    string `json:"body"`
+	Head    struct {
+		Ref string `json:"ref"`
+	} `json:"head"`
+	Base struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
+}
+
+func (p githubPR) toPullRequest() PullRequest {
+	return PullRequest{
+		Number: p.Number,
+		URL:    p.HTMLURL,
+		Title:  p.Title,
+		Body:   p.Body,
+		Head:   p.Head.Ref,
+		Base:   p.Base.Ref,
+	}
+}

--- a/core/github/pr/github_client_test.go
+++ b/core/github/pr/github_client_test.go
@@ -1,0 +1,75 @@
+package pr
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestGitHubClientListCreateUpdateWithRetry(t *testing.T) {
+	t.Parallel()
+
+	var createAttempts int32
+	var updateAttempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pulls"):
+			_, _ = w.Write([]byte(`[{"number":7,"html_url":"https://example/pr/7","title":"existing","body":"x","head":{"ref":"wrkr-bot/remediation/repo/adhoc/abc"},"base":{"ref":"main"}}]`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/pulls"):
+			if atomic.AddInt32(&createAttempts, 1) == 1 {
+				w.WriteHeader(http.StatusBadGateway)
+				_, _ = w.Write([]byte(`{"message":"retry"}`))
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"number":9,"html_url":"https://example/pr/9","title":"new","body":"b","head":{"ref":"h"},"base":{"ref":"main"}}`))
+		case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/pulls/"):
+			if atomic.AddInt32(&updateAttempts, 1) == 1 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte(`{"message":"retry"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"number":7,"html_url":"https://example/pr/7","title":"updated","body":"u","head":{"ref":"wrkr-bot/remediation/repo/adhoc/abc"},"base":{"ref":"main"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(fmt.Sprintf("unknown route: %s %s", r.Method, r.URL.Path)))
+		}
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient(server.URL, "token", server.Client())
+
+	list, err := client.ListOpenByHead(context.Background(), "acme", "repo", "wrkr-bot/remediation/repo/adhoc/abc", "main")
+	if err != nil {
+		t.Fatalf("list prs: %v", err)
+	}
+	if len(list) != 1 || list[0].Number != 7 {
+		t.Fatalf("unexpected list result: %#v", list)
+	}
+
+	created, err := client.Create(context.Background(), "acme", "repo", CreateRequest{Title: "new", Head: "h", Base: "main", Body: "b"})
+	if err != nil {
+		t.Fatalf("create pr: %v", err)
+	}
+	if created.Number != 9 {
+		t.Fatalf("expected created pr #9, got %#v", created)
+	}
+	if atomic.LoadInt32(&createAttempts) != 2 {
+		t.Fatalf("expected one retry on create, attempts=%d", createAttempts)
+	}
+
+	updated, err := client.Update(context.Background(), "acme", "repo", 7, UpdateRequest{Title: "updated", Body: "u"})
+	if err != nil {
+		t.Fatalf("update pr: %v", err)
+	}
+	if updated.Title != "updated" {
+		t.Fatalf("expected updated title, got %#v", updated)
+	}
+	if atomic.LoadInt32(&updateAttempts) != 2 {
+		t.Fatalf("expected one retry on update, attempts=%d", updateAttempts)
+	}
+}

--- a/core/github/pr/types.go
+++ b/core/github/pr/types.go
@@ -1,0 +1,47 @@
+package pr
+
+import "context"
+
+// PullRequest is a minimal deterministic PR contract used by wrkr fix automation.
+type PullRequest struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+	Title  string `json:"title"`
+	Body   string `json:"body"`
+	Head   string `json:"head"`
+	Base   string `json:"base"`
+}
+
+type CreateRequest struct {
+	Title string `json:"title"`
+	Head  string `json:"head"`
+	Base  string `json:"base"`
+	Body  string `json:"body"`
+}
+
+type UpdateRequest struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+// API abstracts GitHub PR APIs for deterministic tests and retry behavior.
+type API interface {
+	ListOpenByHead(ctx context.Context, owner, repo, headBranch, baseBranch string) ([]PullRequest, error)
+	Create(ctx context.Context, owner, repo string, req CreateRequest) (PullRequest, error)
+	Update(ctx context.Context, owner, repo string, number int, req UpdateRequest) (PullRequest, error)
+}
+
+type UpsertInput struct {
+	Owner       string
+	Repo        string
+	HeadBranch  string
+	BaseBranch  string
+	Title       string
+	Body        string
+	Fingerprint string
+}
+
+type UpsertResult struct {
+	Action      string      `json:"action"`
+	PullRequest PullRequest `json:"pull_request"`
+}

--- a/core/github/pr/upsert.go
+++ b/core/github/pr/upsert.go
@@ -1,0 +1,73 @@
+package pr
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func Upsert(ctx context.Context, api API, in UpsertInput) (UpsertResult, error) {
+	if strings.TrimSpace(in.Owner) == "" || strings.TrimSpace(in.Repo) == "" {
+		return UpsertResult{}, fmt.Errorf("owner/repo are required")
+	}
+	if strings.TrimSpace(in.HeadBranch) == "" || strings.TrimSpace(in.BaseBranch) == "" {
+		return UpsertResult{}, fmt.Errorf("head/base branches are required")
+	}
+	if strings.TrimSpace(in.Title) == "" {
+		return UpsertResult{}, fmt.Errorf("title is required")
+	}
+
+	body := ensureFingerprintMarker(in.Body, in.Fingerprint)
+	existing, err := api.ListOpenByHead(ctx, in.Owner, in.Repo, in.HeadBranch, in.BaseBranch)
+	if err != nil {
+		return UpsertResult{}, err
+	}
+	if len(existing) > 0 {
+		sort.Slice(existing, func(i, j int) bool { return existing[i].Number < existing[j].Number })
+		current := existing[0]
+		if hasFingerprint(current.Body, in.Fingerprint) && strings.TrimSpace(current.Title) == strings.TrimSpace(in.Title) {
+			return UpsertResult{Action: "noop", PullRequest: current}, nil
+		}
+		updated, err := api.Update(ctx, in.Owner, in.Repo, current.Number, UpdateRequest{Title: in.Title, Body: body})
+		if err != nil {
+			return UpsertResult{}, err
+		}
+		return UpsertResult{Action: "updated", PullRequest: updated}, nil
+	}
+
+	created, err := api.Create(ctx, in.Owner, in.Repo, CreateRequest{
+		Title: in.Title,
+		Head:  in.HeadBranch,
+		Base:  in.BaseBranch,
+		Body:  body,
+	})
+	if err != nil {
+		return UpsertResult{}, err
+	}
+	return UpsertResult{Action: "created", PullRequest: created}, nil
+}
+
+func ensureFingerprintMarker(body, fingerprint string) string {
+	trimmedFP := strings.TrimSpace(fingerprint)
+	if trimmedFP == "" {
+		return strings.TrimSpace(body)
+	}
+	marker := "<!-- wrkr-fingerprint:" + trimmedFP + " -->"
+	trimmedBody := strings.TrimSpace(body)
+	if strings.Contains(trimmedBody, marker) {
+		return trimmedBody
+	}
+	if trimmedBody == "" {
+		return marker
+	}
+	return trimmedBody + "\n\n" + marker
+}
+
+func hasFingerprint(body, fingerprint string) bool {
+	trimmedFP := strings.TrimSpace(fingerprint)
+	if trimmedFP == "" {
+		return false
+	}
+	return strings.Contains(body, "<!-- wrkr-fingerprint:"+trimmedFP+" -->")
+}

--- a/core/github/pr/upsert_test.go
+++ b/core/github/pr/upsert_test.go
@@ -1,0 +1,125 @@
+package pr
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestBranchNameDeterministic(t *testing.T) {
+	t.Parallel()
+
+	got := BranchName("wrkr-bot", "acme/backend", "weekly", "abcdef1234567890")
+	want := "wrkr-bot/remediation/acme-backend/weekly/abcdef123456"
+	if got != want {
+		t.Fatalf("unexpected branch\nwant=%q\ngot=%q", want, got)
+	}
+}
+
+func TestUpsertCreateThenNoopIdempotent(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeAPI{}
+	in := UpsertInput{
+		Owner:       "acme",
+		Repo:        "backend",
+		HeadBranch:  "wrkr-bot/remediation/backend/weekly/abc",
+		BaseBranch:  "main",
+		Title:       "wrkr remediation",
+		Body:        "summary",
+		Fingerprint: "abc123",
+	}
+
+	first, err := Upsert(context.Background(), api, in)
+	if err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	if first.Action != "created" {
+		t.Fatalf("expected created action, got %q", first.Action)
+	}
+
+	second, err := Upsert(context.Background(), api, in)
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if second.Action != "noop" {
+		t.Fatalf("expected noop action on identical rerun, got %q", second.Action)
+	}
+	if api.createCalls != 1 {
+		t.Fatalf("expected one create call, got %d", api.createCalls)
+	}
+}
+
+func TestUpsertUpdatesWhenFingerprintChanges(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeAPI{}
+	in := UpsertInput{
+		Owner:       "acme",
+		Repo:        "backend",
+		HeadBranch:  "wrkr-bot/remediation/backend/weekly/abc",
+		BaseBranch:  "main",
+		Title:       "wrkr remediation",
+		Body:        "summary",
+		Fingerprint: "abc123",
+	}
+	if _, err := Upsert(context.Background(), api, in); err != nil {
+		t.Fatalf("seed upsert: %v", err)
+	}
+
+	in.Fingerprint = "def456"
+	in.Body = "summary updated"
+	updated, err := Upsert(context.Background(), api, in)
+	if err != nil {
+		t.Fatalf("update upsert: %v", err)
+	}
+	if updated.Action != "updated" {
+		t.Fatalf("expected updated action, got %q", updated.Action)
+	}
+	if api.updateCalls != 1 {
+		t.Fatalf("expected one update call, got %d", api.updateCalls)
+	}
+}
+
+type fakeAPI struct {
+	prs         []PullRequest
+	createCalls int
+	updateCalls int
+}
+
+func (f *fakeAPI) ListOpenByHead(_ context.Context, _ string, _ string, headBranch, baseBranch string) ([]PullRequest, error) {
+	out := make([]PullRequest, 0)
+	for _, item := range f.prs {
+		if item.Head == headBranch && item.Base == baseBranch {
+			out = append(out, item)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeAPI) Create(_ context.Context, _ string, _ string, req CreateRequest) (PullRequest, error) {
+	f.createCalls++
+	created := PullRequest{
+		Number: 100 + f.createCalls,
+		URL:    fmt.Sprintf("https://example.test/pr/%d", 100+f.createCalls),
+		Title:  req.Title,
+		Body:   req.Body,
+		Head:   req.Head,
+		Base:   req.Base,
+	}
+	f.prs = append(f.prs, created)
+	return created, nil
+}
+
+func (f *fakeAPI) Update(_ context.Context, _ string, _ string, number int, req UpdateRequest) (PullRequest, error) {
+	f.updateCalls++
+	for i := range f.prs {
+		if f.prs[i].Number != number {
+			continue
+		}
+		f.prs[i].Title = req.Title
+		f.prs[i].Body = req.Body
+		return f.prs[i], nil
+	}
+	return PullRequest{}, fmt.Errorf("pr %d not found", number)
+}

--- a/internal/e2e/action/action_e2e_test.go
+++ b/internal/e2e/action/action_e2e_test.go
@@ -3,7 +3,11 @@ package action
 import (
 	"testing"
 
+	coreaction "github.com/Clyra-AI/wrkr/core/action"
 	"github.com/Clyra-AI/wrkr/core/action/changes"
+	profileeval "github.com/Clyra-AI/wrkr/core/policy/profileeval"
+	"github.com/Clyra-AI/wrkr/core/score"
+	"github.com/Clyra-AI/wrkr/core/state"
 )
 
 func TestDocsOnlyPRE2EDoesNotTriggerComment(t *testing.T) {
@@ -21,5 +25,48 @@ func TestAIConfigChangeE2ETriggersComment(t *testing.T) {
 	paths := []string{"README.md", ".codex/config.toml"}
 	if !changes.HasRelevantChanges(paths) {
 		t.Fatal("expected AI config path to trigger action comments")
+	}
+}
+
+func TestPRModeE2ECommentsOnlyForRelevantChanges(t *testing.T) {
+	t.Parallel()
+
+	docsOnly := coreaction.RunPRMode(coreaction.PRModeInput{
+		ChangedPaths:    []string{"README.md", "docs/usage.md"},
+		RiskDelta:       4.0,
+		ComplianceDelta: -1.5,
+		BlockThreshold:  5.0,
+	})
+	if docsOnly.ShouldComment {
+		t.Fatalf("expected docs-only PR to suppress comment, got %+v", docsOnly)
+	}
+
+	relevant := coreaction.RunPRMode(coreaction.PRModeInput{
+		ChangedPaths:    []string{"README.md", ".codex/config.toml"},
+		RiskDelta:       6.1,
+		ComplianceDelta: -3.2,
+		BlockThreshold:  6.0,
+	})
+	if !relevant.ShouldComment {
+		t.Fatalf("expected relevant changes to trigger comment, got %+v", relevant)
+	}
+	if !relevant.BlockMerge {
+		t.Fatalf("expected threshold breach to block merge, got %+v", relevant)
+	}
+}
+
+func TestScheduledModeE2EIncludesDeterministicDeltas(t *testing.T) {
+	t.Parallel()
+
+	snapshot := state.Snapshot{
+		Profile:      &profileeval.Result{CompliancePercent: 92.75, DeltaPercent: -2.25},
+		PostureScore: &score.Result{Score: 81.40, TrendDelta: +1.60},
+	}
+	result := coreaction.RunScheduled(snapshot)
+	if result.ScoreDeltaText != "posture score delta +1.60 (current 81.40)" {
+		t.Fatalf("unexpected score delta text: %q", result.ScoreDeltaText)
+	}
+	if result.ComplianceDeltaText != "profile compliance delta -2.25% (current 92.75%)" {
+		t.Fatalf("unexpected compliance delta text: %q", result.ComplianceDeltaText)
 	}
 }

--- a/internal/e2e/github_pr/github_pr_e2e_test.go
+++ b/internal/e2e/github_pr/github_pr_e2e_test.go
@@ -1,0 +1,132 @@
+package githubpre2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/cli"
+	"github.com/Clyra-AI/wrkr/core/config"
+	"github.com/Clyra-AI/wrkr/core/github/pr"
+	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/risk"
+	"github.com/Clyra-AI/wrkr/core/source"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+func TestE2EPRUpsertIdempotentWithSimulatedAPI(t *testing.T) {
+	t.Parallel()
+
+	var storedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pulls"):
+			if storedBody == "" {
+				_, _ = w.Write([]byte(`[]`))
+				return
+			}
+			_, _ = w.Write([]byte(`[{"number":42,"html_url":"https://example/pr/42","title":"wrkr remediation","body":` + jsonString(storedBody) + `,"head":{"ref":"wrkr-bot/remediation/backend/weekly/abc123"},"base":{"ref":"main"}}]`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/pulls"):
+			var payload struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			storedBody = payload.Body
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"number":42,"html_url":"https://example/pr/42","title":"wrkr remediation","body":` + jsonString(storedBody) + `,"head":{"ref":"wrkr-bot/remediation/backend/weekly/abc123"},"base":{"ref":"main"}}`))
+		case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/pulls/"):
+			var payload struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			storedBody = payload.Body
+			_, _ = w.Write([]byte(`{"number":42,"html_url":"https://example/pr/42","title":"wrkr remediation","body":` + jsonString(storedBody) + `,"head":{"ref":"wrkr-bot/remediation/backend/weekly/abc123"},"base":{"ref":"main"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := pr.NewGitHubClient(server.URL, "token", server.Client())
+	input := pr.UpsertInput{
+		Owner:       "acme",
+		Repo:        "backend",
+		HeadBranch:  "wrkr-bot/remediation/backend/weekly/abc123",
+		BaseBranch:  "main",
+		Title:       "wrkr remediation",
+		Body:        "summary",
+		Fingerprint: "abc123",
+	}
+
+	first, err := pr.Upsert(context.Background(), client, input)
+	if err != nil {
+		t.Fatalf("first upsert failed: %v", err)
+	}
+	if first.Action != "created" {
+		t.Fatalf("expected created action, got %q", first.Action)
+	}
+
+	second, err := pr.Upsert(context.Background(), client, input)
+	if err != nil {
+		t.Fatalf("second upsert failed: %v", err)
+	}
+	if second.Action != "noop" {
+		t.Fatalf("expected noop on identical rerun, got %q", second.Action)
+	}
+}
+
+func TestE2EFixOpenPRFailsClosedWithScanOnlyToken(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	configPath := filepath.Join(tmp, "config.json")
+
+	cfg := config.Default()
+	cfg.DefaultTarget = config.Target{Mode: config.TargetRepo, Value: "acme/backend"}
+	cfg.Auth.Scan.Token = "scan-token-only"
+	if err := config.Save(configPath, cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	snapshot := state.Snapshot{
+		Version: state.SnapshotVersion,
+		Target:  source.Target{Mode: "repo", Value: "acme/backend"},
+		Findings: []model.Finding{
+			{FindingType: "policy_violation", RuleID: "WRKR-004", Severity: model.SeverityHigh, ToolType: "ci", Location: ".github/workflows/pr.yml", Repo: "backend", Org: "acme"},
+		},
+		RiskReport: &risk.Report{Ranked: []risk.ScoredFinding{{Score: 9.8, Finding: model.Finding{FindingType: "policy_violation", RuleID: "WRKR-004", Severity: model.SeverityHigh, ToolType: "ci", Location: ".github/workflows/pr.yml", Repo: "backend", Org: "acme"}}}},
+	}
+	if err := state.Save(statePath, snapshot); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := cli.Run([]string{"fix", "--state", statePath, "--config", configPath, "--open-pr", "--repo", "acme/backend", "--json"}, &out, &errOut)
+	if code != 4 {
+		t.Fatalf("expected exit 4 for scan-only token, got %d stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(errOut.Bytes(), &payload); err != nil {
+		t.Fatalf("parse error payload: %v", err)
+	}
+	errorObj, ok := payload["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error object, got %v", payload)
+	}
+	if errorObj["code"] != "approval_required" {
+		t.Fatalf("expected approval_required code, got %v", errorObj["code"])
+	}
+}
+
+func jsonString(in string) string {
+	blob, _ := json.Marshal(in)
+	return string(blob)
+}

--- a/internal/integration/fix/fix_integration_test.go
+++ b/internal/integration/fix/fix_integration_test.go
@@ -1,0 +1,68 @@
+package fixintegration
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/fix"
+	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/risk"
+)
+
+func TestIntegrationBuildPlanProducesTopThreeDeterministicRemediations(t *testing.T) {
+	t.Parallel()
+
+	ranked := []risk.ScoredFinding{
+		{Score: 9.8, Finding: model.Finding{FindingType: "policy_violation", RuleID: "WRKR-004", ToolType: "ci", Location: ".github/workflows/pr.yml", Repo: "backend", Org: "acme"}, Reasons: []string{"autonomy_multiplier=1.3"}},
+		{Score: 9.4, Finding: model.Finding{FindingType: "skill_policy_conflict", ToolType: "skill", Location: ".agents/skills/release/SKILL.md", Repo: "backend", Org: "acme"}, Reasons: []string{"skill_policy_conflict_high_severity"}},
+		{Score: 8.7, Finding: model.Finding{FindingType: "ai_dependency", ToolType: "dependency", Location: "go.mod", Repo: "backend", Org: "acme"}, Reasons: []string{"trust_deficit=2.1"}},
+		{Score: 8.1, Finding: model.Finding{FindingType: "mcp_server", ToolType: "mcp", Location: ".codex/config.toml", Repo: "backend", Org: "acme"}, Reasons: []string{"blast_radius=4.5"}},
+	}
+
+	planA, err := fix.BuildPlan(ranked, 3)
+	if err != nil {
+		t.Fatalf("build plan A: %v", err)
+	}
+	planB, err := fix.BuildPlan(ranked, 3)
+	if err != nil {
+		t.Fatalf("build plan B: %v", err)
+	}
+	if len(planA.Remediations) != 3 {
+		t.Fatalf("expected 3 remediations, got %d", len(planA.Remediations))
+	}
+	for _, item := range planA.Remediations {
+		if item.PatchPreview == "" {
+			t.Fatalf("expected patch preview for %+v", item)
+		}
+		if item.CommitMessage == "" {
+			t.Fatalf("expected commit message for %+v", item)
+		}
+	}
+
+	blobA, _ := json.Marshal(planA)
+	blobB, _ := json.Marshal(planB)
+	if string(blobA) != string(blobB) {
+		t.Fatalf("expected deterministic plan output\nA=%s\nB=%s", blobA, blobB)
+	}
+}
+
+func TestIntegrationUnsupportedFindingsReturnReasonCodes(t *testing.T) {
+	t.Parallel()
+
+	ranked := []risk.ScoredFinding{
+		{Score: 9.9, Finding: model.Finding{FindingType: "unknown", ToolType: "misc", Location: "README.md", Repo: "backend", Org: "acme"}},
+	}
+	plan, err := fix.BuildPlan(ranked, 1)
+	if err != nil {
+		t.Fatalf("build plan: %v", err)
+	}
+	if len(plan.Remediations) != 0 {
+		t.Fatalf("expected no remediations, got %d", len(plan.Remediations))
+	}
+	if len(plan.Skipped) != 1 {
+		t.Fatalf("expected one skipped finding, got %d", len(plan.Skipped))
+	}
+	if plan.Skipped[0].ReasonCode != fix.ReasonUnsupportedFindingType {
+		t.Fatalf("expected unsupported reason code, got %+v", plan.Skipped[0])
+	}
+}


### PR DESCRIPTION
## Problem
Epic 6 in `product/PLAN_v1.md` required deterministic remediation planning, fail-closed PR automation with split auth profiles, and action-mode runtime contracts for scheduled/PR workflows.

## Changes
- Added deterministic remediation planning surface:
  - `core/fix` planner with embedded template catalog and explicit non-fixable reason codes.
  - new `wrkr fix` CLI flow (`--top`, `--open-pr`) with deterministic patch previews and commit messages.
- Added GitHub PR integration with split auth enforcement:
  - `core/auth` fix-profile resolver (scan-only token fails closed).
  - `core/github/pr` deterministic branch naming, idempotent upsert (create/update/noop), and retry-safe GitHub client.
- Added action integration surface:
  - `core/action` scheduled and PR mode runtime helpers.
  - `action/action.yaml` and `action/entrypoint.sh` for `wrkr-action` execution.
  - `.github/workflows/wrkr-action-ci.yml` for action contract coverage.
- Added integration/e2e tests for fix planner, GitHub PR behavior, and action-mode contracts.
- Updated README for Epic 6 status and `wrkr fix` usage/contracts.

## Validation
- `make prepush-full` (pass, includes CodeQL)
- `go test ./core/fix/... -count=1`
- `go test ./internal/integration/fix -count=1`
- `go test ./internal/e2e/github_pr -count=1`
- `go test ./internal/e2e/action -count=1`
- `go run ./cmd/wrkr fix --state .tmp/epic6/state.json --top 3 --json`
