### PR TITLE
fix: harden scan path and artifact safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ CLI output expectations:
 
 - Go is primary runtime language (single static binary model).
 - Target toolchain versions:
-  - Go `1.26.1`
+  - Go: follow `go.mod` for the enforced floor and `product/dev_guides.md` for the org-wide version policy. Do not duplicate a literal Go version in this file.
   - Python `3.13+` (scripts/tools)
   - Node `22+` (docs/UI only; not core runtime logic)
 - Use exact/pinned dependency versions where applicable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Workflow-backed govern-first paths and summaries now expose static trigger posture such as scheduled, workflow-dispatch, and deploy-pipeline backed execution when it changes governance urgency.
 - Govern-first ranking now prioritizes the most urgent write, deploy, production-backed, and approval-gap paths first while keeping weaker paths visible lower in the ranked output.
 - `recommended_action` now separates visibility, approval, proof, and control-first path classes more sharply on real-world govern-first scans and report summaries.
+- Clarified repo-local contributor and agent guidance so Wrkr now delegates Go toolchain authority to the enforced 1.26.2 floor in `go.mod` and the development standards.
 
 ### Deprecated
 
@@ -32,6 +33,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 ### Fixed
 
 - Hosted GitHub scans now retry recognizable rate-limit `403` responses using the observed reset window instead of failing immediately as generic runtime errors.
+- Blocked scan sidecar output paths from aliasing managed state and proof artifacts, so invalid configurations now fail fast instead of corrupting saved scan state.
+- Made `wrkr scan --path` honor single-repo root inputs while preserving deterministic repo-set scans for scenario bundles and local multi-repo roots.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/la
 ```
 
 This curated path is the recommended first-value workflow for evaluation because it avoids repo-root fixture noise from Wrkr's own scenario, docs, and test fixtures while still showing the shipped wedge: discovery, posture, evidence, verification, and regression gates.
+`--path` is explicit now: point it at a repo root when the selected directory itself carries repo-root signals such as `.git`, `go.mod`, `AGENTS.md`, `.codex/`, or `.github/`; point it at `./scenarios/wrkr/scan-mixed-org/repos` or another bundle root when you want Wrkr to scan immediate child repos as a deterministic repo-set.
 
 ### Security Teams (Recommended first path)
 
@@ -71,7 +72,7 @@ wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json
 wrkr verify --chain --state ./.wrkr/last-scan.json --json
 ```
 
-`--json` keeps stdout reserved for the final machine-readable payload. `--json-path` adds a byte-identical JSON artifact on disk, hosted org scans surface deterministic progress/retry/completion lines on stderr without polluting stdout JSON, and `--resume` reuses durable org-scan checkpoint state under the scan-state directory when an earlier hosted scan was interrupted. `--profile assessment` narrows the govern-first readout for customer-style scans without changing raw findings, proof chains, or exit codes.
+`--json` keeps stdout reserved for the final machine-readable payload. `--json-path` adds a byte-identical JSON artifact on disk, hosted org scans surface deterministic progress/retry/completion lines on stderr without polluting stdout JSON, and `--resume` reuses durable org-scan checkpoint state under the scan-state directory when an earlier hosted scan was interrupted. `--json-path`, `--report-md-path`, and `--sarif-path` must each stay unique and must not alias `--state` or Wrkr-managed sibling artifacts; collisions now fail closed with `invalid_input` before any scan state is mutated. `--profile assessment` narrows the govern-first readout for customer-style scans without changing raw findings, proof chains, or exit codes.
 If a hosted org scan is interrupted, rerun the same target with `--resume`. Treat `partial_result`, `source_errors`, or `source_degraded` as incomplete posture output and rerun after rate limits, permission issues, or upstream failures are resolved.
 `wrkr evidence` now requires the saved proof chain to be intact before it stages or publishes a bundle, and `wrkr verify --chain` remains the explicit operator/CI integrity gate. `--resume` also revalidates checkpoint files and reused materialized repo roots so symlink-swapped entries fail closed instead of being treated as trusted scan roots.
 When one run needs both hosted and local scope, use repeatable `--target` flags:
@@ -91,6 +92,8 @@ If hosted prerequisites are not ready yet, start with one of these deterministic
 wrkr scan --path ./your-repo --json
 wrkr scan --my-setup --json
 ```
+
+Use `./your-repo` when the selected directory itself is the repo root. Use a bundle root like `./scenarios/wrkr/scan-mixed-org/repos` when the selected directory is intentionally a set of immediate child repos.
 
 ### Developers (Secondary local hygiene)
 
@@ -400,7 +403,7 @@ wrkr regress run --baseline ./.wrkr/inventory-baseline.json --state ./.wrkr/last
 Wrkr treats machine-readable output and exit codes as product contracts.
 
 - `--json` emits stable machine-readable output.
-- `--json-path` writes the same final machine-readable scan payload to disk without changing the `--json` stdout contract.
+- `--json-path` writes the same final machine-readable scan payload to disk without changing the `--json` stdout contract, and every requested sidecar path must stay unique from `--state` and other scan-owned artifacts.
 - `--sarif` emits SARIF `2.1.0` for security tooling and GitHub code scanning workflows.
 - Partial-result mode preserves findings when a detector or source path fails non-fatally.
 - `--timeout` and signal cancellation are enforced end-to-end.

--- a/core/cli/managed_artifacts.go
+++ b/core/cli/managed_artifacts.go
@@ -95,30 +95,35 @@ func canonicalArtifactPath(raw string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve artifact output path: %w", err)
 	}
+	return resolveArtifactPath(absPath)
+}
 
-	info, err := os.Lstat(absPath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return absPath, nil
+func resolveArtifactPath(absPath string) (string, error) {
+	missingTail := make([]string, 0, 4)
+	candidate := absPath
+	for {
+		resolved, err := filepath.EvalSymlinks(candidate)
+		if err == nil {
+			for i := len(missingTail) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missingTail[i])
+			}
+			return filepath.Clean(resolved), nil
 		}
-		return "", fmt.Errorf("stat artifact output path: %w", err)
-	}
-	if info.Mode()&os.ModeSymlink == 0 {
-		return absPath, nil
-	}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("resolve artifact output path: %w", err)
+		}
 
-	targetPath, err := os.Readlink(absPath)
-	if err != nil {
-		return "", fmt.Errorf("read artifact output symlink target: %w", err)
-	}
-	if !filepath.IsAbs(targetPath) {
-		parentDir, err := filepath.EvalSymlinks(filepath.Dir(absPath))
-		if err != nil {
-			return "", fmt.Errorf("resolve artifact output symlink parent: %w", err)
+		parent := filepath.Dir(candidate)
+		if parent == candidate {
+			for i := len(missingTail) - 1; i >= 0; i-- {
+				candidate = filepath.Join(candidate, missingTail[i])
+			}
+			return filepath.Clean(candidate), nil
 		}
-		targetPath = filepath.Join(parentDir, targetPath)
+
+		missingTail = append(missingTail, filepath.Base(candidate))
+		candidate = parent
 	}
-	return filepath.Clean(targetPath), nil
 }
 
 func detectScanArtifactPathCollisions(entries []scanArtifactPathEntry) error {

--- a/core/cli/managed_artifacts.go
+++ b/core/cli/managed_artifacts.go
@@ -18,6 +18,12 @@ type managedArtifactSnapshot struct {
 	perm    os.FileMode
 }
 
+type scanArtifactPathEntry struct {
+	label string
+	path  string
+	key   string
+}
+
 func captureManagedArtifacts(paths ...string) ([]managedArtifactSnapshot, error) {
 	snapshots := make([]managedArtifactSnapshot, 0, len(paths))
 	seen := map[string]struct{}{}
@@ -61,6 +67,102 @@ func captureManagedArtifact(path string) (managedArtifactSnapshot, error) {
 		payload: payload,
 		perm:    info.Mode().Perm(),
 	}, nil
+}
+
+func normalizeManagedArtifactPath(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("scan artifact path must not be empty")
+	}
+	return filepath.Clean(trimmed), nil
+}
+
+func newScanArtifactPathEntry(label, path string) (scanArtifactPathEntry, error) {
+	key, err := canonicalArtifactPath(path)
+	if err != nil {
+		return scanArtifactPathEntry{}, err
+	}
+	return scanArtifactPathEntry{
+		label: label,
+		path:  path,
+		key:   key,
+	}, nil
+}
+
+func canonicalArtifactPath(raw string) (string, error) {
+	cleanPath := filepath.Clean(strings.TrimSpace(raw))
+	absPath, err := filepath.Abs(cleanPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve artifact output path: %w", err)
+	}
+
+	info, err := os.Lstat(absPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return absPath, nil
+		}
+		return "", fmt.Errorf("stat artifact output path: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return absPath, nil
+	}
+
+	targetPath, err := os.Readlink(absPath)
+	if err != nil {
+		return "", fmt.Errorf("read artifact output symlink target: %w", err)
+	}
+	if !filepath.IsAbs(targetPath) {
+		parentDir, err := filepath.EvalSymlinks(filepath.Dir(absPath))
+		if err != nil {
+			return "", fmt.Errorf("resolve artifact output symlink parent: %w", err)
+		}
+		targetPath = filepath.Join(parentDir, targetPath)
+	}
+	return filepath.Clean(targetPath), nil
+}
+
+func detectScanArtifactPathCollisions(entries []scanArtifactPathEntry) error {
+	byKey := make(map[string][]scanArtifactPathEntry, len(entries))
+	keyOrder := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.key) == "" {
+			continue
+		}
+		if _, ok := byKey[entry.key]; !ok {
+			keyOrder = append(keyOrder, entry.key)
+		}
+		byKey[entry.key] = append(byKey[entry.key], entry)
+	}
+
+	conflicts := make([]string, 0)
+	for _, key := range keyOrder {
+		group := byKey[key]
+		if len(group) < 2 {
+			continue
+		}
+		labels := make([]string, 0, len(group))
+		for _, entry := range group {
+			labels = append(labels, entry.label)
+		}
+		conflicts = append(conflicts, fmt.Sprintf("%s resolve to the same path %s", humanArtifactLabelList(labels), key))
+	}
+	if len(conflicts) == 0 {
+		return nil
+	}
+	return fmt.Errorf("scan artifact path collision: %s", strings.Join(conflicts, "; "))
+}
+
+func humanArtifactLabelList(labels []string) string {
+	switch len(labels) {
+	case 0:
+		return ""
+	case 1:
+		return labels[0]
+	case 2:
+		return labels[0] + " and " + labels[1]
+	default:
+		return strings.Join(labels[:len(labels)-1], ", ") + ", and " + labels[len(labels)-1]
+	}
 }
 
 func restoreManagedArtifacts(snapshots []managedArtifactSnapshot) error {

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -91,10 +91,6 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	if *timeout < 0 {
 		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", "--timeout must be >= 0", exitInvalidInput)
 	}
-	jsonSink, jsonSinkErr := newJSONOutputSink(*jsonOut, *jsonPath, stdout)
-	if jsonSinkErr != nil {
-		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", jsonSinkErr.Error(), exitInvalidInput)
-	}
 	productionTargetsFile := strings.TrimSpace(*productionTargetsPath)
 	if *productionTargetsStrict && productionTargetsFile == "" {
 		return emitError(
@@ -140,11 +136,24 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 			exitDependencyMissing,
 		)
 	}
-	statePath := state.ResolvePath(*statePathFlag)
-	artifactPreflight, preflightErr := preflightScanArtifacts(*reportMD, *reportMDPath, *reportTemplate, *reportShareProfile, *sarifOut, *sarifPath)
+	artifactPreflight, preflightErr := preflightScanArtifacts(
+		state.ResolvePath(*statePathFlag),
+		*jsonPath,
+		*reportMD,
+		*reportMDPath,
+		*reportTemplate,
+		*reportShareProfile,
+		*sarifOut,
+		*sarifPath,
+	)
 	if preflightErr != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", preflightErr.Error(), exitInvalidInput)
 	}
+	jsonSink, jsonSinkErr := newJSONOutputSink(*jsonOut, artifactPreflight.JSONPath, stdout)
+	if jsonSinkErr != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", jsonSinkErr.Error(), exitInvalidInput)
+	}
+	statePath := artifactPreflight.StatePath
 
 	ctx := parentCtx
 	cancel := func() {}
@@ -206,7 +215,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		repoRisk[repo.Org+"::"+repo.Repo] = repo.Score
 	}
 
-	manifestPath := manifest.ResolvePath(statePath)
+	manifestPath := artifactPreflight.ManifestPath
 	previousManifest, manifestErr := loadLifecycleManifest(manifestPath, statePath, previousSnapshot)
 	if manifestErr != nil {
 		return emitScanFailure(manifestErr)
@@ -344,15 +353,15 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		Identities:   nextManifest.Identities,
 		Transitions:  transitions,
 	}
-	chainPath := lifecycle.ChainPath(statePath)
-	proofChainPath := proofemit.ChainPath(statePath)
+	chainPath := artifactPreflight.LifecyclePath
+	proofChainPath := artifactPreflight.ProofChainPath
 	managedSnapshots, snapshotErr := captureManagedArtifacts(
 		statePath,
 		manifestPath,
 		chainPath,
 		proofChainPath,
-		proofemit.ChainAttestationPath(proofChainPath),
-		proofemit.SigningKeyPath(statePath),
+		artifactPreflight.ProofAttestationPath,
+		artifactPreflight.SigningKeyPath,
 		artifactPreflight.ReportPath,
 		artifactPreflight.SARIFPath,
 		jsonSink.outputPath,
@@ -567,14 +576,84 @@ func toolTouchesLocalMachine(tool agginventory.Tool) bool {
 }
 
 type scanArtifactPreflight struct {
-	ReportTemplate     reportcore.Template
-	ReportShareProfile reportcore.ShareProfile
-	ReportPath         string
-	SARIFPath          string
+	StatePath            string
+	ManifestPath         string
+	LifecyclePath        string
+	ProofChainPath       string
+	ProofAttestationPath string
+	SigningKeyPath       string
+	JSONPath             string
+	ReportTemplate       reportcore.Template
+	ReportShareProfile   reportcore.ShareProfile
+	ReportPath           string
+	SARIFPath            string
 }
 
-func preflightScanArtifacts(reportEnabled bool, reportPath, reportTemplateRaw, reportShareProfileRaw string, sarifEnabled bool, sarifPath string) (scanArtifactPreflight, error) {
+func preflightScanArtifacts(statePathRaw, jsonPath string, reportEnabled bool, reportPath, reportTemplateRaw, reportShareProfileRaw string, sarifEnabled bool, sarifPath string) (scanArtifactPreflight, error) {
 	preflight := scanArtifactPreflight{}
+	statePath, err := normalizeManagedArtifactPath(statePathRaw)
+	if err != nil {
+		return scanArtifactPreflight{}, err
+	}
+	manifestPath, err := normalizeManagedArtifactPath(manifest.ResolvePath(statePath))
+	if err != nil {
+		return scanArtifactPreflight{}, err
+	}
+	lifecyclePath, err := normalizeManagedArtifactPath(lifecycle.ChainPath(statePath))
+	if err != nil {
+		return scanArtifactPreflight{}, err
+	}
+	proofChainPath, err := normalizeManagedArtifactPath(proofemit.ChainPath(statePath))
+	if err != nil {
+		return scanArtifactPreflight{}, err
+	}
+	proofAttestationPath, err := normalizeManagedArtifactPath(proofemit.ChainAttestationPath(proofChainPath))
+	if err != nil {
+		return scanArtifactPreflight{}, err
+	}
+	signingKeyPath, err := normalizeManagedArtifactPath(proofemit.SigningKeyPath(statePath))
+	if err != nil {
+		return scanArtifactPreflight{}, err
+	}
+
+	preflight.StatePath = statePath
+	preflight.ManifestPath = manifestPath
+	preflight.LifecyclePath = lifecyclePath
+	preflight.ProofChainPath = proofChainPath
+	preflight.ProofAttestationPath = proofAttestationPath
+	preflight.SigningKeyPath = signingKeyPath
+
+	entries := make([]scanArtifactPathEntry, 0, 9)
+	for _, item := range []struct {
+		label string
+		path  string
+	}{
+		{label: "--state", path: preflight.StatePath},
+		{label: "manifest", path: preflight.ManifestPath},
+		{label: "lifecycle chain", path: preflight.LifecyclePath},
+		{label: "proof chain", path: preflight.ProofChainPath},
+		{label: "proof attestation", path: preflight.ProofAttestationPath},
+		{label: "proof signing key", path: preflight.SigningKeyPath},
+	} {
+		entry, entryErr := newScanArtifactPathEntry(item.label, item.path)
+		if entryErr != nil {
+			return scanArtifactPreflight{}, entryErr
+		}
+		entries = append(entries, entry)
+	}
+
+	if strings.TrimSpace(jsonPath) != "" {
+		path, err := resolveArtifactOutputPath(jsonPath)
+		if err != nil {
+			return scanArtifactPreflight{}, err
+		}
+		preflight.JSONPath = path
+		entry, entryErr := newScanArtifactPathEntry("--json-path", path)
+		if entryErr != nil {
+			return scanArtifactPreflight{}, entryErr
+		}
+		entries = append(entries, entry)
+	}
 	if reportEnabled {
 		template, shareProfile, err := parseReportTemplateShare(reportTemplateRaw, reportShareProfileRaw)
 		if err != nil {
@@ -587,6 +666,11 @@ func preflightScanArtifacts(reportEnabled bool, reportPath, reportTemplateRaw, r
 		preflight.ReportTemplate = template
 		preflight.ReportShareProfile = shareProfile
 		preflight.ReportPath = path
+		entry, entryErr := newScanArtifactPathEntry("--report-md-path", path)
+		if entryErr != nil {
+			return scanArtifactPreflight{}, entryErr
+		}
+		entries = append(entries, entry)
 	}
 	if sarifEnabled {
 		path, err := resolveArtifactOutputPath(sarifPath)
@@ -594,6 +678,14 @@ func preflightScanArtifacts(reportEnabled bool, reportPath, reportTemplateRaw, r
 			return scanArtifactPreflight{}, err
 		}
 		preflight.SARIFPath = path
+		entry, entryErr := newScanArtifactPathEntry("--sarif-path", path)
+		if entryErr != nil {
+			return scanArtifactPreflight{}, entryErr
+		}
+		entries = append(entries, entry)
+	}
+	if err := detectScanArtifactPathCollisions(entries); err != nil {
+		return scanArtifactPreflight{}, err
 	}
 	return preflight, nil
 }

--- a/core/cli/scan_contract_fix_test.go
+++ b/core/cli/scan_contract_fix_test.go
@@ -8,86 +8,106 @@ import (
 	"testing"
 )
 
-func TestScanStateFailureDoesNotWriteAuxiliaryArtifacts(t *testing.T) {
+func TestScanPathRepoRootProducesSingleRepoManifestAndRootFinding(t *testing.T) {
 	t.Parallel()
 
-	tmp := t.TempDir()
-	reposPath := filepath.Join(tmp, "repos")
-	repoPath := filepath.Join(reposPath, "backend")
-	if err := os.MkdirAll(filepath.Join(repoPath, ".codex"), 0o755); err != nil {
-		t.Fatalf("mkdir repo: %v", err)
+	repoRoot := filepath.Join(t.TempDir(), "demo-repo")
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatalf("mkdir repo root: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(repoPath, ".codex", "config.toml"), []byte("approval_policy = \"never\"\n"), 0o600); err != nil {
-		t.Fatalf("write codex config: %v", err)
-	}
-
-	blockedTarget := filepath.Join(tmp, "blocked-state-target")
-	if err := os.MkdirAll(blockedTarget, 0o755); err != nil {
-		t.Fatalf("mkdir blocked target: %v", err)
-	}
-	statePath := filepath.Join(tmp, "state.json")
-	if err := os.Symlink(blockedTarget, statePath); err != nil {
-		t.Skipf("symlink not supported in this environment: %v", err)
+	if err := os.WriteFile(filepath.Join(repoRoot, "AGENTS.md"), []byte("agent instructions\n"), 0o600); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
 	}
 
 	var out bytes.Buffer
 	var errOut bytes.Buffer
-	code := Run([]string{"scan", "--path", reposPath, "--state", statePath, "--json"}, &out, &errOut)
-	if code != exitRuntime {
-		t.Fatalf("expected exit %d, got %d (%s)", exitRuntime, code, errOut.String())
+	code := Run([]string{"scan", "--path", repoRoot, "--state", filepath.Join(t.TempDir(), "state.json"), "--json"}, &out, &errOut)
+	if code != exitSuccess {
+		t.Fatalf("scan failed: %d stderr=%q", code, errOut.String())
 	}
-	assertErrorCode(t, errOut.Bytes(), "runtime_failure")
 
-	for _, name := range []string{"wrkr-manifest.yaml", "identity-chain.json", "proof-chain.json", "proof-signing-key.json"} {
-		if _, err := os.Stat(filepath.Join(tmp, name)); !os.IsNotExist(err) {
-			t.Fatalf("expected %s to be absent after state failure, got %v", name, err)
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse scan payload: %v", err)
+	}
+	sourceManifest, ok := payload["source_manifest"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected source_manifest object, got %T", payload["source_manifest"])
+	}
+	repos, ok := sourceManifest["repos"].([]any)
+	if !ok || len(repos) != 1 {
+		t.Fatalf("expected one repo manifest entry, got %v", sourceManifest["repos"])
+	}
+	firstRepo, ok := repos[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected repo manifest shape: %T", repos[0])
+	}
+	if firstRepo["repo"] != "demo-repo" {
+		t.Fatalf("expected repo name demo-repo, got %v", firstRepo["repo"])
+	}
+
+	findings, ok := payload["findings"].([]any)
+	if !ok {
+		t.Fatalf("expected findings array, got %T", payload["findings"])
+	}
+	foundRootSignal := false
+	for _, item := range findings {
+		finding, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if finding["location"] == "AGENTS.md" && finding["repo"] == "demo-repo" {
+			foundRootSignal = true
+			break
 		}
 	}
+	if !foundRootSignal {
+		t.Fatalf("expected a root-level AGENTS.md finding in payload: %v", findings)
+	}
 }
 
-func TestScanPolicyWeightOverrideFailureReturnsPolicySchemaViolation(t *testing.T) {
+func TestScanPathRepoSetPreservesDeterministicChildOrdering(t *testing.T) {
 	t.Parallel()
 
-	tmp := t.TempDir()
-	reposPath := filepath.Join(tmp, "repos")
-	repoPath := filepath.Join(reposPath, "backend")
-	if err := os.MkdirAll(filepath.Join(repoPath, ".codex"), 0o755); err != nil {
-		t.Fatalf("mkdir repo: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(repoPath, ".codex", "config.toml"), []byte("approval_policy = \"never\"\n"), 0o600); err != nil {
-		t.Fatalf("write codex config: %v", err)
-	}
-
-	policyPath := filepath.Join(tmp, "wrkr-policy.yaml")
-	policy := []byte("rules: []\nscore_weights:\n  policy_pass_rate: 101\n")
-	if err := os.WriteFile(policyPath, policy, 0o600); err != nil {
-		t.Fatalf("write policy file: %v", err)
+	reposRoot := filepath.Join(t.TempDir(), "repos")
+	for _, name := range []string{"zeta", "alpha"} {
+		repoRoot := filepath.Join(reposRoot, name)
+		if err := os.MkdirAll(filepath.Join(repoRoot, ".codex"), 0o755); err != nil {
+			t.Fatalf("mkdir repo %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(repoRoot, ".codex", "config.toml"), []byte("approval_policy = \"never\"\n"), 0o600); err != nil {
+			t.Fatalf("write codex config for %s: %v", name, err)
+		}
 	}
 
 	var out bytes.Buffer
 	var errOut bytes.Buffer
-	code := Run([]string{"scan", "--path", reposPath, "--state", filepath.Join(tmp, "state.json"), "--policy", policyPath, "--json"}, &out, &errOut)
-	if code != exitPolicyViolation {
-		t.Fatalf("expected exit %d, got %d (%s)", exitPolicyViolation, code, errOut.String())
+	code := Run([]string{"scan", "--path", reposRoot, "--state", filepath.Join(t.TempDir(), "state.json"), "--json"}, &out, &errOut)
+	if code != exitSuccess {
+		t.Fatalf("scan failed: %d stderr=%q", code, errOut.String())
 	}
-	assertPolicyError(t, errOut.Bytes(), "policy_schema_violation", exitPolicyViolation)
-}
 
-func assertPolicyError(t *testing.T, payload []byte, expectedCode string, expectedExit int) {
-	t.Helper()
-
-	var envelope map[string]any
-	if err := json.Unmarshal(payload, &envelope); err != nil {
-		t.Fatalf("parse error payload: %v (%q)", err, string(payload))
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse scan payload: %v", err)
 	}
-	errorPayload, ok := envelope["error"].(map[string]any)
+	sourceManifest, ok := payload["source_manifest"].(map[string]any)
 	if !ok {
-		t.Fatalf("expected error object in payload, got %v", envelope)
+		t.Fatalf("expected source_manifest object, got %T", payload["source_manifest"])
 	}
-	if errorPayload["code"] != expectedCode {
-		t.Fatalf("expected error code %q, got %v", expectedCode, errorPayload["code"])
+	repos, ok := sourceManifest["repos"].([]any)
+	if !ok || len(repos) != 2 {
+		t.Fatalf("expected two repo manifest entries, got %v", sourceManifest["repos"])
 	}
-	if errorPayload["exit_code"] != float64(expectedExit) {
-		t.Fatalf("expected exit_code=%d, got %v", expectedExit, errorPayload["exit_code"])
+	firstRepo, ok := repos[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected first repo manifest shape: %T", repos[0])
+	}
+	secondRepo, ok := repos[1].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected second repo manifest shape: %T", repos[1])
+	}
+	if firstRepo["repo"] != "alpha" || secondRepo["repo"] != "zeta" {
+		t.Fatalf("expected deterministic alpha/zeta ordering, got %v", repos)
 	}
 }

--- a/core/cli/scan_json_path_test.go
+++ b/core/cli/scan_json_path_test.go
@@ -190,6 +190,63 @@ func TestScanJSONPathRejectsAliasWithStatePathBeforeWritingManagedArtifacts(t *t
 	}
 }
 
+func TestScanJSONPathRejectsAliasViaSymlinkedParentPath(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink fixture is not portable on windows")
+	}
+
+	tmp := t.TempDir()
+	reposPath := filepath.Join(tmp, "repos")
+	repoPath := filepath.Join(reposPath, "alpha", ".codex")
+	realDir := filepath.Join(tmp, "real")
+	linkDir := filepath.Join(tmp, "link")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoPath, "config.toml"), []byte("approval_policy = \"never\"\n"), 0o600); err != nil {
+		t.Fatalf("write codex config: %v", err)
+	}
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("mkdir real dir: %v", err)
+	}
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlink unsupported in current environment: %v", err)
+	}
+
+	statePath := filepath.Join(realDir, "state.json")
+	jsonPath := filepath.Join(linkDir, "state.json")
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"scan",
+		"--path", reposPath,
+		"--state", statePath,
+		"--json",
+		"--json-path", jsonPath,
+	}, &out, &errOut)
+	if code != exitInvalidInput {
+		t.Fatalf("expected exit %d, got %d stdout=%q stderr=%q", exitInvalidInput, code, out.String(), errOut.String())
+	}
+	assertErrorEnvelopeCode(t, errOut.Bytes(), "invalid_input", exitInvalidInput)
+
+	envelope := parseTrailingJSONEnvelope(t, errOut.Bytes())
+	errorPayload, ok := envelope["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error payload, got %v", envelope)
+	}
+	message, _ := errorPayload["message"].(string)
+	for _, want := range []string{"--state", "--json-path"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("expected error message %q to mention %s", message, want)
+		}
+	}
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("expected %s to remain absent after rejected collision, got err=%v", statePath, err)
+	}
+}
+
 func TestScanJSONPathRejectsAliasWithReportPath(t *testing.T) {
 	t.Parallel()
 

--- a/core/cli/scan_json_path_test.go
+++ b/core/cli/scan_json_path_test.go
@@ -8,6 +8,10 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/lifecycle"
+	"github.com/Clyra-AI/wrkr/core/manifest"
+	"github.com/Clyra-AI/wrkr/core/proofemit"
 )
 
 func TestScanJSONPathWritesByteIdenticalPayloadToStdoutAndFile(t *testing.T) {
@@ -130,6 +134,104 @@ func TestScanJSONPathRejectsDirectory(t *testing.T) {
 		t.Fatalf("expected exit %d, got %d (%s)", exitInvalidInput, code, errOut.String())
 	}
 	assertErrorEnvelopeCode(t, errOut.Bytes(), "invalid_input", exitInvalidInput)
+}
+
+func TestScanJSONPathRejectsAliasWithStatePathBeforeWritingManagedArtifacts(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	reposPath := filepath.Join(tmp, "repos")
+	repoPath := filepath.Join(reposPath, "alpha", ".codex")
+	statePath := filepath.Join(tmp, ".wrkr", "state.json")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoPath, "config.toml"), []byte("approval_policy = \"never\"\n"), 0o600); err != nil {
+		t.Fatalf("write codex config: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"scan",
+		"--path", reposPath,
+		"--state", statePath,
+		"--json",
+		"--json-path", statePath,
+	}, &out, &errOut)
+	if code != exitInvalidInput {
+		t.Fatalf("expected exit %d, got %d stdout=%q stderr=%q", exitInvalidInput, code, out.String(), errOut.String())
+	}
+	assertErrorEnvelopeCode(t, errOut.Bytes(), "invalid_input", exitInvalidInput)
+
+	envelope := parseTrailingJSONEnvelope(t, errOut.Bytes())
+	errorPayload, ok := envelope["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error payload, got %v", envelope)
+	}
+	message, _ := errorPayload["message"].(string)
+	for _, want := range []string{"--state", "--json-path"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("expected error message %q to mention %s", message, want)
+		}
+	}
+
+	for _, path := range []string{
+		statePath,
+		manifest.ResolvePath(statePath),
+		lifecycle.ChainPath(statePath),
+		proofemit.ChainPath(statePath),
+		proofemit.ChainAttestationPath(proofemit.ChainPath(statePath)),
+		proofemit.SigningKeyPath(statePath),
+	} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to remain absent after rejected collision, got err=%v", path, err)
+		}
+	}
+}
+
+func TestScanJSONPathRejectsAliasWithReportPath(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	reposPath := filepath.Join(tmp, "repos")
+	repoPath := filepath.Join(reposPath, "alpha", ".codex")
+	statePath := filepath.Join(tmp, "state.json")
+	sidecarPath := filepath.Join(tmp, "scan-artifact.json")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoPath, "config.toml"), []byte("approval_policy = \"never\"\n"), 0o600); err != nil {
+		t.Fatalf("write codex config: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"scan",
+		"--path", reposPath,
+		"--state", statePath,
+		"--json",
+		"--json-path", sidecarPath,
+		"--report-md",
+		"--report-md-path", sidecarPath,
+	}, &out, &errOut)
+	if code != exitInvalidInput {
+		t.Fatalf("expected exit %d, got %d stdout=%q stderr=%q", exitInvalidInput, code, out.String(), errOut.String())
+	}
+	assertErrorEnvelopeCode(t, errOut.Bytes(), "invalid_input", exitInvalidInput)
+
+	envelope := parseTrailingJSONEnvelope(t, errOut.Bytes())
+	errorPayload, ok := envelope["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error payload, got %v", envelope)
+	}
+	message, _ := errorPayload["message"].(string)
+	for _, want := range []string{"--json-path", "--report-md-path"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("expected error message %q to mention %s", message, want)
+		}
+	}
 }
 
 func TestScanJSONPathWriteFailureReturnsRuntimeFailure(t *testing.T) {

--- a/core/cli/scan_transaction_test.go
+++ b/core/cli/scan_transaction_test.go
@@ -212,3 +212,58 @@ func TestScanLateJSONPathWriteFailureRollsBackManagedArtifacts(t *testing.T) {
 	assertOptionalTestFileEquals(t, attestationPath, attestationBefore)
 	assertOptionalTestFileEquals(t, signingKeyPath, signingKeyBefore)
 }
+
+func TestScanRejectedJSONPathAliasPreservesManagedArtifacts(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	reposPath := filepath.Join(tmp, "repos")
+	repoPath := filepath.Join(reposPath, "alpha", ".codex")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoPath, "config.toml"), []byte("approval_policy = \"never\"\n"), 0o600); err != nil {
+		t.Fatalf("write codex config: %v", err)
+	}
+
+	statePath := filepath.Join(tmp, ".wrkr", "state.json")
+	var initialOut bytes.Buffer
+	var initialErr bytes.Buffer
+	if code := Run([]string{"scan", "--path", reposPath, "--state", statePath, "--json"}, &initialOut, &initialErr); code != exitSuccess {
+		t.Fatalf("initial scan failed: %d stdout=%q stderr=%q", code, initialOut.String(), initialErr.String())
+	}
+
+	manifestPath := manifest.ResolvePath(statePath)
+	lifecyclePath := lifecycle.ChainPath(statePath)
+	proofPath := proofemit.ChainPath(statePath)
+	attestationPath := proofemit.ChainAttestationPath(proofPath)
+	signingKeyPath := proofemit.SigningKeyPath(statePath)
+
+	stateBefore := readOptionalTestFile(t, statePath)
+	manifestBefore := readOptionalTestFile(t, manifestPath)
+	lifecycleBefore := readOptionalTestFile(t, lifecyclePath)
+	proofBefore := readOptionalTestFile(t, proofPath)
+	attestationBefore := readOptionalTestFile(t, attestationPath)
+	signingKeyBefore := readOptionalTestFile(t, signingKeyPath)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"scan",
+		"--path", reposPath,
+		"--state", statePath,
+		"--json",
+		"--json-path", statePath,
+	}, &out, &errOut)
+	if code != exitInvalidInput {
+		t.Fatalf("expected invalid input exit, got %d stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+	assertErrorEnvelopeCode(t, errOut.Bytes(), "invalid_input", exitInvalidInput)
+
+	assertOptionalTestFileEquals(t, statePath, stateBefore)
+	assertOptionalTestFileEquals(t, manifestPath, manifestBefore)
+	assertOptionalTestFileEquals(t, lifecyclePath, lifecycleBefore)
+	assertOptionalTestFileEquals(t, proofPath, proofBefore)
+	assertOptionalTestFileEquals(t, attestationPath, attestationBefore)
+	assertOptionalTestFileEquals(t, signingKeyPath, signingKeyBefore)
+}

--- a/core/source/local/local.go
+++ b/core/source/local/local.go
@@ -10,18 +10,51 @@ import (
 	"github.com/Clyra-AI/wrkr/core/source"
 )
 
+var repoRootSignals = []string{
+	".agents",
+	".claude",
+	".codex",
+	".cursor",
+	".git",
+	".github",
+	".mcp.json",
+	".vscode/mcp.json",
+	".cursorrules",
+	"AGENTS.md",
+	"AGENTS.override.md",
+	"CLAUDE.md",
+	"Cargo.toml",
+	"Gemfile",
+	"Jenkinsfile",
+	"build.gradle",
+	"build.gradle.kts",
+	"composer.json",
+	"go.mod",
+	"package.json",
+	"pnpm-workspace.yaml",
+	"pom.xml",
+	"pyproject.toml",
+	"requirements.txt",
+}
+
 // Acquire discovers local repositories from a directory path.
 func Acquire(root string) ([]source.RepoManifest, error) {
 	root = strings.TrimSpace(root)
 	if root == "" {
 		return nil, fmt.Errorf("path target is required")
 	}
+	root = filepath.Clean(root)
 	info, err := os.Stat(root)
 	if err != nil {
 		return nil, fmt.Errorf("read path target: %w", err)
 	}
 	if !info.IsDir() {
 		return nil, fmt.Errorf("path target must be a directory: %s", root)
+	}
+	if hasSignals, err := hasRepoRootSignals(root); err != nil {
+		return nil, fmt.Errorf("classify path target: %w", err)
+	} else if hasSignals {
+		return []source.RepoManifest{repoManifestForRoot(root)}, nil
 	}
 
 	entries, err := os.ReadDir(root)
@@ -47,4 +80,55 @@ func Acquire(root string) ([]source.RepoManifest, error) {
 	}
 	sort.Slice(manifests, func(i, j int) bool { return manifests[i].Repo < manifests[j].Repo })
 	return manifests, nil
+}
+
+func hasRepoRootSignals(root string) (bool, error) {
+	for _, rel := range repoRootSignals {
+		exists, err := pathExists(filepath.Join(root, rel))
+		if err != nil {
+			return false, err
+		}
+		if exists {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func pathExists(path string) (bool, error) {
+	if _, err := os.Lstat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func repoManifestForRoot(root string) source.RepoManifest {
+	return source.RepoManifest{
+		Repo:     repoNameForRoot(root),
+		Location: filepath.ToSlash(root),
+		Source:   "local_path",
+	}
+}
+
+func repoNameForRoot(root string) string {
+	cleanRoot := filepath.Clean(root)
+	name := filepath.Base(cleanRoot)
+	if name != "" && name != "." && name != string(filepath.Separator) {
+		return name
+	}
+
+	absRoot, err := filepath.Abs(cleanRoot)
+	if err == nil {
+		name = filepath.Base(absRoot)
+		if name != "" && name != "." && name != string(filepath.Separator) {
+			return name
+		}
+		if volume := filepath.VolumeName(absRoot); volume != "" {
+			return volume
+		}
+	}
+	return "local-root"
 }

--- a/core/source/local/local.go
+++ b/core/source/local/local.go
@@ -1,11 +1,13 @@
 package local
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 
 	"github.com/Clyra-AI/wrkr/core/source"
 )
@@ -86,6 +88,9 @@ func hasRepoRootSignals(root string) (bool, error) {
 	for _, rel := range repoRootSignals {
 		exists, err := pathExists(filepath.Join(root, rel))
 		if err != nil {
+			if errors.Is(err, os.ErrPermission) || errors.Is(err, syscall.ENOTDIR) {
+				continue
+			}
 			return false, err
 		}
 		if exists {

--- a/core/source/local/local_test.go
+++ b/core/source/local/local_test.go
@@ -31,3 +31,32 @@ func TestAcquirePathRepos(t *testing.T) {
 		t.Fatalf("unexpected order: %+v", repos)
 	}
 }
+
+func TestAcquireTreatsRootSignalsAsSingleRepo(t *testing.T) {
+	t.Parallel()
+
+	tmp := filepath.Join(t.TempDir(), "repo-root")
+	if err := os.MkdirAll(filepath.Join(tmp, ".codex"), 0o755); err != nil {
+		t.Fatalf("mkdir codex dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "AGENTS.md"), []byte("agent instructions\n"), 0o600); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, "internal"), 0o755); err != nil {
+		t.Fatalf("mkdir internal dir: %v", err)
+	}
+
+	repos, err := Acquire(tmp)
+	if err != nil {
+		t.Fatalf("acquire local repo root: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("expected one repo root manifest, got %d (%+v)", len(repos), repos)
+	}
+	if repos[0].Repo != "repo-root" {
+		t.Fatalf("expected repo name repo-root, got %+v", repos[0])
+	}
+	if repos[0].Location != filepath.ToSlash(tmp) {
+		t.Fatalf("expected repo root location %s, got %s", filepath.ToSlash(tmp), repos[0].Location)
+	}
+}

--- a/core/source/local/local_test.go
+++ b/core/source/local/local_test.go
@@ -3,6 +3,7 @@ package local
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -58,5 +59,42 @@ func TestAcquireTreatsRootSignalsAsSingleRepo(t *testing.T) {
 	}
 	if repos[0].Location != filepath.ToSlash(tmp) {
 		t.Fatalf("expected repo root location %s, got %s", filepath.ToSlash(tmp), repos[0].Location)
+	}
+}
+
+func TestAcquireIgnoresUnreadableRepoRootSignalProbe(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod-based permission fixture is not portable on windows")
+	}
+
+	tmp := t.TempDir()
+	for _, name := range []string{"zeta", "alpha"} {
+		if err := os.MkdirAll(filepath.Join(tmp, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+	}
+
+	lockedSignalDir := filepath.Join(tmp, ".vscode")
+	if err := os.MkdirAll(lockedSignalDir, 0o700); err != nil {
+		t.Fatalf("mkdir locked signal dir: %v", err)
+	}
+	if err := os.Chmod(lockedSignalDir, 0o600); err != nil {
+		t.Skipf("chmod unsupported in current environment: %v", err)
+	}
+	defer func() {
+		_ = os.Chmod(lockedSignalDir, 0o700)
+	}()
+
+	repos, err := Acquire(tmp)
+	if err != nil {
+		t.Fatalf("expected unreadable optional signal probe to be ignored, got %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d (%+v)", len(repos), repos)
+	}
+	if repos[0].Repo != "alpha" || repos[1].Repo != "zeta" {
+		t.Fatalf("unexpected order: %+v", repos)
 	}
 }

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -35,7 +35,8 @@ wrkr inventory --diff --baseline ./.wrkr/inventory-baseline.json --state ./.wrkr
 ```
 
 `wrkr evidence` now fails closed when the saved proof chain is malformed or tampered, and `wrkr verify --chain --json` remains the explicit machine gate for integrity.
-Use the curated scenario first when you want the evaluator-safe path because it avoids repo-root fixture noise from Wrkr's own scenarios, docs, and test fixtures.
+Use the curated scenario first when you want the evaluator-safe path because it avoids repo-root fixture noise from Wrkr's own scenarios, docs, and test fixtures. That scenario path is the canonical `repo_set` example for `--path`: Wrkr scans the immediate child repos in the bundle instead of treating the bundle root as one repo.
+Use `wrkr scan --path ./your-repo --json` when the selected directory itself is the repo root and carries repo-root signals such as `.git`, `go.mod`, `AGENTS.md`, or `.codex/`. Use a bundle root like `./scenarios/wrkr/scan-mixed-org/repos` when you want immediate child repos scanned as a deterministic repo-set.
 
 Use these next when you want deeper triage:
 

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -14,6 +14,10 @@ For `my_setup`, use `--target my_setup:local-machine`.
 Acquisition behavior is fail-closed by target:
 
 - `--path` runs fully local/offline.
+- `--path` supports two deterministic interpretations:
+  - `repo_root`: scan the selected directory itself as one repo when it carries repo-root signals such as `.git`, `go.mod`, `AGENTS.md`, `.codex/`, `.github/`, or other supported tool/config markers.
+  - `repo_set`: scan the immediate non-hidden child repos when the selected directory is a bundle root without repo-root signals, such as `./scenarios/wrkr/scan-mixed-org/repos`.
+- `repo_set` child repos are enumerated in deterministic lexical order by repo name.
 - `--my-setup` runs fully local/offline against the local machine setup rooted at the current user home directory.
   It inspects supported user-home tool configs, selected environment key names, and common workspace roots for local agent project markers without emitting raw secret values.
 - `--repo` and `--org` require real GitHub acquisition via `--github-api` or `WRKR_GITHUB_API_BASE`.
@@ -31,6 +35,7 @@ Acquisition behavior is fail-closed by target:
 - `--state` defaults to `.wrkr/last-scan.json`, with manifest/proof artifacts written alongside it.
 - Scan-owned managed artifacts are published transactionally: state snapshot, lifecycle chain, proof chain/attestation, manifest, and any requested `--json-path`, `--report-md-path`, or `--sarif-path` sidecars commit as one generation.
 - Invalid scan-owned artifact paths such as `--report-md-path` and `--sarif-path` are preflight-validated before any managed artifact mutation.
+- `--json-path`, `--report-md-path`, and `--sarif-path` must stay unique from one another and from Wrkr-managed artifacts derived from `--state`; collisions fail closed with `invalid_input` (exit `6`) before any scan-managed artifact is written.
 - Late write failures after preflight still fail closed and roll managed artifacts back to the previous committed generation instead of leaving mixed state/proof/manifest outputs behind.
 - For `--path` scans, detector file reads stay bounded to the selected repo root. Root-escaping symlinked config, env, workflow, and MCP files are rejected with deterministic `parse_error.kind=unsafe_path` diagnostics instead of being read.
 
@@ -104,7 +109,7 @@ Opinionated large-org command path:
 wrkr scan --github-org acme --github-api https://api.github.com --state ./.wrkr/last-scan.json --timeout 30m --json --json-path ./.wrkr/scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
 ```
 
-When `--json` is set for hosted org scans, Wrkr keeps stdout reserved for the final JSON payload and emits additive progress, retry, cooldown, resume, and completion lines to stderr only. `--quiet` suppresses those progress lines. `--json-path` writes the same final JSON payload to disk, and `--json --json-path` emits byte-identical payload bytes to both stdout and the selected file.
+When `--json` is set for hosted org scans, Wrkr keeps stdout reserved for the final JSON payload and emits additive progress, retry, cooldown, resume, and completion lines to stderr only. `--quiet` suppresses those progress lines. `--json-path` writes the same final JSON payload to disk, and `--json --json-path` emits byte-identical payload bytes to both stdout and the selected file. Any requested `--json-path`, `--report-md-path`, or `--sarif-path` must be unique from one another and from scan-managed `--state` sibling artifacts.
 `--resume` is supported only when every requested target is an org target. Wrkr stores internal checkpoint metadata under the scan-state directory in `org-checkpoints/` and reuses already-materialized repositories only when the checkpoint target set, per-org repo sets, and materialized-root path still match the current org-target scan.
 Resume also revalidates that checkpoint files and reused repo roots are still trusted local artifacts under the managed materialized root; symlink-swapped entries fail closed as `unsafe_operation_blocked`.
 Mixed target sets such as org-plus-path scans fail closed with `invalid_input` when `--resume` is requested.
@@ -122,6 +127,7 @@ wrkr scan --target org:acme --target path:./repos --github-api https://api.githu
 wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --profile assessment --report-md --report-md-path ./.tmp/scan-summary.md --report-template operator --json
 ```
 
+This is the canonical `repo_set` example for `--path`: the selected directory is a bundle of immediate child repos, so Wrkr preserves per-child repo manifests and deterministic ordering instead of collapsing the bundle into one repo.
 Expected JSON keys include `status`, `target`, `findings`, `ranked_findings`, `top_findings`, `attack_paths`, `top_attack_paths`, additive `action_paths`, additive `action_path_to_control_first`, `inventory`, `privilege_budget`, `agent_privilege_map`, `repo_exposure_summaries`, `profile`, `posture_score`, `compliance_summary`, additive `activation`, and optional `report` when summary output is requested.
 Explicit multi-target runs also emit additive `targets[]` arrays at the top level and inside `source_manifest`, and saved state snapshots preserve the same additive `targets[]` contract.
 For local-machine scans, `target.mode` is `my_setup`.

--- a/docs/contracts/readme_contract.md
+++ b/docs/contracts/readme_contract.md
@@ -69,6 +69,7 @@ Section requirements:
   - Keep developer-machine hygiene as the secondary path.
   - Place hosted prerequisites (`--github-api` and token guidance) adjacent to the first hosted org workflow.
   - Include explicit deterministic fallback commands before hosted setup can dead-end (`wrkr scan --path` and/or `wrkr scan --my-setup`).
+  - Explain the dual `wrkr scan --path` contract: repo-root fallback for one selected repo, and bundle-root repo-set behavior for paths such as `./scenarios/wrkr/*/repos`.
   - Include `wrkr scan --my-setup`, `wrkr mcp-list`, and `wrkr inventory --diff`.
   - Include `wrkr scan --github-org`, `wrkr evidence`, and `wrkr verify` when security/platform-led launch copy is used.
   - Keep deterministic `--json` command anchors.

--- a/docs/examples/quickstart.md
+++ b/docs/examples/quickstart.md
@@ -29,6 +29,7 @@ wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/la
 ```
 
 Use this flow first when you want the evaluator-safe path. It avoids repo-root fixture noise from Wrkr's own scenarios, docs, and tests while still exercising the shipped wedge.
+This is the canonical `repo_set` path example: Wrkr scans the immediate child repos under `./scenarios/wrkr/scan-mixed-org/repos` in deterministic order instead of treating that bundle root as one repo.
 
 ## Security/platform posture first
 
@@ -66,7 +67,7 @@ wrkr scan --path ./your-repo --json
 wrkr scan --my-setup --json
 ```
 
-Use `--path` when you want repo-local discovery with no hosted setup. Use `--my-setup` when you want developer-machine hygiene for local configs, MCP posture, and secret-presence signals.
+Use `--path` when you want repo-local discovery with no hosted setup. When `./your-repo` itself is the repo root and carries repo-root signals such as `.git`, `go.mod`, `AGENTS.md`, or `.codex/`, Wrkr scans that directory as one repo. Use a bundle root like `./scenarios/wrkr/scan-mixed-org/repos` when you want Wrkr to scan immediate child repos as a repo-set. Use `--my-setup` when you want developer-machine hygiene for local configs, MCP posture, and secret-presence signals.
 
 ## Developer-machine hygiene (secondary path)
 

--- a/docs/examples/security-team.md
+++ b/docs/examples/security-team.md
@@ -11,7 +11,7 @@ Hosted prerequisites for this path:
 - token resolution order is `--github-token`, config `auth.scan.token`, `WRKR_GITHUB_TOKEN`, then `GITHUB_TOKEN`
 - fine-grained PAT guidance: select only the target repositories and grant read-only repository metadata plus read-only repository contents
 - connector endpoints: `GET /orgs/{org}/repos`, `GET /repos/{owner}/{repo}`, `GET /repos/{owner}/{repo}/git/trees/{default_branch}?recursive=1`, `GET /repos/{owner}/{repo}/git/blobs/{sha}`
-- if hosted prerequisites are not ready yet, start with `wrkr scan --path ./your-repo --json` or `wrkr scan --my-setup --json` first and return to this flow when GitHub access is configured
+- if hosted prerequisites are not ready yet, start with `wrkr scan --path ./your-repo --json` or `wrkr scan --my-setup --json` first and return to this flow when GitHub access is configured; `--path` scans the selected directory itself when it is the repo root and uses bundle roots like `./scenarios/wrkr/scan-mixed-org/repos` when you want a deterministic repo-set
 
 ```bash
 wrkr scan --github-org acme --github-api https://api.github.com --state ./.wrkr/last-scan.json --timeout 30m --profile assessment --json --json-path ./.wrkr/scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -42,7 +42,7 @@ Wrkr does not perform live MCP probing or package vulnerability assessment in th
 ### Should I start with `wrkr scan --my-setup` or `wrkr scan --github-org`?
 
 For the current public launch, start with `wrkr scan --github-org ... --github-api ... --json` when the goal is org posture, shared inventory review, or compliance handoff.
-If hosted prerequisites are not ready yet, use `wrkr scan --path ./your-repo --json` as the zero-integration repo-local fallback or `wrkr scan --my-setup --json` for developer-machine hygiene.
+If hosted prerequisites are not ready yet, use `wrkr scan --path ./your-repo --json` as the zero-integration repo-local fallback or `wrkr scan --my-setup --json` for developer-machine hygiene. `--path` scans the selected directory itself when that directory is the repo root with signals such as `.git`, `go.mod`, `AGENTS.md`, or `.codex/`; it scans immediate child repos instead when you point it at a bundle root such as `./scenarios/wrkr/scan-mixed-org/repos`.
 Developers doing only local checks can still start with `wrkr scan --my-setup --json`.
 
 For larger orgs, prefer the opinionated path:

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -49,7 +49,7 @@ wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --json
 wrkr verify --chain --json
 ```
 
-If hosted prerequisites are not ready yet, start with `wrkr scan --path ./your-repo --json` or `wrkr scan --my-setup --json` and return to the org posture flow once GitHub access is configured.
+If hosted prerequisites are not ready yet, start with `wrkr scan --path ./your-repo --json` or `wrkr scan --my-setup --json` and return to the org posture flow once GitHub access is configured. `--path` scans the selected directory itself when it is the repo root and uses bundle roots such as `./scenarios/wrkr/scan-mixed-org/repos` when you want immediate child repos scanned as a repo-set.
 
 Low first-run `framework_coverage` is an evidence-state signal, not a parser failure. Wrkr measures what is currently documented in the scanned state.
 

--- a/internal/e2e/cli_contract/cli_contract_e2e_test.go
+++ b/internal/e2e/cli_contract/cli_contract_e2e_test.go
@@ -287,3 +287,174 @@ func TestE2EOrgJSONProgressStaysOnStderr(t *testing.T) {
 		t.Fatalf("expected stderr completion progress, got %q", errOut.String())
 	}
 }
+
+func TestE2EScanRejectedArtifactAliasLeavesSavedStateUsableForEvidence(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	reposPath := filepath.Join(tmp, "repos")
+	repoPath := filepath.Join(reposPath, "alpha", ".codex")
+	statePath := filepath.Join(tmp, ".wrkr", "state.json")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoPath, "config.toml"), []byte("approval_policy = \"never\"\n"), 0o600); err != nil {
+		t.Fatalf("write codex config: %v", err)
+	}
+
+	var scanOut bytes.Buffer
+	var scanErr bytes.Buffer
+	if code := cli.Run([]string{"scan", "--path", reposPath, "--state", statePath, "--json"}, &scanOut, &scanErr); code != 0 {
+		t.Fatalf("initial scan failed: %d (%s)", code, scanErr.String())
+	}
+
+	var rejectedOut bytes.Buffer
+	var rejectedErr bytes.Buffer
+	if code := cli.Run([]string{"scan", "--path", reposPath, "--state", statePath, "--json", "--json-path", statePath}, &rejectedOut, &rejectedErr); code != 6 {
+		t.Fatalf("expected invalid-input collision rejection, got %d stdout=%q stderr=%q", code, rejectedOut.String(), rejectedErr.String())
+	}
+
+	var rejectedPayload map[string]any
+	if err := json.Unmarshal(rejectedErr.Bytes(), &rejectedPayload); err != nil {
+		t.Fatalf("parse rejected scan payload: %v", err)
+	}
+	errObj, ok := rejectedPayload["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing error payload: %v", rejectedPayload)
+	}
+	if errObj["code"] != "invalid_input" {
+		t.Fatalf("unexpected rejected scan code: %v", errObj["code"])
+	}
+
+	outputDir := filepath.Join(tmp, "evidence")
+	var evidenceOut bytes.Buffer
+	var evidenceErr bytes.Buffer
+	if code := cli.Run([]string{"evidence", "--frameworks", "soc2", "--state", statePath, "--output", outputDir, "--json"}, &evidenceOut, &evidenceErr); code != 0 {
+		t.Fatalf("evidence failed after rejected collision: %d stdout=%q stderr=%q", code, evidenceOut.String(), evidenceErr.String())
+	}
+
+	var evidencePayload map[string]any
+	if err := json.Unmarshal(evidenceOut.Bytes(), &evidencePayload); err != nil {
+		t.Fatalf("parse evidence payload: %v", err)
+	}
+	if evidencePayload["status"] != "ok" {
+		t.Fatalf("unexpected evidence payload: %v", evidencePayload)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "manifest.json")); err != nil {
+		t.Fatalf("expected manifest.json after evidence run: %v", err)
+	}
+}
+
+func TestE2EScanPathRepoRootFallbackFindsRootSignals(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := filepath.Join(t.TempDir(), "fallback-repo")
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatalf("mkdir repo root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, "AGENTS.md"), []byte("agent instructions\n"), 0o600); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := cli.Run([]string{"scan", "--path", repoRoot, "--state", filepath.Join(t.TempDir(), "state.json"), "--json"}, &out, &errOut); code != 0 {
+		t.Fatalf("scan failed: %d (%s)", code, errOut.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse scan payload: %v", err)
+	}
+	sourceManifest, ok := payload["source_manifest"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected source_manifest object, got %T", payload["source_manifest"])
+	}
+	repos, ok := sourceManifest["repos"].([]any)
+	if !ok || len(repos) != 1 {
+		t.Fatalf("expected one repo manifest entry, got %v", sourceManifest["repos"])
+	}
+	firstRepo, ok := repos[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected repo manifest shape: %T", repos[0])
+	}
+	if firstRepo["repo"] != "fallback-repo" {
+		t.Fatalf("expected repo name fallback-repo, got %v", firstRepo["repo"])
+	}
+
+	findings, ok := payload["findings"].([]any)
+	if !ok {
+		t.Fatalf("expected findings array, got %T", payload["findings"])
+	}
+	foundRootSignal := false
+	for _, item := range findings {
+		finding, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if finding["location"] == "AGENTS.md" && finding["repo"] == "fallback-repo" {
+			foundRootSignal = true
+			break
+		}
+	}
+	if !foundRootSignal {
+		t.Fatalf("expected root-level AGENTS.md finding in payload: %v", findings)
+	}
+}
+
+func TestE2EScanScenarioBundlePathKeepsPerChildRepoOrdering(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindCLIContractRepoRoot(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "scan-mixed-org", "repos")
+	statePath := filepath.Join(t.TempDir(), "state.json")
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := cli.Run([]string{"scan", "--path", scanPath, "--state", statePath, "--json"}, &out, &errOut); code != 0 {
+		t.Fatalf("scan failed: %d (%s)", code, errOut.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse scan payload: %v", err)
+	}
+	sourceManifest, ok := payload["source_manifest"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected source_manifest object, got %T", payload["source_manifest"])
+	}
+	repos, ok := sourceManifest["repos"].([]any)
+	if !ok || len(repos) < 4 {
+		t.Fatalf("expected shipped scenario bundle repos, got %v", sourceManifest["repos"])
+	}
+
+	wantOrder := []string{"backend", "data-pipeline", "experiments", "frontend", "infra"}
+	for idx, want := range wantOrder {
+		repo, ok := repos[idx].(map[string]any)
+		if !ok {
+			t.Fatalf("unexpected repo manifest shape at %d: %T", idx, repos[idx])
+		}
+		if repo["repo"] != want {
+			t.Fatalf("expected repo %q at index %d, got %v", want, idx, repo["repo"])
+		}
+	}
+}
+
+func mustFindCLIContractRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(wd, "go.mod")); statErr == nil {
+			return wd
+		}
+		next := filepath.Dir(wd)
+		if next == wd {
+			t.Fatal("could not find repo root")
+		}
+		wd = next
+	}
+}

--- a/product/PLAN_NEXT.md
+++ b/product/PLAN_NEXT.md
@@ -1,47 +1,70 @@
-# PLAN Adhoc: hosted acquisition resilience, mixed-scope scan targets, and govern-first actionability
+# PLAN Adhoc: scan path contract hardening, managed artifact safety, and repo-local toolchain alignment
 
 Date: 2026-04-13
 Source of truth:
-- user-provided recommendations in this run
-- user-provided nightly `govulncheck` failure for `GO-2026-4947`, `GO-2026-4946`, `GO-2026-4870`, and `GO-2026-4866`
+- user-provided full-repo code review findings in this run
 - `product/dev_guides.md`
 - `product/architecture_guides.md`
-Scope: Restore nightly security gating, harden hosted GitHub org acquisition against 403 rate limiting, add one-run mixed remote/local scan targeting, and sharpen govern-first path ranking/reporting without weakening determinism, fail-closed behavior, or existing single-target scan workflows.
+Scope: Planning only for the release-blocking `scan --path` contract mismatch, scan sidecar artifact collision safety, and the AGENTS/go toolchain drift. No implementation work is performed in this plan.
 
 ## Global Decisions (Locked)
 
-- Treat the nightly `govulncheck` break as Wave 1 remediation. The first fully fixed Go floor for this repo is `1.26.2`, so the uplift is atomic across runtime, CI, docs, and enforcement surfaces.
-- Preserve exit code integers exactly as documented. Where rate limiting needs a sharper machine-readable contract, change the JSON error `code` and message contract without inventing a new numeric exit code.
-- Add mixed-scope scans as an additive `scan --target <mode>:<value>` surface where `<mode>` is one of `repo`, `org`, `path`, or `my_setup`.
-- Keep legacy single-target flags (`--repo`, `--org`, `--github-org`, `--path`, `--my-setup`) as supported shims that internally expand to a one-entry target set.
-- Keep `wrkr init` and persisted `config.default_target` single-target in this plan. Multi-target defaults are explicitly deferred to avoid widening the config contract while the new scan target-set API settles.
-- For multi-target scan JSON/state/source manifests, add an additive `targets[]` array and use `target.mode=multi` only when more than one explicit target is requested. Existing single-target runs keep the current `target` shape unchanged.
-- `--resume` remains fail-closed and deterministic. In this plan it is supported only when every requested target is an org target; mixed target sets with `--resume` must return `invalid_input`.
-- Rate-limit handling must be driven by observed status/body/header evidence, not guessed public/private repo assumptions. If GitHub returns a recognizable rate-limit `403`, Wrkr should retry from `Retry-After` or `X-RateLimit-Reset` when present and surface the observed basis clearly when retries are exhausted.
-- Govern-first output should prefer the strongest operator action path available: write-capable, deploy-write, production-target-backed, identity-backed, and approval-gap-backed paths headline first; weaker non-write paths remain visible but do not displace stronger paths.
-- Workflow trigger exposure remains a static posture statement only. New output may say `scheduled`, `workflow_dispatch`, or deploy-pipeline backed, but must not imply runtime observation or session capture.
+- Treat the two scan findings as Wave 1 release blockers. They change real command behavior today and must land before any new outward-facing scan/report/evidence work.
+- Preserve Wrkr's core contracts:
+  - deterministic behavior
+  - offline-first defaults for local path scans
+  - fail-closed behavior for unsafe or ambiguous artifact/output configurations
+  - stable exit code integers and machine-readable envelopes
+- Keep existing numeric exit codes unchanged. For scan artifact aliasing, use the existing `invalid_input` envelope and exit code `6` rather than inventing a new exit code.
+- Preserve the public repo-local fallback `wrkr scan --path ./your-repo --json`.
+- Preserve current local repo-set workflows and shipped scenario bundle usage under `scenarios/wrkr/*/repos`.
+- Define one explicit `--path` contract that supports both:
+  - `repo_root`: the selected directory itself is scanned as one repo when it contains qualifying root-level repo signals
+  - `repo_set`: the selected directory is scanned as a set of immediate child repos only when it lacks qualifying root-level repo signals and contains one or more non-hidden child directories
+- Centralize the `repo_root` vs `repo_set` classifier in the Source layer and back it with deterministic fixtures. Do not spread heuristic decisions into detector code.
+- Preflight all managed and optional scan artifact paths as one canonical set before the first write:
+  - state snapshot
+  - manifest
+  - lifecycle chain
+  - proof chain
+  - proof attestation
+  - signing key
+  - optional `--json-path`
+  - optional `--report-md-path`
+  - optional `--sarif-path`
+- Any collision among those paths, or between optional outputs themselves, must fail before mutation.
+- Do not change schema versions in this plan. Any behavior change must fit the current `v1` scan/state/inventory/proof contracts.
+- Replace the stale literal Go floor in `AGENTS.md` with a single-source-of-truth model: the repo-local guide should delegate to `go.mod` and `product/dev_guides.md`, and enforcement must catch future drift.
 
 ## Current Baseline (Observed)
 
-- `core/source/github/connector.go` retries `429` and `5xx` responses, honors `Retry-After` and `X-RateLimit-Reset`, but currently treats recognizable rate-limit `403` responses as non-retryable hard failures.
-- `core/cli/scan.go` appends auth guidance when the hosted failure string contains `github API status 403` plus `rate limit`, but the JSON error code remains the generic `runtime_failure`.
-- `core/cli/scan_helpers.go` still enforces exactly one target source (`--repo`, `--org`, `--github-org`, `--path`, or `--my-setup`) per scan invocation.
-- Local path scans already cover multiple repos beneath one filesystem root, but Wrkr cannot yet combine multiple orgs, multiple local roots, or mixed remote and local targets in one deterministic scan/proof run.
-- `core/detect/workflowcap/analyze.go` already derives `workflow_triggers`, `approval_source`, `deployment_gate`, and `proof_requirement`, and `core/aggregate/privilegebudget/budget.go` already turns those into approval-gap reasons, but `core/report/build.go` and govern-first summaries do not headline trigger class or ownership quality strongly enough.
-- `core/risk/action_paths.go` already emits the stable `recommended_action` enum `inventory|approval|proof|control`, and synthetic tests prove all four values are reachable, but the user-observed real subset scan still collapses too many serious paths to `proof`.
-- `core/owners/owners.go` currently resolves `CODEOWNERS` first and falls back deterministically to repo-derived ownership, but unresolved/conflict ownership is not yet weighted strongly enough in top govern-first path selection or report wording.
-- `.github/workflows/nightly.yml`, `.tool-versions`, `go.mod`, `scripts/check_toolchain_pins.sh`, and contract tests are still pinned to `Go 1.26.1`; the provided nightly failure says called stdlib vulnerabilities are fixed in `Go 1.26.2`.
+- [core/source/local/local.go](/Users/tr/wrkr/core/source/local/local.go:13) treats `--path` as a directory of repos and enumerates immediate child directories only.
+- [core/source/local/local_test.go](/Users/tr/wrkr/core/source/local/local_test.go:9) validates only the repo-set behavior; there is no single-repo-root coverage.
+- Public docs repeatedly advertise single-repo-root usage:
+  - [README.md](/Users/tr/wrkr/README.md:91)
+  - [docs/commands/scan.md](/Users/tr/wrkr/docs/commands/scan.md:35)
+  - [docs/examples/quickstart.md](/Users/tr/wrkr/docs/examples/quickstart.md:65)
+  - [docs/faq.md](/Users/tr/wrkr/docs/faq.md:45)
+  - [docs/examples/security-team.md](/Users/tr/wrkr/docs/examples/security-team.md:14)
+- The existing shipped scenario path `./scenarios/wrkr/scan-mixed-org/repos` relies on the current repo-set interpretation, so the fix must preserve that supported workflow.
+- [core/cli/scan.go](/Users/tr/wrkr/core/cli/scan.go:94) resolves optional sidecar outputs, but [core/cli/scan.go](/Users/tr/wrkr/core/cli/scan.go:349) does not reject alias collisions with managed artifacts before writes begin.
+- [core/cli/jsonmode.go](/Users/tr/wrkr/core/cli/jsonmode.go:37) and [core/cli/report.go](/Users/tr/wrkr/core/cli/report.go:262) validate file-path shape, not artifact identity uniqueness.
+- Reproduced failure path:
+  - `wrkr scan --path "$tmp/root" --state "$tmp/state.json" --json-path "$tmp/state.json" --json` exits `0`
+  - the saved `state.json` is overwritten with final scan payload keys like `status` and `top_findings`
+  - `wrkr evidence --frameworks soc2 --state "$tmp/state.json" --output "$tmp/evidence" --json` then fails because `risk_report` is missing
+- [AGENTS.md](/Users/tr/wrkr/AGENTS.md:108) still says Go `1.26.1`, while [go.mod](/Users/tr/wrkr/go.mod:3), [product/dev_guides.md](/Users/tr/wrkr/product/dev_guides.md:135), and CI pins are already on `1.26.2`.
+- Working tree baseline is clean, so follow-on implementation can branch cleanly from the generated plan.
 
 ## Exit Criteria
 
-- The nightly workflow and local binary-mode `govulncheck` are green under `Go 1.26.2`, and no `1.26.1` pin remains on enforced surfaces.
-- Hosted repo/org acquisition retries recognizable rate-limit `403` and `429` responses deterministically, reports retry/cooldown progress, and emits a sharper machine-readable exhausted-rate-limit error contract when retries are spent.
-- One `wrkr scan` invocation can combine multiple org and local targets deterministically in one output/proof run via additive target-set syntax, while single-target legacy flows keep working unchanged.
-- Multi-target state/source manifest/report payloads expose deterministic additive `targets[]` data, and `--resume` behavior is explicit, safe, and contract-tested.
-- Govern-first ranking selects the strongest alarming path first when stronger write/deploy/production/identity/approval-backed candidates exist.
-- `recommended_action` meaningfully separates visibility gaps, approval gaps, proof gaps, and urgent control-first paths on realistic scan fixtures, not just synthetic unit cases.
-- Reports and markdown summaries surface trigger class, identity, and ownership quality when those signals materially change governance priority.
-- Validation passes on all mapped lanes:
+- `wrkr scan --path <single-repo-root> --json` emits one repo in `source_manifest.repos`, detects root-level config files such as `AGENTS.md`, and no longer returns an empty false-negative result for qualifying repo roots.
+- Existing repo-set fixtures and scenario bundle paths still scan as multiple repos with deterministic repo naming and order.
+- `wrkr scan` rejects any collision among managed artifact paths and optional output paths with `invalid_input` and exit code `6` before mutating state/proof/manifest artifacts.
+- Rejected collision runs preserve the previous committed managed artifact generation, or preserve artifact absence if no prior generation existed.
+- README and command docs explain the final `--path` contract without ambiguity and keep the repo-local fallback first-value path copy-pasteable.
+- `AGENTS.md` no longer conflicts with the enforced Go floor, and an automated check prevents recurrence.
+- Validation passes on the mapped lanes:
   - `make lint-fast`
   - `make test-fast`
   - `make test-contracts`
@@ -49,826 +72,346 @@ Scope: Restore nightly security gating, harden hosted GitHub org acquisition aga
   - `make prepush-full`
   - `make test-hardening`
   - `make test-chaos`
-  - `make test-perf`
-  - `make codeql`
-  - `go build -o .tmp/wrkr ./cmd/wrkr`
-  - `go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 -mode=binary .tmp/wrkr`
-  - rerun of the previously failing `nightly` workflow lane
+  - docs consistency/storyline/smoke checks for touched flows
 
 ## Public API and Contract Map
 
-- Stable surfaces:
-  - existing single-target scan flags: `--repo`, `--org`, `--github-org`, `--path`, `--my-setup`
+- Stable public surfaces:
+  - `wrkr scan`
+  - the `--path` flag itself
   - existing exit code integers `0..8`
-  - existing `recommended_action` enum values: `inventory|approval|proof|control`
-  - existing single-target JSON/state/source-manifest `target` object shape
-  - existing proof, lifecycle, and compliance artifact locations and chain behavior
-- Additive stable surfaces introduced by this plan:
-  - repeatable `--target <mode>:<value>` for `scan`
-  - additive `targets[]` in scan payload, state snapshot, and source manifest
-  - additive `target.mode=multi` only for explicit multi-target runs
-  - additive rate-limit-specific JSON error `code=rate_limited` with exit code `1`
-  - additive trigger-class/report facts for workflow-backed govern-first paths and exposure groups
+  - scan JSON top-level contract for valid runs
+  - saved scan state/proof artifact locations beside `--state`
+  - downstream command flow: `scan -> report/evidence/regress/verify`
+- Changed public surfaces in this plan:
+  - `--path` now has an explicit dual contract: deterministic `repo_root` or deterministic `repo_set`
+  - previously accepted aliasing sidecar configurations become hard `invalid_input` failures before mutation
 - Internal surfaces:
-  - GitHub connector retry classification logic
-  - checkpoint file layout and target-set resume bookkeeping
-  - govern-first ranking weights and report fact selection heuristics
-  - detector correlation internals for non-human identity matching
+  - local path classifier logic in `core/source/local`
+  - managed artifact collision preflight helper(s) in `core/cli`
+  - AGENTS/toolchain drift enforcement in hygiene scripts/tests
 - Shim/deprecation path:
-  - legacy single-target flags remain first-class and internally map to a one-entry target set
-  - `config.default_target` remains single-target; no config migration is introduced in this plan
-  - no deprecation warning is added yet for single-target flags
+  - no new scan flags are introduced
+  - no deprecation notice is added for current repo-set usage
+  - repo-set behavior remains supported under `--path` for shipped scenarios and local multi-repo roots
 - Schema/versioning policy:
-  - remain on `state`/scan schema `v1`
-  - only additive fields/values are allowed in this plan
-  - single-target outputs remain byte-compatible aside from intentional Go/toolchain version fields
-  - multi-target is opt-in and requires consumers to read `targets[]` when `target.mode=multi`
+  - stay on current scan/state/inventory/proof schema versions
+  - no JSON keys are removed
+  - no schema bump is allowed for these fixes
+  - if any additive metadata is proposed during implementation, it must be acceptance-backed and documented as additive only
 - Machine-readable error expectations:
-  - missing hosted acquisition prerequisite: `dependency_missing`, exit `7`
-  - exhausted hosted rate limit after bounded retry: `rate_limited`, exit `1`
-  - unsupported `--resume` plus non-org target-set mix: `invalid_input`, exit `6`
-  - non-rate-limit upstream failures: `runtime_failure`, exit `1`
-  - no change to `policy_schema_violation`, `unsafe_operation_blocked`, `scan_timeout`, or `scan_canceled`
+  - artifact path alias collision -> `invalid_input`, exit `6`
+  - invalid sidecar path shape stays `invalid_input`, exit `6`
+  - valid repo-root `--path` scan still exits `0` and returns the standard scan payload
+  - valid repo-set `--path` scan still exits `0` and returns the standard scan payload
 
 ## Docs and OSS Readiness Baseline
 
-- `README.md` and `docs/commands/scan.md` must become the source-of-truth entry points for the additive multi-target scan contract and hosted rate-limit behavior.
-- `docs/commands/init.md` must explicitly state that `init` still persists one default target in this wave and that multi-target scans are driven by explicit `scan --target ...` flags.
-- `product/wrkr.md` must stop claiming strict mutual exclusivity across scan target sources once the additive target-set contract ships.
-- `CHANGELOG.md` must record:
-  - the Go `1.26.2` security uplift
-  - hosted scan rate-limit resilience/error contract updates
-  - additive multi-target scan support
-  - govern-first/reporting actionability improvements
-- OSS trust surfaces to verify after the change:
-  - `README.md`
-  - `CHANGELOG.md`
-  - `CONTRIBUTING.md`
-  - `SECURITY.md`
-- Docs must keep integration-before-internals order:
-  - first explain how to run a mixed target scan
-  - then explain JSON/state/report contract additions
-  - then explain resume and rate-limit behavior
+- README first screen must continue to present `wrkr scan --path ./your-repo --json` as the local/offline fallback.
+- `docs/commands/scan.md` is the command-contract source of truth for:
+  - `repo_root` vs `repo_set` path semantics
+  - sidecar uniqueness/fail-closed rules
+  - downstream lifecycle path from saved scan state into evidence/report/regress
+- `docs/examples/quickstart.md`, `docs/examples/security-team.md`, `docs/faq.md`, and `docs/positioning.md` mirror the command contract but must not redefine it.
+- Integration-first flow for touched docs:
+  - show the working `scan --path` repo-root flow first
+  - explain repo-set/scenario-bundle usage second
+  - explain fail-closed output-path rules before report/evidence examples
+- Lifecycle path model for touched docs:
+  - saved scan state is the canonical handoff artifact
+  - optional sidecars are additive and must never replace or alias that handoff artifact
+- OSS/governance trust baseline:
+  - `CHANGELOG.md`: required updates for all three stories
+  - `AGENTS.md`: updated as repo-local contributor/agent guidance
+  - `CONTRIBUTING.md`: verify no content change is required; explicitly defer if unchanged
+  - `SECURITY.md`: verify no content change is required; explicitly defer if unchanged
 
 ## Recommendation Traceability
 
 | Recommendation | Why | Story IDs |
 |---|---|---|
-| Retry and classify enterprise-scale `403` GitHub rate limiting and surface the right error code | Hosted org scans currently fail too generically and do not treat recognizable `403` throttles as retryable | W1-S2, W1-S3 |
-| Support one-run org, multi-org, remote, and local scans | Scan still enforces one target source per invocation | W2-S1, W2-S2, W2-S3 |
-| Bias govern-first ranking toward actually alarming paths | Top path still over-selects weaker non-write surfaces when stronger write/deploy paths exist | W4-S1 |
-| Make `recommended_action` meaningfully discriminate `inventory|approval|proof|control` | Real scans still flatten serious paths into `proof` too often | W4-S2 |
-| Improve identity and ownership actionability | Governance wedge is stronger when path identity and ownership strength are explicit | W3-S1 |
-| Surface long-running workflow trigger class explicitly | Trigger posture exists internally but is not visible enough in summaries | W3-S2 |
-| Fix nightly security failure from vulnerable stdlib floor | Nightly `govulncheck` remains red until Go is lifted to the first fully fixed version | W1-S1 |
+| Fix the public `scan --path` contract so it actually scans the supplied repo root | Current implementation silently misses root-level files while docs tell users to scan a repo root directly | W1-S1 |
+| Reject sidecar output paths that alias managed scan artifacts | Current scan can succeed while clobbering its own saved state and breaking downstream commands | W1-S2 |
+| Align the repo-local toolchain contract in `AGENTS.md` with the enforced Go floor | Current repo-local guidance conflicts with `go.mod`, CI, and the normative dev guide | W2-S1 |
 
 ## Test Matrix Wiring
 
 - Fast lane:
   - `make lint-fast`
-  - focused package tests for touched code
-  - `go build -o .tmp/wrkr ./cmd/wrkr`
+  - focused unit tests in `core/source/local`, `core/cli`, and hygiene tests
+  - docs parity/storyline checks for touched command/docs flows
 - Core CI lane:
   - `make prepush`
   - `make test-contracts`
   - `make test-scenarios`
 - Acceptance lane:
-  - `scripts/run_v1_acceptance.sh --mode=local`
-  - scenario fixtures covering hosted rate-limit recovery, additive target sets, and govern-first report output
+  - targeted `internal/e2e/cli_contract` coverage for repo-root `--path`
+  - targeted end-to-end safety coverage proving rejected alias collisions do not poison downstream evidence/report/regress flows
 - Cross-platform lane:
-  - existing `windows-smoke` required check
-  - deterministic scan contract tests that do not assume POSIX-only path behavior
+  - `windows-smoke`
+  - targeted path-classification and path-collision tests must avoid POSIX-only assumptions
 - Risk lane:
   - `make prepush-full`
   - `make test-hardening`
   - `make test-chaos`
-  - `make test-perf`
-  - `make codeql`
-  - `go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 -mode=binary .tmp/wrkr`
 - Merge/release gating rule:
-  - every story’s mapped lanes must be green
-  - no multi-target schema or error-contract change merges without updated docs and contract tests
-  - the previously failing `nightly` lane must be rerun and green before closing Wave 1
+  - both Wave 1 stories are required before the next release candidate or release tag
+  - no CLI/docs/contract story closes without docs and changelog landing in the same PR
+  - no fail-closed artifact safety story closes without hardening/chaos coverage
 
-## Epic W1: Nightly Security and Hosted Acquisition Hard Blockers
+## Epic W1: Scan Contract and State-Safety Blockers
 
-Objective: clear the nightly vulnerability gate first, then harden hosted GitHub acquisition so large-org scans survive recognizable throttling without weakening fail-closed semantics.
+Objective: remove the two release-blocking scan defects without weakening deterministic local/offline behavior or the existing repo-set scenario workflows.
 
-### Story W1-S1: Apply atomic Go 1.26.2 uplift and rerun the nightly vuln gate
+### Story W1-S1: Make `scan --path` deterministic for both single repo roots and repo-set directories
 
 Priority: P0
 Tasks:
-- Update all enforced Go pin surfaces from `1.26.1` to `1.26.2`.
-- Update CI workflows, local toolchain files, docs, and enforcement tests in the same branch.
-- Rebuild the CLI and rerun binary-mode `govulncheck`.
-- Rerun the previously failing `nightly` workflow lane after the uplift lands.
+- Add an explicit path-target classifier in the Source layer that determines `repo_root` vs `repo_set` from deterministic root-level signals.
+- Scan the selected directory itself as one repo when it qualifies as a repo root.
+- Preserve immediate-child repo-set enumeration when the selected directory is a shipped or user-managed repo bundle root.
+- Keep deterministic repo naming, ordering, and deduplication across both modes.
+- Add contract fixtures for:
+  - root-level `AGENTS.md` / `.codex` repo-root scans
+  - existing multi-repo bundle directories under `scenarios/wrkr/*/repos`
+- Update README and command/example docs so repo-root and repo-set semantics are explicit and non-conflicting.
 Repo paths:
-- `go.mod`
-- `.tool-versions`
-- `.github/workflows/main.yml`
-- `.github/workflows/pr.yml`
-- `.github/workflows/release.yml`
-- `.github/workflows/nightly.yml`
-- `.github/workflows/wrkr-action-ci.yml`
-- `.github/workflows/wrkr-sarif.yml`
-- `scripts/check_toolchain_pins.sh`
-- `testinfra/hygiene/toolchain_pins_test.go`
-- `testinfra/contracts/story0_contracts_test.go`
-- `CONTRIBUTING.md`
+- `core/source/local/local.go`
+- `core/source/local/local_test.go`
+- `core/cli/root_test.go`
+- `core/cli/scan_contract_fix_test.go`
+- `internal/e2e/cli_contract/cli_contract_e2e_test.go`
 - `README.md`
-- `product/dev_guides.md`
-- `CHANGELOG.md`
-Run commands:
-- `rg -n '1\\.26\\.1|1\\.26\\.2|go-version:|go-version-file:' go.mod .tool-versions .github/workflows scripts testinfra README.md CONTRIBUTING.md product`
-- `go build -o .tmp/wrkr ./cmd/wrkr`
-- `go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 -mode=binary .tmp/wrkr`
-- `make lint-fast`
-- `make test-contracts`
-- `gh workflow run nightly.yml --ref <branch>`
-Test requirements:
-- Toolchain/runtime/security scanner changes:
-  - atomic pin updates across `go.mod`, local toolchain files, CI, docs, and enforcement tests
-  - built-artifact validation with `govulncheck -mode=binary`
-  - rerun of the previously failing workflow lane
-- Docs/examples changes:
-  - docs consistency checks for touched version declarations
-Matrix wiring:
-- Fast lane: `make lint-fast`, focused toolchain pin tests, build
-- Core CI lane: `make test-contracts`
-- Acceptance lane: not required beyond plan-level acceptance because behavior is unchanged
-- Cross-platform lane: existing workflow matrix after pin uplift
-- Risk lane: `govulncheck`, `make codeql`, rerun `nightly`
-Acceptance criteria:
-- No enforced pin surface remains on `1.26.1`.
-- Local binary `govulncheck` reports no called stdlib vulnerabilities from the provided nightly failure set.
-- The rerun `nightly` workflow is green on the uplift branch.
-- CLI behavior, JSON output, schemas, and exit codes remain unchanged apart from updated version/toolchain references.
-Changelog impact: required
-Changelog section: Security
-Draft changelog entry: Raised Wrkr's enforced Go toolchain floor to 1.26.2 across local, CI, and nightly scanner surfaces to clear called standard-library vulnerabilities flagged by nightly `govulncheck`.
-Semver marker override: none
-Contract/API impact:
-- Developer and CI minimum Go version moves to `1.26.2`.
-- Runtime CLI, JSON, and exit-code contracts remain unchanged.
-Versioning/migration impact:
-- No schema migration.
-- Contributors and automation must use `Go 1.26.2`.
-Architecture constraints:
-- Treat the pin change as an atomic contract update.
-- Do not weaken or bypass `govulncheck`.
-- Keep the change thin; no unrelated dependency churn.
-ADR required: no
-TDD first failing test(s):
-- Pin-enforcement tests in `testinfra/hygiene/toolchain_pins_test.go`
-- branch/toolchain contract tests in `testinfra/contracts/story0_contracts_test.go`
-Cost/perf impact: low
-Chaos/failure hypothesis:
-- If one enforced pin surface stays on `1.26.1`, nightly or contributor environments drift and the security lane remains red.
-
-### Story W1-S2: Recognize and retry rate-limit `403` responses during hosted acquisition
-
-Priority: P0
-Tasks:
-- Extend GitHub connector retry classification so recognizable rate-limit `403` responses are treated like throttling, not permanent failures.
-- Reuse `Retry-After` and `X-RateLimit-Reset` parsing for both `429` and recognized `403` throttles.
-- Keep header/body detection evidence-based so Wrkr does not guess public/private rate-limit class incorrectly.
-- Thread status code and retry delay through org progress output for recognizable `403` retries.
-Repo paths:
-- `core/source/github/connector.go`
-- `core/source/github/connector_test.go`
-- `core/cli/scan_helpers.go`
-- `core/cli/scan_progress.go`
-- `core/cli/scan_progress_test.go`
 - `docs/commands/scan.md`
+- `docs/examples/quickstart.md`
+- `docs/examples/security-team.md`
+- `docs/faq.md`
+- `docs/positioning.md`
+- `docs/contracts/readme_contract.md`
 - `CHANGELOG.md`
 Run commands:
-- `go test ./core/source/github ./core/cli -count=1`
-- `make test-hardening`
-- `make test-chaos`
-- `make prepush-full`
+- `go test ./core/source/local ./core/cli ./internal/e2e/cli_contract -count=1`
+- `make test-contracts`
+- `make test-scenarios`
+- `scripts/check_docs_cli_parity.sh`
+- `scripts/check_docs_storyline.sh`
+- `scripts/run_docs_smoke.sh --subset`
 Test requirements:
-- Gate/policy/fail-closed changes:
-  - deterministic allow/block/retry fixtures for recognizable `403` rate-limit bodies/headers
-  - fail-closed tests for non-rate-limit `403` responses so auth and permission failures do not retry
-- Job runtime/state/concurrency changes:
-  - retry/backoff tests
-  - contention-free progress emission tests
-  - chaos coverage for exhausted rate-limit windows and canceled sleeps
+- CLI behavior changes:
+  - `--json` stability tests for repo-root and repo-set path scans
+  - exit-code contract tests remain `0` for valid repo-root and repo-set scans
+  - machine-readable scan payload assertions for `source_manifest.repos`
+- Scenario/spec tests:
+  - outside-in fixture validating a single repo root with only root-level signals
+  - regression fixture validating existing multi-repo bundle behavior
+- Docs/examples changes:
+  - docs consistency checks
+  - README first-screen contract checks
+  - integration-before-internals guidance checks for the updated fallback flow
 Matrix wiring:
-- Fast lane: focused connector and CLI unit tests
-- Core CI lane: `make prepush-full`
-- Acceptance lane: scenario or integration fixture for org acquisition with `403` throttle recovery
-- Cross-platform lane: CLI progress/error tests remain platform-neutral
-- Risk lane: `make test-hardening`, `make test-chaos`
+- Fast lane: focused `core/source/local` and `core/cli` tests plus docs parity
+- Core CI lane: `make prepush`, `make test-contracts`, `make test-scenarios`
+- Acceptance lane: `go test ./internal/e2e/cli_contract -count=1`
+- Cross-platform lane: `windows-smoke` plus targeted path-behavior assertions that avoid platform-specific separators in expectations
+- Risk lane: `make prepush-full`
 Acceptance criteria:
-- Recognizable GitHub rate-limit `403` responses retry using observed `Retry-After` or `X-RateLimit-Reset` when present.
-- Non-rate-limit `403` responses still fail immediately without retry.
-- Org progress output shows retry attempts for recognized `403` throttles just as it does for `429`.
-- Retry behavior remains deterministic and bounded.
+- A temp repo with only a root `AGENTS.md` scanned via `wrkr scan --path <repo-root> --json` produces one repo manifest entry and at least one root-level finding.
+- Existing scenario-bundle paths under `scenarios/wrkr/*/repos` still produce per-child repo manifests with deterministic ordering.
+- No detector-layer code is required to guess path mode.
+- README and docs no longer describe `--path` in conflicting ways.
 Changelog impact: required
 Changelog section: Fixed
-Draft changelog entry: Hosted GitHub scans now retry recognizable rate-limit `403` responses using the observed reset window instead of failing immediately as generic runtime errors.
+Draft changelog entry: Made `wrkr scan --path` honor single-repo root inputs while preserving deterministic repo-set scans for scenario bundles and local multi-repo roots.
 Semver marker override: none
 Contract/API impact:
-- Hosted acquisition retry semantics expand to cover recognized `403` throttles.
-- Exit code integers remain unchanged.
+- Public `--path` behavior is corrected and explicitly defined.
+- No new flags or exit codes are introduced.
 Versioning/migration impact:
-- No schema migration.
-- Operators may now see successful recovery where the same scan previously failed fast on `403` throttling.
+- No schema/version bump.
+- Automation that accidentally relied on false-negative empty results from single-repo-root scans will now receive the correct repo findings and state.
 Architecture constraints:
-- Keep retry classification inside the hosted source boundary.
-- Do not let rate-limit retries mask true authz/authn failures.
-- Preserve cancellation/timeout propagation through sleeps and retries.
-ADR required: no
-TDD first failing test(s):
-- `TestConnectorHonorsRetryAfter429` companion tests for rate-limit `403`
-- CLI progress tests covering `status=403` retry lines
-Cost/perf impact: low
-Chaos/failure hypothesis:
-- If `403` classification is too broad, Wrkr could spin on permanent auth failures; if too narrow, enterprise-scale org scans still fail on recoverable throttles.
-
-### Story W1-S3: Emit a deterministic exhausted-rate-limit error contract for hosted scans
-
-Priority: P0
-Tasks:
-- Change exhausted hosted rate-limit failures from generic `runtime_failure` to a specific JSON error code while preserving exit code `1`.
-- Make the error message include observed status, retry exhaustion context, and actionable auth/reset guidance.
-- Update docs and CLI contract tests for the new machine-readable error code and unchanged numeric exit behavior.
-- Ensure per-repo materialization failures and whole-scan acquisition failures remain distinguishable.
-Repo paths:
-- `core/cli/scan.go`
-- `core/cli/root.go`
-- `core/cli/scan_github_auth_test.go`
-- `core/cli/root_test.go`
-- `docs/commands/scan.md`
-- `product/architecture_guides.md`
-- `CHANGELOG.md`
-Run commands:
-- `go test ./core/cli -count=1`
-- `make test-contracts`
-- `make prepush-full`
-Test requirements:
-- CLI behavior changes:
-  - `--json` stability tests
-  - exit-code contract tests
-  - machine-readable error envelope tests
-- API/contract lifecycle changes:
-  - public error-code map updates
-  - migration expectation checks for automation consuming hosted scan failures
-Matrix wiring:
-- Fast lane: focused CLI unit/contract tests
-- Core CI lane: `make test-contracts`, `make prepush-full`
-- Acceptance lane: hosted-scan failure fixture asserting `error.code=rate_limited`
-- Cross-platform lane: JSON envelope tests
-- Risk lane: included in `make prepush-full`
-Acceptance criteria:
-- Exhausted hosted throttling emits `error.code=rate_limited` with exit code `1`.
-- Missing hosted prerequisites still emit `dependency_missing` with exit code `7`.
-- Non-rate-limit upstream failures still emit `runtime_failure`.
-- Docs explicitly describe the new hosted rate-limit error contract.
-Changelog impact: required
-Changelog section: Changed
-Draft changelog entry: Hosted GitHub scans now emit a dedicated `rate_limited` JSON error code after bounded retry exhaustion while keeping the documented runtime exit code unchanged.
-Semver marker override: none
-Contract/API impact:
-- JSON error code contract changes for one hosted failure class.
-- Numeric exit code remains `1`.
-Versioning/migration impact:
-- Additive contract tightening within schema `v1`; automation that keys on JSON error codes must accept `rate_limited` for hosted throttling.
-Architecture constraints:
-- Keep error specialization at the CLI boundary.
-- Do not widen the generic error envelope shape in this wave.
-ADR required: no
-TDD first failing test(s):
-- existing hosted rate-limit auth test updated from `runtime_failure` to `rate_limited`
-- root-level JSON error envelope tests for exit-code stability
-Cost/perf impact: low
-Chaos/failure hypothesis:
-- If the specialized error contract is inconsistent, automation will not know whether to retry, wait, or fail closed.
-
-## Epic W2: Mixed-Scope Scan Target Sets
-
-Objective: let one deterministic scan/proof run cover multiple orgs and local roots without collapsing boundaries, breaking single-target flows, or inventing unsafe resume semantics.
-
-### Story W2-S1: Add an additive `scan --target` contract and multi-target schema surfaces
-
-Priority: P0
-Tasks:
-- Add repeatable `--target <mode>:<value>` parsing to `scan`.
-- Keep legacy single-target flags supported as shims and reject mixed legacy-plus-`--target` ambiguity deterministically.
-- Add additive `targets[]` to scan payload, source manifest, and state snapshot.
-- Define `target.mode=multi` for explicit multi-target runs while preserving the existing single-target shape.
-- Update docs and contract tests for the new CLI and payload surfaces.
-Repo paths:
-- `core/cli/scan.go`
-- `core/cli/scan_helpers.go`
-- `core/source/types.go`
-- `core/state/state.go`
-- `core/state/state_test.go`
-- `core/cli/root_test.go`
-- `docs/commands/scan.md`
-- `README.md`
-- `product/wrkr.md`
-- `CHANGELOG.md`
-Run commands:
-- `go test ./core/cli ./core/state -count=1`
-- `make test-contracts`
-- `make prepush-full`
-Test requirements:
-- Schema/artifact changes:
-  - state/scan payload fixture updates
-  - compatibility tests for existing single-target snapshots
-- CLI behavior changes:
-  - help/usage tests
-  - `--json` stability tests
-  - invalid-input tests for ambiguous target combinations
-- API/contract lifecycle changes:
-  - public API map updates for additive `targets[]`
-Matrix wiring:
-- Fast lane: focused CLI/state tests
-- Core CI lane: `make test-contracts`, `make prepush-full`
-- Acceptance lane: end-to-end scan payload assertion for `--target` runs
-- Cross-platform lane: target parsing and JSON/state tests
-- Risk lane: included in `make prepush-full`
-Acceptance criteria:
-- `wrkr scan --target org:acme --target path:./repos --json` is accepted.
-- Legacy single-target flags still behave exactly as they do today when used alone.
-- Ambiguous combinations like `--repo ... --target ...` fail closed with `invalid_input`.
-- Single-target JSON/state outputs keep existing `target` behavior; explicit multi-target runs also emit deterministic `targets[]`.
-Changelog impact: required
-Changelog section: Added
-Draft changelog entry: Added repeatable `wrkr scan --target <mode>:<value>` support so one scan can combine multiple hosted and local targets while preserving legacy single-target flags.
-Semver marker override: none
-Contract/API impact:
-- Adds a new CLI flag family and additive payload/state fields.
-- Keeps existing single-target flags and payloads stable.
-Versioning/migration impact:
-- No schema version bump; `targets[]` is additive.
-- Consumers that invoke multi-target scans must read `targets[]` when `target.mode=multi`.
-Architecture constraints:
-- Keep target parsing/orchestration thin in `core/cli`.
-- Do not widen persisted config scope in this wave.
-- Preserve explicit side-effect semantics between parsing and acquisition.
+- Keep path-mode classification inside the Source boundary.
+- Use thin orchestration with focused packages; do not leak path classification into detectors or reporting.
+- Preserve explicit side-effect semantics and deterministic ordering.
+- Preserve cancellation/timeout propagation through the local acquisition path.
+- Keep the classifier extensible so future repo-root signal additions do not require broad detector rewrites.
 ADR required: yes
 TDD first failing test(s):
-- CLI parsing tests for repeatable `--target`
-- state snapshot compatibility tests proving old single-target fixtures still load
+- `core/source/local/local_test.go` single-repo-root fixture
+- `core/cli/root_test.go` or a dedicated scan path contract test for `wrkr scan --path <repo-root> --json`
+- `internal/e2e/cli_contract/cli_contract_e2e_test.go` repo-root fallback example
 Cost/perf impact: low
 Chaos/failure hypothesis:
-- If multi-target state/schema is underspecified, downstream diff/report/proof consumers will see unstable target identity and drift noise.
+- If the classifier over-classifies repo bundles as single repos, per-repo ownership/risk output collapses.
+- If it under-classifies single repo roots as bundles, the public fallback remains a silent false negative.
 
-### Story W2-S2: Implement deterministic acquisition and de-duplication across mixed target sets
+### Story W1-S2: Fail closed when scan sidecar outputs alias managed artifacts
 
 Priority: P0
 Tasks:
-- Introduce a target-set acquisition path that executes multiple repo/org/path/my-setup targets in deterministic order.
-- De-duplicate discovered repos deterministically when the same repo is reached from multiple targets.
-- Keep materialized hosted repos inside managed roots and preserve local path semantics for pre-cloned repos.
-- Carry per-target source failures into one manifest without hiding partial results.
-- Add realistic mixed-target scenarios for remote-plus-local scan coverage.
+- Add one canonical scan-artifact preflight that resolves every managed and optional artifact path before the first write.
+- Reject collisions among:
+  - `--state`
+  - manifest path
+  - lifecycle chain
+  - proof chain
+  - proof attestation
+  - proof signing key
+  - `--json-path`
+  - `--report-md-path`
+  - `--sarif-path`
+- Return a deterministic `invalid_input` error that identifies the conflicting path pair(s).
+- Preserve the existing atomic rollback model for late write failures after successful preflight.
+- Add regression tests proving a rejected collision does not poison downstream `evidence`, `report`, `inventory`, or `regress` flows.
 Repo paths:
-- `core/cli/scan_helpers.go`
-- `core/source/github/connector.go`
-- `core/source/org/acquire.go`
-- `core/source/org/materialized.go`
-- `core/source/local`
-- `core/source/types.go`
-- `core/cli/scan_progress.go`
-- `core/cli/scan_progress_test.go`
-- `core/cli/root_test.go`
-- `scenarios/wrkr/multi-target-mixed-sources/**`
-- `internal/scenarios/**`
-- `CHANGELOG.md`
-Run commands:
-- `go test ./core/source/... ./core/cli -count=1`
-- `go test ./internal/scenarios -count=1 -tags=scenario`
-- `go build -o .tmp/wrkr ./cmd/wrkr`
-- `./.tmp/wrkr scan --target org:acme --target org:enterprise-example --target path:./scenarios/wrkr/scan-mixed-org/repos --state ./.tmp/multi-target.json --json`
-- `make prepush-full`
-- `make test-perf`
-Test requirements:
-- Job runtime/state/concurrency changes:
-  - deterministic ordering tests across mixed target sets
-  - duplicate-repo collapse tests
-  - crash-safe/atomic-write tests for one output snapshot from many targets
-- Scenario/spec tests:
-  - mixed remote/local outside-in fixtures
-  - partial-result/fail-closed behavior when one hosted target degrades
-- Determinism/hash/sign/packaging changes:
-  - repeat-run byte-stability checks for identical multi-target input sets
-Matrix wiring:
-- Fast lane: focused source and CLI tests
-- Core CI lane: `make prepush-full`
-- Acceptance lane: new multi-target scenario suite plus `scripts/run_v1_acceptance.sh --mode=local`
-- Cross-platform lane: build and scan contract tests using portable fixture paths
-- Risk lane: `make test-perf`
-Acceptance criteria:
-- One scan run can combine multiple org targets and at least one local path target.
-- Duplicate repos discovered through overlapping targets appear once in deterministic order.
-- Output proof/state/report generation still happens as one transactional generation.
-- Partial-result behavior remains explicit when one target degrades without invalidating the whole scan.
-Changelog impact: required
-Changelog section: Added
-Draft changelog entry: Wrkr can now scan multiple hosted orgs and local repository roots in one deterministic run, producing a single proof/state/report generation with explicit per-target failures when needed.
-Semver marker override: none
-Contract/API impact:
-- Additive multi-target execution behavior for `scan`.
-- Existing single-target source manifest semantics remain intact.
-Versioning/migration impact:
-- No schema bump beyond additive `targets[]`.
-- New multi-target scenarios become part of acceptance evidence.
-Architecture constraints:
-- Keep source acquisition boundaries explicit; do not leak target-set orchestration into detectors or risk scoring.
-- Preserve cancellation and timeout propagation across the target fan-out.
-- Avoid hidden concurrency that would make repo ordering nondeterministic.
-ADR required: no
-TDD first failing test(s):
-- mixed-target acquisition tests in `core/cli/root_test.go`
-- target-set scenario fixtures under `internal/scenarios`
-Cost/perf impact: medium
-Chaos/failure hypothesis:
-- If de-dup or ordering is unstable, repeated multi-target scans will drift even when source content has not changed.
-
-### Story W2-S3: Add fail-closed multi-target progress and resume rules
-
-Priority: P1
-Tasks:
-- Extend org progress reporting so target identity is visible when multiple orgs are in flight.
-- Define and implement resume rules that permit `--resume` only for target sets composed entirely of org targets.
-- Store checkpoint metadata per target set and validate trusted managed roots before reuse.
-- Document unsupported target mixes for `--resume` explicitly.
-Repo paths:
-- `core/cli/scan_progress.go`
-- `core/cli/scan_progress_test.go`
-- `core/source/org/checkpoint.go`
-- `core/source/org/checkpoint_test.go`
-- `core/source/org/acquire_resume_test.go`
 - `core/cli/scan.go`
+- `core/cli/jsonmode.go`
+- `core/cli/managed_artifacts.go`
+- `core/cli/report.go`
+- `core/cli/scan_json_path_test.go`
+- `core/cli/scan_transaction_test.go`
+- `core/cli/root_test.go`
+- `internal/e2e/cli_contract/cli_contract_e2e_test.go`
 - `docs/commands/scan.md`
+- `README.md`
 - `CHANGELOG.md`
 Run commands:
-- `go test ./core/source/org ./core/cli -count=1`
+- `go test ./core/cli ./internal/e2e/cli_contract -count=1`
+- `make test-contracts`
 - `make test-hardening`
 - `make test-chaos`
 - `make prepush-full`
 Test requirements:
 - CLI behavior changes:
-  - progress contract tests for multi-org progress lines
-  - invalid-input tests for unsupported `--resume` target mixes
+  - `--json` stability tests for rejected alias collisions
+  - exit-code contract tests for `invalid_input` / exit `6`
+  - machine-readable error envelope tests naming the collision
 - Gate/policy/fail-closed changes:
-  - trusted-marker and checkpoint validation tests
-  - fail-closed tests for stale or mismatched target-set checkpoints
+  - deterministic alias-collision fixtures for state/json/report/SARIF/proof path pairs
+  - tests proving rejection happens before managed artifact mutation
 - Job runtime/state/concurrency changes:
-  - resume lifecycle tests
-  - crash-safe checkpoint reuse tests
+  - rollback preservation tests for preexisting state/proof artifacts
+  - interrupted/failing write tests must still preserve the previous generation after successful preflight
+- Docs/examples changes:
+  - docs consistency checks for updated sidecar rules
 Matrix wiring:
-- Fast lane: focused org checkpoint/progress tests
-- Core CI lane: `make prepush-full`
-- Acceptance lane: interrupted multi-org scan resume fixture
-- Cross-platform lane: progress/error output contract tests
-- Risk lane: `make test-hardening`, `make test-chaos`
+- Fast lane: focused `core/cli` tests
+- Core CI lane: `make test-contracts`
+- Acceptance lane: targeted CLI/e2e flow proving rejected collisions do not break a follow-on `wrkr evidence` or `wrkr inventory`
+- Cross-platform lane: path-collision tests must normalize absolute/canonical path handling across Windows and POSIX
+- Risk lane: `make prepush-full`, `make test-hardening`, `make test-chaos`
 Acceptance criteria:
-- Multi-org progress lines identify the target org deterministically.
-- `--resume` works for multi-org target sets when all targets are orgs and the checkpoint still matches.
-- Mixed target sets with `--resume` fail closed with `invalid_input`.
-- Checkpoint reuse never escapes the managed materialized root.
+- `wrkr scan --json-path <state-path>` fails with `invalid_input` and exit `6` before mutating scan state.
+- Sidecar-to-sidecar duplicates such as `--json-path` == `--report-md-path` also fail closed.
+- Valid unique sidecar paths continue to work without JSON/exit-code drift.
+- A previously valid saved state remains usable by downstream commands after a rejected collision run.
 Changelog impact: required
-Changelog section: Changed
-Draft changelog entry: Multi-org scans now expose clearer per-target progress and fail-closed resume behavior, including explicit rejection of unsupported mixed-target resume combinations.
+Changelog section: Fixed
+Draft changelog entry: Blocked scan sidecar output paths from aliasing managed state and proof artifacts, so invalid configurations now fail fast instead of corrupting saved scan state.
 Semver marker override: none
 Contract/API impact:
-- Progress/output wording changes for multi-org scans.
-- `--resume` validation contract becomes explicit for multi-target runs.
+- Previously accepted but unsafe aliasing output configurations now return `invalid_input` with exit `6`.
+- Valid scan contracts are unchanged.
 Versioning/migration impact:
-- No schema migration.
-- Operators must re-run mixed target scans from scratch if local and hosted targets are combined.
+- No schema/version bump.
+- Automation using colliding output paths must switch to unique sidecar paths.
 Architecture constraints:
-- Keep checkpoint trust and resume rules in the source boundary.
-- Do not introduce silent best-effort resume for unsupported mixes.
-ADR required: no
+- Keep collision detection in CLI orchestration, not in lower-level state/proof writers.
+- Resolve and compare canonical paths once up front.
+- Preserve explicit plan/apply style semantics: preflight first, mutate second.
+- Keep the atomic-write and rollback boundaries authoritative.
+- Preserve cancellation/timeout propagation and deterministic error reporting.
+ADR required: yes
 TDD first failing test(s):
-- new multi-org progress tests
-- checkpoint validation tests for mismatched target sets
+- `core/cli/scan_json_path_test.go` alias collision case
+- `core/cli/scan_transaction_test.go` preservation case for preexisting managed artifacts
+- `internal/e2e/cli_contract/cli_contract_e2e_test.go` rejected-collision then downstream-command sanity flow
 Cost/perf impact: low
 Chaos/failure hypothesis:
-- If resume rules are permissive, stale checkpoints can produce incomplete or misleading multi-target output.
+- If any managed/optional alias escapes preflight, a nominally successful scan can still overwrite its own canonical handoff artifact and break downstream evidence/report/regress commands.
 
-## Epic W3: Identity, Ownership, and Workflow Posture Enrichment
+## Epic W2: Repo-Local Toolchain Contract Hygiene
 
-Objective: improve the raw signals feeding govern-first decisions so Wrkr can say which durable identity is behind a risky path, who owns it, how strong that ownership is, and what static workflow posture makes the path long-running or deployment-sensitive.
+Objective: remove contributor/agent guidance drift and prevent the repo-local Go floor from diverging again from authoritative enforcement surfaces.
 
-### Story W3-S1: Strengthen workflow-backed identity correlation and ownership precedence
+### Story W2-S1: Delegate AGENTS toolchain authority to enforced sources and add a drift check
 
-Priority: P0
+Priority: P2
 Tasks:
-- Expand workflow-backed non-human identity extraction so GitHub App, bot-user, and service-account hints correlate more reliably to privilege-map entries.
-- Preserve stronger ownership evidence when multiple candidate owners exist and prefer explicit `CODEOWNERS` ownership over inferred fallback in merged summaries.
-- Increase governance severity for unknown identity, unresolved ownership, and cross-repo ownership conflict cases.
-- Update govern-first summary selection to reflect stronger explicit-owner versus weak-owner distinctions.
+- Replace the stale literal Go `1.26.1` declaration in `AGENTS.md` with repo-local guidance that points to `go.mod` and `product/dev_guides.md` as the authoritative toolchain floor.
+- Add an enforcement check so `AGENTS.md` cannot drift back to a conflicting explicit Go floor without failing CI/local hygiene.
+- Keep the guidance readable for both human contributors and repo-local coding agents.
 Repo paths:
-- `core/detect/nonhumanidentity/detector.go`
-- `core/detect/nonhumanidentity/detector_test.go`
-- `core/owners/owners.go`
-- `core/owners/owners_test.go`
-- `core/aggregate/privilegebudget/budget.go`
-- `core/aggregate/privilegebudget/budget_test.go`
-- `core/risk/action_paths.go`
-- `core/risk/govern_first.go`
-- `core/risk/govern_first_test.go`
-- `core/report/build.go`
-- `core/report/report_test.go`
+- `AGENTS.md`
+- `scripts/check_toolchain_pins.sh`
+- `testinfra/hygiene/toolchain_pins_test.go`
 - `CHANGELOG.md`
 Run commands:
-- `go test ./core/detect/nonhumanidentity ./core/owners ./core/aggregate/privilegebudget ./core/risk ./core/report -count=1`
-- `make prepush-full`
-- `make test-hardening`
+- `scripts/check_toolchain_pins.sh`
+- `go test ./testinfra/hygiene -count=1`
+- `make lint-fast`
 Test requirements:
-- Unit:
-  - detector correlation tests
-  - owner resolution precedence tests
-- Integration:
-  - privilege-map to action-path ownership/identity propagation tests
-- Scenario/spec tests:
-  - realistic workflow-backed paths with explicit, inferred, unresolved, and conflicting ownership
+- Docs/governance changes:
+  - enforcement-first drift check for AGENTS vs authoritative toolchain sources
+  - no runtime or schema contract changes
+- Toolchain/runtime/security scanner changes:
+  - none beyond contributor guidance alignment and enforcement
 Matrix wiring:
-- Fast lane: focused package tests
-- Core CI lane: `make prepush-full`
-- Acceptance lane: realistic govern-first scenario fixture
-- Cross-platform lane: standard Go tests
-- Risk lane: `make test-hardening`
+- Fast lane: `make lint-fast`, `go test ./testinfra/hygiene -count=1`
+- Core CI lane: covered by `make prepush`
+- Acceptance lane: not required
+- Cross-platform lane: keep the drift check in portable shell or Go test logic
+- Risk lane: not required
 Acceptance criteria:
-- Workflow-backed action paths surface the most specific known non-human identity available.
-- Explicit ownership outranks fallback ownership in merged path summaries.
-- Unknown identity and unresolved ownership materially raise govern-first pressure rather than being treated as neutral metadata.
-- Reports identify when ownership is explicit, inferred, unresolved, or conflicting.
+- `AGENTS.md` no longer claims Go `1.26.1`.
+- CI/local hygiene fails if AGENTS introduces a conflicting explicit Go floor in the future.
+- No runtime behavior, JSON payload, schema, or exit code changes occur.
 Changelog impact: required
 Changelog section: Changed
-Draft changelog entry: Govern-first summaries now highlight stronger workflow identity and ownership evidence, with unresolved or conflicting ownership treated as a higher-priority governance signal.
+Draft changelog entry: Clarified repo-local contributor and agent guidance so Wrkr now delegates Go toolchain authority to the enforced 1.26.2 floor in `go.mod` and the development standards.
 Semver marker override: none
 Contract/API impact:
-- Existing action-path/report fields keep the same names but their prioritization and wording become sharper.
+- Contributor/agent governance guidance only.
+- No runtime public API change.
 Versioning/migration impact:
-- No schema migration.
-- Consumers should expect stronger differentiation among ownership and identity states in top summaries.
+- None.
 Architecture constraints:
-- Keep detector parsing structured and static-only.
-- Preserve source -> detection -> aggregation -> risk -> report boundaries.
-- Avoid regex-only ownership or identity logic for structured workflow/config inputs.
+- Keep one authoritative toolchain source of truth.
+- Prefer enforceable delegation over duplicated mutable version strings across governance docs.
 ADR required: no
 TDD first failing test(s):
-- identity correlation unit tests for workflow-backed privilege entries
-- owner precedence tests proving explicit beats fallback/conflict in merged action paths
+- `testinfra/hygiene/toolchain_pins_test.go` or a dedicated AGENTS/toolchain drift fixture
 Cost/perf impact: low
 Chaos/failure hypothesis:
-- If correlation gets stronger without deterministic precedence, the same path could oscillate between owners or identities across runs.
-
-### Story W3-S2: Surface workflow trigger class and long-running deployment posture in action paths and reports
-
-Priority: P1
-Tasks:
-- Normalize workflow trigger class for govern-first use, including `scheduled`, `workflow_dispatch`, and deploy-pipeline backed posture.
-- Thread trigger/deployment posture into privilege-map-derived action paths and grouped exposure summaries.
-- Update markdown/report summaries so top govern-first paths mention trigger class when it materially changes urgency.
-- Keep the wording explicitly static and posture-based.
-Repo paths:
-- `core/detect/workflowcap/analyze.go`
-- `core/detect/workflowcap/analyze_test.go`
-- `core/aggregate/privilegebudget/budget.go`
-- `core/aggregate/inventory/privileges.go`
-- `core/risk/action_paths.go`
-- `core/risk/govern_first.go`
-- `core/report/build.go`
-- `core/report/render_markdown.go`
-- `core/report/report_test.go`
-- `docs/commands/scan.md`
-- `CHANGELOG.md`
-Run commands:
-- `go test ./core/detect/workflowcap ./core/aggregate/privilegebudget ./core/risk ./core/report -count=1`
-- `make prepush-full`
-- `scripts/run_v1_acceptance.sh --mode=local`
-Test requirements:
-- Schema/artifact changes:
-  - additive field tests if new trigger-class fields land in action paths/exposure groups
-- CLI/report behavior changes:
-  - markdown/report summary tests
-  - `--json` stability tests for additive posture fields
-- Scenario/spec tests:
-  - scheduled/manual/deploy workflow fixtures
-Matrix wiring:
-- Fast lane: focused package tests
-- Core CI lane: `make prepush-full`
-- Acceptance lane: `scripts/run_v1_acceptance.sh --mode=local`
-- Cross-platform lane: JSON/report rendering tests
-- Risk lane: included in `make prepush-full`
-Acceptance criteria:
-- Workflow-backed action paths expose trigger class when it materially affects posture.
-- Top report summaries and grouped exposures can say `scheduled`, `workflow_dispatch`, or deploy-pipeline backed without implying runtime observation.
-- Existing approval/proof fields remain intact and deterministic.
-Changelog impact: required
-Changelog section: Changed
-Draft changelog entry: Workflow-backed govern-first paths and summaries now expose static trigger posture such as scheduled, workflow-dispatch, and deploy-pipeline backed execution when it changes governance urgency.
-Semver marker override: none
-Contract/API impact:
-- Additive action-path/report posture facts may appear in JSON and markdown output.
-Versioning/migration impact:
-- No schema version bump expected; treat any new trigger field as additive.
-Architecture constraints:
-- Keep trigger classification static-only.
-- Reuse structured workflow parsing rather than brittle text matching.
-ADR required: no
-TDD first failing test(s):
-- workflow capability tests for trigger normalization
-- report rendering tests expecting trigger posture in top summaries
-Cost/perf impact: low
-Chaos/failure hypothesis:
-- If trigger posture leaks runtime language, Wrkr will overclaim observation it does not have and weaken trust.
-
-## Epic W4: Govern-First Ranking and Recommended Action Sharpness
-
-Objective: take the enriched path signals and ensure the headline govern-first output points operators at the most urgent path first, while keeping non-write and proof-oriented paths visible in the ranked set.
-
-### Story W4-S1: Reweight control-first path ranking toward alarming write and deployment paths
-
-Priority: P0
-Tasks:
-- Revisit path ranking weights so write-capable, deploy-write, production-target-backed, identity-backed, and approval-gap-backed paths outrank weaker candidates when both exist.
-- Preserve deterministic tie-breakers after the new weighting is applied.
-- Keep weaker non-write paths in the ranked list and exposure groups instead of dropping them entirely.
-- Update report assessment selection so `top_path_to_control_first` follows the stronger ranking.
-Repo paths:
-- `core/risk/action_paths.go`
-- `core/risk/risk.go`
-- `core/risk/govern_first.go`
-- `core/risk/action_paths_test.go`
-- `core/risk/risk_test.go`
-- `core/report/build.go`
-- `core/report/report_test.go`
-- `CHANGELOG.md`
-Run commands:
-- `go test ./core/risk ./core/report -count=1`
-- `make prepush-full`
-- `make test-hardening`
-- `make test-perf`
-Test requirements:
-- Unit:
-  - control-first ordering tests using stronger write/deploy/production cases
-- Integration:
-  - deterministic ranking tests across mixed weak/strong candidates
-- Scenario/spec tests:
-  - realistic subset fixtures proving stronger paths headline first
-- Determinism/hash/sign/packaging changes:
-  - byte-stable report/action-path ordering checks
-Matrix wiring:
-- Fast lane: focused risk/report tests
-- Core CI lane: `make prepush-full`
-- Acceptance lane: realistic govern-first subset scenario
-- Cross-platform lane: deterministic ordering tests
-- Risk lane: `make test-hardening`, `make test-perf`
-Acceptance criteria:
-- When stronger write/deploy/production/identity/approval-backed paths exist, `top_path_to_control_first` selects one of them ahead of weaker non-write paths.
-- Non-write paths still appear in ranked govern-first output when relevant.
-- Ordering remains deterministic under ties and repeat runs.
-Changelog impact: required
-Changelog section: Changed
-Draft changelog entry: Govern-first ranking now prioritizes the most urgent write, deploy, production-backed, and approval-gap paths first while keeping weaker paths visible lower in the ranked output.
-Semver marker override: none
-Contract/API impact:
-- Existing fields remain stable; ranked order and top-path selection become more urgent and actionable.
-Versioning/migration impact:
-- No schema migration.
-- Consumers should not assume older relative ordering among equally severe path types.
-Architecture constraints:
-- Keep ranking logic in the risk boundary.
-- Do not let report-layer presentation override risk ordering heuristics.
-ADR required: no
-TDD first failing test(s):
-- ranking tests that currently allow a weaker non-write candidate to lead over a stronger write/deploy path
-Cost/perf impact: low
-Chaos/failure hypothesis:
-- If the new weights are not bounded by deterministic tie-breakers, top-path output can thrash across equivalent runs.
-
-### Story W4-S2: Make `recommended_action` discriminate visibility, approval, proof, and control gaps on real scans
-
-Priority: P0
-Tasks:
-- Refine `recommendedActionForPath` so visibility-only gaps, approval gaps, proof gaps, and immediate control-first paths are separated on realistic fixtures.
-- Use enriched identity, ownership, delivery, deployment, and trigger posture to keep `proof` from swallowing stronger approval/control cases.
-- Update report headline facts, remediation text, and markdown wording so the sharper action classes are visible to operators.
-- Add realistic fixtures proving all four action classes remain reachable outside purely synthetic unit cases.
-Repo paths:
-- `core/risk/action_paths.go`
-- `core/risk/govern_first.go`
-- `core/risk/action_paths_test.go`
-- `core/risk/govern_first_test.go`
-- `core/report/build.go`
-- `core/report/render_markdown.go`
-- `core/report/report_test.go`
-- `scenarios/wrkr/govern-first-realistic/**`
-- `internal/scenarios/**`
-- `docs/commands/scan.md`
-- `CHANGELOG.md`
-Run commands:
-- `go test ./core/risk ./core/report -count=1`
-- `go test ./internal/scenarios -count=1 -tags=scenario`
-- `scripts/run_v1_acceptance.sh --mode=local`
-- `make prepush-full`
-Test requirements:
-- CLI/report behavior changes:
-  - remediation wording tests
-  - `--json` stability tests for `recommended_action`
-- Scenario/spec tests:
-  - realistic govern-first scans with one clear `inventory`, `approval`, `proof`, and `control` case
-- Contract tests:
-  - stable enum test for `inventory|approval|proof|control`
-Matrix wiring:
-- Fast lane: focused risk/report tests
-- Core CI lane: `make prepush-full`
-- Acceptance lane: realistic govern-first scenario suite plus `scripts/run_v1_acceptance.sh --mode=local`
-- Cross-platform lane: stable JSON enum/output tests
-- Risk lane: included in `make prepush-full`
-Acceptance criteria:
-- Visibility-only gaps land on `inventory`.
-- Approval-model gaps land on `approval` when identity/ownership/proof are otherwise strong enough.
-- Proof gaps land on `proof` only when control/approval is not yet the right headline.
-- Dangerous write/deploy/production-backed paths land on `control`.
-- Report and markdown summaries describe the sharper action classes clearly.
-Changelog impact: required
-Changelog section: Changed
-Draft changelog entry: `recommended_action` now separates visibility, approval, proof, and control-first path classes more sharply on real-world govern-first scans and report summaries.
-Semver marker override: none
-Contract/API impact:
-- Stable enum values stay the same.
-- Classification thresholds and remediation wording become sharper.
-Versioning/migration impact:
-- No schema migration.
-- Downstream automation should continue matching enum values, not prior heuristic frequency.
-Architecture constraints:
-- Keep action classification in the risk boundary with report-only projection above it.
-- Preserve deterministic ordering and explanation facts.
-ADR required: no
-TDD first failing test(s):
-- realistic scenario fixtures that currently collapse distinct cases to `proof`
-- report tests expecting sharper remediation wording by action class
-Cost/perf impact: low
-Chaos/failure hypothesis:
-- If `recommended_action` remains too flat, the strongest control-first path will still read like a documentation gap instead of a VP Eng escalation.
+- If AGENTS drifts again, contributors and local agents can debug under an unsupported Go floor and reproduce different outcomes than CI.
 
 ## Minimum-Now Sequence
 
-1. Baseline and branch:
-   - confirm the repo is clean except for this plan file
-   - branch from updated `origin/main`
-2. Wave 1a security gate recovery:
-   - W1-S1
-   - validate with `make lint-fast`, `make test-contracts`, `go build -o .tmp/wrkr ./cmd/wrkr`, `govulncheck -mode=binary`, rerun `nightly`
-3. Wave 1b hosted acquisition resilience:
-   - W1-S2
-   - W1-S3
-   - validate with `go test ./core/source/github ./core/cli -count=1`, `make test-hardening`, `make test-chaos`, `make prepush-full`
-4. Wave 2 mixed-scope scan contract and execution:
-   - W2-S1
-   - W2-S2
-   - W2-S3
-   - validate with `make test-contracts`, `go test ./core/source/... ./core/cli ./core/state -count=1`, `go test ./internal/scenarios -count=1 -tags=scenario`, `make test-perf`, `make prepush-full`
-5. Wave 3 signal enrichment:
-   - W3-S1
-   - W3-S2
-   - validate with `go test ./core/detect/nonhumanidentity ./core/owners ./core/detect/workflowcap ./core/aggregate/privilegebudget ./core/risk ./core/report -count=1`, `make prepush-full`
-6. Wave 4 ranking and action-class sharpness:
-   - W4-S1
-   - W4-S2
-   - validate with `go test ./core/risk ./core/report -count=1`, `go test ./internal/scenarios -count=1 -tags=scenario`, `scripts/run_v1_acceptance.sh --mode=local`, `make prepush-full`
-7. Full-plan closeout:
-   - `make lint-fast`
-   - `make test-fast`
-   - `make test-contracts`
-   - `make test-scenarios`
-   - `make prepush-full`
-   - `make test-hardening`
-   - `make test-chaos`
-   - `make test-perf`
-   - `make codeql`
-   - `go build -o .tmp/wrkr ./cmd/wrkr`
-   - `go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 -mode=binary .tmp/wrkr`
-8. Re-check Exit Criteria and update `CHANGELOG.md` `## [Unreleased]` entries from the story-level drafts.
+1. Wave 1, Story W1-S2: block artifact-path alias collisions before any further scan contract work lands. This removes the state-clobbering failure mode immediately.
+2. Wave 1, Story W1-S1: fix the public `--path` contract while preserving repo-set behavior used by shipped scenarios and existing docs.
+3. Wave 2, Story W2-S1: clean up AGENTS toolchain drift and add recurrence protection after the runtime blockers are gone.
 
 ## Explicit Non-Goals
 
-- No weakening or bypass of `govulncheck`, CodeQL, hardening, chaos, or policy gates.
-- No dashboard/UI work.
-- No runtime session observation, workflow run scraping, or control-plane enforcement claims.
-- No `wrkr init` redesign to persist multi-target defaults in this wave.
-- No GitHub acquisition expansion beyond repo/org materialization already in scope.
-- No new exit code integers.
+- No new scan flags or schema versions.
+- No change to hosted GitHub acquisition behavior, rate limiting, or PR publishing.
+- No docs-site redesign or broader docs IA rewrite.
+- No changes to proof formats, lifecycle state model, or report templates beyond what is required to keep docs/flows accurate.
+- No Go toolchain uplift work in runtime/CI surfaces; the authoritative floor is already `1.26.2` and this plan only fixes repo-local drift.
 
 ## Definition of Done
 
-- Every recommendation in this run is mapped to one or more shipped stories above.
-- All additive CLI/schema/report changes are documented in `README.md`, `docs/commands/scan.md`, and `CHANGELOG.md`.
-- Existing single-target scans continue to pass unchanged contract tests.
-- Multi-target scans, rate-limit retries, and govern-first/report improvements are covered by unit, contract, integration, and scenario tests at the appropriate layer.
-- Wave 1 reruns the previously failing nightly lane and records that it is green on the implementation branch.
-- Risk-bearing changes pass `make prepush-full`, `make test-hardening`, and `make test-chaos`.
-- Performance-sensitive acquisition/orchestration changes pass `make test-perf`.
-- No hidden nondeterminism is introduced in target ordering, repo de-duplication, action-path ranking, or report output.
-- The worktree after implementation contains only intended scoped changes from this plan and no unrelated dirty files.
+- Every recommendation maps to at least one shipped story outcome.
+- Wave 1 stories land with:
+  - code
+  - tests
+  - docs
+  - changelog
+  - CI wiring
+- `--path` repo-root and repo-set behavior are both deterministic and acceptance-backed.
+- Artifact-path aliasing fails fast before mutation and is covered by hardening/chaos-aware tests.
+- `AGENTS.md` no longer conflicts with enforced toolchain authority and future drift is automatically caught.
+- Required PR checks remain green:
+  - `fast-lane`
+  - `windows-smoke`
+- No dirty files remain beyond the intended implementation changes and the updated plan/changelog/docs artifacts.

--- a/scripts/check_toolchain_pins.sh
+++ b/scripts/check_toolchain_pins.sh
@@ -243,6 +243,21 @@ else
   exit 3
 fi
 
+if [[ ! -f AGENTS.md ]]; then
+  echo "missing AGENTS.md" >&2
+  exit 3
+fi
+
+if grep -Eq 'Go `[0-9]+\.[0-9]+(\.[0-9]+)?`' AGENTS.md; then
+  echo "AGENTS.md must delegate Go toolchain authority to go.mod and product/dev_guides.md; remove explicit Go version literals" >&2
+  exit 3
+fi
+
+if ! grep -Fq '`go.mod`' AGENTS.md || ! grep -Fq '`product/dev_guides.md`' AGENTS.md; then
+  echo "AGENTS.md must point Go toolchain authority at go.mod and product/dev_guides.md" >&2
+  exit 3
+fi
+
 gosec_expected="$(read_expected_pin "gosec" || true)"
 if [[ -z "$gosec_expected" ]]; then
   echo "missing expected pin in $dev_guides_path for gosec" >&2

--- a/testinfra/hygiene/toolchain_pins_test.go
+++ b/testinfra/hygiene/toolchain_pins_test.go
@@ -66,6 +66,32 @@ func TestCheckToolchainPinsFailsOnReleaseIntegrityDrift(t *testing.T) {
 	}
 }
 
+func TestCheckToolchainPinsFailsWhenAgentsPinsExplicitGoVersion(t *testing.T) {
+	t.Parallel()
+
+	fixtureRoot := writeToolchainPinFixture(t, fixturePins{
+		gosecVersion:        "v2.23.0",
+		golangciLintVersion: "v2.0.1",
+		cosignVersion:       "v2.5.3",
+		syftVersion:         "v1.32.0",
+		grypeVersion:        "v0.99.1",
+		agentsContent: strings.Join([]string{
+			"# AGENTS.md",
+			"",
+			"- Go `1.26.1`",
+			"",
+		}, "\n"),
+	})
+	_, stderr, err := runToolchainPinCheck(t, fixtureRoot)
+	if err == nil {
+		t.Fatal("expected checker to fail when AGENTS.md pins an explicit Go version")
+	}
+	expected := "AGENTS.md must delegate Go toolchain authority to go.mod and product/dev_guides.md; remove explicit Go version literals"
+	if !strings.Contains(stderr, expected) {
+		t.Fatalf("expected deterministic AGENTS drift message %q, got %q", expected, stderr)
+	}
+}
+
 func TestReleaseWorkflowUsesDocumentedReleaseIntegrityPins(t *testing.T) {
 	t.Parallel()
 
@@ -98,6 +124,7 @@ type fixturePins struct {
 	cosignVersion       string
 	syftVersion         string
 	grypeVersion        string
+	agentsContent       string
 }
 
 func writeToolchainPinFixture(t *testing.T, versions fixturePins) string {
@@ -123,6 +150,16 @@ func writeToolchainPinFixture(t *testing.T, versions fixturePins) string {
 		"| Grype | `v0.99.1` |",
 		"",
 	}, "\n"))
+	agentsContent := versions.agentsContent
+	if agentsContent == "" {
+		agentsContent = strings.Join([]string{
+			"# AGENTS.md",
+			"",
+			"- Go: follow `go.mod` for the enforced floor and `product/dev_guides.md` for the org-wide version policy.",
+			"",
+		}, "\n")
+	}
+	mustWriteFile(t, filepath.Join(root, "AGENTS.md"), agentsContent)
 
 	workflow := strings.Join([]string{
 		"name: fixture",


### PR DESCRIPTION
## Problem
- `wrkr scan --path` treated every directory as a repo bundle, so pointing it at a single repo root could silently miss root-level signals and return false-negative local scans.
- Optional scan sidecar outputs like `--json-path` could alias managed `--state` artifacts or each other, which risked corrupting saved scan state needed by downstream evidence flows.
- Repo-local agent guidance still duplicated a stale Go floor instead of deferring to the enforced toolchain source of truth.

## Changes
- taught local path acquisition to distinguish repo-root inputs from repo-set bundle roots using deterministic repo-root signals
- preflight scan-managed and optional artifact paths together and fail closed on collisions before any state/proof/report mutation
- added unit, transaction, contract, and e2e coverage for repo-root fallback, artifact alias rejection, and preserved downstream evidence usability
- aligned docs, changelog, plan notes, and AGENTS/toolchain pin enforcement with the hardened scan contract

## Validation
- `go run ./cmd/wrkr scan --json`
- `make prepush-full`
