### PR TITLE
Epic 7: determinism hardening and cross-product assurance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,3 +86,6 @@ jobs:
           make test-integration
           make test-e2e
           make test-contracts
+          scripts/validate_contracts.sh
+          scripts/validate_scenarios.sh
+          go test ./internal/scenarios -count=1 -tags=scenario

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,6 +40,21 @@ jobs:
       - name: Run prepush full
         run: make prepush-full
 
+      - name: Run contract determinism smoke
+        run: scripts/validate_contracts.sh
+
+      - name: Run hardening suites
+        run: scripts/test_hardening_all.sh
+
+      - name: Run chaos suites
+        run: scripts/test_chaos_all.sh
+
+      - name: Run performance budgets
+        run: scripts/test_perf_budgets.sh
+
+      - name: Run cross-product interop suite
+        run: go test ./internal/integration/interop -count=1
+
       - name: Run race lane
         run: go test -race ./... -count=1
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,8 +39,7 @@ jobs:
             workflow_or_policy:
               - '.github/workflows/**'
               - '.github/required-checks.json'
-              - 'scripts/check_branch_protection_contract.sh'
-              - 'scripts/run_codeql.sh'
+              - 'scripts/**/*.sh'
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -76,6 +75,7 @@ jobs:
           make lint-fast
           make test-fast
           make test-contracts
+          scripts/validate_scenarios.sh
 
       - name: Run ruff
         if: steps.pyfiles.outputs.has_python == 'true' && steps.changes.outputs.python == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,19 @@ jobs:
       - name: Run deterministic tests
         run: go test ./... -count=1
 
+      - name: Run contract and scenario gates
+        run: |
+          make test-contracts
+          scripts/validate_contracts.sh
+          scripts/validate_scenarios.sh
+          go test ./internal/scenarios -count=1 -tags=scenario
+
+      - name: Run release hardening and perf subsets
+        run: |
+          scripts/test_hardening_core.sh
+          scripts/test_perf_budgets.sh
+          go test ./internal/integration/interop -count=1
+
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ GO ?= go
 PKGS := ./...
 GOFILES := $(shell git ls-files '*.go')
 
-.PHONY: fmt lint lint-fast test test-fast test-integration test-e2e test-contracts \
-	build hooks prepush prepush-full codeql lint-ci test-docs-consistency test-docs-storyline \
-	test-adapter-parity
+.PHONY: fmt lint lint-fast test test-fast test-integration test-e2e test-contracts test-scenarios \
+	test-hardening test-chaos test-perf test-risk-lane build hooks prepush prepush-full codeql lint-ci \
+	test-docs-consistency test-docs-storyline test-adapter-parity
 
 fmt:
 	@if [[ -n "$(GOFILES)" ]]; then \
@@ -36,6 +36,21 @@ test-e2e:
 test-contracts:
 	@$(GO) test ./testinfra/... -count=1
 
+test-scenarios:
+	@scripts/validate_scenarios.sh
+	@$(GO) test ./internal/scenarios -count=1 -tags=scenario
+
+test-hardening:
+	@scripts/test_hardening_all.sh
+
+test-chaos:
+	@scripts/test_chaos_all.sh
+
+test-perf:
+	@scripts/test_perf_budgets.sh
+
+test-risk-lane: test-contracts test-scenarios test-hardening test-chaos test-perf
+
 test-docs-consistency:
 	@echo "docs consistency checks are not yet implemented"
 
@@ -54,7 +69,7 @@ hooks:
 
 prepush: fmt lint-fast test-fast test-contracts build
 
-prepush-full: prepush lint test test-integration test-e2e codeql
+prepush-full: prepush lint test test-integration test-e2e test-scenarios codeql
 
 codeql:
 	@scripts/run_codeql.sh

--- a/core/risk/risk_bench_test.go
+++ b/core/risk/risk_bench_test.go
@@ -1,0 +1,27 @@
+package risk
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Clyra-AI/wrkr/core/model"
+)
+
+func BenchmarkRiskScoreDeterministic(b *testing.B) {
+	findings := []model.Finding{
+		{FindingType: "policy_violation", RuleID: "WRKR-014", Severity: model.SeverityHigh, ToolType: "policy", Location: "WRKR-014", Repo: "frontend", Org: "acme", Autonomy: "headless_auto"},
+		{FindingType: "skill_policy_conflict", Severity: model.SeverityHigh, ToolType: "skill", Location: ".agents/skills/release/SKILL.md", Repo: "frontend", Org: "acme", Permissions: []string{"proc.exec"}},
+		{FindingType: "skill_metrics", Severity: model.SeverityMedium, ToolType: "skill", Location: ".agents/skills", Repo: "frontend", Org: "acme", Permissions: []string{"proc.exec", "filesystem.write"}, Evidence: []model.Evidence{
+			{Key: "skill_privilege_concentration.exec_write_ratio", Value: "0.66"},
+			{Key: "skill_sprawl.total", Value: "3"},
+			{Key: "skill_sprawl.exec", Value: "2"},
+			{Key: "skill_sprawl.write", Value: "1"},
+		}},
+	}
+	now := time.Date(2026, 2, 21, 0, 0, 0, 0, time.UTC)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = Score(findings, 5, now)
+	}
+}

--- a/core/score/score_bench_test.go
+++ b/core/score/score_bench_test.go
@@ -1,0 +1,37 @@
+package score
+
+import (
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/manifest"
+	"github.com/Clyra-AI/wrkr/core/model"
+	profileeval "github.com/Clyra-AI/wrkr/core/policy/profileeval"
+	scoremodel "github.com/Clyra-AI/wrkr/core/score/model"
+)
+
+func BenchmarkScoreComputeDeterministic(b *testing.B) {
+	findings := []model.Finding{
+		{FindingType: "policy_check", RuleID: "WRKR-001", CheckResult: model.CheckResultPass, Severity: model.SeverityLow, ToolType: "policy", Location: "WRKR-001", Repo: "backend", Org: "acme"},
+		{FindingType: "policy_check", RuleID: "WRKR-002", CheckResult: model.CheckResultFail, Severity: model.SeverityHigh, ToolType: "policy", Location: "WRKR-002", Repo: "backend", Org: "acme"},
+		{FindingType: "skill_policy_conflict", Severity: model.SeverityHigh, ToolType: "skill", Location: ".agents/skills/deploy/SKILL.md", Repo: "backend", Org: "acme"},
+	}
+	identities := []manifest.IdentityRecord{
+		{AgentID: "wrkr:cursor:acme", ToolID: "cursor:.cursor/rules/default.mdc", Org: "acme", Present: true, ApprovalState: "valid"},
+		{AgentID: "wrkr:codex:acme", ToolID: "codex:AGENTS.md", Org: "acme", Present: true, ApprovalState: "missing"},
+	}
+	profile := profileeval.Result{ProfileName: "standard", CompliancePercent: 75}
+	weights := scoremodel.DefaultWeights()
+
+	input := Input{
+		Findings:        findings,
+		Identities:      identities,
+		ProfileResult:   profile,
+		TransitionCount: 1,
+		Weights:         weights,
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = Compute(input)
+	}
+}

--- a/internal/integration/integration_suite_test.go
+++ b/internal/integration/integration_suite_test.go
@@ -1,0 +1,7 @@
+package integration
+
+import "testing"
+
+func TestIntegrationSuitePackageAvailable(t *testing.T) {
+	t.Parallel()
+}

--- a/internal/integration/interop/interop_integration_test.go
+++ b/internal/integration/interop/interop_integration_test.go
@@ -1,0 +1,169 @@
+package interop
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	proof "github.com/Clyra-AI/proof"
+	verifycore "github.com/Clyra-AI/wrkr/core/verify"
+	"gopkg.in/yaml.v3"
+)
+
+type fixtureRecord struct {
+	SourceProduct string         `json:"source_product"`
+	RecordType    string         `json:"record_type"`
+	Event         map[string]any `json:"event"`
+}
+
+func TestIntegrationCrossProductProofInterop(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	fixturePath := filepath.Join(repoRoot, "scenarios", "cross-product", "proof-record-interop", "records-from-all-3.jsonl")
+	expectedPath := filepath.Join(repoRoot, "scenarios", "cross-product", "proof-record-interop", "expected.yaml")
+
+	records := loadFixtureRecords(t, fixturePath)
+	if len(records) < 3 {
+		t.Fatalf("expected at least 3 fixture records, got %d", len(records))
+	}
+
+	sourceProducts := map[string]struct{}{}
+	agentIDs := map[string]struct{}{}
+	for _, record := range records {
+		sourceProducts[strings.TrimSpace(record.SourceProduct)] = struct{}{}
+		agentID, _ := record.Event["agent_id"].(string)
+		if strings.TrimSpace(agentID) != "" {
+			agentIDs[strings.TrimSpace(agentID)] = struct{}{}
+		}
+	}
+	if len(agentIDs) != 1 {
+		t.Fatalf("expected single agent_id across fixture records, got %v", keys(agentIDs))
+	}
+	if len(sourceProducts) != 3 {
+		t.Fatalf("expected 3 source products, got %v", keys(sourceProducts))
+	}
+
+	chain := proof.NewChain("wrkr-proof")
+	for i, item := range records {
+		record, err := proof.NewRecord(proof.RecordOpts{
+			Timestamp:     time.Date(2026, 2, 21, 12, 0, i, 0, time.UTC),
+			Source:        "scenario",
+			SourceProduct: item.SourceProduct,
+			Type:          item.RecordType,
+			Event:         item.Event,
+			Controls:      proof.Controls{PermissionsEnforced: true},
+		})
+		if err != nil {
+			t.Fatalf("new record %d: %v", i, err)
+		}
+		if err := proof.AppendToChain(chain, record); err != nil {
+			t.Fatalf("append record %d: %v", i, err)
+		}
+	}
+
+	tmp := t.TempDir()
+	chainPath := filepath.Join(tmp, "chain.json")
+	writeChain(t, chainPath, chain)
+
+	result, err := verifycore.Chain(chainPath)
+	if err != nil {
+		t.Fatalf("verify mixed chain: %v", err)
+	}
+	if !result.Intact {
+		t.Fatalf("expected mixed chain to verify intact, got %+v", result)
+	}
+
+	expected := loadExpectedInterop(t, expectedPath)
+	if strings.TrimSpace(expected["chain"].(string)) != "intact" {
+		t.Fatalf("unexpected expected.yaml chain contract: %v", expected)
+	}
+}
+
+func loadFixtureRecords(t *testing.T, path string) []fixtureRecord {
+	t.Helper()
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	out := make([]fixtureRecord, 0)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var record fixtureRecord
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("parse jsonl line %q: %v", line, err)
+		}
+		out = append(out, record)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan fixture: %v", err)
+	}
+	return out
+}
+
+func loadExpectedInterop(t *testing.T, path string) map[string]any {
+	t.Helper()
+
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read expected yaml: %v", err)
+	}
+	out := map[string]any{}
+	if err := yaml.Unmarshal(payload, &out); err != nil {
+		t.Fatalf("parse expected yaml: %v", err)
+	}
+	return out
+}
+
+func writeChain(t *testing.T, path string, chain *proof.Chain) {
+	t.Helper()
+
+	payload, err := json.MarshalIndent(chain, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal chain: %v", err)
+	}
+	payload = append(payload, '\n')
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatalf("write chain: %v", err)
+	}
+}
+
+func keys(in map[string]struct{}) []string {
+	out := make([]string, 0, len(in))
+	for key := range in {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func mustFindRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(wd, "go.mod")); statErr == nil {
+			return wd
+		}
+		next := filepath.Dir(wd)
+		if next == wd {
+			t.Fatal("could not find repo root")
+		}
+		wd = next
+	}
+}

--- a/internal/scenarios/contracts_test.go
+++ b/internal/scenarios/contracts_test.go
@@ -1,0 +1,152 @@
+package scenarios
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestScenarioContracts(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRootWithoutTag(t)
+	requiredPaths := []string{
+		"scenarios/wrkr/scan-mixed-org/repos",
+		"scenarios/wrkr/policy-check/repos",
+		"scenarios/cross-product/proof-record-interop/records-from-all-3.jsonl",
+		"scenarios/cross-product/proof-record-interop/expected.yaml",
+		"internal/scenarios/coverage_map.json",
+	}
+	for _, rel := range requiredPaths {
+		if _, err := os.Stat(filepath.Join(repoRoot, rel)); err != nil {
+			t.Fatalf("required scenario contract path missing %s: %v", rel, err)
+		}
+	}
+
+	scenariosRoot := filepath.Join(repoRoot, "scenarios")
+	if err := filepath.WalkDir(scenariosRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		switch strings.ToLower(filepath.Ext(path)) {
+		case ".json":
+			payload, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+			if !json.Valid(payload) {
+				t.Fatalf("invalid JSON fixture: %s", path)
+			}
+		case ".yaml", ".yml":
+			payload, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+			var value any
+			if yamlErr := yaml.Unmarshal(payload, &value); yamlErr != nil {
+				t.Fatalf("invalid YAML fixture %s: %v", path, yamlErr)
+			}
+		case ".jsonl":
+			file, openErr := os.Open(path)
+			if openErr != nil {
+				return openErr
+			}
+			defer func() {
+				_ = file.Close()
+			}()
+			scanner := bufio.NewScanner(file)
+			line := 0
+			for scanner.Scan() {
+				line++
+				trimmed := strings.TrimSpace(scanner.Text())
+				if trimmed == "" {
+					continue
+				}
+				if !json.Valid([]byte(trimmed)) {
+					t.Fatalf("invalid JSONL fixture %s line %d", path, line)
+				}
+			}
+			if err := scanner.Err(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk scenarios fixtures: %v", err)
+	}
+
+	coveragePath := filepath.Join(repoRoot, "internal", "scenarios", "coverage_map.json")
+	payload, err := os.ReadFile(coveragePath)
+	if err != nil {
+		t.Fatalf("read coverage map: %v", err)
+	}
+	coverage := map[string][]string{}
+	if err := json.Unmarshal(payload, &coverage); err != nil {
+		t.Fatalf("parse coverage map: %v", err)
+	}
+
+	requiredMappings := []string{"FR11", "FR12", "FR13", "AC15", "AC18", "AC19", "AC20"}
+	testSymbols := scenarioTestSymbols(t, repoRoot)
+	for _, key := range requiredMappings {
+		mapped, ok := coverage[key]
+		if !ok || len(mapped) == 0 {
+			t.Fatalf("coverage map missing non-empty mapping for %s", key)
+		}
+		for _, testName := range mapped {
+			if _, exists := testSymbols[strings.TrimSpace(testName)]; !exists {
+				t.Fatalf("coverage map for %s references unknown scenario test %q", key, testName)
+			}
+		}
+	}
+}
+
+func scenarioTestSymbols(t *testing.T, repoRoot string) map[string]struct{} {
+	t.Helper()
+
+	files, err := filepath.Glob(filepath.Join(repoRoot, "internal", "scenarios", "*_test.go"))
+	if err != nil {
+		t.Fatalf("glob scenario test files: %v", err)
+	}
+	pattern := regexp.MustCompile(`func\s+(TestScenario[A-Za-z0-9_]+)\s*\(`)
+	symbols := map[string]struct{}{}
+	for _, file := range files {
+		payload, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		for _, match := range pattern.FindAllStringSubmatch(string(payload), -1) {
+			if len(match) == 2 {
+				symbols[match[1]] = struct{}{}
+			}
+		}
+	}
+	return symbols
+}
+
+func mustFindRepoRootWithoutTag(t *testing.T) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(wd, "go.mod")); statErr == nil {
+			return wd
+		}
+		next := filepath.Dir(wd)
+		if next == wd {
+			t.Fatal("could not locate repo root")
+		}
+		wd = next
+	}
+}

--- a/internal/scenarios/coverage_map.json
+++ b/internal/scenarios/coverage_map.json
@@ -1,0 +1,25 @@
+{
+  "FR11": [
+    "TestScenarioPolicyCheckContracts",
+    "TestScenarioEpic7PolicyOutcomesAndProofRecords"
+  ],
+  "FR12": [
+    "TestScenarioProfileComplianceAndScoreDeterminism",
+    "TestScenarioEpic7ProfileAndScoreContractsDeterministic"
+  ],
+  "FR13": [
+    "TestScenarioEpic7ProfileAndScoreContractsDeterministic"
+  ],
+  "AC15": [
+    "TestScenarioEpic7SkillConflictSignals"
+  ],
+  "AC18": [
+    "TestScenarioEpic7PolicyOutcomesAndProofRecords"
+  ],
+  "AC19": [
+    "TestScenarioEpic7ProfileAndScoreContractsDeterministic"
+  ],
+  "AC20": [
+    "TestScenarioEpic7ProfileAndScoreContractsDeterministic"
+  ]
+}

--- a/internal/scenarios/epic7_scenario_test.go
+++ b/internal/scenarios/epic7_scenario_test.go
@@ -1,0 +1,233 @@
+//go:build scenario
+
+package scenarios
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/cli"
+	"github.com/Clyra-AI/wrkr/core/proofemit"
+)
+
+func TestScenarioEpic7SkillConflictSignals(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "scan-mixed-org", "repos")
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	payload := runScenarioScan(t, []string{"scan", "--path", scanPath, "--state", statePath, "--json"})
+
+	findings, ok := payload["findings"].([]any)
+	if !ok {
+		t.Fatalf("expected findings array, got %T", payload["findings"])
+	}
+	conflictCount := 0
+	for _, item := range findings {
+		finding, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if finding["finding_type"] == "skill_policy_conflict" {
+			conflictCount++
+		}
+	}
+	if conflictCount == 0 {
+		t.Fatal("expected at least one skill_policy_conflict finding in mixed-org scenario")
+	}
+
+	ranked, ok := payload["ranked_findings"].([]any)
+	if !ok {
+		t.Fatalf("expected ranked_findings array, got %T", payload["ranked_findings"])
+	}
+	seen := map[string]int{}
+	for _, item := range ranked {
+		record, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		key, _ := record["canonical_key"].(string)
+		if key == "" {
+			continue
+		}
+		seen[key]++
+	}
+	if seen["skill_policy_conflict:local:frontend"] != 1 {
+		t.Fatalf("expected one canonical skill conflict key for frontend, got %d", seen["skill_policy_conflict:local:frontend"])
+	}
+
+	summaries, ok := payload["repo_exposure_summaries"].([]any)
+	if !ok {
+		t.Fatalf("expected repo_exposure_summaries array, got %T", payload["repo_exposure_summaries"])
+	}
+	hasSkillFields := false
+	for _, item := range summaries {
+		summary, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if summary["repo"] != "frontend" {
+			continue
+		}
+		_, hasCeiling := summary["skill_privilege_ceiling"]
+		_, hasConcentration := summary["skill_privilege_concentration"]
+		_, hasSprawl := summary["skill_sprawl"]
+		if hasCeiling && hasConcentration && hasSprawl {
+			hasSkillFields = true
+		}
+	}
+	if !hasSkillFields {
+		t.Fatal("expected frontend repo exposure summary to include skill risk fields")
+	}
+}
+
+func TestScenarioEpic7PolicyOutcomesAndProofRecords(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "policy-check", "repos")
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	payload := runScenarioScan(t, []string{"scan", "--path", scanPath, "--state", statePath, "--json"})
+
+	findings, ok := payload["findings"].([]any)
+	if !ok {
+		t.Fatalf("expected findings array, got %T", payload["findings"])
+	}
+
+	rules := map[string]string{}
+	for _, item := range findings {
+		finding, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if finding["finding_type"] != "policy_check" {
+			continue
+		}
+		ruleID, _ := finding["rule_id"].(string)
+		checkResult, _ := finding["check_result"].(string)
+		if ruleID != "" {
+			rules[ruleID] = checkResult
+		}
+	}
+
+	want := map[string]string{"WRKR-001": "fail", "WRKR-002": "fail", "WRKR-004": "pass", "WRKR-099": "fail"}
+	for ruleID, expected := range want {
+		if got := rules[ruleID]; got != expected {
+			t.Fatalf("unexpected policy outcome for %s: got %q want %q (all=%v)", ruleID, got, expected, rules)
+		}
+	}
+
+	chainPath := proofemit.ChainPath(statePath)
+	var verifyOut bytes.Buffer
+	var verifyErr bytes.Buffer
+	if code := cli.Run([]string{"verify", "--chain", "--path", chainPath, "--json"}, &verifyOut, &verifyErr); code != 0 {
+		t.Fatalf("verify chain failed: %d (%s)", code, verifyErr.String())
+	}
+
+	chainPayload, err := os.ReadFile(chainPath)
+	if err != nil {
+		t.Fatalf("read chain: %v", err)
+	}
+	var chain map[string]any
+	if err := json.Unmarshal(chainPayload, &chain); err != nil {
+		t.Fatalf("parse chain: %v", err)
+	}
+	records, ok := chain["records"].([]any)
+	if !ok || len(records) == 0 {
+		t.Fatalf("expected chain records, got %v", chain)
+	}
+	hasPolicyViolationRecord := false
+	for _, item := range records {
+		record, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if record["record_type"] != "scan_finding" {
+			continue
+		}
+		event, ok := record["event"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if event["finding_type"] == "policy_violation" {
+			hasPolicyViolationRecord = true
+			break
+		}
+	}
+	if !hasPolicyViolationRecord {
+		t.Fatal("expected policy_violation proof record in chain")
+	}
+}
+
+func TestScenarioEpic7ProfileAndScoreContractsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "policy-check", "repos")
+	statePath := filepath.Join(t.TempDir(), "state.json")
+
+	first := runScenarioScan(t, []string{"scan", "--path", scanPath, "--state", statePath, "--profile", "standard", "--json"})
+	second := runScenarioScan(t, []string{"scan", "--path", scanPath, "--state", statePath, "--profile", "standard", "--json"})
+
+	profileA, ok := first["profile"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected profile payload, got %T", first["profile"])
+	}
+	profileB, ok := second["profile"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected profile payload, got %T", second["profile"])
+	}
+	if profileA["compliance_percent"] != profileB["compliance_percent"] {
+		t.Fatalf("profile compliance must be deterministic: %v vs %v", profileA["compliance_percent"], profileB["compliance_percent"])
+	}
+	if !reflect.DeepEqual(profileA["failing_rules"], profileB["failing_rules"]) {
+		t.Fatalf("failing_rules must be deterministic: %v vs %v", profileA["failing_rules"], profileB["failing_rules"])
+	}
+	for _, key := range []string{"compliance_percent", "failing_rules", "compliance_delta", "status"} {
+		if _, present := profileA[key]; !present {
+			t.Fatalf("profile payload missing %q: %v", key, profileA)
+		}
+	}
+
+	scoreA, ok := first["posture_score"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected posture_score payload, got %T", first["posture_score"])
+	}
+	for _, key := range []string{"score", "grade", "weighted_breakdown", "weights", "trend_delta"} {
+		if _, present := scoreA[key]; !present {
+			t.Fatalf("posture_score payload missing %q: %v", key, scoreA)
+		}
+	}
+
+	var scoreOut bytes.Buffer
+	var scoreErr bytes.Buffer
+	if code := cli.Run([]string{"score", "--state", statePath, "--json"}, &scoreOut, &scoreErr); code != 0 {
+		t.Fatalf("score command failed: %d (%s)", code, scoreErr.String())
+	}
+	var scorePayload map[string]any
+	if err := json.Unmarshal(scoreOut.Bytes(), &scorePayload); err != nil {
+		t.Fatalf("parse score payload: %v", err)
+	}
+	if scoreA["score"] != scorePayload["score"] || scoreA["grade"] != scorePayload["grade"] {
+		t.Fatalf("scan posture_score and score command output mismatch: scan=%v score=%v", scoreA, scorePayload)
+	}
+}
+
+func runScenarioScan(t *testing.T, args []string) map[string]any {
+	t.Helper()
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := cli.Run(args, &out, &errOut); code != 0 {
+		t.Fatalf("scan command failed: %d (%s)", code, errOut.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse JSON payload: %v", err)
+	}
+	return payload
+}

--- a/perf/bench_baseline.json
+++ b/perf/bench_baseline.json
@@ -1,0 +1,17 @@
+{
+  "version": "v1",
+  "benchmarks": [
+    {
+      "name": "BenchmarkScoreComputeDeterministic",
+      "unit": "ns/op",
+      "median": 1500000,
+      "max_regression_factor": 1.25
+    },
+    {
+      "name": "BenchmarkRiskScoreDeterministic",
+      "unit": "ns/op",
+      "median": 1800000,
+      "max_regression_factor": 1.25
+    }
+  ]
+}

--- a/perf/runtime_slo_budgets.json
+++ b/perf/runtime_slo_budgets.json
@@ -1,0 +1,13 @@
+{
+  "version": "v1",
+  "scan": {
+    "repos_100": {"max_seconds": 600},
+    "repos_500": {"max_seconds": 1800},
+    "diff_100": {"max_seconds": 120}
+  },
+  "commands": {
+    "score": {"p95_ms": 150},
+    "verify_chain": {"p95_ms": 1000},
+    "regress_run": {"p95_ms": 300}
+  }
+}

--- a/scenarios/cross-product/proof-record-interop/expected.yaml
+++ b/scenarios/cross-product/proof-record-interop/expected.yaml
@@ -1,0 +1,7 @@
+chain: intact
+products:
+  - wrkr
+  - gait
+  - axym
+agent_id_consistent: true
+minimum_records: 3

--- a/scenarios/cross-product/proof-record-interop/records-from-all-3.jsonl
+++ b/scenarios/cross-product/proof-record-interop/records-from-all-3.jsonl
@@ -1,0 +1,3 @@
+{"source_product":"wrkr","record_type":"scan_finding","event":{"agent_id":"wrkr:codex:acme","finding_type":"skill_policy_conflict","rule_id":"WRKR-014"}}
+{"source_product":"gait","record_type":"policy_enforcement","event":{"agent_id":"wrkr:codex:acme","decision":"block","policy_id":"gait-deny-exec"}}
+{"source_product":"axym","record_type":"risk_assessment","event":{"agent_id":"wrkr:codex:acme","assessment_type":"control_mapping","framework":"soc2","control_id":"CC7.2"}}

--- a/scenarios/cross-product/see-prove-control-loop/expected-final-bundle.yaml
+++ b/scenarios/cross-product/see-prove-control-loop/expected-final-bundle.yaml
@@ -1,0 +1,4 @@
+status: draft
+note: >-
+  Scenario scaffold for Tier 12 see-prove-control loop.
+  The full multi-product harness is validated by integration tests and CI scripts.

--- a/scripts/test_chaos_all.sh
+++ b/scripts/test_chaos_all.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+scripts/test_chaos_proof.sh
+scripts/test_chaos_source.sh

--- a/scripts/test_chaos_proof.sh
+++ b/scripts/test_chaos_proof.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+go test ./core/verify -run 'TestChain(TamperDetected|MixedSourceCompatibility)$' -count=5
+go test ./internal/e2e/verify -run 'TestE2EVerifyChainSuccessAndTamper$' -count=3

--- a/scripts/test_chaos_source.sh
+++ b/scripts/test_chaos_source.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+go test ./core/source/github -run 'Test(ListOrgReposIntegrationSimulatedAPI|AcquireRepoRetriesTransientStatus)$' -count=5
+go test ./internal/integration/source -run 'TestIntegrationOrgAcquireWithSimulatedGitHub$' -count=3

--- a/scripts/test_hardening_all.sh
+++ b/scripts/test_hardening_all.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+scripts/test_hardening_core.sh
+scripts/test_hardening_soak.sh
+go test ./internal/integration/... -count=1

--- a/scripts/test_hardening_core.sh
+++ b/scripts/test_hardening_core.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+go test ./core/evidence -run 'TestBuildEvidence(RejectsNonManagedNonEmptyOutputDir|RejectsMarkerDirectory|RejectsMarkerSymlink|RejectsSymlinkOutputDir|BuildManifestEntriesRejectsSymlinkFile)$' -count=1
+go test ./core/source/github -run 'TestAcquireRepoRetriesTransientStatus$' -count=1
+go test ./core/verify -run 'TestChain(TamperDetected|MixedSourceCompatibility)$' -count=1

--- a/scripts/test_hardening_soak.sh
+++ b/scripts/test_hardening_soak.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export LOCK_PROFILE="${LOCK_PROFILE:-swarm}"
+export LOCK_TIMEOUT="${LOCK_TIMEOUT:-5s}"
+export LOCK_RETRY="${LOCK_RETRY:-10ms}"
+
+go test ./internal/e2e/diff -run 'TestE2EDiffNoNoiseOnUnchangedInput$' -count=4
+go test ./internal/e2e/regress -run 'TestE2ERegressInitAndRunDetectsDrift$' -count=4

--- a/scripts/test_perf_budgets.sh
+++ b/scripts/test_perf_budgets.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required for benchmark budget validation" >&2
+  exit 7
+fi
+
+bench_output="$(mktemp)"
+trap 'rm -f "$bench_output"' EXIT
+
+go test -run '^$' -bench 'Benchmark(ScoreComputeDeterministic|RiskScoreDeterministic)$' -benchmem -count=5 ./core/score ./core/risk | tee "$bench_output"
+
+python3 - "$bench_output" <<'PY'
+import json
+import math
+import pathlib
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+
+output_path = pathlib.Path(sys.argv[1])
+root = pathlib.Path('.')
+bench_contract = json.loads((root / 'perf' / 'bench_baseline.json').read_text(encoding='utf-8'))
+runtime_contract = json.loads((root / 'perf' / 'runtime_slo_budgets.json').read_text(encoding='utf-8'))
+bench_entries = {item['name']: item for item in bench_contract['benchmarks']}
+
+pattern = re.compile(r'^(Benchmark\S+)\s+\d+\s+([0-9]+(?:\.[0-9]+)?)\s+ns/op')
+observed = {}
+for line in output_path.read_text(encoding='utf-8').splitlines():
+    match = pattern.match(line.strip())
+    if not match:
+        continue
+    name = re.sub(r'-\d+$', '', match.group(1))
+    value = float(match.group(2))
+    observed.setdefault(name, []).append(value)
+
+errors = []
+for name, contract in bench_entries.items():
+    values = observed.get(name, [])
+    if not values:
+        errors.append(f'missing benchmark output: {name}')
+        continue
+    median = statistics.median(values)
+    limit = float(contract['median']) * float(contract['max_regression_factor'])
+    if median > limit:
+        errors.append(f'{name} median {median:.2f}ns/op exceeds limit {limit:.2f}ns/op')
+
+wrkr_bin = root / '.tmp' / 'wrkr'
+wrkr_bin.parent.mkdir(parents=True, exist_ok=True)
+if not wrkr_bin.exists():
+    subprocess.run(['go', 'build', '-o', str(wrkr_bin), './cmd/wrkr'], cwd=root, check=True)
+
+
+def timed_run(cmd):
+    start = time.perf_counter()
+    proc = subprocess.run(cmd, cwd=root, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+    duration = time.perf_counter() - start
+    return proc.returncode, duration, proc.stderr.strip()
+
+
+def p95_ms(values):
+    ordered = sorted(values)
+    if not ordered:
+        return 0.0
+    index = max(0, math.ceil(0.95 * len(ordered)) - 1)
+    return ordered[index] * 1000.0
+
+
+tmpdir = pathlib.Path(tempfile.mkdtemp(prefix='wrkr-perf-'))
+try:
+    repos100 = tmpdir / 'repos-100'
+    repos500 = tmpdir / 'repos-500'
+    for i in range(100):
+        (repos100 / f'repo-{i:03d}').mkdir(parents=True, exist_ok=True)
+    for i in range(500):
+        (repos500 / f'repo-{i:03d}').mkdir(parents=True, exist_ok=True)
+
+    state100 = tmpdir / 'state-100.json'
+    state500 = tmpdir / 'state-500.json'
+
+    rc, duration100, stderr100 = timed_run([str(wrkr_bin), 'scan', '--path', str(repos100), '--state', str(state100), '--json'])
+    if rc != 0:
+        errors.append(f'scan 100 repos failed with exit {rc}: {stderr100}')
+    else:
+        budget100 = float(runtime_contract['scan']['repos_100']['max_seconds'])
+        if duration100 > budget100:
+            errors.append(f'scan 100 repos took {duration100:.2f}s (budget {budget100:.2f}s)')
+
+    rc, duration500, stderr500 = timed_run([str(wrkr_bin), 'scan', '--path', str(repos500), '--state', str(state500), '--json'])
+    if rc != 0:
+        errors.append(f'scan 500 repos failed with exit {rc}: {stderr500}')
+    else:
+        budget500 = float(runtime_contract['scan']['repos_500']['max_seconds'])
+        if duration500 > budget500:
+            errors.append(f'scan 500 repos took {duration500:.2f}s (budget {budget500:.2f}s)')
+
+    baseline = tmpdir / 'baseline-100.json'
+    rc, _, stderr = timed_run([str(wrkr_bin), 'regress', 'init', '--baseline', str(state100), '--output', str(baseline), '--json'])
+    if rc != 0:
+        errors.append(f'regress init failed with exit {rc}: {stderr}')
+
+    command_budgets = runtime_contract.get('commands', {})
+
+    score_runs = []
+    for _ in range(5):
+        rc, duration, stderr = timed_run([str(wrkr_bin), 'score', '--state', str(state100), '--json'])
+        if rc != 0:
+            errors.append(f'score command failed with exit {rc}: {stderr}')
+            break
+        score_runs.append(duration)
+    if score_runs:
+        limit = float(command_budgets['score']['p95_ms'])
+        measured = p95_ms(score_runs)
+        if measured > limit:
+            errors.append(f'score p95 {measured:.2f}ms exceeds budget {limit:.2f}ms')
+
+    verify_runs = []
+    for _ in range(5):
+        rc, duration, stderr = timed_run([str(wrkr_bin), 'verify', '--chain', '--state', str(state100), '--json'])
+        if rc != 0:
+            errors.append(f'verify command failed with exit {rc}: {stderr}')
+            break
+        verify_runs.append(duration)
+    if verify_runs:
+        limit = float(command_budgets['verify_chain']['p95_ms'])
+        measured = p95_ms(verify_runs)
+        if measured > limit:
+            errors.append(f'verify p95 {measured:.2f}ms exceeds budget {limit:.2f}ms')
+
+    regress_runs = []
+    for _ in range(5):
+        rc, duration, stderr = timed_run([str(wrkr_bin), 'regress', 'run', '--baseline', str(baseline), '--state', str(state100), '--json'])
+        if rc != 0:
+            errors.append(f'regress run failed with exit {rc}: {stderr}')
+            break
+        regress_runs.append(duration)
+    if regress_runs:
+        limit = float(command_budgets['regress_run']['p95_ms'])
+        measured = p95_ms(regress_runs)
+        if measured > limit:
+            errors.append(f'regress run p95 {measured:.2f}ms exceeds budget {limit:.2f}ms')
+finally:
+    shutil.rmtree(tmpdir)
+
+if errors:
+    for err in errors:
+        print(err, file=sys.stderr)
+    sys.exit(1)
+
+print('benchmark and runtime budgets: pass')
+PY

--- a/scripts/validate_contracts.sh
+++ b/scripts/validate_contracts.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+go test ./testinfra/contracts -run 'TestStory7(SchemaContractsStable|SkillConflictAndExposureContracts|ConflictDedupeCanonicalContract|ExitCodeContractsAcrossCommandFamilies|EvidenceOutputDirSafetyContracts|EvidenceManifestExcludesOwnershipMarker|CommandAnchorDeterminism)$' -count=1

--- a/scripts/validate_scenarios.sh
+++ b/scripts/validate_scenarios.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+go test ./internal/scenarios -run '^TestScenarioContracts$' -count=1

--- a/testinfra/contracts/story7_contracts_test.go
+++ b/testinfra/contracts/story7_contracts_test.go
@@ -1,0 +1,462 @@
+package contracts
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/cli"
+)
+
+func TestStory7SchemaContractsStable(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	schemasRoot := filepath.Join(repoRoot, "schemas", "v1")
+
+	files := make([]string, 0)
+	if err := filepath.WalkDir(schemasRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".schema.json") {
+			return nil
+		}
+		rel, err := filepath.Rel(repoRoot, path)
+		if err != nil {
+			return err
+		}
+		payload, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		var schema map[string]any
+		if err := json.Unmarshal(payload, &schema); err != nil {
+			t.Fatalf("schema %s must parse as JSON: %v", rel, err)
+		}
+		if _, ok := schema["$schema"].(string); !ok {
+			t.Fatalf("schema %s missing $schema", rel)
+		}
+		if _, hasType := schema["type"].(string); !hasType {
+			if _, hasOneOf := schema["oneOf"]; !hasOneOf {
+				if _, hasAnyOf := schema["anyOf"]; !hasAnyOf {
+					if _, hasAllOf := schema["allOf"]; !hasAllOf {
+						t.Fatalf("schema %s missing root contract discriminator (type/oneOf/anyOf/allOf)", rel)
+					}
+				}
+			}
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	}); err != nil {
+		t.Fatalf("walk schemas: %v", err)
+	}
+
+	sort.Strings(files)
+	want := []string{
+		"schemas/v1/cli/command-envelope.schema.json",
+		"schemas/v1/config/config.schema.json",
+		"schemas/v1/evidence/evidence-bundle.schema.json",
+		"schemas/v1/export/inventory-export.schema.json",
+		"schemas/v1/findings/finding.schema.json",
+		"schemas/v1/identity/identity-manifest.schema.json",
+		"schemas/v1/inventory/inventory.schema.json",
+		"schemas/v1/policy/rule-pack.schema.json",
+		"schemas/v1/profile/profile-result.schema.json",
+		"schemas/v1/proof-outputs/proof-chain.schema.json",
+		"schemas/v1/proof-outputs/proof-record.schema.json",
+		"schemas/v1/regress/regress-baseline.schema.json",
+		"schemas/v1/regress/regress-result.schema.json",
+		"schemas/v1/risk/risk-report.schema.json",
+		"schemas/v1/score/score.schema.json",
+	}
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("schema contract drift\ngot:  %v\nwant: %v", files, want)
+	}
+}
+
+func TestStory7SkillConflictAndExposureContracts(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "scan-mixed-org", "repos")
+	statePath := filepath.Join(t.TempDir(), "state.json")
+
+	payload := runScanJSON(t, scanPath, statePath)
+
+	findings, ok := payload["findings"].([]any)
+	if !ok {
+		t.Fatalf("expected findings array, got %T", payload["findings"])
+	}
+	conflicts := 0
+	for _, item := range findings {
+		finding, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if finding["finding_type"] != "skill_policy_conflict" {
+			continue
+		}
+		conflicts++
+		evidence, ok := finding["evidence"].([]any)
+		if !ok {
+			t.Fatalf("skill_policy_conflict must include evidence array: %v", finding)
+		}
+		haveGrant := false
+		haveRule := false
+		for _, item := range evidence {
+			record, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			switch record["key"] {
+			case "grant":
+				haveGrant = true
+			case "conflicting_policy_rule":
+				haveRule = true
+			}
+		}
+		if !haveGrant || !haveRule {
+			t.Fatalf("skill_policy_conflict missing evidence keys grant/conflicting_policy_rule: %v", finding)
+		}
+	}
+	if conflicts == 0 {
+		t.Fatal("expected at least one skill_policy_conflict finding")
+	}
+
+	summaries, ok := payload["repo_exposure_summaries"].([]any)
+	if !ok || len(summaries) == 0 {
+		t.Fatalf("expected repo_exposure_summaries, got %T", payload["repo_exposure_summaries"])
+	}
+
+	foundFrontend := false
+	for _, item := range summaries {
+		summary, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if summary["repo"] != "frontend" {
+			continue
+		}
+		foundFrontend = true
+		if _, ok := summary["skill_privilege_ceiling"].([]any); !ok {
+			t.Fatalf("frontend summary missing skill_privilege_ceiling: %v", summary)
+		}
+		concentration, ok := summary["skill_privilege_concentration"].(map[string]any)
+		if !ok {
+			t.Fatalf("frontend summary missing skill_privilege_concentration: %v", summary)
+		}
+		for _, key := range []string{"exec_ratio", "write_ratio", "exec_write_ratio"} {
+			if _, present := concentration[key]; !present {
+				t.Fatalf("skill_privilege_concentration missing %s: %v", key, concentration)
+			}
+		}
+		sprawl, ok := summary["skill_sprawl"].(map[string]any)
+		if !ok {
+			t.Fatalf("frontend summary missing skill_sprawl: %v", summary)
+		}
+		for _, key := range []string{"total", "exec", "write", "read", "none"} {
+			if _, present := sprawl[key]; !present {
+				t.Fatalf("skill_sprawl missing %s: %v", key, sprawl)
+			}
+		}
+	}
+	if !foundFrontend {
+		t.Fatal("expected repo_exposure_summaries entry for frontend")
+	}
+}
+
+func TestStory7ConflictDedupeCanonicalContract(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "scan-mixed-org", "repos")
+	statePath := filepath.Join(t.TempDir(), "state.json")
+
+	payload := runScanJSON(t, scanPath, statePath)
+	ranked, ok := payload["ranked_findings"].([]any)
+	if !ok {
+		t.Fatalf("expected ranked_findings array, got %T", payload["ranked_findings"])
+	}
+
+	seen := map[string]int{}
+	for _, item := range ranked {
+		record, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		key, _ := record["canonical_key"].(string)
+		if key == "" {
+			t.Fatalf("ranked finding missing canonical_key: %v", record)
+		}
+		seen[key]++
+	}
+
+	for key, count := range seen {
+		if count > 1 {
+			t.Fatalf("ranked findings contain duplicate canonical key %q (%d)", key, count)
+		}
+	}
+	if seen["skill_policy_conflict:local:frontend"] != 1 {
+		t.Fatalf("expected exactly one canonical skill conflict key, got %d", seen["skill_policy_conflict:local:frontend"])
+	}
+}
+
+func TestStory7ExitCodeContractsAcrossCommandFamilies(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		code int
+	}{
+		{name: "scan_invalid_target_combo", args: []string{"scan", "--repo", "acme/backend", "--org", "acme", "--json"}, code: 6},
+		{name: "verify_missing_chain_flag", args: []string{"verify", "--json"}, code: 6},
+		{name: "regress_missing_baseline", args: []string{"regress", "run", "--json"}, code: 6},
+		{name: "evidence_missing_frameworks", args: []string{"evidence", "--json"}, code: 6},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var out bytes.Buffer
+			var errOut bytes.Buffer
+			if code := cli.Run(tc.args, &out, &errOut); code != tc.code {
+				t.Fatalf("expected exit %d, got %d (stderr=%q)", tc.code, code, errOut.String())
+			}
+		})
+	}
+}
+
+func TestStory7EvidenceOutputDirSafetyContracts(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "scan-mixed-org", "repos")
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+
+	_ = runScanJSON(t, scanPath, statePath)
+
+	t.Run("reject_non_managed_non_empty", func(t *testing.T) {
+		outputDir := filepath.Join(tmp, "non-managed")
+		if err := os.MkdirAll(outputDir, 0o750); err != nil {
+			t.Fatalf("mkdir output dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(outputDir, "stale.txt"), []byte("stale"), 0o600); err != nil {
+			t.Fatalf("write stale file: %v", err)
+		}
+		assertEvidenceUnsafeExit8(t, statePath, outputDir)
+	})
+
+	t.Run("reject_marker_directory", func(t *testing.T) {
+		outputDir := filepath.Join(tmp, "marker-dir")
+		if err := os.MkdirAll(filepath.Join(outputDir, ".wrkr-evidence-managed"), 0o750); err != nil {
+			t.Fatalf("mkdir marker dir: %v", err)
+		}
+		assertEvidenceUnsafeExit8(t, statePath, outputDir)
+	})
+
+	t.Run("reject_marker_symlink", func(t *testing.T) {
+		outputDir := filepath.Join(tmp, "marker-symlink")
+		if err := os.MkdirAll(outputDir, 0o750); err != nil {
+			t.Fatalf("mkdir output dir: %v", err)
+		}
+		targetPath := filepath.Join(outputDir, "marker-target.txt")
+		if err := os.WriteFile(targetPath, []byte("managed by wrkr evidence build\n"), 0o600); err != nil {
+			t.Fatalf("write marker target: %v", err)
+		}
+		if err := os.Symlink("marker-target.txt", filepath.Join(outputDir, ".wrkr-evidence-managed")); err != nil {
+			t.Skipf("symlink not supported in this environment: %v", err)
+		}
+		assertEvidenceUnsafeExit8(t, statePath, outputDir)
+	})
+}
+
+func TestStory7EvidenceManifestExcludesOwnershipMarker(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "scan-mixed-org", "repos")
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	outputDir := filepath.Join(tmp, "evidence")
+
+	_ = runScanJSON(t, scanPath, statePath)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := cli.Run([]string{"evidence", "--frameworks", "soc2", "--state", statePath, "--output", outputDir, "--json"}, &out, &errOut); code != 0 {
+		t.Fatalf("evidence command failed: %d (%s)", code, errOut.String())
+	}
+
+	manifestPath := filepath.Join(outputDir, "manifest.json")
+	payload, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var manifest map[string]any
+	if err := json.Unmarshal(payload, &manifest); err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	files, ok := manifest["files"].([]any)
+	if !ok {
+		t.Fatalf("manifest missing files array: %v", manifest)
+	}
+	for _, item := range files {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		pathValue, _ := entry["path"].(string)
+		if pathValue == ".wrkr-evidence-managed" {
+			t.Fatal("ownership marker must be excluded from manifest entries")
+		}
+	}
+}
+
+func TestStory7CommandAnchorDeterminism(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	reposPath := filepath.Join(tmp, "repos")
+	stateA := filepath.Join(tmp, "state-a.json")
+	stateB := filepath.Join(tmp, "state-b.json")
+	baselinePath := filepath.Join(tmp, "baseline.json")
+	if err := os.MkdirAll(filepath.Join(reposPath, "alpha"), 0o755); err != nil {
+		t.Fatalf("mkdir repo fixture: %v", err)
+	}
+
+	firstScan := runScanJSON(t, reposPath, stateA)
+	secondScan := runScanJSON(t, reposPath, stateB)
+	if !reflect.DeepEqual(normalizeVolatile(firstScan), normalizeVolatile(secondScan)) {
+		t.Fatalf("scan --json is not deterministic after volatile-field normalization\nfirst=%v\nsecond=%v", normalizeVolatile(firstScan), normalizeVolatile(secondScan))
+	}
+
+	var initOut bytes.Buffer
+	var initErr bytes.Buffer
+	if code := cli.Run([]string{"regress", "init", "--baseline", stateA, "--output", baselinePath, "--json"}, &initOut, &initErr); code != 0 {
+		t.Fatalf("regress init failed: %d (%s)", code, initErr.String())
+	}
+
+	firstRun := runRegressJSON(t, baselinePath, stateA)
+	secondRun := runRegressJSON(t, baselinePath, stateA)
+	if !reflect.DeepEqual(firstRun, secondRun) {
+		t.Fatalf("regress run output must be deterministic\nfirst=%v\nsecond=%v", firstRun, secondRun)
+	}
+
+	firstVerify := runVerifyJSON(t, stateA)
+	secondVerify := runVerifyJSON(t, stateA)
+	if !reflect.DeepEqual(firstVerify, secondVerify) {
+		t.Fatalf("verify --chain --json output must be deterministic\nfirst=%v\nsecond=%v", firstVerify, secondVerify)
+	}
+}
+
+func runScanJSON(t *testing.T, scanPath string, statePath string) map[string]any {
+	t.Helper()
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := cli.Run([]string{"scan", "--path", scanPath, "--state", statePath, "--json"}, &out, &errOut); code != 0 {
+		t.Fatalf("scan failed: %d (%s)", code, errOut.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse scan payload: %v", err)
+	}
+	return payload
+}
+
+func runRegressJSON(t *testing.T, baselinePath string, statePath string) map[string]any {
+	t.Helper()
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := cli.Run([]string{"regress", "run", "--baseline", baselinePath, "--state", statePath, "--json"}, &out, &errOut); code != 0 {
+		t.Fatalf("regress run failed: %d (%s)", code, errOut.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse regress payload: %v", err)
+	}
+	return payload
+}
+
+func runVerifyJSON(t *testing.T, statePath string) map[string]any {
+	t.Helper()
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := cli.Run([]string{"verify", "--chain", "--state", statePath, "--json"}, &out, &errOut); code != 0 {
+		t.Fatalf("verify failed: %d (%s)", code, errOut.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse verify payload: %v", err)
+	}
+	return payload
+}
+
+func assertEvidenceUnsafeExit8(t *testing.T, statePath string, outputDir string) {
+	t.Helper()
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := cli.Run([]string{"evidence", "--frameworks", "soc2", "--state", statePath, "--output", outputDir, "--json"}, &out, &errOut)
+	if code != 8 {
+		t.Fatalf("expected exit 8, got %d (stderr=%q)", code, errOut.String())
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected empty stdout on unsafe output-path failure, got %q", out.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(errOut.Bytes(), &payload); err != nil {
+		t.Fatalf("parse error payload: %v", err)
+	}
+	errObj, ok := payload["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing error object in %v", payload)
+	}
+	if errObj["code"] != "unsafe_operation_blocked" {
+		t.Fatalf("unexpected error code: %v", errObj["code"])
+	}
+	if errObj["exit_code"] != float64(8) {
+		t.Fatalf("unexpected error exit code: %v", errObj["exit_code"])
+	}
+}
+
+func normalizeVolatile(input map[string]any) map[string]any {
+	normalized := normalizeAny(input)
+	cast, _ := normalized.(map[string]any)
+	return cast
+}
+
+func normalizeAny(input any) any {
+	switch typed := input.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, value := range typed {
+			switch key {
+			case "generated_at", "exported_at", "timestamp", "created_at", "updated_at":
+				continue
+			default:
+				out[key] = normalizeAny(value)
+			}
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, value := range typed {
+			out = append(out, normalizeAny(value))
+		}
+		return out
+	default:
+		return typed
+	}
+}


### PR DESCRIPTION
## Problem
Epic 7 in `product/PLAN_v1.md` required deterministic contract enforcement, hardening/chaos/perf/soak coverage, and Tier 12 cross-product interop validation with CI lane wiring.

## Changes
- Added Story 7.1 Tier 9/Tier 11 coverage:
  - `testinfra/contracts/story7_contracts_test.go`
  - `internal/scenarios/contracts_test.go`
  - `internal/scenarios/coverage_map.json`
  - `internal/scenarios/epic7_scenario_test.go`
  - `scripts/validate_contracts.sh`
  - `scripts/validate_scenarios.sh`
- Added Story 7.2 hardening/chaos/perf/interop suite scaffolding:
  - `scripts/test_hardening_*.sh`, `scripts/test_chaos_*.sh`, `scripts/test_perf_budgets.sh`
  - `perf/bench_baseline.json`, `perf/runtime_slo_budgets.json`
  - `core/score/score_bench_test.go`, `core/risk/risk_bench_test.go`
  - `internal/integration/interop/interop_integration_test.go`
  - `scenarios/cross-product/**`
- Wired required lanes into `Makefile` and GitHub Actions (`pr`, `main`, `nightly`, `release`).

## Validation
- `make prepush-full`
- `make test-risk-lane`
- `go test ./...`
- `go test ./... -count=1`
- `go test ./testinfra/contracts -count=1`
- `scripts/validate_scenarios.sh`
- `go test ./internal/scenarios -count=1 -tags=scenario`
- `go test ./internal/integration -count=1`
- `go test -bench . -benchmem -count=5 ./core/...`
- `scripts/test_hardening_all.sh`
- `scripts/test_chaos_all.sh`
- `scripts/test_perf_budgets.sh`
- `wrkr scan --json` (temp fixture path/state)
