### PR TITLE
scan: add workflow and governance modeling

### DIFF
--- a/core/aggregate/attackpath/graph.go
+++ b/core/aggregate/attackpath/graph.go
@@ -129,6 +129,15 @@ func buildRepoGraph(org string, repo string, findings []model.Finding) Graph {
 				addEdge(synthetic)
 			}
 		}
+		if strings.TrimSpace(finding.FindingType) == "ci_autonomy" || strings.TrimSpace(finding.FindingType) == "compiled_action" {
+			syntheticNodes, syntheticEdges := workflowRelationshipNodesAndEdges(org, repo, node, finding)
+			for _, synthetic := range syntheticNodes {
+				addNode(synthetic)
+			}
+			for _, synthetic := range syntheticEdges {
+				addEdge(synthetic)
+			}
+		}
 	}
 
 	sortNodes(entryNodes)
@@ -353,6 +362,37 @@ func syntheticNode(org, repo, kind, findingType, toolType, location, canonicalKe
 		Location:    node.Location,
 	})
 	return node
+}
+
+func workflowRelationshipNodesAndEdges(org string, repo string, workflowNode Node, finding model.Finding) ([]Node, []Edge) {
+	type capabilityTarget struct {
+		findingType string
+		rationale   string
+	}
+	targetsByCapability := map[string]capabilityTarget{
+		"pull_request.write": {findingType: "workflow_pull_request", rationale: "workflow_to_pull_request"},
+		"merge.execute":      {findingType: "workflow_merge_capability", rationale: "workflow_to_merge"},
+		"deploy.write":       {findingType: "workflow_deploy_capability", rationale: "workflow_to_deploy"},
+	}
+
+	nodes := make([]Node, 0, len(finding.Permissions))
+	edges := make([]Edge, 0, len(finding.Permissions))
+	seen := map[string]struct{}{}
+	for _, permission := range finding.Permissions {
+		capability := strings.ToLower(strings.TrimSpace(permission))
+		target, ok := targetsByCapability[capability]
+		if !ok {
+			continue
+		}
+		if _, exists := seen[capability]; exists {
+			continue
+		}
+		seen[capability] = struct{}{}
+		node := syntheticNode(org, repo, "target", target.findingType, capability, finding.Location, workflowNode.CanonicalKey+"|workflow:"+capability)
+		nodes = append(nodes, node)
+		edges = append(edges, newEdge(org, repo, workflowNode, node, target.rationale))
+	}
+	return nodes, edges
 }
 
 func splitEvidenceList(finding model.Finding, key string) []string {

--- a/core/aggregate/attackpath/graph_test.go
+++ b/core/aggregate/attackpath/graph_test.go
@@ -124,6 +124,48 @@ func TestAttackPathNodeEdgeIDs_AreDeterministic(t *testing.T) {
 	}
 }
 
+func TestAttackGraph_IncludesWorkflowDeliveryCapabilityEdges(t *testing.T) {
+	t.Parallel()
+
+	findings := []model.Finding{
+		{
+			FindingType: "prompt_channel_override",
+			ToolType:    "prompt_channel",
+			Location:    "AGENTS.md",
+			Repo:        "repo",
+			Org:         "acme",
+		},
+		{
+			FindingType: "ci_autonomy",
+			ToolType:    "ci_agent",
+			Location:    ".github/workflows/release.yml",
+			Repo:        "repo",
+			Org:         "acme",
+			Permissions: []string{"pull_request.write", "merge.execute", "deploy.write"},
+		},
+	}
+
+	graphs := Build(findings)
+	if len(graphs) != 1 {
+		t.Fatalf("expected one graph, got %d", len(graphs))
+	}
+	graph := graphs[0]
+	for _, want := range []string{
+		"target::workflow_pull_request::pull_request.write::.github/workflows/release.yml",
+		"target::workflow_merge_capability::merge.execute::.github/workflows/release.yml",
+		"target::workflow_deploy_capability::deploy.write::.github/workflows/release.yml",
+	} {
+		if !hasNode(graph.Nodes, want) {
+			t.Fatalf("expected workflow capability node %s in graph: %#v", want, graph.Nodes)
+		}
+	}
+	for _, want := range []string{"workflow_to_pull_request", "workflow_to_merge", "workflow_to_deploy"} {
+		if !hasEdgeRationale(graph.Edges, want) {
+			t.Fatalf("expected workflow rationale %s in graph edges: %#v", want, graph.Edges)
+		}
+	}
+}
+
 func TestAttackGraph_SeparatesSameFileAgentsByInstanceIdentity(t *testing.T) {
 	t.Parallel()
 

--- a/core/aggregate/inventory/inventory.go
+++ b/core/aggregate/inventory/inventory.go
@@ -15,9 +15,11 @@ import (
 )
 
 type ToolLocation struct {
-	Repo     string `json:"repo" yaml:"repo"`
-	Location string `json:"location" yaml:"location"`
-	Owner    string `json:"owner" yaml:"owner"`
+	Repo            string `json:"repo" yaml:"repo"`
+	Location        string `json:"location" yaml:"location"`
+	Owner           string `json:"owner" yaml:"owner"`
+	OwnerSource     string `json:"owner_source,omitempty" yaml:"owner_source,omitempty"`
+	OwnershipStatus string `json:"ownership_status,omitempty" yaml:"ownership_status,omitempty"`
 }
 
 type Agent struct {
@@ -300,11 +302,17 @@ func Build(input BuildInput) Inventory {
 		if finding.Repo != "" {
 			item.repoSet[finding.Repo] = struct{}{}
 		}
-		owner := owners.ResolveOwner(repoRoot(input.Manifest, finding.Repo), finding.Repo, findingOrg, finding.Location)
+		owner := owners.Resolve(repoRoot(input.Manifest, finding.Repo), finding.Repo, findingOrg, finding.Location)
 		locKey := finding.Repo + "::" + finding.Location
 		if _, exists := item.locSet[locKey]; !exists {
 			item.locSet[locKey] = struct{}{}
-			item.tool.Locations = append(item.tool.Locations, ToolLocation{Repo: finding.Repo, Location: finding.Location, Owner: owner})
+			item.tool.Locations = append(item.tool.Locations, ToolLocation{
+				Repo:            finding.Repo,
+				Location:        finding.Location,
+				Owner:           owner.Owner,
+				OwnerSource:     owner.OwnerSource,
+				OwnershipStatus: owner.OwnershipStatus,
+			})
 		}
 		for _, permission := range finding.Permissions {
 			trimmed := strings.TrimSpace(permission)
@@ -348,6 +356,12 @@ func Build(input BuildInput) Inventory {
 			}
 			if item.tool.Locations[i].Location != item.tool.Locations[j].Location {
 				return item.tool.Locations[i].Location < item.tool.Locations[j].Location
+			}
+			if item.tool.Locations[i].OwnerSource != item.tool.Locations[j].OwnerSource {
+				return item.tool.Locations[i].OwnerSource < item.tool.Locations[j].OwnerSource
+			}
+			if item.tool.Locations[i].OwnershipStatus != item.tool.Locations[j].OwnershipStatus {
+				return item.tool.Locations[i].OwnershipStatus < item.tool.Locations[j].OwnershipStatus
 			}
 			return item.tool.Locations[i].Owner < item.tool.Locations[j].Owner
 		})

--- a/core/aggregate/inventory/inventory_test.go
+++ b/core/aggregate/inventory/inventory_test.go
@@ -1,6 +1,8 @@
 package inventory
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -130,6 +132,46 @@ func TestBuildMethodologyMetadataPassThrough(t *testing.T) {
 	}
 	if inv.Tools[0].PermissionTier != "none" || inv.Tools[0].RiskTier != "low" {
 		t.Fatalf("unexpected permission/risk tiers: %+v", inv.Tools[0])
+	}
+}
+
+func TestBuildAddsOwnershipProvenanceToToolLocations(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoRoot, "CODEOWNERS"), []byte(".github/workflows/* @acme/security\n"), 0o600); err != nil {
+		t.Fatalf("write CODEOWNERS: %v", err)
+	}
+	manifest := source.Manifest{
+		Target: source.Target{Mode: "repo", Value: "acme/payments-prod"},
+		Repos:  []source.RepoManifest{{Repo: "acme/payments-prod", Location: repoRoot}},
+	}
+	findings := []model.Finding{
+		{FindingType: "ci_autonomy", ToolType: "ci_agent", Location: ".github/workflows/release.yml", Repo: "acme/payments-prod", Org: "acme"},
+		{FindingType: "compiled_action", ToolType: "compiled_action", Location: ".github/workflows/release.yml", Repo: "acme/payments-prod", Org: "acme"},
+	}
+	ctx := map[string]ToolContext{
+		KeyForFinding(findings[0]): {RiskScore: 8.2, EndpointClass: "workspace", DataClass: "code", AutonomyLevel: "headless_auto", ApprovalStatus: "missing", LifecycleState: identity.StateDiscovered},
+		KeyForFinding(findings[1]): {RiskScore: 7.8, EndpointClass: "workspace", DataClass: "code", AutonomyLevel: "headless_auto", ApprovalStatus: "missing", LifecycleState: identity.StateDiscovered},
+	}
+
+	inv := Build(BuildInput{
+		Manifest:              manifest,
+		Findings:              findings,
+		Contexts:              ctx,
+		RepoExposureSummaries: []exposure.RepoExposureSummary{},
+		GeneratedAt:           time.Date(2026, 3, 25, 12, 0, 0, 0, time.UTC),
+	})
+
+	if len(inv.Tools) == 0 || len(inv.Tools[0].Locations) == 0 {
+		t.Fatalf("expected tool locations, got %+v", inv.Tools)
+	}
+	location := inv.Tools[0].Locations[0]
+	if location.Owner != "@acme/security" {
+		t.Fatalf("expected CODEOWNERS owner, got %+v", location)
+	}
+	if location.OwnerSource != "codeowners" || location.OwnershipStatus != "explicit" {
+		t.Fatalf("expected explicit CODEOWNERS provenance, got %+v", location)
 	}
 }
 

--- a/core/aggregate/inventory/privileges.go
+++ b/core/aggregate/inventory/privileges.go
@@ -48,6 +48,15 @@ type AgentPrivilegeMapEntry struct {
 	DeploymentStatus         string               `json:"deployment_status,omitempty" yaml:"deployment_status,omitempty"`
 	DeploymentArtifacts      []string             `json:"deployment_artifacts,omitempty" yaml:"deployment_artifacts,omitempty"`
 	DeploymentEvidenceKeys   []string             `json:"deployment_evidence_keys,omitempty" yaml:"deployment_evidence_keys,omitempty"`
+	OperationalOwner         string               `json:"operational_owner,omitempty" yaml:"operational_owner,omitempty"`
+	OwnerSource              string               `json:"owner_source,omitempty" yaml:"owner_source,omitempty"`
+	OwnershipStatus          string               `json:"ownership_status,omitempty" yaml:"ownership_status,omitempty"`
+	ApprovalGapReasons       []string             `json:"approval_gap_reasons,omitempty" yaml:"approval_gap_reasons,omitempty"`
+	PullRequestWrite         bool                 `json:"pull_request_write,omitempty" yaml:"pull_request_write,omitempty"`
+	MergeExecute             bool                 `json:"merge_execute,omitempty" yaml:"merge_execute,omitempty"`
+	DeployWrite              bool                 `json:"deploy_write,omitempty" yaml:"deploy_write,omitempty"`
+	DeliveryChainStatus      string               `json:"delivery_chain_status,omitempty" yaml:"delivery_chain_status,omitempty"`
+	ProductionTargetStatus   string               `json:"production_target_status,omitempty" yaml:"production_target_status,omitempty"`
 	WriteCapable             bool                 `json:"write_capable" yaml:"write_capable"`
 	CredentialAccess         bool                 `json:"credential_access" yaml:"credential_access"`
 	ExecCapable              bool                 `json:"exec_capable" yaml:"exec_capable"`

--- a/core/aggregate/privilegebudget/budget.go
+++ b/core/aggregate/privilegebudget/budget.go
@@ -8,6 +8,7 @@ import (
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/identity"
 	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/owners"
 	"github.com/Clyra-AI/wrkr/core/policy/productiontargets"
 )
 
@@ -78,6 +79,9 @@ func Build(
 			writeCapable := hasAnyPermission(tool.Permissions, writeSet)
 			credentialAccess := hasCredentialAccess(tool)
 			execCapable := hasExecPermission(tool.Permissions)
+			pullRequestWrite := hasExactPermission(tool.Permissions, "pull_request.write")
+			mergeExecute := hasExactPermission(tool.Permissions, "merge.execute")
+			deployWrite := hasExactPermission(tool.Permissions, "deploy.write")
 
 			matchedTargets := []string{}
 			productionWrite := false
@@ -92,6 +96,8 @@ func Build(
 			if deploymentStatus == "" {
 				deploymentStatus = "unknown"
 			}
+			approvalReasons := approvalGapReasons(signalsByAgent[tool.AgentID], tool.Permissions, deploymentStatus)
+			owner := resolveOperationalOwner(tool, tool.Repos, "", tool.Org)
 
 			entries = append(entries, agginventory.AgentPrivilegeMapEntry{
 				AgentID:                  tool.AgentID,
@@ -101,6 +107,7 @@ func Build(
 				Org:                      tool.Org,
 				Repos:                    cloneStringSlice(tool.Repos),
 				Permissions:              cloneStringSlice(tool.Permissions),
+				Location:                 primaryLocation(tool),
 				EndpointClass:            tool.EndpointClass,
 				DataClass:                tool.DataClass,
 				AutonomyLevel:            tool.AutonomyLevel,
@@ -114,6 +121,15 @@ func Build(
 				DeploymentStatus:         deploymentStatus,
 				DeploymentArtifacts:      cloneStringSlice(agentContext.DeploymentArtifacts),
 				DeploymentEvidenceKeys:   cloneStringSlice(agentContext.DeploymentEvidenceKeys),
+				OperationalOwner:         owner.Owner,
+				OwnerSource:              owner.OwnerSource,
+				OwnershipStatus:          owner.OwnershipStatus,
+				ApprovalGapReasons:       approvalReasons,
+				PullRequestWrite:         pullRequestWrite,
+				MergeExecute:             mergeExecute,
+				DeployWrite:              deployWrite,
+				DeliveryChainStatus:      deliveryChainStatus(pullRequestWrite, mergeExecute, deployWrite),
+				ProductionTargetStatus:   currentProductionTargetStatus(productionConfigured),
 				WriteCapable:             writeCapable,
 				CredentialAccess:         credentialAccess,
 				ExecCapable:              execCapable,
@@ -231,6 +247,9 @@ func buildInstanceEntries(
 		writeCapable := hasAnyPermission(permissions, writeSet)
 		credentialAccess := hasCredentialAccessForSurface(dataClass, permissions, agent.BoundAuthSurfaces)
 		execCapable := hasExecPermission(permissions)
+		pullRequestWrite := hasExactPermission(permissions, "pull_request.write")
+		mergeExecute := hasExactPermission(permissions, "merge.execute")
+		deployWrite := hasExactPermission(permissions, "deploy.write")
 		matchedTargets := []string{}
 		productionWrite := false
 		if productionConfigured && productionRules != nil && writeCapable {
@@ -242,6 +261,8 @@ func buildInstanceEntries(
 		if deploymentStatus == "" {
 			deploymentStatus = "unknown"
 		}
+		approvalReasons := approvalGapReasons(signals, permissions, deploymentStatus)
+		owner := resolveOperationalOwner(tool, repos, strings.TrimSpace(agent.Location), org)
 
 		entries = append(entries, agginventory.AgentPrivilegeMapEntry{
 			AgentID:                  strings.TrimSpace(agent.AgentID),
@@ -268,6 +289,15 @@ func buildInstanceEntries(
 			DeploymentStatus:         deploymentStatus,
 			DeploymentArtifacts:      cloneStringSlice(agent.DeploymentArtifacts),
 			DeploymentEvidenceKeys:   cloneStringSlice(agent.DeploymentEvidenceKeys),
+			OperationalOwner:         owner.Owner,
+			OwnerSource:              owner.OwnerSource,
+			OwnershipStatus:          owner.OwnershipStatus,
+			ApprovalGapReasons:       approvalReasons,
+			PullRequestWrite:         pullRequestWrite,
+			MergeExecute:             mergeExecute,
+			DeployWrite:              deployWrite,
+			DeliveryChainStatus:      deliveryChainStatus(pullRequestWrite, mergeExecute, deployWrite),
+			ProductionTargetStatus:   currentProductionTargetStatus(productionConfigured),
 			WriteCapable:             writeCapable,
 			CredentialAccess:         credentialAccess,
 			ExecCapable:              execCapable,
@@ -608,6 +638,259 @@ func hasCredentialAccessForSurface(dataClass string, permissions []string, authS
 func hasExecPermission(permissions []string) bool {
 	for _, permission := range permissions {
 		if normalizeToken(permission) == "proc.exec" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExactPermission(permissions []string, target string) bool {
+	target = normalizeToken(target)
+	for _, permission := range permissions {
+		if normalizeToken(permission) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func deliveryChainStatus(pullRequestWrite, mergeExecute, deployWrite bool) string {
+	switch {
+	case pullRequestWrite && mergeExecute && deployWrite:
+		return "pr_merge_deploy"
+	case mergeExecute && deployWrite:
+		return "merge_deploy"
+	case pullRequestWrite && mergeExecute:
+		return "pr_merge"
+	case deployWrite:
+		return "deploy_only"
+	case pullRequestWrite:
+		return "pr_only"
+	case mergeExecute:
+		return "merge_only"
+	default:
+		return "none"
+	}
+}
+
+func currentProductionTargetStatus(productionConfigured bool) string {
+	if productionConfigured {
+		return agginventory.ProductionTargetsStatusConfigured
+	}
+	return agginventory.ProductionTargetsStatusNotConfigured
+}
+
+func resolveOperationalOwner(tool agginventory.Tool, repos []string, location string, org string) owners.Resolution {
+	type candidate struct {
+		owner           string
+		ownerSource     string
+		ownershipStatus string
+	}
+	candidates := map[string]candidate{}
+	trimmedLocation := strings.TrimSpace(location)
+	for _, item := range tool.Locations {
+		if trimmedLocation != "" && strings.TrimSpace(item.Location) != trimmedLocation {
+			continue
+		}
+		if len(repos) > 0 && !containsString(repos, item.Repo) {
+			continue
+		}
+		key := strings.Join([]string{
+			strings.TrimSpace(item.Owner),
+			strings.TrimSpace(item.OwnerSource),
+			strings.TrimSpace(item.OwnershipStatus),
+		}, "|")
+		candidates[key] = candidate{
+			owner:           strings.TrimSpace(item.Owner),
+			ownerSource:     strings.TrimSpace(item.OwnerSource),
+			ownershipStatus: strings.TrimSpace(item.OwnershipStatus),
+		}
+	}
+	if len(candidates) == 0 {
+		return fallbackOperationalOwner(repos, org)
+	}
+
+	ownerSet := map[string]candidate{}
+	for _, item := range candidates {
+		current, exists := ownerSet[item.owner]
+		if !exists || ownershipPriority(item.ownershipStatus) < ownershipPriority(current.ownershipStatus) {
+			ownerSet[item.owner] = item
+		}
+	}
+	if len(ownerSet) == 1 {
+		for _, item := range ownerSet {
+			return owners.Resolution{
+				Owner:           item.owner,
+				OwnerSource:     item.ownerSource,
+				OwnershipStatus: item.ownershipStatus,
+			}
+		}
+	}
+
+	fallback := fallbackOperationalOwner(repos, org)
+	fallback.OwnerSource = owners.OwnerSourceConflict
+	fallback.OwnershipStatus = owners.OwnershipStatusUnresolved
+	return fallback
+}
+
+func fallbackOperationalOwner(repos []string, org string) owners.Resolution {
+	repo := ""
+	if len(repos) > 0 {
+		sortedRepos := append([]string(nil), repos...)
+		sort.Strings(sortedRepos)
+		repo = strings.TrimSpace(sortedRepos[0])
+	}
+	status := owners.OwnershipStatusInferred
+	if repo == "" {
+		status = owners.OwnershipStatusUnresolved
+	}
+	return owners.Resolution{
+		Owner:           owners.FallbackOwner(repo, org),
+		OwnerSource:     owners.OwnerSourceRepoFallback,
+		OwnershipStatus: status,
+	}
+}
+
+func primaryLocation(tool agginventory.Tool) string {
+	if len(tool.Locations) == 0 {
+		return ""
+	}
+	locations := append([]agginventory.ToolLocation(nil), tool.Locations...)
+	sort.Slice(locations, func(i, j int) bool {
+		if locations[i].Repo != locations[j].Repo {
+			return locations[i].Repo < locations[j].Repo
+		}
+		return locations[i].Location < locations[j].Location
+	})
+	return strings.TrimSpace(locations[0].Location)
+}
+
+func containsString(values []string, target string) bool {
+	target = strings.TrimSpace(target)
+	for _, value := range values {
+		if strings.TrimSpace(value) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func ownershipPriority(status string) int {
+	switch strings.TrimSpace(status) {
+	case owners.OwnershipStatusExplicit:
+		return 0
+	case owners.OwnershipStatusInferred:
+		return 1
+	default:
+		return 2
+	}
+}
+
+func approvalGapReasons(signals findingSignals, permissions []string, deploymentStatus string) []string {
+	reasons := []string{}
+	hasDeliveryPath := hasWriteLikePermission(permissions) ||
+		hasExactPermission(permissions, "pull_request.write") ||
+		hasExactPermission(permissions, "merge.execute") ||
+		hasExactPermission(permissions, "deploy.write") ||
+		strings.TrimSpace(deploymentStatus) == "deployed" ||
+		boolSignalState(signals.EvidenceKV["auto_deploy"]) == "true"
+	if !hasDeliveryPath {
+		return nil
+	}
+
+	switch stringSignalState(signals.EvidenceKV["approval_source"], "missing") {
+	case "missing":
+		reasons = append(reasons, "approval_source_missing")
+	case "ambiguous":
+		reasons = append(reasons, "approval_source_ambiguous")
+	}
+
+	switch stringSignalState(signals.EvidenceKV["deployment_gate"], "missing") {
+	case "missing":
+		reasons = append(reasons, "deployment_gate_missing")
+	case "open":
+		reasons = append(reasons, "deployment_gate_open")
+	case "ambiguous":
+		reasons = append(reasons, "deployment_gate_ambiguous")
+	}
+
+	if boolSignalState(signals.EvidenceKV["auto_deploy"]) == "true" {
+		switch boolSignalState(signals.EvidenceKV["human_gate"]) {
+		case "missing":
+			reasons = append(reasons, "human_gate_missing")
+		case "false":
+			reasons = append(reasons, "auto_deploy_without_human_gate")
+		case "mixed":
+			reasons = append(reasons, "human_gate_ambiguous")
+		}
+	}
+
+	switch stringSignalState(signals.EvidenceKV["proof_requirement"], "missing") {
+	case "missing":
+		reasons = append(reasons, "proof_requirement_missing")
+	case "ambiguous":
+		reasons = append(reasons, "proof_requirement_ambiguous")
+	}
+
+	if len(reasons) == 0 {
+		return nil
+	}
+	return dedupeSortedPreserveCase(reasons)
+}
+
+func stringSignalState(values []string, missing string) string {
+	if len(values) == 0 {
+		return missing
+	}
+	normalized := dedupeSorted(values)
+	if len(normalized) == 1 {
+		return normalized[0]
+	}
+	if len(normalized) == 2 {
+		onlyMissing := 0
+		for _, value := range normalized {
+			if value == missing {
+				onlyMissing++
+			}
+		}
+		if onlyMissing == 1 {
+			for _, value := range normalized {
+				if value != missing {
+					return value
+				}
+			}
+		}
+	}
+	return "ambiguous"
+}
+
+func boolSignalState(values []string) string {
+	if len(values) == 0 {
+		return "missing"
+	}
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		switch strings.TrimSpace(strings.ToLower(value)) {
+		case "true", "1", "yes", "enabled":
+			seen["true"] = struct{}{}
+		case "false", "0", "no", "disabled":
+			seen["false"] = struct{}{}
+		default:
+			seen["mixed"] = struct{}{}
+		}
+	}
+	if len(seen) == 1 {
+		for value := range seen {
+			return value
+		}
+	}
+	return "mixed"
+}
+
+func hasWriteLikePermission(permissions []string) bool {
+	for _, permission := range permissions {
+		normalized := strings.ToLower(strings.TrimSpace(permission))
+		if strings.Contains(normalized, "write") || strings.Contains(normalized, "deploy") || normalized == "merge.execute" {
 			return true
 		}
 	}

--- a/core/aggregate/privilegebudget/budget_test.go
+++ b/core/aggregate/privilegebudget/budget_test.go
@@ -250,6 +250,54 @@ func TestBuildIncludesAgentLayerContextDeterministically(t *testing.T) {
 	}
 }
 
+func TestBuildDerivesOperationalOwnerAndApprovalGapReasons(t *testing.T) {
+	t.Parallel()
+
+	tools := []agginventory.Tool{
+		{
+			ToolID:      "workflow-1",
+			AgentID:     identity.AgentID(identity.ToolID("compiled_action", ".github/workflows/release.yml"), "local"),
+			ToolType:    "compiled_action",
+			Org:         "local",
+			Repos:       []string{"alpha-service", "beta-service"},
+			Permissions: []string{"deploy.write", "pull_request.write"},
+			Locations: []agginventory.ToolLocation{
+				{Repo: "alpha-service", Location: ".github/workflows/release.yml", Owner: "@local/alpha", OwnerSource: "codeowners", OwnershipStatus: "explicit"},
+				{Repo: "beta-service", Location: ".github/workflows/release.yml", Owner: "@local/beta", OwnerSource: "codeowners", OwnershipStatus: "explicit"},
+			},
+		},
+	}
+	findings := []model.Finding{
+		{
+			FindingType: "compiled_action",
+			ToolType:    "compiled_action",
+			Location:    ".github/workflows/release.yml",
+			Repo:        "alpha-service",
+			Org:         "local",
+			Permissions: []string{"deploy.write", "pull_request.write"},
+			Evidence: []model.Evidence{
+				{Key: "auto_deploy", Value: "true"},
+				{Key: "approval_source", Value: "missing"},
+				{Key: "deployment_gate", Value: "ambiguous"},
+				{Key: "proof_requirement", Value: "missing"},
+			},
+		},
+	}
+
+	_, entries := Build(tools, nil, findings, nil)
+	if len(entries) != 1 {
+		t.Fatalf("expected one privilege entry, got %+v", entries)
+	}
+	if entries[0].OwnershipStatus != "unresolved" || entries[0].OwnerSource != "multi_repo_conflict" {
+		t.Fatalf("expected unresolved operational owner, got %+v", entries[0])
+	}
+	for _, reason := range []string{"approval_source_missing", "deployment_gate_ambiguous", "proof_requirement_missing"} {
+		if !containsString(entries[0].ApprovalGapReasons, reason) {
+			t.Fatalf("expected approval gap reason %q in %+v", reason, entries[0].ApprovalGapReasons)
+		}
+	}
+}
+
 func TestBuildResolvesInstanceScopedAgentContextForToolEntries(t *testing.T) {
 	t.Parallel()
 

--- a/core/cli/root_test.go
+++ b/core/cli/root_test.go
@@ -987,6 +987,123 @@ func TestScanProductionTargetsMissingStrictFails(t *testing.T) {
 	}
 }
 
+func TestScanActionPathsCarryDeliveryChainAndProductionTargetStatus(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                string
+		productionTargets   string
+		wantStatus          string
+		wantProductionWrite bool
+		wantAction          string
+	}{
+		{
+			name: "configured",
+			productionTargets: `
+schema_version: v1
+targets:
+  repos:
+    exact:
+      - payments-prod
+`,
+			wantStatus:          "configured",
+			wantProductionWrite: true,
+			wantAction:          "control",
+		},
+		{
+			name:                "not configured",
+			productionTargets:   "",
+			wantStatus:          "not_configured",
+			wantProductionWrite: false,
+			wantAction:          "approval",
+		},
+		{
+			name:                "invalid",
+			productionTargets:   "schema_version: v2\n",
+			wantStatus:          "invalid",
+			wantProductionWrite: false,
+			wantAction:          "approval",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmp := t.TempDir()
+			reposPath := filepath.Join(tmp, "repos")
+			repoPath := filepath.Join(reposPath, "payments-prod")
+			if err := os.MkdirAll(filepath.Join(repoPath, ".github", "workflows"), 0o755); err != nil {
+				t.Fatalf("mkdir workflow dir: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(repoPath, ".github", "workflows", "release.yml"), []byte(`name: release
+on:
+  pull_request:
+    branches: [main]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: codex --full-auto --approval never
+      - run: gh pr merge --auto "$PR_URL"
+      - run: kubectl apply -f k8s/
+`), 0o600); err != nil {
+				t.Fatalf("write workflow: %v", err)
+			}
+
+			args := []string{"scan", "--path", reposPath, "--state", filepath.Join(tmp, "state.json"), "--json"}
+			if tc.productionTargets != "" {
+				targetsPath := filepath.Join(tmp, "production-targets.yaml")
+				if err := os.WriteFile(targetsPath, []byte(tc.productionTargets), 0o600); err != nil {
+					t.Fatalf("write production targets: %v", err)
+				}
+				args = append(args, "--production-targets", targetsPath)
+			}
+
+			var out bytes.Buffer
+			var errOut bytes.Buffer
+			code := Run(args, &out, &errOut)
+			if code != 0 {
+				t.Fatalf("scan failed: %d %s", code, errOut.String())
+			}
+
+			var payload map[string]any
+			if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+				t.Fatalf("parse scan output: %v", err)
+			}
+			actionPaths, ok := payload["action_paths"].([]any)
+			if !ok || len(actionPaths) == 0 {
+				t.Fatalf("expected action_paths payload, got %v", payload["action_paths"])
+			}
+			first, ok := actionPaths[0].(map[string]any)
+			if !ok {
+				t.Fatalf("unexpected action path payload: %T", actionPaths[0])
+			}
+			for _, key := range []string{"pull_request_write", "merge_execute", "deploy_write"} {
+				if first[key] != true {
+					t.Fatalf("expected %s=true, got %v", key, first[key])
+				}
+			}
+			if first["delivery_chain_status"] != "pr_merge_deploy" {
+				t.Fatalf("expected full delivery chain status, got %v", first["delivery_chain_status"])
+			}
+			if first["production_target_status"] != tc.wantStatus {
+				t.Fatalf("expected production_target_status=%s, got %v", tc.wantStatus, first["production_target_status"])
+			}
+			if first["production_write"] != tc.wantProductionWrite {
+				t.Fatalf("expected production_write=%t, got %v", tc.wantProductionWrite, first["production_write"])
+			}
+			if first["recommended_action"] != tc.wantAction {
+				t.Fatalf("expected recommended_action=%s, got %v", tc.wantAction, first["recommended_action"])
+			}
+		})
+	}
+}
+
 func TestScanProductionTargetsStrictWithoutPathFails(t *testing.T) {
 	t.Parallel()
 

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -269,6 +269,9 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	if !inventoryOut.PrivilegeBudget.ProductionWrite.Configured {
 		inventoryOut.PrivilegeBudget.ProductionWrite.Count = nil
 	}
+	for idx := range inventoryOut.AgentPrivilegeMap {
+		inventoryOut.AgentPrivilegeMap[idx].ProductionTargetStatus = productionWriteStatus
+	}
 	agginventory.ApplySecurityVisibilityToPrivilegeMap(&inventoryOut)
 	riskReport.ActionPaths, riskReport.ActionPathToControlFirst = risk.BuildActionPaths(riskReport.AttackPaths, &inventoryOut)
 

--- a/core/detect/agentframework/detector.go
+++ b/core/detect/agentframework/detector.go
@@ -21,6 +21,8 @@ type AgentSpec struct {
 	Deployment       []string `json:"deployment_artifacts" yaml:"deployment_artifacts" toml:"deployment_artifacts"`
 	DataClass        string   `json:"data_class" yaml:"data_class" toml:"data_class"`
 	ApprovalStatus   string   `json:"approval_status" yaml:"approval_status" toml:"approval_status"`
+	ApprovalSource   string   `json:"approval_source" yaml:"approval_source" toml:"approval_source"`
+	ProofRequirement string   `json:"proof_requirement" yaml:"proof_requirement" toml:"proof_requirement"`
 	DynamicDiscovery bool     `json:"dynamic_discovery" yaml:"dynamic_discovery" toml:"dynamic_discovery"`
 	KillSwitch       bool     `json:"kill_switch" yaml:"kill_switch" toml:"kill_switch"`
 	AutoDeploy       bool     `json:"auto_deploy" yaml:"auto_deploy" toml:"auto_deploy"`
@@ -196,6 +198,8 @@ func frameworkFinding(scope detect.Scope, cfg DetectorConfig, agent AgentSpec) m
 		{Key: "deployment_status", Value: deploymentStatus},
 		{Key: "data_class", Value: fallback(strings.TrimSpace(agent.DataClass), "unknown")},
 		{Key: "approval_status", Value: fallback(strings.TrimSpace(agent.ApprovalStatus), "missing")},
+		{Key: "approval_source", Value: normalizeApprovalSource(agent)},
+		{Key: "proof_requirement", Value: normalizeProofRequirement(agent, deploymentStatus)},
 		{Key: "dynamic_discovery", Value: fmt.Sprintf("%t", agent.DynamicDiscovery)},
 		{Key: "kill_switch", Value: fmt.Sprintf("%t", agent.KillSwitch)},
 		{Key: "auto_deploy", Value: fmt.Sprintf("%t", agent.AutoDeploy)},
@@ -329,10 +333,35 @@ func deriveDeploymentGate(agent AgentSpec) string {
 	if !agent.AutoDeploy {
 		return ""
 	}
-	if agent.HumanGate {
+	if agent.HumanGate && normalizeApprovalSource(agent) != "missing" {
 		return "enforced"
 	}
+	if agent.HumanGate {
+		return "ambiguous"
+	}
+	return "open"
+}
+
+func normalizeApprovalSource(agent AgentSpec) string {
+	explicit := strings.ToLower(strings.TrimSpace(agent.ApprovalSource))
+	if explicit != "" {
+		return explicit
+	}
+	if agent.AutoDeploy {
+		return "missing"
+	}
 	return "missing"
+}
+
+func normalizeProofRequirement(agent AgentSpec, deploymentStatus string) string {
+	explicit := strings.ToLower(strings.TrimSpace(agent.ProofRequirement))
+	if explicit != "" {
+		return explicit
+	}
+	if agent.AutoDeploy || deploymentStatus == "deployed" {
+		return "missing"
+	}
+	return "not_applicable"
 }
 
 func mergeFrameworkFindings(findings []model.Finding) []model.Finding {

--- a/core/detect/agentframework/detector_test.go
+++ b/core/detect/agentframework/detector_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Clyra-AI/wrkr/core/model"
 )
 
-func TestDetect_DefaultsDeploymentGateFromHumanGate(t *testing.T) {
+func TestDetect_DefaultsDeploymentGateToAmbiguousWithoutApprovalSource(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -36,8 +36,8 @@ func TestDetect_DefaultsDeploymentGateFromHumanGate(t *testing.T) {
 	if len(findings) != 1 {
 		t.Fatalf("expected one finding, got %d", len(findings))
 	}
-	if value := evidenceValue(findings[0], "deployment_gate"); value != "enforced" {
-		t.Fatalf("expected deployment_gate=enforced, got %q", value)
+	if value := evidenceValue(findings[0], "deployment_gate"); value != "ambiguous" {
+		t.Fatalf("expected deployment_gate=ambiguous, got %q", value)
 	}
 }
 
@@ -68,6 +68,40 @@ func TestDetect_UsesExplicitDeploymentGate(t *testing.T) {
 	}
 	if value := evidenceValue(findings[0], "deployment_gate"); value != "approved" {
 		t.Fatalf("expected deployment_gate=approved, got %q", value)
+	}
+}
+
+func TestDetect_EmitsApprovalSourceAndProofRequirement(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	configPath := ".wrkr/agents/langchain.yaml"
+	writeFile(t, root, configPath, `agents:
+  - name: release_agent
+    file: agents/release.py
+    auto_deploy: true
+    human_gate: true
+    approval_source: manual_approval_step
+    proof_requirement: attestation
+`)
+
+	findings, err := Detect(context.Background(), detect.Scope{Org: "acme", Repo: "payments", Root: root}, DetectorConfig{
+		DetectorID: "agentframework_langchain",
+		Framework:  "langchain",
+		ConfigPath: configPath,
+		Format:     "yaml",
+	})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+	if value := evidenceValue(findings[0], "approval_source"); value != "manual_approval_step" {
+		t.Fatalf("expected approval_source=manual_approval_step, got %q", value)
+	}
+	if value := evidenceValue(findings[0], "proof_requirement"); value != "attestation" {
+		t.Fatalf("expected proof_requirement=attestation, got %q", value)
 	}
 }
 

--- a/core/detect/agentframework/source.go
+++ b/core/detect/agentframework/source.go
@@ -523,6 +523,8 @@ func sourceAgentSpec(rel, content, block, variableName, callName string, startLi
 		firstNamedString(block, []string{"approval_status", "approvalStatus"}),
 		"missing",
 	)
+	approvalSource := firstNamedString(block, []string{"approval_source", "approvalSource"})
+	proofRequirement := firstNamedString(block, []string{"proof_requirement", "proofRequirement"})
 
 	return AgentSpec{
 		Name:             symbol,
@@ -535,6 +537,8 @@ func sourceAgentSpec(rel, content, block, variableName, callName string, startLi
 		Deployment:       uniqueSorted(deployment),
 		DataClass:        dataClass,
 		ApprovalStatus:   approvalStatus,
+		ApprovalSource:   approvalSource,
+		ProofRequirement: proofRequirement,
 		DynamicDiscovery: hasAnyKeyword(block, "handoff", "handoffs", "delegate", "delegation", "dynamic_discovery", "discover_tools", "tool_registry", "register_tool"),
 		KillSwitch:       extractNamedBool(block, []string{"kill_switch", "killSwitch"}),
 		AutoDeploy:       extractNamedBool(block, []string{"auto_deploy", "autoDeploy"}),
@@ -564,6 +568,8 @@ func sourceFinding(scope detect.Scope, plan sourcePlan, agent AgentSpec, languag
 		{Key: "deployment_status", Value: deploymentStatus},
 		{Key: "data_class", Value: fallback(strings.TrimSpace(agent.DataClass), "unknown")},
 		{Key: "approval_status", Value: fallback(strings.TrimSpace(agent.ApprovalStatus), "missing")},
+		{Key: "approval_source", Value: normalizeApprovalSource(agent)},
+		{Key: "proof_requirement", Value: normalizeProofRequirement(agent, deploymentStatus)},
 		{Key: "dynamic_discovery", Value: fmt.Sprintf("%t", agent.DynamicDiscovery)},
 		{Key: "kill_switch", Value: fmt.Sprintf("%t", agent.KillSwitch)},
 		{Key: "auto_deploy", Value: fmt.Sprintf("%t", agent.AutoDeploy)},

--- a/core/detect/ciagent/detector.go
+++ b/core/detect/ciagent/detector.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Clyra-AI/wrkr/core/detect"
+	"github.com/Clyra-AI/wrkr/core/detect/workflowcap"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/risk/autonomy"
 )
@@ -45,12 +46,32 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 			return nil, readErr
 		}
 		content := string(payload)
+		workflowAnalysis, workflowErr := workflowcap.Analyze(rel, payload)
 		signals := autonomy.Signals{
-			Tool:            detectTool(content),
-			Headless:        isHeadlessInvocation(content),
-			HasApprovalGate: hasApprovalGate(content),
-			HasSecretAccess: hasSecretAccess(content),
-			DangerousFlags:  hasDangerousFlags(content),
+			Tool:            workflowAnalysis.Tool,
+			Headless:        workflowAnalysis.Headless,
+			HasApprovalGate: workflowAnalysis.HasApprovalGate,
+			HasSecretAccess: workflowAnalysis.HasSecretAccess,
+			DangerousFlags:  workflowAnalysis.DangerousFlags,
+		}
+		if workflowErr != nil {
+			signals.Tool = detectTool(content)
+			signals.Headless = isHeadlessInvocation(content)
+			signals.HasApprovalGate = hasApprovalGate(content)
+			signals.HasSecretAccess = hasSecretAccess(content)
+			signals.DangerousFlags = hasDangerousFlags(content)
+		}
+		if signals.Tool == "" {
+			signals.Tool = detectTool(content)
+		}
+		if !signals.Headless {
+			signals.Headless = isHeadlessInvocation(content)
+		}
+		if !signals.HasSecretAccess {
+			signals.HasSecretAccess = hasSecretAccess(content)
+		}
+		if !signals.DangerousFlags {
+			signals.DangerousFlags = hasDangerousFlags(content)
 		}
 		if !signals.Headless && signals.Tool == "" {
 			continue
@@ -60,6 +81,20 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 		checkResult := model.CheckResultPass
 		if signals.Headless && signals.HasSecretAccess && !signals.HasApprovalGate {
 			checkResult = model.CheckResultFail
+		}
+		evidence := []model.Evidence{
+			{Key: "tool", Value: signals.Tool},
+			{Key: "headless", Value: boolString(signals.Headless)},
+			{Key: "approval_gate", Value: boolString(signals.HasApprovalGate)},
+			{Key: "secret_access", Value: boolString(signals.HasSecretAccess)},
+			{Key: "dangerous_flags", Value: boolString(signals.DangerousFlags)},
+		}
+		if workflowErr == nil {
+			evidence = append(evidence, workflowAnalysis.Evidence...)
+		}
+		permissions := permissionsFromSignals(signals)
+		if workflowErr == nil {
+			permissions = append(permissions, workflowAnalysis.Capabilities...)
 		}
 		findings = append(findings, model.Finding{
 			FindingType: "ci_autonomy",
@@ -71,14 +106,8 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 			Org:         fallbackOrg(scope.Org),
 			Detector:    detectorID,
 			Autonomy:    level,
-			Permissions: permissionsFromSignals(signals),
-			Evidence: []model.Evidence{
-				{Key: "tool", Value: signals.Tool},
-				{Key: "headless", Value: boolString(signals.Headless)},
-				{Key: "approval_gate", Value: boolString(signals.HasApprovalGate)},
-				{Key: "secret_access", Value: boolString(signals.HasSecretAccess)},
-				{Key: "dangerous_flags", Value: boolString(signals.DangerousFlags)},
-			},
+			Permissions: uniqueStrings(permissions),
+			Evidence:    evidence,
 			Remediation: "Require approval gates for headless agent workflows that can access secrets.",
 		})
 	}
@@ -155,6 +184,29 @@ func permissionsFromSignals(signals autonomy.Signals) []string {
 		perms = append(perms, "headless.execute")
 	}
 	return perms
+}
+
+func uniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	set := map[string]struct{}{}
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		set[trimmed] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func boolString(v bool) string {

--- a/core/detect/ciagent/detector_test.go
+++ b/core/detect/ciagent/detector_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Clyra-AI/wrkr/core/detect"
+	"github.com/Clyra-AI/wrkr/core/model"
 )
 
 func TestDetectCIAutonomyCriticalFinding(t *testing.T) {
@@ -29,6 +30,120 @@ func TestDetectCIAutonomyCriticalFinding(t *testing.T) {
 	}
 }
 
+func TestDetectCIAutonomyDerivesWorkflowCapabilities(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(workflowPath, 0o755); err != nil {
+		t.Fatalf("mkdir workflow path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowPath, "release.yml"), []byte(`name: release
+on:
+  pull_request:
+    branches: [main]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: codex --full-auto --approval never
+      - run: gh pr merge --auto "$PR_URL"
+      - run: kubectl apply -f k8s/
+      - run: alembic upgrade head
+`), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	findings, err := New().Detect(context.Background(), detect.Scope{Org: "acme", Repo: "payments", Root: root}, detect.Options{})
+	if err != nil {
+		t.Fatalf("detect ciagent: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one ciagent finding, got %+v", findings)
+	}
+	for _, permission := range []string{"repo.write", "pull_request.write", "merge.execute", "deploy.write", "db.write"} {
+		if !hasPermission(findings[0].Permissions, permission) {
+			t.Fatalf("expected permission %q in %+v", permission, findings[0].Permissions)
+		}
+	}
+	if value := evidenceValue(findings[0], "workflow_capability.merge.execute"); value != "step.run:gh_pr_merge" {
+		t.Fatalf("expected merge execute evidence, got %q", value)
+	}
+}
+
+func TestDetectCIAutonomyDoesNotOverclaimMergeWhenWorkflowIsReadOnly(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(workflowPath, 0o755); err != nil {
+		t.Fatalf("mkdir workflow path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowPath, "dry-run.yml"), []byte(`name: dry-run
+on: workflow_dispatch
+permissions: read-all
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: codex --full-auto --approval never
+      - run: gh pr merge --auto "$PR_URL"
+`), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	findings, err := New().Detect(context.Background(), detect.Scope{Org: "acme", Repo: "payments", Root: root}, detect.Options{})
+	if err != nil {
+		t.Fatalf("detect ciagent: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one ciagent finding, got %+v", findings)
+	}
+	if hasPermission(findings[0].Permissions, "merge.execute") {
+		t.Fatalf("did not expect merge.execute permission in %+v", findings[0].Permissions)
+	}
+}
+
+func TestDetectCIAutonomyCarriesApprovalAndProofEvidence(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(workflowPath, 0o755); err != nil {
+		t.Fatalf("mkdir workflow path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowPath, "release.yml"), []byte(`name: release
+on:
+  workflow_dispatch:
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: trstringer/manual-approval@v1
+      - run: codex --full-auto --approval never
+      - run: wrkr evidence --state .wrkr/last-scan.json
+`), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	findings, err := New().Detect(context.Background(), detect.Scope{Org: "acme", Repo: "payments", Root: root}, detect.Options{})
+	if err != nil {
+		t.Fatalf("detect ciagent: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one ciagent finding, got %+v", findings)
+	}
+	if value := evidenceValue(findings[0], "approval_source"); value != "manual_approval_step" {
+		t.Fatalf("expected approval_source=manual_approval_step, got %q", value)
+	}
+	if value := evidenceValue(findings[0], "proof_requirement"); value != "evidence" {
+		t.Fatalf("expected proof_requirement=evidence, got %q", value)
+	}
+}
+
 func mustFindRepoRoot(t *testing.T) string {
 	t.Helper()
 
@@ -46,4 +161,22 @@ func mustFindRepoRoot(t *testing.T) string {
 		}
 		wd = next
 	}
+}
+
+func hasPermission(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func evidenceValue(finding model.Finding, key string) string {
+	for _, item := range finding.Evidence {
+		if item.Key == key {
+			return item.Value
+		}
+	}
+	return ""
 }

--- a/core/detect/compiledaction/detector.go
+++ b/core/detect/compiledaction/detector.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Clyra-AI/wrkr/core/detect"
+	"github.com/Clyra-AI/wrkr/core/detect/workflowcap"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"gopkg.in/yaml.v3"
 )
@@ -72,6 +73,14 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 			continue
 		}
 
+		path := filepath.Join(scope.Root, filepath.FromSlash(rel))
+		// #nosec G304 -- detector reads workflow/plan definitions from selected root.
+		payload, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil, readErr
+		}
+		workflowAnalysis, workflowErr := workflowcap.Analyze(rel, payload)
+
 		doc, parseErr := parseActionDocument(scope.Root, rel)
 		if parseErr != nil {
 			findings = append(findings, model.Finding{
@@ -89,11 +98,9 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 
 		if isEmptyAction(doc) {
 			if strings.HasPrefix(rel, ".github/workflows/") {
-				path := filepath.Join(scope.Root, filepath.FromSlash(rel))
-				// #nosec G304 -- detector reads workflow from selected repository root.
-				payload, readErr := os.ReadFile(path)
-				if readErr != nil {
-					return nil, readErr
+				if workflowErr == nil && len(workflowAnalysis.Capabilities) > 0 {
+					findings = append(findings, workflowFinding(scope, rel, workflowAnalysis))
+					continue
 				}
 				if strings.Contains(string(payload), "gait eval --script") {
 					findings = append(findings, model.Finding{
@@ -104,6 +111,7 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 						Repo:        scope.Repo,
 						Org:         fallbackOrg(scope.Org),
 						Detector:    detectorID,
+						Permissions: nil,
 						Evidence: []model.Evidence{
 							{Key: "step_count", Value: "1"},
 							{Key: "tool_sequence", Value: "gait.eval.script"},
@@ -123,6 +131,17 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 			}
 		}
 		sort.Strings(sequence)
+		evidence := []model.Evidence{
+			{Key: "step_count", Value: fmt.Sprintf("%d", len(doc.Steps))},
+			{Key: "tool_sequence", Value: strings.Join(sequence, ",")},
+			{Key: "risk_classes", Value: strings.Join(doc.RiskClasses, ",")},
+			{Key: "approval_source", Value: doc.ApprovalSource},
+		}
+		permissions := []string(nil)
+		if workflowErr == nil {
+			evidence = append(evidence, workflowAnalysis.Evidence...)
+			permissions = append(permissions, workflowAnalysis.Capabilities...)
+		}
 		findings = append(findings, model.Finding{
 			FindingType: "compiled_action",
 			Severity:    model.SeverityMedium,
@@ -131,12 +150,8 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 			Repo:        scope.Repo,
 			Org:         fallbackOrg(scope.Org),
 			Detector:    detectorID,
-			Evidence: []model.Evidence{
-				{Key: "step_count", Value: fmt.Sprintf("%d", len(doc.Steps))},
-				{Key: "tool_sequence", Value: strings.Join(sequence, ",")},
-				{Key: "risk_classes", Value: strings.Join(doc.RiskClasses, ",")},
-				{Key: "approval_source", Value: doc.ApprovalSource},
-			},
+			Permissions: uniqueStrings(permissions),
+			Evidence:    evidence,
 		})
 	}
 
@@ -178,4 +193,61 @@ func fallbackOrg(org string) string {
 		return "local"
 	}
 	return org
+}
+
+func workflowFinding(scope detect.Scope, rel string, analysis workflowcap.Result) model.Finding {
+	severity := model.SeverityMedium
+	if containsAny(analysis.Capabilities, "merge.execute", "deploy.write", "db.write", "iac.write") {
+		severity = model.SeverityHigh
+	}
+	evidence := append([]model.Evidence{
+		{Key: "step_count", Value: fmt.Sprintf("%d", analysis.StepCount)},
+	}, analysis.Evidence...)
+	return model.Finding{
+		FindingType: "compiled_action",
+		Severity:    severity,
+		ToolType:    "compiled_action",
+		Location:    rel,
+		Repo:        scope.Repo,
+		Org:         fallbackOrg(scope.Org),
+		Detector:    detectorID,
+		Permissions: uniqueStrings(analysis.Capabilities),
+		Evidence:    evidence,
+	}
+}
+
+func containsAny(values []string, needles ...string) bool {
+	set := map[string]struct{}{}
+	for _, value := range values {
+		set[strings.TrimSpace(value)] = struct{}{}
+	}
+	for _, needle := range needles {
+		if _, ok := set[strings.TrimSpace(needle)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func uniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	set := map[string]struct{}{}
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		set[trimmed] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/core/detect/compiledaction/detector_test.go
+++ b/core/detect/compiledaction/detector_test.go
@@ -1,0 +1,96 @@
+package compiledaction
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/detect"
+	"github.com/Clyra-AI/wrkr/core/model"
+)
+
+func TestDetectCompiledActionDerivesWorkflowCapabilities(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("mkdir workflow dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "release.yml"), []byte(`name: release
+on:
+  pull_request:
+    branches: [main]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh pr merge --auto "$PR_URL"
+      - run: terraform apply -auto-approve
+      - run: kubectl apply -f k8s/
+`), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	findings, err := New().Detect(context.Background(), detect.Scope{Org: "acme", Repo: "payments", Root: root}, detect.Options{})
+	if err != nil {
+		t.Fatalf("detect compiled action: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %+v", findings)
+	}
+	for _, permission := range []string{"repo.write", "pull_request.write", "merge.execute", "deploy.write", "iac.write"} {
+		if !containsPermission(findings[0].Permissions, permission) {
+			t.Fatalf("expected permission %q in %+v", permission, findings[0].Permissions)
+		}
+	}
+	if evidenceValue(findings[0], "workflow_capability.iac.write") == "" {
+		t.Fatalf("expected iac capability evidence, got %+v", findings[0].Evidence)
+	}
+}
+
+func TestDetectCompiledActionWorkflowParseErrorIsExplicit(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("mkdir workflow dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "bad.yml"), []byte("jobs:\n  release:\n    steps: ["), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	findings, err := New().Detect(context.Background(), detect.Scope{Org: "acme", Repo: "payments", Root: root}, detect.Options{})
+	if err != nil {
+		t.Fatalf("detect compiled action: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one parse_error finding, got %+v", findings)
+	}
+	if findings[0].FindingType != "parse_error" {
+		t.Fatalf("expected parse_error finding, got %+v", findings[0])
+	}
+}
+
+func containsPermission(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func evidenceValue(finding model.Finding, key string) string {
+	for _, evidence := range finding.Evidence {
+		if evidence.Key == key {
+			return evidence.Value
+		}
+	}
+	return ""
+}

--- a/core/detect/workflowcap/analyze.go
+++ b/core/detect/workflowcap/analyze.go
@@ -205,6 +205,9 @@ func Analyze(path string, payload []byte) (Result, *model.ParseError) {
 
 		jobApprovalSource := ""
 		jobDeploymentGate := ""
+		jobHasDeliverySurface := false
+		jobHasGovernanceSurface := false
+		jobProofRequirements := map[string]struct{}{}
 		if strings.TrimSpace(job.Environment.Name) != "" {
 			jobApprovalSource = "environment"
 			jobDeploymentGate = "ambiguous"
@@ -212,14 +215,20 @@ func Analyze(path string, payload []byte) (Result, *model.ParseError) {
 
 		for _, step := range job.Steps {
 			result.StepCount++
+			stepTool := detectTool(step)
 			if result.Tool == "" {
-				result.Tool = detectTool(step)
+				result.Tool = stepTool
+			}
+			if stepTool != "" {
+				jobHasGovernanceSurface = true
 			}
 			if isHeadlessStep(step) {
 				result.Headless = true
+				jobHasGovernanceSurface = true
 			}
 			if hasDangerousFlags(step) {
 				result.DangerousFlags = true
+				jobHasGovernanceSurface = true
 			}
 			if stepHasSecretAccess(step, job.Env) {
 				result.HasSecretAccess = true
@@ -227,18 +236,22 @@ func Analyze(path string, payload []byte) (Result, *model.ParseError) {
 
 			if reason := mergeExecuteReason(step); reason != "" && (perms.allows("contents") || perms.allows("pull-requests")) {
 				addCapabilityReason(capabilityReasons, "merge.execute", reason)
+				jobHasDeliverySurface = true
 				hasDeliverySurface = true
 			}
 			if reason := deployWriteReason(step); reason != "" {
 				addCapabilityReason(capabilityReasons, "deploy.write", reason)
+				jobHasDeliverySurface = true
 				hasDeliverySurface = true
 			}
 			if reason := dbWriteReason(step); reason != "" {
 				addCapabilityReason(capabilityReasons, "db.write", reason)
+				jobHasDeliverySurface = true
 				hasDeliverySurface = true
 			}
 			if reason := iacWriteReason(step); reason != "" {
 				addCapabilityReason(capabilityReasons, "iac.write", reason)
+				jobHasDeliverySurface = true
 				hasDeliverySurface = true
 			}
 
@@ -248,29 +261,34 @@ func Analyze(path string, payload []byte) (Result, *model.ParseError) {
 				result.HasApprovalGate = true
 			}
 			if requirement := proofRequirement(step); requirement != "" {
-				proofRequirements[requirement] = struct{}{}
+				jobProofRequirements[requirement] = struct{}{}
 			}
 		}
 
-		if jobApprovalSource == "" {
-			if containsTrigger(result.Triggers, "workflow_dispatch") {
-				jobApprovalSource = "workflow_dispatch"
-			} else if hasDeliverySurface {
-				jobApprovalSource = "missing"
+		if jobHasDeliverySurface || jobHasGovernanceSurface {
+			if jobApprovalSource == "" {
+				if containsTrigger(result.Triggers, "workflow_dispatch") {
+					jobApprovalSource = "workflow_dispatch"
+				} else {
+					jobApprovalSource = "missing"
+				}
 			}
-		}
-		if jobDeploymentGate == "" {
-			if hasDeliverySurface {
+			if jobHasDeliverySurface && jobDeploymentGate == "" {
 				jobDeploymentGate = "open"
-			} else {
-				jobDeploymentGate = "missing"
 			}
-		}
-		if jobApprovalSource != "" {
-			approvalSources[jobApprovalSource] = struct{}{}
-		}
-		if jobDeploymentGate != "" {
-			deploymentGates[jobDeploymentGate] = struct{}{}
+			if len(jobProofRequirements) == 0 {
+				proofRequirements["missing"] = struct{}{}
+			} else {
+				for requirement := range jobProofRequirements {
+					proofRequirements[requirement] = struct{}{}
+				}
+			}
+			if jobApprovalSource != "" {
+				approvalSources[jobApprovalSource] = struct{}{}
+			}
+			if jobHasDeliverySurface && jobDeploymentGate != "" {
+				deploymentGates[jobDeploymentGate] = struct{}{}
+			}
 		}
 	}
 
@@ -569,9 +587,6 @@ func chooseApprovalSource(values map[string]struct{}) string {
 	if len(values) == 0 {
 		return "missing"
 	}
-	if _, ok := values["manual_approval_step"]; ok {
-		return "manual_approval_step"
-	}
 	if len(values) == 1 {
 		return sortedSet(values)[0]
 	}
@@ -582,20 +597,17 @@ func chooseDeploymentGate(values map[string]struct{}) string {
 	if len(values) == 0 {
 		return "missing"
 	}
-	if _, ok := values["approved"]; ok {
-		return "approved"
+	if len(values) == 1 {
+		return sortedSet(values)[0]
 	}
-	if _, ok := values["ambiguous"]; ok {
-		return "ambiguous"
-	}
-	if _, ok := values["open"]; ok {
-		return "open"
-	}
-	return sortedSet(values)[0]
+	return "ambiguous"
 }
 
 func chooseProofRequirement(values map[string]struct{}) string {
 	if len(values) == 0 {
+		return "missing"
+	}
+	if _, ok := values["missing"]; ok {
 		return "missing"
 	}
 	if _, ok := values["attestation"]; ok {

--- a/core/detect/workflowcap/analyze.go
+++ b/core/detect/workflowcap/analyze.go
@@ -1,0 +1,618 @@
+package workflowcap
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Clyra-AI/wrkr/core/model"
+	"gopkg.in/yaml.v3"
+)
+
+const detectorID = "workflowcap"
+
+type Result struct {
+	Capabilities     []string
+	Evidence         []model.Evidence
+	Tool             string
+	Headless         bool
+	DangerousFlags   bool
+	HasSecretAccess  bool
+	HasApprovalGate  bool
+	StepCount        int
+	Triggers         []string
+	ApprovalSource   string
+	DeploymentGate   string
+	ProofRequirement string
+}
+
+type workflowDocument struct {
+	On          triggerField           `yaml:"on"`
+	Permissions permissionField        `yaml:"permissions"`
+	Jobs        map[string]workflowJob `yaml:"jobs"`
+}
+
+type workflowJob struct {
+	Permissions permissionField   `yaml:"permissions"`
+	Environment environmentField  `yaml:"environment"`
+	Env         map[string]string `yaml:"env"`
+	Steps       []workflowStep    `yaml:"steps"`
+}
+
+type workflowStep struct {
+	Name string            `yaml:"name"`
+	Uses string            `yaml:"uses"`
+	Run  string            `yaml:"run"`
+	Env  map[string]string `yaml:"env"`
+	With map[string]any    `yaml:"with"`
+}
+
+type permissionField struct {
+	Mode   string
+	Values map[string]string
+}
+
+func (p *permissionField) UnmarshalYAML(node *yaml.Node) error {
+	p.Mode = ""
+	p.Values = nil
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		var mode string
+		if err := node.Decode(&mode); err != nil {
+			return err
+		}
+		p.Mode = strings.ToLower(strings.TrimSpace(mode))
+		return nil
+	case yaml.MappingNode:
+		decoded := map[string]string{}
+		if err := node.Decode(&decoded); err != nil {
+			return err
+		}
+		values := map[string]string{}
+		for key, value := range decoded {
+			key = strings.ToLower(strings.TrimSpace(key))
+			value = strings.ToLower(strings.TrimSpace(value))
+			if key == "" || value == "" {
+				continue
+			}
+			values[key] = value
+		}
+		if len(values) > 0 {
+			p.Values = values
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported permissions shape")
+	}
+}
+
+func (p permissionField) allows(scope string) bool {
+	scope = strings.ToLower(strings.TrimSpace(scope))
+	switch p.Mode {
+	case "write-all":
+		return true
+	case "read-all":
+		return false
+	}
+	if len(p.Values) == 0 {
+		return false
+	}
+	value := strings.ToLower(strings.TrimSpace(p.Values[scope]))
+	return value == "write"
+}
+
+type environmentField struct {
+	Name string
+}
+
+func (e *environmentField) UnmarshalYAML(node *yaml.Node) error {
+	e.Name = ""
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		e.Name = strings.TrimSpace(node.Value)
+	case yaml.MappingNode:
+		for idx := 0; idx+1 < len(node.Content); idx += 2 {
+			if strings.EqualFold(strings.TrimSpace(node.Content[idx].Value), "name") {
+				e.Name = strings.TrimSpace(node.Content[idx+1].Value)
+				break
+			}
+		}
+	}
+	return nil
+}
+
+type triggerField struct {
+	Names []string
+}
+
+func (t *triggerField) UnmarshalYAML(node *yaml.Node) error {
+	t.Names = nil
+	if node == nil {
+		return nil
+	}
+	names := map[string]struct{}{}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if name := strings.TrimSpace(node.Value); name != "" {
+			names[name] = struct{}{}
+		}
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			if name := strings.TrimSpace(child.Value); name != "" {
+				names[name] = struct{}{}
+			}
+		}
+	case yaml.MappingNode:
+		for idx := 0; idx+1 < len(node.Content); idx += 2 {
+			if name := strings.TrimSpace(node.Content[idx].Value); name != "" {
+				names[name] = struct{}{}
+			}
+		}
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	t.Names = make([]string, 0, len(names))
+	for name := range names {
+		t.Names = append(t.Names, name)
+	}
+	sort.Strings(t.Names)
+	return nil
+}
+
+func Analyze(path string, payload []byte) (Result, *model.ParseError) {
+	var doc workflowDocument
+	if err := yaml.Unmarshal(payload, &doc); err != nil {
+		return Result{}, &model.ParseError{
+			Kind:     "parse_error",
+			Format:   "yaml",
+			Path:     strings.TrimSpace(path),
+			Detector: detectorID,
+			Message:  err.Error(),
+		}
+	}
+
+	result := Result{
+		Triggers: append([]string(nil), doc.On.Names...),
+	}
+	capabilityReasons := map[string]map[string]struct{}{}
+	approvalSources := map[string]struct{}{}
+	deploymentGates := map[string]struct{}{}
+	proofRequirements := map[string]struct{}{}
+
+	jobNames := make([]string, 0, len(doc.Jobs))
+	for name := range doc.Jobs {
+		jobNames = append(jobNames, name)
+	}
+	sort.Strings(jobNames)
+
+	hasDeliverySurface := false
+	for _, jobName := range jobNames {
+		job := doc.Jobs[jobName]
+		perms := effectivePermissions(doc.Permissions, job.Permissions)
+		if perms.allows("contents") {
+			addCapabilityReason(capabilityReasons, "repo.write", "permissions.contents=write")
+		}
+		if perms.allows("pull-requests") {
+			addCapabilityReason(capabilityReasons, "pull_request.write", "permissions.pull-requests=write")
+		}
+
+		jobApprovalSource := ""
+		jobDeploymentGate := ""
+		if strings.TrimSpace(job.Environment.Name) != "" {
+			jobApprovalSource = "environment"
+			jobDeploymentGate = "ambiguous"
+		}
+
+		for _, step := range job.Steps {
+			result.StepCount++
+			if result.Tool == "" {
+				result.Tool = detectTool(step)
+			}
+			if isHeadlessStep(step) {
+				result.Headless = true
+			}
+			if hasDangerousFlags(step) {
+				result.DangerousFlags = true
+			}
+			if stepHasSecretAccess(step, job.Env) {
+				result.HasSecretAccess = true
+			}
+
+			if reason := mergeExecuteReason(step); reason != "" && (perms.allows("contents") || perms.allows("pull-requests")) {
+				addCapabilityReason(capabilityReasons, "merge.execute", reason)
+				hasDeliverySurface = true
+			}
+			if reason := deployWriteReason(step); reason != "" {
+				addCapabilityReason(capabilityReasons, "deploy.write", reason)
+				hasDeliverySurface = true
+			}
+			if reason := dbWriteReason(step); reason != "" {
+				addCapabilityReason(capabilityReasons, "db.write", reason)
+				hasDeliverySurface = true
+			}
+			if reason := iacWriteReason(step); reason != "" {
+				addCapabilityReason(capabilityReasons, "iac.write", reason)
+				hasDeliverySurface = true
+			}
+
+			if source := manualApprovalSource(step); source != "" {
+				jobApprovalSource = source
+				jobDeploymentGate = "approved"
+				result.HasApprovalGate = true
+			}
+			if requirement := proofRequirement(step); requirement != "" {
+				proofRequirements[requirement] = struct{}{}
+			}
+		}
+
+		if jobApprovalSource == "" {
+			if containsTrigger(result.Triggers, "workflow_dispatch") {
+				jobApprovalSource = "workflow_dispatch"
+			} else if hasDeliverySurface {
+				jobApprovalSource = "missing"
+			}
+		}
+		if jobDeploymentGate == "" {
+			if hasDeliverySurface {
+				jobDeploymentGate = "open"
+			} else {
+				jobDeploymentGate = "missing"
+			}
+		}
+		if jobApprovalSource != "" {
+			approvalSources[jobApprovalSource] = struct{}{}
+		}
+		if jobDeploymentGate != "" {
+			deploymentGates[jobDeploymentGate] = struct{}{}
+		}
+	}
+
+	if hasDeliverySurface && len(proofRequirements) == 0 {
+		proofRequirements["missing"] = struct{}{}
+	}
+
+	result.Capabilities = sortedKeys(capabilityReasons)
+	result.ApprovalSource = chooseApprovalSource(approvalSources)
+	result.DeploymentGate = chooseDeploymentGate(deploymentGates)
+	result.ProofRequirement = chooseProofRequirement(proofRequirements)
+	result.HasApprovalGate = result.HasApprovalGate || result.DeploymentGate == "approved"
+
+	evidence := make([]model.Evidence, 0, len(result.Capabilities)+5)
+	if len(result.Capabilities) > 0 {
+		evidence = append(evidence, model.Evidence{
+			Key:   "workflow_capabilities",
+			Value: strings.Join(result.Capabilities, ","),
+		})
+		for _, capability := range result.Capabilities {
+			reasons := capabilityReasons[capability]
+			evidence = append(evidence, model.Evidence{
+				Key:   "workflow_capability." + capability,
+				Value: strings.Join(sortedSet(reasons), ","),
+			})
+		}
+	}
+	if len(result.Triggers) > 0 {
+		evidence = append(evidence, model.Evidence{
+			Key:   "workflow_triggers",
+			Value: strings.Join(result.Triggers, ","),
+		})
+	}
+	if result.ApprovalSource != "" {
+		evidence = append(evidence, model.Evidence{Key: "approval_source", Value: result.ApprovalSource})
+	}
+	if result.DeploymentGate != "" {
+		evidence = append(evidence, model.Evidence{Key: "deployment_gate", Value: result.DeploymentGate})
+	}
+	if result.ProofRequirement != "" {
+		evidence = append(evidence, model.Evidence{Key: "proof_requirement", Value: result.ProofRequirement})
+	}
+	result.Evidence = evidence
+	return result, nil
+}
+
+func effectivePermissions(root, job permissionField) permissionField {
+	if job.Mode != "" || len(job.Values) > 0 {
+		return job
+	}
+	return root
+}
+
+func detectTool(step workflowStep) string {
+	values := normalizedStepValues(step, nil)
+	for _, value := range values {
+		switch {
+		case strings.Contains(value, "claude"):
+			return "claude"
+		case strings.Contains(value, "codex"):
+			return "codex"
+		case strings.Contains(value, "copilot"):
+			return "copilot"
+		case strings.Contains(value, "cursor"):
+			return "cursor"
+		case strings.Contains(value, "gait eval --script"):
+			return "gait"
+		}
+	}
+	return ""
+}
+
+func isHeadlessStep(step workflowStep) bool {
+	for _, value := range normalizedStepValues(step, nil) {
+		switch {
+		case strings.Contains(value, "claude -p"),
+			strings.Contains(value, "claude code -p"),
+			strings.Contains(value, "codex --full-auto"),
+			strings.Contains(value, "gait eval --script"):
+			return true
+		}
+	}
+	return false
+}
+
+func hasDangerousFlags(step workflowStep) bool {
+	for _, value := range normalizedStepValues(step, nil) {
+		switch {
+		case strings.Contains(value, "--dangerouslyskippermissions"),
+			strings.Contains(value, "--dangerously-skip-permissions"),
+			strings.Contains(value, "--approval never"):
+			return true
+		}
+	}
+	return false
+}
+
+func stepHasSecretAccess(step workflowStep, jobEnv map[string]string) bool {
+	values := normalizedStepValues(step, jobEnv)
+	for _, value := range values {
+		if strings.Contains(value, "secrets.") || strings.Contains(value, "${{ secrets.") {
+			return true
+		}
+	}
+	return false
+}
+
+func mergeExecuteReason(step workflowStep) string {
+	for _, value := range normalizedStepValues(step, nil) {
+		switch {
+		case strings.Contains(value, "gh pr merge"):
+			return "step.run:gh_pr_merge"
+		case strings.Contains(value, "enable-pull-request-automerge"):
+			return "step.uses:enable_pull_request_automerge"
+		case strings.Contains(value, "automerge-action"):
+			return "step.uses:automerge_action"
+		}
+	}
+	return ""
+}
+
+func deployWriteReason(step workflowStep) string {
+	for _, value := range normalizedStepValues(step, nil) {
+		switch {
+		case strings.Contains(value, "kubectl apply"):
+			return "step.run:kubectl_apply"
+		case strings.Contains(value, "helm upgrade"), strings.Contains(value, "helm install"):
+			return "step.run:helm_release"
+		case strings.Contains(value, "terraform apply"):
+			return "step.run:terraform_apply"
+		case strings.Contains(value, "terragrunt apply"):
+			return "step.run:terragrunt_apply"
+		case strings.Contains(value, "pulumi up"):
+			return "step.run:pulumi_up"
+		case strings.Contains(value, "serverless deploy"):
+			return "step.run:serverless_deploy"
+		case strings.Contains(value, "fly deploy"):
+			return "step.run:fly_deploy"
+		case strings.Contains(value, "vercel deploy --prod"):
+			return "step.run:vercel_prod_deploy"
+		case strings.Contains(value, "netlify deploy --prod"):
+			return "step.run:netlify_prod_deploy"
+		case strings.Contains(value, "aws ecs update-service"):
+			return "step.run:aws_ecs_update_service"
+		case strings.Contains(value, "gcloud run deploy"):
+			return "step.run:gcloud_run_deploy"
+		case strings.Contains(value, "azure/k8s-deploy"):
+			return "step.uses:azure_k8s_deploy"
+		case strings.Contains(value, "amazon-ecs-deploy-task-definition"):
+			return "step.uses:amazon_ecs_deploy"
+		case strings.Contains(value, "deploy-cloudrun"):
+			return "step.uses:deploy_cloudrun"
+		}
+	}
+	return ""
+}
+
+func dbWriteReason(step workflowStep) string {
+	for _, value := range normalizedStepValues(step, nil) {
+		switch {
+		case strings.Contains(value, "alembic upgrade"):
+			return "step.run:alembic_upgrade"
+		case strings.Contains(value, "prisma migrate deploy"):
+			return "step.run:prisma_migrate_deploy"
+		case strings.Contains(value, "liquibase update"):
+			return "step.run:liquibase_update"
+		case strings.Contains(value, "flyway migrate"):
+			return "step.run:flyway_migrate"
+		case strings.Contains(value, "goose up"):
+			return "step.run:goose_up"
+		case strings.Contains(value, "dbmate up"):
+			return "step.run:dbmate_up"
+		case strings.Contains(value, "rails db:migrate"):
+			return "step.run:rails_db_migrate"
+		case strings.Contains(value, "knex migrate:latest"):
+			return "step.run:knex_migrate_latest"
+		case strings.Contains(value, "sqitch deploy"):
+			return "step.run:sqitch_deploy"
+		}
+	}
+	return ""
+}
+
+func iacWriteReason(step workflowStep) string {
+	for _, value := range normalizedStepValues(step, nil) {
+		switch {
+		case strings.Contains(value, "terraform apply"):
+			return "step.run:terraform_apply"
+		case strings.Contains(value, "terragrunt apply"):
+			return "step.run:terragrunt_apply"
+		case strings.Contains(value, "pulumi up"):
+			return "step.run:pulumi_up"
+		case strings.Contains(value, "helm upgrade"), strings.Contains(value, "helm install"):
+			return "step.run:helm_release"
+		}
+	}
+	return ""
+}
+
+func manualApprovalSource(step workflowStep) string {
+	for _, value := range normalizedStepValues(step, nil) {
+		if strings.Contains(value, "manual-approval") {
+			return "manual_approval_step"
+		}
+	}
+	return ""
+}
+
+func proofRequirement(step workflowStep) string {
+	for _, value := range normalizedStepValues(step, nil) {
+		switch {
+		case strings.Contains(value, "wrkr evidence"),
+			strings.Contains(value, "wrkr verify"):
+			return "evidence"
+		case strings.Contains(value, "cosign attest"),
+			strings.Contains(value, "attest-build-provenance"),
+			strings.Contains(value, "slsa-github-generator"),
+			strings.Contains(value, "gh attestation"),
+			strings.Contains(value, "slsa-verifier"):
+			return "attestation"
+		}
+	}
+	return ""
+}
+
+func normalizedStepValues(step workflowStep, jobEnv map[string]string) []string {
+	values := []string{
+		strings.ToLower(strings.TrimSpace(step.Name)),
+		strings.ToLower(strings.TrimSpace(step.Uses)),
+		strings.ToLower(strings.TrimSpace(step.Run)),
+	}
+	for _, env := range []map[string]string{jobEnv, step.Env} {
+		for key, value := range env {
+			values = append(values, strings.ToLower(strings.TrimSpace(key)))
+			values = append(values, strings.ToLower(strings.TrimSpace(value)))
+		}
+	}
+	values = append(values, normalizeDynamicValues(step.With)...)
+	return values
+}
+
+func normalizeDynamicValues(values map[string]any) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values)*2)
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		out = append(out, strings.ToLower(strings.TrimSpace(key)))
+		out = append(out, strings.ToLower(strings.TrimSpace(fmt.Sprint(values[key]))))
+	}
+	return out
+}
+
+func addCapabilityReason(target map[string]map[string]struct{}, capability, reason string) {
+	capability = strings.TrimSpace(capability)
+	reason = strings.TrimSpace(reason)
+	if capability == "" || reason == "" {
+		return
+	}
+	if target[capability] == nil {
+		target[capability] = map[string]struct{}{}
+	}
+	target[capability][reason] = struct{}{}
+}
+
+func sortedKeys(values map[string]map[string]struct{}) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for key := range values {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedSet(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func chooseApprovalSource(values map[string]struct{}) string {
+	if len(values) == 0 {
+		return "missing"
+	}
+	if _, ok := values["manual_approval_step"]; ok {
+		return "manual_approval_step"
+	}
+	if len(values) == 1 {
+		return sortedSet(values)[0]
+	}
+	return "ambiguous"
+}
+
+func chooseDeploymentGate(values map[string]struct{}) string {
+	if len(values) == 0 {
+		return "missing"
+	}
+	if _, ok := values["approved"]; ok {
+		return "approved"
+	}
+	if _, ok := values["ambiguous"]; ok {
+		return "ambiguous"
+	}
+	if _, ok := values["open"]; ok {
+		return "open"
+	}
+	return sortedSet(values)[0]
+}
+
+func chooseProofRequirement(values map[string]struct{}) string {
+	if len(values) == 0 {
+		return "missing"
+	}
+	if _, ok := values["attestation"]; ok {
+		return "attestation"
+	}
+	if _, ok := values["evidence"]; ok {
+		return "evidence"
+	}
+	return sortedSet(values)[0]
+}
+
+func containsTrigger(triggers []string, needle string) bool {
+	needle = strings.TrimSpace(needle)
+	for _, trigger := range triggers {
+		if strings.TrimSpace(trigger) == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/core/detect/workflowcap/analyze_test.go
+++ b/core/detect/workflowcap/analyze_test.go
@@ -1,0 +1,109 @@
+package workflowcap
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAnalyzeDerivesStructuredWorkflowCapabilities(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`name: release
+on:
+  pull_request:
+    branches: [main]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: codex --full-auto --approval never
+      - run: gh pr merge --auto "$PR_URL"
+      - run: terraform apply -auto-approve
+      - run: kubectl apply -f k8s/
+      - run: alembic upgrade head
+      - run: wrkr evidence --state .wrkr/last-scan.json
+`)
+
+	result, parseErr := Analyze(".github/workflows/release.yml", payload)
+	if parseErr != nil {
+		t.Fatalf("analyze workflow: %v", parseErr)
+	}
+	for _, capability := range []string{"repo.write", "pull_request.write", "merge.execute", "deploy.write", "db.write", "iac.write"} {
+		if !contains(result.Capabilities, capability) {
+			t.Fatalf("expected capability %q in %v", capability, result.Capabilities)
+		}
+	}
+	if result.Tool != "codex" {
+		t.Fatalf("expected tool codex, got %q", result.Tool)
+	}
+	if !result.Headless {
+		t.Fatal("expected headless detection")
+	}
+	if !result.DangerousFlags {
+		t.Fatal("expected dangerous flag detection")
+	}
+	if result.ProofRequirement != "evidence" {
+		t.Fatalf("expected proof requirement evidence, got %q", result.ProofRequirement)
+	}
+	if evidenceValue(result, "workflow_capability.merge.execute") != "step.run:gh_pr_merge" {
+		t.Fatalf("expected merge execute evidence, got %q", evidenceValue(result, "workflow_capability.merge.execute"))
+	}
+	if !strings.Contains(evidenceValue(result, "workflow_capability.deploy.write"), "kubectl_apply") {
+		t.Fatalf("expected deploy evidence to mention kubectl apply, got %q", evidenceValue(result, "workflow_capability.deploy.write"))
+	}
+}
+
+func TestAnalyzeRequiresStructuredEvidenceBeforeClaimingMergeCapability(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`name: read-only
+on: workflow_dispatch
+permissions: read-all
+jobs:
+  dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh pr merge --auto "$PR_URL"
+`)
+
+	result, parseErr := Analyze(".github/workflows/dry-run.yml", payload)
+	if parseErr != nil {
+		t.Fatalf("analyze workflow: %v", parseErr)
+	}
+	if contains(result.Capabilities, "merge.execute") {
+		t.Fatalf("did not expect merge.execute from read-only permissions: %v", result.Capabilities)
+	}
+}
+
+func TestAnalyzeMalformedWorkflowReturnsParseError(t *testing.T) {
+	t.Parallel()
+
+	_, parseErr := Analyze(".github/workflows/bad.yml", []byte("jobs:\n  build:\n    steps: ["))
+	if parseErr == nil {
+		t.Fatal("expected parse error")
+	}
+	if parseErr.Kind != "parse_error" {
+		t.Fatalf("expected parse_error kind, got %+v", parseErr)
+	}
+}
+
+func evidenceValue(result Result, key string) string {
+	for _, evidence := range result.Evidence {
+		if evidence.Key == key {
+			return evidence.Value
+		}
+	}
+	return ""
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/core/detect/workflowcap/analyze_test.go
+++ b/core/detect/workflowcap/analyze_test.go
@@ -90,6 +90,102 @@ func TestAnalyzeMalformedWorkflowReturnsParseError(t *testing.T) {
 	}
 }
 
+func TestAnalyzeTreatsMixedDeliveryGovernanceAsAmbiguous(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`name: release
+on:
+  push:
+    branches: [main]
+jobs:
+  approved:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: trstringer/manual-approval@v1
+      - run: kubectl apply -f k8s/
+      - run: wrkr evidence --state .wrkr/approved.json
+  ungated:
+    runs-on: ubuntu-latest
+    steps:
+      - run: kubectl apply -f k8s/
+      - run: wrkr evidence --state .wrkr/ungated.json
+`)
+
+	result, parseErr := Analyze(".github/workflows/release.yml", payload)
+	if parseErr != nil {
+		t.Fatalf("analyze workflow: %v", parseErr)
+	}
+	if result.DeploymentGate != "ambiguous" {
+		t.Fatalf("expected ambiguous deployment gate, got %q", result.DeploymentGate)
+	}
+	if result.ApprovalSource != "ambiguous" {
+		t.Fatalf("expected ambiguous approval source, got %q", result.ApprovalSource)
+	}
+}
+
+func TestAnalyzeMarksMissingProofWhenDeliveryPathLacksEvidence(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`name: release
+on:
+  push:
+    branches: [main]
+jobs:
+  covered:
+    runs-on: ubuntu-latest
+    steps:
+      - run: kubectl apply -f k8s/
+      - run: wrkr evidence --state .wrkr/covered.json
+  uncovered:
+    runs-on: ubuntu-latest
+    steps:
+      - run: kubectl apply -f k8s/
+`)
+
+	result, parseErr := Analyze(".github/workflows/release.yml", payload)
+	if parseErr != nil {
+		t.Fatalf("analyze workflow: %v", parseErr)
+	}
+	if result.ProofRequirement != "missing" {
+		t.Fatalf("expected missing proof requirement, got %q", result.ProofRequirement)
+	}
+}
+
+func TestAnalyzeIgnoresNonDeliveryJobsWhenAggregatingGovernance(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`name: release
+on:
+  push:
+    branches: [main]
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: trstringer/manual-approval@v1
+      - run: kubectl apply -f k8s/
+      - run: wrkr evidence --state .wrkr/release.json
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: go test ./...
+`)
+
+	result, parseErr := Analyze(".github/workflows/release.yml", payload)
+	if parseErr != nil {
+		t.Fatalf("analyze workflow: %v", parseErr)
+	}
+	if result.DeploymentGate != "approved" {
+		t.Fatalf("expected approved deployment gate, got %q", result.DeploymentGate)
+	}
+	if result.ApprovalSource != "manual_approval_step" {
+		t.Fatalf("expected manual approval source, got %q", result.ApprovalSource)
+	}
+	if result.ProofRequirement != "evidence" {
+		t.Fatalf("expected evidence proof requirement, got %q", result.ProofRequirement)
+	}
+}
+
 func evidenceValue(result Result, key string) string {
 	for _, evidence := range result.Evidence {
 		if evidence.Key == key {

--- a/core/owners/owners.go
+++ b/core/owners/owners.go
@@ -12,8 +12,23 @@ type rule struct {
 	owner   string
 }
 
-// ResolveOwner derives ownership from CODEOWNERS with deterministic fallback.
-func ResolveOwner(root, repo, org, location string) string {
+const (
+	OwnerSourceCodeowners   = "codeowners"
+	OwnerSourceRepoFallback = "repo_fallback"
+	OwnerSourceConflict     = "multi_repo_conflict"
+
+	OwnershipStatusExplicit   = "explicit"
+	OwnershipStatusInferred   = "inferred"
+	OwnershipStatusUnresolved = "unresolved"
+)
+
+type Resolution struct {
+	Owner           string
+	OwnerSource     string
+	OwnershipStatus string
+}
+
+func Resolve(root, repo, org, location string) Resolution {
 	rules := loadCodeowners(root)
 	normalized := normalizePath(location)
 	owner := ""
@@ -23,9 +38,26 @@ func ResolveOwner(root, repo, org, location string) string {
 		}
 	}
 	if owner != "" {
-		return owner
+		return Resolution{
+			Owner:           owner,
+			OwnerSource:     OwnerSourceCodeowners,
+			OwnershipStatus: OwnershipStatusExplicit,
+		}
 	}
-	return fallbackOwner(repo, org)
+	status := OwnershipStatusInferred
+	if strings.TrimSpace(repo) == "" {
+		status = OwnershipStatusUnresolved
+	}
+	return Resolution{
+		Owner:           FallbackOwner(repo, org),
+		OwnerSource:     OwnerSourceRepoFallback,
+		OwnershipStatus: status,
+	}
+}
+
+// ResolveOwner derives ownership from CODEOWNERS with deterministic fallback.
+func ResolveOwner(root, repo, org, location string) string {
+	return Resolve(root, repo, org, location).Owner
 }
 
 func loadCodeowners(root string) []rule {
@@ -82,7 +114,7 @@ func matchPattern(pattern, path string) bool {
 	return strings.HasSuffix(path, pattern)
 }
 
-func fallbackOwner(repo, org string) string {
+func FallbackOwner(repo, org string) string {
 	trimmedRepo := strings.TrimSpace(repo)
 	team := "owners"
 	if trimmedRepo != "" {

--- a/core/owners/owners_test.go
+++ b/core/owners/owners_test.go
@@ -20,10 +20,41 @@ func TestResolveOwnerFromCodeowners(t *testing.T) {
 	}
 }
 
+func TestResolveReturnsOwnershipMetadata(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	content := "* @acme/platform\n.github/workflows/* @acme/security\n"
+	if err := os.WriteFile(filepath.Join(root, "CODEOWNERS"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write CODEOWNERS: %v", err)
+	}
+	resolution := Resolve(root, "acme/repo", "acme", ".github/workflows/scan.yml")
+	if resolution.Owner != "@acme/security" {
+		t.Fatalf("unexpected owner: %+v", resolution)
+	}
+	if resolution.OwnerSource != OwnerSourceCodeowners || resolution.OwnershipStatus != OwnershipStatusExplicit {
+		t.Fatalf("expected explicit CODEOWNERS resolution, got %+v", resolution)
+	}
+}
+
 func TestResolveOwnerFallback(t *testing.T) {
 	t.Parallel()
 	owner := ResolveOwner(t.TempDir(), "acme/payments-service", "acme", ".cursor/mcp.json")
 	if owner != "@acme/payments" {
 		t.Fatalf("unexpected fallback owner: %s", owner)
+	}
+}
+
+func TestResolveFallbackMetadataTracksInferredAndUnresolvedStates(t *testing.T) {
+	t.Parallel()
+
+	inferred := Resolve(t.TempDir(), "acme/payments-service", "acme", ".cursor/mcp.json")
+	if inferred.OwnerSource != OwnerSourceRepoFallback || inferred.OwnershipStatus != OwnershipStatusInferred {
+		t.Fatalf("expected inferred fallback, got %+v", inferred)
+	}
+
+	unresolved := Resolve(t.TempDir(), "", "acme", ".cursor/mcp.json")
+	if unresolved.OwnerSource != OwnerSourceRepoFallback || unresolved.OwnershipStatus != OwnershipStatusUnresolved {
+		t.Fatalf("expected unresolved fallback, got %+v", unresolved)
 	}
 }

--- a/core/policy/eval/eval.go
+++ b/core/policy/eval/eval.go
@@ -65,33 +65,61 @@ func applyRule(rule policy.Rule, findings []model.Finding) (bool, string) {
 		if len(agents) == 0 {
 			return legacyRuleResult("require_tool_config", findings)
 		}
-		approvalGaps := 0
+		approvalStatusMissing := 0
+		approvalSourceMissing := 0
+		approvalSourceAmbiguous := 0
 		for _, finding := range agents {
 			status := strings.ToLower(strings.TrimSpace(evidenceValue(finding, "approval_status")))
 			if status == "" {
 				status = "missing"
 			}
 			if status != "approved" && status != "valid" {
-				approvalGaps++
+				approvalStatusMissing++
+			}
+			switch normalizeEvidenceState(evidenceValue(finding, "approval_source"), "missing") {
+			case "missing":
+				approvalSourceMissing++
+			case "ambiguous":
+				approvalSourceAmbiguous++
 			}
 		}
-		return approvalGaps == 0, fmt.Sprintf("agent_count=%d,approval_gaps=%d", len(agents), approvalGaps)
+		return approvalStatusMissing == 0 && approvalSourceMissing == 0 && approvalSourceAmbiguous == 0,
+			fmt.Sprintf(
+				"agent_count=%d,approval_status_missing=%d,approval_source_missing=%d,approval_source_ambiguous=%d",
+				len(agents),
+				approvalStatusMissing,
+				approvalSourceMissing,
+				approvalSourceAmbiguous,
+			)
 	case "agent_prod_write_human_gate":
 		agents := agentFindings(findings)
 		if len(agents) == 0 {
 			return legacyRuleResult("block_secret_presence", findings)
 		}
 		violations := 0
+		proofRequirementMissing := 0
 		for _, finding := range agents {
 			deployment := strings.ToLower(strings.TrimSpace(evidenceValue(finding, "deployment_status")))
 			autoDeploy := boolEvidence(finding, "auto_deploy")
-			humanGate := boolEvidenceWithDefault(finding, "human_gate", true)
+			humanGate := boolEvidenceWithDefault(finding, "human_gate", false)
 			if hasWriteLikePermission(finding.Permissions) && (deployment == "deployed" || autoDeploy) && !humanGate {
 				violations++
 			}
+			if hasWriteLikePermission(finding.Permissions) && (deployment == "deployed" || autoDeploy) {
+				switch normalizeEvidenceState(evidenceValue(finding, "proof_requirement"), "missing") {
+				case "missing", "ambiguous":
+					proofRequirementMissing++
+				}
+			}
 		}
 		secretCount := countType(findings, "secret_presence")
-		return violations == 0 && secretCount == 0, fmt.Sprintf("prod_write_without_human_gate=%d,secret_presence=%d", violations, secretCount)
+		return violations == 0 && secretCount == 0 && proofRequirementMissing == 0,
+			fmt.Sprintf(
+				"prod_write_without_human_gate=%d,proof_requirement_missing=%d,secret_presence=%d",
+				violations,
+				proofRequirementMissing,
+				secretCount,
+			)
 	case "agent_secret_controls":
 		agents := agentFindings(findings)
 		if len(agents) == 0 {
@@ -180,19 +208,20 @@ func applyRule(rule policy.Rule, findings []model.Finding) (bool, string) {
 			return legacyRuleResult("credential_refs_reviewed", findings)
 		}
 		violations := 0
+		ambiguous := 0
 		for _, finding := range agents {
 			if !boolEvidence(finding, "auto_deploy") {
 				continue
 			}
-			gate := strings.ToLower(strings.TrimSpace(evidenceValue(finding, "deployment_gate")))
-			if gate == "" && boolEvidenceWithDefault(finding, "human_gate", false) {
-				gate = "enforced"
-			}
+			gate := normalizeEvidenceState(evidenceValue(finding, "deployment_gate"), "missing")
 			if gate != "approved" && gate != "enforced" {
 				violations++
 			}
+			if gate == "ambiguous" {
+				ambiguous++
+			}
 		}
-		return violations == 0, fmt.Sprintf("auto_deploy_gate_gaps=%d", violations)
+		return violations == 0, fmt.Sprintf("auto_deploy_gate_gaps=%d,auto_deploy_gate_ambiguous=%d", violations, ambiguous)
 	case "agent_autodeploy_without_human_gate":
 		agents := agentFindings(findings)
 		if len(agents) == 0 {
@@ -425,4 +454,17 @@ func hasSecretSignal(finding model.Finding) bool {
 	}
 	authSurfaces := strings.ToLower(strings.TrimSpace(evidenceValue(finding, "auth_surfaces")))
 	return strings.Contains(authSurfaces, "secret") || strings.Contains(authSurfaces, "token") || strings.Contains(authSurfaces, "credential")
+}
+
+func normalizeEvidenceState(value string, missing string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if normalized == "" {
+		return missing
+	}
+	switch normalized {
+	case "approved", "enforced", "open", "missing", "ambiguous", "manual_approval_step", "environment", "workflow_dispatch", "evidence", "attestation", "not_applicable":
+		return normalized
+	default:
+		return normalized
+	}
 }

--- a/core/policy/eval/eval_test.go
+++ b/core/policy/eval/eval_test.go
@@ -105,11 +105,40 @@ func TestPolicyEval_WRKRA001_NoApprovalFails(t *testing.T) {
 		Evidence: []model.Evidence{
 			{Key: "symbol", Value: "release_agent"},
 			{Key: "approval_status", Value: "missing"},
+			{Key: "approval_source", Value: "missing"},
 		},
 	}}
 	out := Evaluate("repo", "org", findings, rules)
 	if !hasViolation(out, "WRKR-A001") {
 		t.Fatalf("expected WRKR-A001 violation, got %+v", out)
+	}
+}
+
+func TestPolicyEval_WRKRA001_MissingApprovalSourceFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	rules := []policy.Rule{{
+		ID:          "WRKR-A001",
+		Title:       "approval required",
+		Severity:    "high",
+		Kind:        "agent_approval_required",
+		Remediation: "set approval_source",
+		Version:     1,
+	}}
+	findings := []model.Finding{{
+		FindingType: "agent_framework",
+		ToolType:    "langchain",
+		Location:    "agents/release.py",
+		Evidence: []model.Evidence{
+			{Key: "symbol", Value: "release_agent"},
+			{Key: "approval_status", Value: "approved"},
+			{Key: "approval_source", Value: "missing"},
+		},
+	}}
+
+	out := Evaluate("repo", "org", findings, rules)
+	if !hasViolation(out, "WRKR-A001") {
+		t.Fatalf("expected WRKR-A001 violation when approval_source is missing, got %+v", out)
 	}
 }
 
@@ -161,6 +190,7 @@ func TestPolicyEval_WRKR002_AgentProdWriteAlsoChecksSecretPresence(t *testing.T)
 				{Key: "symbol", Value: "release_agent"},
 				{Key: "deployment_status", Value: "deployed"},
 				{Key: "human_gate", Value: "true"},
+				{Key: "proof_requirement", Value: "attestation"},
 			},
 		},
 		{
@@ -175,7 +205,37 @@ func TestPolicyEval_WRKR002_AgentProdWriteAlsoChecksSecretPresence(t *testing.T)
 	}
 }
 
-func TestPolicyEval_WRKRA009_UsesHumanGateFallbackWithoutDeploymentGate(t *testing.T) {
+func TestPolicyEval_WRKRA002_MissingProofRequirementFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	rules := []policy.Rule{{
+		ID:          "WRKR-A002",
+		Title:       "production write agents require human gate and proof requirements",
+		Severity:    "high",
+		Kind:        "agent_prod_write_human_gate",
+		Remediation: "declare proof requirement",
+		Version:     1,
+	}}
+	findings := []model.Finding{{
+		FindingType: "agent_framework",
+		ToolType:    "langchain",
+		Location:    "agents/release.py",
+		Permissions: []string{"deploy.write"},
+		Evidence: []model.Evidence{
+			{Key: "symbol", Value: "release_agent"},
+			{Key: "deployment_status", Value: "deployed"},
+			{Key: "human_gate", Value: "true"},
+			{Key: "proof_requirement", Value: "missing"},
+		},
+	}}
+
+	out := Evaluate("repo", "org", findings, rules)
+	if !hasViolation(out, "WRKR-A002") {
+		t.Fatalf("expected WRKR-A002 violation when proof_requirement is missing, got %+v", out)
+	}
+}
+
+func TestPolicyEval_WRKRA009_RequiresExplicitGateSource(t *testing.T) {
 	t.Parallel()
 
 	rules := []policy.Rule{{
@@ -194,6 +254,8 @@ func TestPolicyEval_WRKRA009_UsesHumanGateFallbackWithoutDeploymentGate(t *testi
 			{Key: "symbol", Value: "release_agent"},
 			{Key: "auto_deploy", Value: "true"},
 			{Key: "human_gate", Value: "true"},
+			{Key: "approval_source", Value: "manual_approval_step"},
+			{Key: "deployment_gate", Value: "enforced"},
 		},
 	}}
 
@@ -226,8 +288,10 @@ func TestPolicyEval_AgentRuleKindsDeterministicPassFail(t *testing.T) {
 		Evidence: []model.Evidence{
 			{Key: "symbol", Value: "ops_agent"},
 			{Key: "approval_status", Value: "approved"},
+			{Key: "approval_source", Value: "manual_approval_step"},
 			{Key: "deployment_status", Value: "deployed"},
 			{Key: "human_gate", Value: "true"},
+			{Key: "proof_requirement", Value: "attestation"},
 			{Key: "secret_control", Value: "managed"},
 			{Key: "external_network", Value: "true"},
 			{Key: "egress_policy", Value: "enforced"},

--- a/core/policy/rules/builtin.yaml
+++ b/core/policy/rules/builtin.yaml
@@ -36,15 +36,15 @@ rules:
     kind: prompt_channel_governance
     version: 1
   - id: WRKR-A001
-    title: Agent approval posture must be explicit
+    title: Agent approval posture must be explicit and sourced
     severity: high
-    remediation: Mark each discovered agent as approved or add a deterministic approval workflow.
+    remediation: Mark each discovered agent as approved and declare the static approval source.
     kind: agent_approval_required
     version: 1
   - id: WRKR-A002
-    title: Production-write agents require human gate
+    title: Production-write agents require human gate and proof requirements
     severity: high
-    remediation: Add an explicit human gate before production-write or auto-deploy agent execution.
+    remediation: Add an explicit human gate and proof requirement before production-write or auto-deploy agent execution.
     kind: agent_prod_write_human_gate
     version: 1
   - id: WRKR-A003
@@ -84,9 +84,9 @@ rules:
     kind: agent_data_classification_required
     version: 1
   - id: WRKR-A009
-    title: Auto-deploy paths require deployment gate controls
+    title: Auto-deploy paths require explicit deployment gate controls
     severity: low
-    remediation: Add deterministic deployment gate metadata for auto-deploying agents.
+    remediation: Add deterministic deployment gate metadata and avoid ambiguous gate declarations for auto-deploying agents.
     kind: agent_auto_deploy_gate
     version: 1
   - id: WRKR-A010

--- a/core/report/activation.go
+++ b/core/report/activation.go
@@ -217,7 +217,7 @@ func classifyGovernFirstClass(entry agginventory.AgentPrivilegeMapEntry) string 
 		return activationClassProductionBacked
 	case entry.WriteCapable && strings.TrimSpace(entry.SecurityVisibilityStatus) == agginventory.SecurityVisibilityUnknownToSecurity:
 		return activationClassUnknownWrite
-	case entry.WriteCapable && isApprovalGap(entry.ApprovalClassification):
+	case entry.WriteCapable && isApprovalGap(entry.ApprovalClassification, entry.ApprovalGapReasons):
 		return activationClassApprovalGap
 	case entry.WriteCapable:
 		return activationClassGovernFirst
@@ -268,6 +268,18 @@ func governFirstNextStep(class string) string {
 	}
 }
 
+func isApprovalGap(status string, reasons []string) bool {
+	if len(reasons) > 0 {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "unknown", "unapproved":
+		return true
+	default:
+		return false
+	}
+}
+
 func firstRepo(entry agginventory.AgentPrivilegeMapEntry) string {
 	if len(entry.Repos) == 0 {
 		return ""
@@ -282,13 +294,4 @@ func activationToolType(entry agginventory.AgentPrivilegeMapEntry) string {
 		return strings.TrimSpace(entry.Framework)
 	}
 	return strings.TrimSpace(entry.ToolType)
-}
-
-func isApprovalGap(status string) bool {
-	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "", "unknown", "unapproved":
-		return true
-	default:
-		return false
-	}
 }

--- a/core/report/build.go
+++ b/core/report/build.go
@@ -933,6 +933,7 @@ func sanitizeActionPathsPublic(in []risk.ActionPath) []risk.ActionPath {
 		copyItem.Repo = redactValue("repo", copyItem.Repo, 6)
 		copyItem.AgentID = redactValue("agent", copyItem.AgentID, 8)
 		copyItem.Location = redactValue("loc", copyItem.Location, 8)
+		copyItem.OperationalOwner = redactValue("owner", copyItem.OperationalOwner, 8)
 		targets := make([]string, 0, len(copyItem.MatchedProductionTargets))
 		for _, target := range copyItem.MatchedProductionTargets {
 			redacted := redactValue("target", target, 8)

--- a/core/risk/action_paths.go
+++ b/core/risk/action_paths.go
@@ -25,6 +25,15 @@ type ActionPath struct {
 	ToolType                 string   `json:"tool_type"`
 	Location                 string   `json:"location,omitempty"`
 	WriteCapable             bool     `json:"write_capable"`
+	OperationalOwner         string   `json:"operational_owner,omitempty"`
+	OwnerSource              string   `json:"owner_source,omitempty"`
+	OwnershipStatus          string   `json:"ownership_status,omitempty"`
+	ApprovalGapReasons       []string `json:"approval_gap_reasons,omitempty"`
+	PullRequestWrite         bool     `json:"pull_request_write,omitempty"`
+	MergeExecute             bool     `json:"merge_execute,omitempty"`
+	DeployWrite              bool     `json:"deploy_write,omitempty"`
+	DeliveryChainStatus      string   `json:"delivery_chain_status,omitempty"`
+	ProductionTargetStatus   string   `json:"production_target_status,omitempty"`
 	ProductionWrite          bool     `json:"production_write"`
 	ApprovalGap              bool     `json:"approval_gap"`
 	SecurityVisibilityStatus string   `json:"security_visibility_status,omitempty"`
@@ -68,8 +77,17 @@ func BuildActionPaths(attackPaths []riskattack.ScoredPath, inventory *agginvento
 			ToolType:                 actionPathToolType(entry),
 			Location:                 strings.TrimSpace(entry.Location),
 			WriteCapable:             entry.WriteCapable,
+			OperationalOwner:         strings.TrimSpace(entry.OperationalOwner),
+			OwnerSource:              strings.TrimSpace(entry.OwnerSource),
+			OwnershipStatus:          strings.TrimSpace(entry.OwnershipStatus),
+			ApprovalGapReasons:       append([]string(nil), entry.ApprovalGapReasons...),
+			PullRequestWrite:         entry.PullRequestWrite,
+			MergeExecute:             entry.MergeExecute,
+			DeployWrite:              entry.DeployWrite,
+			DeliveryChainStatus:      strings.TrimSpace(entry.DeliveryChainStatus),
+			ProductionTargetStatus:   strings.TrimSpace(entry.ProductionTargetStatus),
 			ProductionWrite:          entry.ProductionWrite,
-			ApprovalGap:              actionPathApprovalGap(entry.ApprovalClassification),
+			ApprovalGap:              actionPathApprovalGap(entry.ApprovalClassification, entry.ApprovalGapReasons),
 			SecurityVisibilityStatus: strings.TrimSpace(entry.SecurityVisibilityStatus),
 			CredentialAccess:         entry.CredentialAccess,
 			DeploymentStatus:         strings.TrimSpace(entry.DeploymentStatus),
@@ -100,6 +118,11 @@ func BuildActionPaths(attackPaths []riskattack.ScoredPath, inventory *agginvento
 		if pi != pj {
 			return pi < pj
 		}
+		ci := deliveryChainPriority(paths[i].DeliveryChainStatus)
+		cj := deliveryChainPriority(paths[j].DeliveryChainStatus)
+		if ci != cj {
+			return ci < cj
+		}
 		if paths[i].RiskScore != paths[j].RiskScore {
 			return paths[i].RiskScore > paths[j].RiskScore
 		}
@@ -126,23 +149,36 @@ func BuildActionPaths(attackPaths []riskattack.ScoredPath, inventory *agginvento
 }
 
 func shouldIncludeActionPath(entry agginventory.AgentPrivilegeMapEntry) bool {
-	return entry.WriteCapable || entry.CredentialAccess || entry.ProductionWrite || actionPathApprovalGap(entry.ApprovalClassification)
+	return entry.WriteCapable ||
+		entry.CredentialAccess ||
+		entry.ProductionWrite ||
+		entry.PullRequestWrite ||
+		entry.MergeExecute ||
+		entry.DeployWrite ||
+		actionPathApprovalGap(entry.ApprovalClassification, entry.ApprovalGapReasons)
 }
 
 func actionPathRecommendedAction(entry agginventory.AgentPrivilegeMapEntry) string {
 	switch {
 	case entry.ProductionWrite:
 		return "control"
-	case actionPathApprovalGap(entry.ApprovalClassification):
+	case actionPathApprovalGap(entry.ApprovalClassification, entry.ApprovalGapReasons):
 		return "approval"
-	case entry.CredentialAccess || strings.EqualFold(strings.TrimSpace(entry.DeploymentStatus), "deployed"):
+	case entry.CredentialAccess ||
+		strings.EqualFold(strings.TrimSpace(entry.DeploymentStatus), "deployed") ||
+		entry.PullRequestWrite ||
+		entry.MergeExecute ||
+		entry.DeployWrite:
 		return "proof"
 	default:
 		return "inventory"
 	}
 }
 
-func actionPathApprovalGap(status string) bool {
+func actionPathApprovalGap(status string, reasons []string) bool {
+	if len(reasons) > 0 {
+		return true
+	}
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "", "unknown", "unapproved":
 		return true
@@ -161,6 +197,25 @@ func actionPriority(action string) int {
 		return 2
 	case "inventory":
 		return 3
+	default:
+		return 99
+	}
+}
+
+func deliveryChainPriority(status string) int {
+	switch strings.TrimSpace(status) {
+	case "pr_merge_deploy":
+		return 0
+	case "merge_deploy":
+		return 1
+	case "pr_merge":
+		return 2
+	case "deploy_only":
+		return 3
+	case "pr_only":
+		return 4
+	case "merge_only":
+		return 5
 	default:
 		return 99
 	}

--- a/core/risk/attackpath/score.go
+++ b/core/risk/attackpath/score.go
@@ -177,6 +177,12 @@ func targetImpact(node aggattack.Node) float64 {
 		return 3.4
 	case "agent_deploy_artifact":
 		return 3.1
+	case "workflow_pull_request":
+		return 2.7
+	case "workflow_merge_capability":
+		return 3.0
+	case "workflow_deploy_capability":
+		return 3.2
 	case "agent_data_binding":
 		return 2.8
 	case "secret_presence":
@@ -211,6 +217,15 @@ func edgeRationaleBonus(edges []aggattack.Edge) (float64, []string) {
 		case "agent_to_auth_surface":
 			bonus += 0.7
 			reasons = append(reasons, "edge_rationale=agent_to_auth_surface")
+		case "workflow_to_pull_request":
+			bonus += 0.4
+			reasons = append(reasons, "edge_rationale=workflow_to_pull_request")
+		case "workflow_to_merge":
+			bonus += 0.6
+			reasons = append(reasons, "edge_rationale=workflow_to_merge")
+		case "workflow_to_deploy":
+			bonus += 0.8
+			reasons = append(reasons, "edge_rationale=workflow_to_deploy")
 		}
 	}
 	return bonus, reasons

--- a/core/risk/risk_test.go
+++ b/core/risk/risk_test.go
@@ -308,6 +308,61 @@ func TestBuildActionPathsRanksAndSelectsControlFirst(t *testing.T) {
 	}
 }
 
+func TestBuildActionPathsCarriesDeliveryChainMetadata(t *testing.T) {
+	t.Parallel()
+
+	inventory := &agginventory.Inventory{
+		AgentPrivilegeMap: []agginventory.AgentPrivilegeMapEntry{
+			{
+				AgentID:                "wrkr:workflow-full:acme",
+				Framework:              "compiled_action",
+				Org:                    "acme",
+				Repos:                  []string{"payments-prod"},
+				Location:               ".github/workflows/release.yml",
+				RiskScore:              8.1,
+				ApprovalClassification: "approved",
+				PullRequestWrite:       true,
+				MergeExecute:           true,
+				DeployWrite:            true,
+				DeliveryChainStatus:    "pr_merge_deploy",
+				ProductionTargetStatus: agginventory.ProductionTargetsStatusNotConfigured,
+			},
+			{
+				AgentID:                "wrkr:workflow-pr:acme",
+				Framework:              "compiled_action",
+				Org:                    "acme",
+				Repos:                  []string{"payments-prod"},
+				Location:               ".github/workflows/pr.yml",
+				RiskScore:              8.1,
+				ApprovalClassification: "approved",
+				PullRequestWrite:       true,
+				DeliveryChainStatus:    "pr_only",
+				ProductionTargetStatus: agginventory.ProductionTargetsStatusNotConfigured,
+			},
+		},
+	}
+
+	actionPaths, choice := BuildActionPaths(nil, inventory)
+	if len(actionPaths) != 2 {
+		t.Fatalf("expected 2 action paths, got %+v", actionPaths)
+	}
+	if actionPaths[0].DeliveryChainStatus != "pr_merge_deploy" {
+		t.Fatalf("expected full delivery chain first, got %+v", actionPaths[0])
+	}
+	if !actionPaths[0].PullRequestWrite || !actionPaths[0].MergeExecute || !actionPaths[0].DeployWrite {
+		t.Fatalf("expected delivery chain booleans on first path, got %+v", actionPaths[0])
+	}
+	if actionPaths[0].ProductionTargetStatus != agginventory.ProductionTargetsStatusNotConfigured {
+		t.Fatalf("expected production target status to carry through, got %+v", actionPaths[0])
+	}
+	if actionPaths[0].RecommendedAction != "proof" {
+		t.Fatalf("expected proof recommendation without production backing, got %+v", actionPaths[0])
+	}
+	if choice == nil || choice.Path.DeliveryChainStatus != "pr_merge_deploy" {
+		t.Fatalf("expected control-first selection to preserve delivery metadata, got %+v", choice)
+	}
+}
+
 func TestScoreKeepsSameFileAgentsDistinctByInstanceIdentity(t *testing.T) {
 	t.Parallel()
 

--- a/docs/commands/report.md
+++ b/docs/commands/report.md
@@ -35,7 +35,7 @@ Expected JSON keys: `status`, `generated_at`, `top_findings`, `attack_paths`, `t
 `summary.compliance_summary` mirrors the same machine-readable contract used by report markdown/PDF generation.
 When the saved scan target is `my_setup`, `summary.activation` exposes the same additive concrete-first activation view used by the local-machine scan flow.
 When the saved scan target is `org` or `path`, `summary.activation` exposes the additive govern-first candidate path view used by the scan flow.
-`summary.action_paths` and top-level `action_paths` expose the ranked govern-first path objects, and `summary.action_path_to_control_first` / top-level `action_path_to_control_first` expose one prioritized path with deterministic summary counts.
+`summary.action_paths` and top-level `action_paths` expose the ranked govern-first path objects, including additive delivery-chain fields such as `pull_request_write`, `merge_execute`, `deploy_write`, `delivery_chain_status`, and `production_target_status`, plus ownership/governance fields such as `operational_owner`, `owner_source`, `ownership_status`, and `approval_gap_reasons`. `summary.action_path_to_control_first` / top-level `action_path_to_control_first` expose one prioritized path with deterministic summary counts.
 `summary.security_visibility` exposes additive reference-basis and `unknown_to_security` counts sourced from the saved scan state.
 When the saved scan state does not carry a usable `reference_basis`, report output suppresses `unknown_to_security` claims and surfaces `reference_basis unavailable` wording instead.
 

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -110,7 +110,7 @@ Expected JSON keys include `status`, `target`, `findings`, `ranked_findings`, `t
 For local-machine scans, `target.mode` is `my_setup`.
 When `target.mode=my_setup`, `activation.items` projects concrete local tool, MCP, secret, and parse-error signals first without mutating the raw `top_findings` ranking. Policy-only items remain available in `ranked_findings` / `top_findings`.
 When `target.mode=org` or `target.mode=path`, `activation.items` projects govern-first candidate paths from the saved privilege map and adds `item_class` values such as `production_target_backed`, `unknown_to_security_write_path`, `approval_gap_path`, and `govern_first_candidate`.
-`action_paths[*]` combines path identity, write capability, approval gap, security visibility, credential/deployment posture, attack-path score, and a stable `recommended_action` enum of `inventory|approval|proof|control`.
+`action_paths[*]` combines path identity, write capability, approval gap, security visibility, credential/deployment posture, delivery-chain metadata (`pull_request_write`, `merge_execute`, `deploy_write`, `delivery_chain_status`), production-target truth (`production_target_status`, `production_write`), attack-path score, and a stable `recommended_action` enum of `inventory|approval|proof|control`.
 `action_path_to_control_first` exposes one prioritized path plus deterministic summary counts (`total_paths`, `write_capable_paths`, `production_target_backed_paths`, `govern_first_paths`) without removing the legacy `attack_paths` surfaces.
 `warnings` is included when Wrkr can prove posture may be incomplete even though the scan succeeded, for example when known MCP-bearing declaration files failed to parse.
 `detector_errors` is included when non-fatal detector failures occur and partial scan results are preserved.
@@ -128,6 +128,9 @@ Source coverage remains intentionally scoped:
 `ranked_findings[*]` and `attack_paths[*]` now include deterministic agent-aware amplification and edge rationale when agent declarations expose deployment, delegation, dynamic discovery, or bound tool/data/auth/deploy chains.
 `inventory.tools[*]` includes deterministic `approval_classification` (`approved|unapproved|unknown`), and `inventory.approval_summary` emits aggregate approval-gap ratios for campaign/report workflows.
 `inventory.tools[*]`, `inventory.agents[*]`, and `agent_privilege_map[*]` also emit additive `security_visibility_status` (`approved|known_unapproved|unknown_to_security`) without overloading `approval_classification`.
+Workflow-backed findings may emit additive first-class workflow capabilities such as `repo.write`, `pull_request.write`, `merge.execute`, `deploy.write`, `db.write`, and `iac.write`. Each capability remains static-only and is paired with `workflow_capability.*` evidence showing which workflow permission or step pattern produced the claim.
+`inventory.tools[*].locations[*]` preserves the legacy `owner` string and adds `owner_source` plus `ownership_status` so CODEOWNERS-backed ownership stays distinguishable from deterministic fallback.
+`agent_privilege_map[*]` and `action_paths[*]` add `operational_owner`, additive ownership provenance, and `approval_gap_reasons` so governance-first paths can show who should act next and why the approval model is incomplete.
 `inventory.security_visibility_summary` emits additive reference-basis and count fields including `unknown_to_security_write_capable_agents`.
 When a downstream workflow does not have a usable `reference_basis`, Wrkr suppresses `unknown_to_security` claims rather than fabricating them.
 `inventory.tools[*]` also emits report-ready `tool_category` and deterministic `confidence_score` (`0.00-1.00`) for inventory breakdown tables.

--- a/docs/trust/detection-coverage-matrix.md
+++ b/docs/trust/detection-coverage-matrix.md
@@ -12,6 +12,7 @@ description: "What Wrkr detects, what it does not detect, and why under determin
 - Direct Python and JS/TS source parsing for supported framework-native agent constructors, registrations, tool bindings, auth surfaces, and entrypoints when declaration files are absent.
 - Explicit bespoke custom-source markers via `wrkr:custom-agent` annotations in Python and JS/TS source files when operators want deterministic custom-agent source coverage without broad heuristics.
 - Prompt-channel override/poisoning patterns from static instruction surfaces with deterministic reason codes and evidence hashes.
+- Structured GitHub Actions workflow capability extraction for `repo.write`, `pull_request.write`, `merge.execute`, `deploy.write`, `db.write`, and `iac.write`, with additive evidence keys that explain which static workflow step or permission produced each claim.
 - Static policy/profile posture signals and ranked findings.
 - Deterministic inventory and risk outputs for both tools and agents, including agent-linked attack-path edges when bindings/deployments are declared in-repo.
 - Optional enrich-mode MCP metadata (`source`, `as_of`, advisory/registry schema IDs, `enrich_quality`, adapter error classes) when `--enrich` is enabled.

--- a/internal/scenarios/approval_gap_modeling_scenario_test.go
+++ b/internal/scenarios/approval_gap_modeling_scenario_test.go
@@ -1,0 +1,54 @@
+//go:build scenario
+
+package scenarios
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestApprovalGapModelingScenario(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "approval-gap-modeling", "repos")
+	payload := runScenarioCommandJSON(t, []string{"scan", "--path", scanPath, "--state", filepath.Join(t.TempDir(), "state.json"), "--json"})
+
+	findings, ok := payload["findings"].([]any)
+	if !ok || len(findings) == 0 {
+		t.Fatalf("expected findings payload, got %v", payload["findings"])
+	}
+	violations := map[string]bool{}
+	for _, item := range findings {
+		finding, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if finding["finding_type"] == "policy_violation" {
+			ruleID, _ := finding["rule_id"].(string)
+			if ruleID != "" {
+				violations[ruleID] = true
+			}
+		}
+	}
+	for _, ruleID := range []string{"WRKR-A001", "WRKR-A002", "WRKR-A009"} {
+		if !violations[ruleID] {
+			t.Fatalf("expected policy violation %s, got %v", ruleID, violations)
+		}
+	}
+
+	actionPaths, ok := payload["action_paths"].([]any)
+	if !ok || len(actionPaths) == 0 {
+		t.Fatalf("expected action_paths payload, got %v", payload["action_paths"])
+	}
+	first, ok := actionPaths[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected action path payload: %T", actionPaths[0])
+	}
+	reasons := toStringSlice(first["approval_gap_reasons"])
+	for _, expected := range []string{"approval_source_missing", "deployment_gate_ambiguous", "proof_requirement_missing"} {
+		if !containsString(reasons, expected) {
+			t.Fatalf("expected approval gap reason %q in %v", expected, reasons)
+		}
+	}
+}

--- a/internal/scenarios/delivery_chain_correlation_scenario_test.go
+++ b/internal/scenarios/delivery_chain_correlation_scenario_test.go
@@ -1,0 +1,38 @@
+//go:build scenario
+
+package scenarios
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDeliveryChainCorrelationScenario(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "delivery-chain-correlation", "repos")
+	targetsPath := filepath.Join(repoRoot, "scenarios", "wrkr", "delivery-chain-correlation", "production-targets.yaml")
+	payload := runScenarioCommandJSON(t, []string{"scan", "--path", scanPath, "--production-targets", targetsPath, "--state", filepath.Join(t.TempDir(), "state.json"), "--json"})
+
+	actionPaths, ok := payload["action_paths"].([]any)
+	if !ok || len(actionPaths) == 0 {
+		t.Fatalf("expected action_paths payload, got %v", payload["action_paths"])
+	}
+	first, ok := actionPaths[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected action path payload: %T", actionPaths[0])
+	}
+	if first["delivery_chain_status"] != "pr_merge_deploy" {
+		t.Fatalf("expected delivery_chain_status=pr_merge_deploy, got %v", first["delivery_chain_status"])
+	}
+	if first["production_target_status"] != "configured" {
+		t.Fatalf("expected production_target_status=configured, got %v", first["production_target_status"])
+	}
+	if first["production_write"] != true {
+		t.Fatalf("expected production_write=true, got %v", first["production_write"])
+	}
+	if first["recommended_action"] != "control" {
+		t.Fatalf("expected recommended_action=control, got %v", first["recommended_action"])
+	}
+}

--- a/internal/scenarios/ownership_quality_scenario_test.go
+++ b/internal/scenarios/ownership_quality_scenario_test.go
@@ -1,0 +1,58 @@
+//go:build scenario
+
+package scenarios
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestOwnershipQualityScenario(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "ownership-quality", "repos")
+	payload := runScenarioCommandJSON(t, []string{"scan", "--path", scanPath, "--state", filepath.Join(t.TempDir(), "state.json"), "--json"})
+
+	agentMap, ok := payload["agent_privilege_map"].([]any)
+	if !ok || len(agentMap) == 0 {
+		t.Fatalf("expected agent_privilege_map payload, got %v", payload["agent_privilege_map"])
+	}
+
+	explicit := findPrivilegeEntryByLocation(agentMap, ".github/workflows/owned.yml")
+	if explicit == nil {
+		t.Fatalf("expected explicit ownership entry, got %v", agentMap)
+	}
+	if explicit["operational_owner"] != "@local/security" || explicit["ownership_status"] != "explicit" {
+		t.Fatalf("expected explicit operational owner, got %v", explicit)
+	}
+
+	inferred := findPrivilegeEntryByLocation(agentMap, ".github/workflows/inferred.yml")
+	if inferred == nil {
+		t.Fatalf("expected inferred ownership entry, got %v", agentMap)
+	}
+	if inferred["ownership_status"] != "inferred" {
+		t.Fatalf("expected inferred ownership status, got %v", inferred)
+	}
+
+	unresolved := findPrivilegeEntryByLocation(agentMap, ".github/workflows/release.yml")
+	if unresolved == nil {
+		t.Fatalf("expected unresolved ownership entry, got %v", agentMap)
+	}
+	if unresolved["ownership_status"] != "unresolved" {
+		t.Fatalf("expected unresolved ownership status, got %v", unresolved)
+	}
+}
+
+func findPrivilegeEntryByLocation(entries []any, location string) map[string]any {
+	for _, item := range entries {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if entry["location"] == location {
+			return entry
+		}
+	}
+	return nil
+}

--- a/internal/scenarios/workflow_capabilities_scenario_test.go
+++ b/internal/scenarios/workflow_capabilities_scenario_test.go
@@ -1,0 +1,51 @@
+//go:build scenario
+
+package scenarios
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestWorkflowCapabilitiesScenario(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "workflow-capabilities", "repos")
+	payload := runScenarioCommandJSON(t, []string{"scan", "--path", scanPath, "--state", filepath.Join(t.TempDir(), "state.json"), "--json"})
+
+	findings, ok := payload["findings"].([]any)
+	if !ok || len(findings) == 0 {
+		t.Fatalf("expected findings array, got %T", payload["findings"])
+	}
+
+	var workflowFinding map[string]any
+	for _, item := range findings {
+		typed, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if typed["finding_type"] == "ci_autonomy" {
+			workflowFinding = typed
+			break
+		}
+	}
+	if workflowFinding == nil {
+		t.Fatalf("expected ci_autonomy finding, got %v", findings)
+	}
+	permissions := toStringSlice(workflowFinding["permissions"])
+	for _, required := range []string{"repo.write", "pull_request.write", "merge.execute", "deploy.write", "db.write", "iac.write"} {
+		if !containsString(permissions, required) {
+			t.Fatalf("expected permission %q in %v", required, permissions)
+		}
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/scenarios/wrkr/approval-gap-modeling/repos/gap-agent-app/.github/workflows/release.yml
+++ b/scenarios/wrkr/approval-gap-modeling/repos/gap-agent-app/.github/workflows/release.yml
@@ -1,0 +1,8 @@
+name: release
+on:
+  workflow_dispatch:
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo release

--- a/scenarios/wrkr/delivery-chain-correlation/production-targets.yaml
+++ b/scenarios/wrkr/delivery-chain-correlation/production-targets.yaml
@@ -1,0 +1,5 @@
+schema_version: v1
+targets:
+  repos:
+    exact:
+      - payments-prod

--- a/scenarios/wrkr/delivery-chain-correlation/repos/payments-prod/.github/workflows/release.yml
+++ b/scenarios/wrkr/delivery-chain-correlation/repos/payments-prod/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: release
+on:
+  pull_request:
+    branches:
+      - main
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: codex --full-auto --approval never
+      - run: gh pr merge --auto "$PR_URL"
+      - run: kubectl apply -f k8s/

--- a/scenarios/wrkr/ownership-quality/repos/alpha-service/.github/workflows/release.yml
+++ b/scenarios/wrkr/ownership-quality/repos/alpha-service/.github/workflows/release.yml
@@ -1,0 +1,12 @@
+name: shared-release
+on:
+  pull_request:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: codex --full-auto --approval never

--- a/scenarios/wrkr/ownership-quality/repos/alpha-service/CODEOWNERS
+++ b/scenarios/wrkr/ownership-quality/repos/alpha-service/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/workflows/release.yml @local/alpha

--- a/scenarios/wrkr/ownership-quality/repos/beta-service/.github/workflows/release.yml
+++ b/scenarios/wrkr/ownership-quality/repos/beta-service/.github/workflows/release.yml
@@ -1,0 +1,12 @@
+name: shared-release
+on:
+  pull_request:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: codex --full-auto --approval never

--- a/scenarios/wrkr/ownership-quality/repos/beta-service/CODEOWNERS
+++ b/scenarios/wrkr/ownership-quality/repos/beta-service/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/workflows/release.yml @local/beta

--- a/scenarios/wrkr/ownership-quality/repos/inferred-owned/.github/workflows/inferred.yml
+++ b/scenarios/wrkr/ownership-quality/repos/inferred-owned/.github/workflows/inferred.yml
@@ -1,0 +1,12 @@
+name: inferred
+on:
+  pull_request:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: codex --full-auto --approval never

--- a/scenarios/wrkr/ownership-quality/repos/payments-owned/.github/workflows/owned.yml
+++ b/scenarios/wrkr/ownership-quality/repos/payments-owned/.github/workflows/owned.yml
@@ -1,0 +1,15 @@
+name: owned
+on:
+  pull_request:
+    branches:
+      - main
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: codex --full-auto --approval never
+      - run: gh pr merge --auto "$PR_URL"
+      - run: kubectl apply -f k8s/

--- a/scenarios/wrkr/ownership-quality/repos/payments-owned/CODEOWNERS
+++ b/scenarios/wrkr/ownership-quality/repos/payments-owned/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/workflows/owned.yml @local/security

--- a/scenarios/wrkr/workflow-capabilities/repos/release-automation/.github/workflows/release.yml
+++ b/scenarios/wrkr/workflow-capabilities/repos/release-automation/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: release
+on:
+  pull_request:
+    branches:
+      - main
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: codex --full-auto --approval never
+      - run: gh pr merge --auto "$PR_URL"
+      - run: terraform apply -auto-approve
+      - run: kubectl apply -f k8s/
+      - run: alembic upgrade head

--- a/schemas/v1/inventory/inventory.schema.json
+++ b/schemas/v1/inventory/inventory.schema.json
@@ -72,7 +72,9 @@
               "properties": {
                 "repo": {"type": "string"},
                 "location": {"type": "string"},
-                "owner": {"type": "string"}
+                "owner": {"type": "string"},
+                "owner_source": {"type": "string", "enum": ["codeowners", "repo_fallback", "multi_repo_conflict"]},
+                "ownership_status": {"type": "string", "enum": ["explicit", "inferred", "unresolved"]}
               }
             }
           },
@@ -298,6 +300,15 @@
           "deployment_status": {"type": "string", "enum": ["unknown", "deployed", "ambiguous"]},
           "deployment_artifacts": {"type": "array", "items": {"type": "string"}},
           "deployment_evidence_keys": {"type": "array", "items": {"type": "string"}},
+          "operational_owner": {"type": "string"},
+          "owner_source": {"type": "string", "enum": ["codeowners", "repo_fallback", "multi_repo_conflict"]},
+          "ownership_status": {"type": "string", "enum": ["explicit", "inferred", "unresolved"]},
+          "approval_gap_reasons": {"type": "array", "items": {"type": "string"}},
+          "pull_request_write": {"type": "boolean"},
+          "merge_execute": {"type": "boolean"},
+          "deploy_write": {"type": "boolean"},
+          "delivery_chain_status": {"type": "string", "enum": ["none", "pr_only", "merge_only", "deploy_only", "pr_merge", "merge_deploy", "pr_merge_deploy"]},
+          "production_target_status": {"type": "string", "enum": ["configured", "not_configured", "invalid"]},
           "write_capable": {"type": "boolean"},
           "credential_access": {"type": "boolean"},
           "exec_capable": {"type": "boolean"},


### PR DESCRIPTION
## Problem
Wave 3 and Wave 4 in `product/PLAN_NEXT.md` need static modeling that keeps delivery-path claims honest and makes governance gaps explainable in inventory and action-path output.

## Changes
- add structured workflow capability extraction for release workflows and compiled-action coverage
- correlate deploy-capable workflows, production targets, ownership provenance, and approval gaps into inventory, risk, and action-path scoring
- expand scenario coverage for workflow capabilities, delivery-chain correlation, ownership quality, and approval-gap modeling
- update CLI/docs/schema output to surface the new governance fields deterministically

## Validation
- `make prepush-full`
- `./.tmp/wrkr scan --path . --json --quiet --timeout 90s --json-path /tmp/wrkr_ship_readiness.json`
