### PR TITLE
fix: resolve PR22 review findings

### DIFF
--- a/action/action.yaml
+++ b/action/action.yaml
@@ -11,6 +11,18 @@ inputs:
     description: number of top findings in report output
     required: false
     default: "5"
+  target_mode:
+    description: explicit scan target mode (repo|org|path)
+    required: false
+    default: ""
+  target_value:
+    description: explicit scan target value for the selected target_mode
+    required: false
+    default: ""
+  config_path:
+    description: optional wrkr config path used when no explicit target is provided
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -19,4 +31,4 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        "${{ github.action_path }}/entrypoint.sh" "${{ inputs.mode }}" "${{ inputs.top }}"
+        "${{ github.action_path }}/entrypoint.sh" "${{ inputs.mode }}" "${{ inputs.top }}" "${{ inputs.target_mode }}" "${{ inputs.target_value }}" "${{ inputs.config_path }}"

--- a/core/github/pr/types.go
+++ b/core/github/pr/types.go
@@ -26,6 +26,7 @@ type UpdateRequest struct {
 
 // API abstracts GitHub PR APIs for deterministic tests and retry behavior.
 type API interface {
+	EnsureHeadRef(ctx context.Context, owner, repo, headBranch, baseBranch string) error
 	ListOpenByHead(ctx context.Context, owner, repo, headBranch, baseBranch string) ([]PullRequest, error)
 	Create(ctx context.Context, owner, repo string, req CreateRequest) (PullRequest, error)
 	Update(ctx context.Context, owner, repo string, number int, req UpdateRequest) (PullRequest, error)

--- a/core/github/pr/upsert.go
+++ b/core/github/pr/upsert.go
@@ -19,6 +19,9 @@ func Upsert(ctx context.Context, api API, in UpsertInput) (UpsertResult, error) 
 	}
 
 	body := ensureFingerprintMarker(in.Body, in.Fingerprint)
+	if err := api.EnsureHeadRef(ctx, in.Owner, in.Repo, in.HeadBranch, in.BaseBranch); err != nil {
+		return UpsertResult{}, err
+	}
 	existing, err := api.ListOpenByHead(ctx, in.Owner, in.Repo, in.HeadBranch, in.BaseBranch)
 	if err != nil {
 		return UpsertResult{}, err

--- a/internal/e2e/action/entrypoint_e2e_test.go
+++ b/internal/e2e/action/entrypoint_e2e_test.go
@@ -1,0 +1,110 @@
+package action
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEntrypointE2EUsesRepositoryFallbackTarget(t *testing.T) {
+	t.Parallel()
+
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available in test environment")
+	}
+
+	repoRoot := mustFindRepoRoot(t)
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+
+	logPath := filepath.Join(tmp, "wrkr.log")
+	wrkrPath := filepath.Join(binDir, "wrkr")
+	wrkrScript := "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"${WRKR_LOG}\"\n"
+	if err := os.WriteFile(wrkrPath, []byte(wrkrScript), 0o755); err != nil {
+		t.Fatalf("write wrkr stub: %v", err)
+	}
+
+	cmd := exec.Command(bashPath, filepath.Join(repoRoot, "action", "entrypoint.sh"), "scheduled", "5", "", "", "")
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"WRKR_LOG="+logPath,
+		"GITHUB_REPOSITORY=acme/backend",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run entrypoint: %v output=%s", err, out)
+	}
+
+	loggedBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read wrkr log: %v", err)
+	}
+	lines := nonEmptyLines(string(loggedBytes))
+	if len(lines) != 3 {
+		t.Fatalf("expected three wrkr invocations, got %d (%v)", len(lines), lines)
+	}
+	if lines[0] != "scan --json --repo acme/backend" {
+		t.Fatalf("expected explicit repo target in scan invocation, got %q", lines[0])
+	}
+	if lines[1] != "report --top 5 --json" {
+		t.Fatalf("unexpected report invocation: %q", lines[1])
+	}
+	if lines[2] != "score --json" {
+		t.Fatalf("unexpected score invocation: %q", lines[2])
+	}
+}
+
+func TestActionMetadataIncludesExplicitTargetInputs(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	payload, err := os.ReadFile(filepath.Join(repoRoot, "action", "action.yaml"))
+	if err != nil {
+		t.Fatalf("read action metadata: %v", err)
+	}
+	content := string(payload)
+	for _, token := range []string{"target_mode", "target_value", "config_path", "${{ inputs.target_mode }}", "${{ inputs.target_value }}"} {
+		if !strings.Contains(content, token) {
+			t.Fatalf("expected action metadata to include %q", token)
+		}
+	}
+}
+
+func nonEmptyLines(in string) []string {
+	parts := strings.Split(in, "\n")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func mustFindRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get wd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(wd, "go.mod")); err == nil {
+			return wd
+		}
+		next := filepath.Dir(wd)
+		if next == wd {
+			t.Fatalf("could not locate repo root from %s", wd)
+		}
+		wd = next
+	}
+}


### PR DESCRIPTION
## Problem
PR #22 review comments identified three actionable gaps:
- action entrypoint executed `wrkr scan --json` without an explicit target.
- GitHub PR client dropped API path prefixes when `GITHUB_API_URL` included one.
- PR upsert could fail create when head branch had no remote ref.

## Changes
- Added explicit action target input wiring (`target_mode`, `target_value`, `config_path`) and deterministic fallback to `--repo "$GITHUB_REPOSITORY"` in action entrypoint.
- Fixed GitHub client URL construction to preserve base path prefixes (e.g. `/api/v3`).
- Added `EnsureHeadRef` flow before create/update upsert logic to auto-create missing head refs from base branch.
- Added focused tests:
  - `core/github/pr` URL and head-ref creation tests
  - `core/github/pr/upsert` ensure-head behavior tests
  - `internal/e2e/github_pr` mock coverage for refs endpoints
  - new `internal/e2e/action/entrypoint_e2e_test.go` for explicit scan target behavior and action metadata

## Validation
- `make prepush-full`
