### PR TITLE
Fix hardening core suite symlink-manifest test coverage

### DIFF
--- a/scripts/test_hardening_core.sh
+++ b/scripts/test_hardening_core.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-go test ./core/evidence -run 'TestBuildEvidence(RejectsNonManagedNonEmptyOutputDir|RejectsMarkerDirectory|RejectsMarkerSymlink|RejectsSymlinkOutputDir|BuildManifestEntriesRejectsSymlinkFile)$' -count=1
+go test ./core/evidence -run 'TestBuildEvidence(RejectsNonManagedNonEmptyOutputDir|RejectsMarkerDirectory|RejectsMarkerSymlink|RejectsSymlinkOutputDir)|TestBuildManifestEntriesRejectsSymlinkFile$' -count=1
 go test ./core/source/github -run 'TestAcquireRepoRetriesTransientStatus$' -count=1
 go test ./core/verify -run 'TestChain(TamperDetected|MixedSourceCompatibility)$' -count=1


### PR DESCRIPTION
## Problem
PR #25 has an unresolved review finding: `scripts/test_hardening_core.sh` listed `TestBuildManifestEntriesRejectsSymlinkFile` inside a `TestBuildEvidence(...)` regex group, so that test name never matched and the hardening lane silently skipped the symlink-manifest guard.

## Changes
- Updated `scripts/test_hardening_core.sh` to run:
  - `TestBuildEvidence(...)` group for evidence guardrails
  - `TestBuildManifestEntriesRejectsSymlinkFile` as an explicit alternative in the same `-run` expression

## Validation
- `bash scripts/test_hardening_core.sh`
- `go run ./cmd/wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --state ./.tmp/ship-readiness-state-pr25.json --json > ./.tmp/ship-readiness-scan-pr25.json`
- `make prepush-full`
