### PR TITLE
fix: sync wrkr prd and close pr23 actionable review gap

### DIFF
--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -27,6 +27,15 @@ run_wrkr() {
 
 scan_args=(--json)
 
+if [[ -n "${target_mode}" && -z "${target_value}" ]]; then
+  echo "incomplete explicit target: target_mode requires target_value" >&2
+  exit 6
+fi
+if [[ -z "${target_mode}" && -n "${target_value}" ]]; then
+  echo "incomplete explicit target: target_value requires target_mode" >&2
+  exit 6
+fi
+
 if [[ -n "${target_mode}" && -n "${target_value}" ]]; then
   case "${target_mode}" in
     repo)


### PR DESCRIPTION
## Problem
- `product/wrkr.md` had drifted behind the implemented/accepted execution scope in `PLAN_v1`.
- PR #23 had one unresolved actionable bot review item: `action/entrypoint.sh` accepted partial explicit target input and silently fell back to other target sources.

## Changes
- Updated `product/wrkr.md` in-place (same structure/level of detail) to align with plan additions:
  - refresh date
  - add FR11/FR12/FR13 (policy engine, profiles, posture score)
  - add AC18/AC19/AC20
  - align CLI, architecture, and data model sections to policy/profile/score contracts
- Fixed `action/entrypoint.sh` to fail-closed on incomplete explicit target inputs:
  - `target_mode` without `target_value` => exit 6
  - `target_value` without `target_mode` => exit 6
- Added e2e coverage in `internal/e2e/action/entrypoint_e2e_test.go` to verify fail-closed behavior and prevent silent fallback regressions.

## PR #23 Comment Triage
- Implement Now:
  - P2 (high confidence): reject incomplete explicit target inputs in action entrypoint (implemented in this PR)
- Defer: none
- Reject: none

## Validation
- `go test ./internal/e2e/action -count=1`
- `go run ./cmd/wrkr scan --path . --json`
- `make prepush-full`
