### PR TITLE
test: track approval-gap scenario fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ venv/
 !scenarios/wrkr/agent-relationship-correlation/repos/correlated-agent-app/.wrkr/
 !scenarios/wrkr/agent-relationship-correlation/repos/correlated-agent-app/.wrkr/agents/
 !scenarios/wrkr/agent-relationship-correlation/repos/correlated-agent-app/.wrkr/agents/mcp-client.yaml
+!scenarios/wrkr/approval-gap-modeling/repos/gap-agent-app/.wrkr/
+!scenarios/wrkr/approval-gap-modeling/repos/gap-agent-app/.wrkr/agents/
+!scenarios/wrkr/approval-gap-modeling/repos/gap-agent-app/.wrkr/agents/langchain.json
 !testinfra/benchmarks/agents/fixtures/**/.wrkr/
 !testinfra/benchmarks/agents/fixtures/**/.wrkr/**
 *.sarif

--- a/scenarios/wrkr/approval-gap-modeling/repos/gap-agent-app/.wrkr/agents/langchain.json
+++ b/scenarios/wrkr/approval-gap-modeling/repos/gap-agent-app/.wrkr/agents/langchain.json
@@ -1,0 +1,12 @@
+{
+  "agents": [
+    {
+      "name": "release_agent",
+      "file": "agents/release.py",
+      "tools": ["deploy.write"],
+      "deployment_artifacts": [".github/workflows/release.yml"],
+      "auto_deploy": true,
+      "human_gate": true
+    }
+  ]
+}


### PR DESCRIPTION
## Problem
- main workflow run 23563708621 failed in `acceptance` and `v1-acceptance` on `TestApprovalGapModelingScenario`.
- The scenario expected `WRKR-A002` and `WRKR-A009`, but the approval-gap fixture file under `scenarios/wrkr/approval-gap-modeling` was only present as an ignored local `.wrkr` file, so clean checkouts and CI never saw it.
- That made local reproduction on a dirty workspace misleading while clean mainline runs failed consistently.

## Changes
- unignored the approval-gap scenario's `.wrkr` fixture path in `.gitignore`
- added the missing tracked fixture file at `scenarios/wrkr/approval-gap-modeling/repos/gap-agent-app/.wrkr/agents/langchain.json`

## Validation
- `go test ./internal/scenarios -run TestApprovalGapModelingScenario -count=1 -tags=scenario -v`
- clean archive reproduction of the scenario from `HEAD` after copying the tracked fixture into the exported tree
- `go test ./core/detect/agentframework ./core/policy/eval ./core/aggregate/privilegebudget -count=1`
- `go run ./cmd/wrkr scan --json`
- `make prepush-full`
