### PR TITLE
launch: align org-first onboarding and evidence guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Govern-first ranking now prioritizes the most urgent write, deploy, production-backed, and approval-gap paths first while keeping weaker paths visible lower in the ranked output.
 - `recommended_action` now separates visibility, approval, proof, and control-first path classes more sharply on real-world govern-first scans and report summaries.
 - Clarified repo-local contributor and agent guidance so Wrkr now delegates Go toolchain authority to the enforced 1.26.2 floor in `go.mod` and the development standards.
+- Added config-backed hosted GitHub API base support to `wrkr init` and `wrkr scan` so org-first onboarding can be configured once without weakening the existing fail-closed hosted-scan contract.
+- Added explicit `coverage_note` guidance to `wrkr evidence --json` so low first-run framework coverage is framed as an evidence gap rather than unsupported framework parsing.
+- Reconciled the public launch docs so hosted org posture is the primary first-screen path, with the evaluator-safe scenario preserved as the explicit fallback and demo flow.
+- Updated first-run evidence docs and docs-site mirrors so evidence-gap guidance sits directly beside the first evidence workflows instead of appearing later as a separate clarification.
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -39,22 +39,7 @@ Canonical pinned install and release-parity guidance lives in [`docs/install/min
 
 ## Start Here
 
-Start with the curated scenario flow when you want the fastest evaluator-safe demo, then widen to org posture once you are ready for hosted acquisition. If the hosted prerequisites are not ready yet, use the deterministic fallback paths below before returning to the org flow.
-
-### Evaluators (Recommended first path)
-
-Use the curated scenario bundle first when you want copy-pasteable discovery, evidence, verify, and regress output without the repo-root fixture noise that shows up if you scan the Wrkr repository root directly.
-
-```bash
-wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json
-wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/wrkr-scenario-evidence --json
-wrkr verify --chain --state ./.wrkr/last-scan.json --json
-wrkr regress init --baseline ./.wrkr/last-scan.json --output ./.tmp/wrkr-regress-baseline.json --json
-wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/last-scan.json --json
-```
-
-This curated path is the recommended first-value workflow for evaluation because it avoids repo-root fixture noise from Wrkr's own scenario, docs, and test fixtures while still showing the shipped wedge: discovery, posture, evidence, verification, and regression gates.
-`--path` is explicit now: point it at a repo root when the selected directory itself carries repo-root signals such as `.git`, `go.mod`, `AGENTS.md`, `.codex/`, or `.github/`; point it at `./scenarios/wrkr/scan-mixed-org/repos` or another bundle root when you want Wrkr to scan immediate child repos as a deterministic repo-set.
+Start with the security/platform org posture flow when hosted prerequisites are ready. If they are not ready yet, use the evaluator-safe scenario or the deterministic local fallback paths below, then return to the hosted org flow once GitHub access is configured.
 
 ### Security Teams (Recommended first path)
 
@@ -67,14 +52,17 @@ Hosted prerequisites for this path:
 - large-org runbook: [`docs/examples/security-team.md`](docs/examples/security-team.md)
 
 ```bash
-wrkr scan --github-org acme --github-api https://api.github.com --state ./.wrkr/last-scan.json --timeout 30m --profile assessment --json --json-path ./.wrkr/scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
+wrkr init --non-interactive --org acme --github-api https://api.github.com --json
+wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --timeout 30m --profile assessment --json --json-path ./.wrkr/scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
 wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence --json
 wrkr verify --chain --state ./.wrkr/last-scan.json --json
 ```
 
 `--json` keeps stdout reserved for the final machine-readable payload. `--json-path` adds a byte-identical JSON artifact on disk, hosted org scans surface deterministic progress/retry/completion lines on stderr without polluting stdout JSON, and `--resume` reuses durable org-scan checkpoint state under the scan-state directory when an earlier hosted scan was interrupted. `--json-path`, `--report-md-path`, and `--sarif-path` must each stay unique and must not alias `--state` or Wrkr-managed sibling artifacts; collisions now fail closed with `invalid_input` before any scan state is mutated. `--profile assessment` narrows the govern-first readout for customer-style scans without changing raw findings, proof chains, or exit codes.
+`wrkr init` can now persist the hosted GitHub API base together with the default org target, so the follow-on `wrkr scan --config ...` path stays copy-pasteable without repeating `--github-api` on every run.
 If a hosted org scan is interrupted, rerun the same target with `--resume`. Treat `partial_result`, `source_errors`, or `source_degraded` as incomplete posture output and rerun after rate limits, permission issues, or upstream failures are resolved.
 `wrkr evidence` now requires the saved proof chain to be intact before it stages or publishes a bundle, and `wrkr verify --chain` remains the explicit operator/CI integrity gate. `--resume` also revalidates checkpoint files and reused materialized repo roots so symlink-swapped entries fail closed instead of being treated as trusted scan roots.
+Low or zero first-run `framework_coverage` means the current hosted scan state is evidence sparse. Treat it as an evidence gap, not a parser failure, and use the additive `coverage_note` in `wrkr evidence --json` when handing results to operators or automation.
 When one run needs both hosted and local scope, use repeatable `--target` flags:
 
 ```bash
@@ -84,9 +72,25 @@ wrkr scan --target org:acme --target path:./your-repos --github-api https://api.
 Explicit multi-target scans add deterministic `targets[]` arrays to the scan payload, saved state, and source manifest.
 `wrkr init` still persists one default target in this wave, so multi-target defaults are intentionally not stored in config yet.
 
-If you are evaluating Wrkr itself, prefer the curated scenario above before scanning the repository root. The Wrkr repo contains scenario and test fixtures, so repo-root fixture noise can overwhelm the posture score and hide the intended first-value path.
+If you are evaluating Wrkr itself, prefer the evaluator-safe scenario fallback below before scanning the repository root. The Wrkr repo contains scenario and test fixtures, so repo-root fixture noise can overwhelm the posture score and hide the intended first-value path.
 
-If hosted prerequisites are not ready yet, start with one of these deterministic fallback paths:
+### Evaluators (Fallback and demo path)
+
+Use the curated scenario bundle when you want a clean evaluator-safe pass through discovery, evidence, verify, and regress without the repo-root fixture noise that shows up if you scan the Wrkr repository root directly.
+
+```bash
+wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/wrkr-scenario-evidence --json
+wrkr verify --chain --state ./.wrkr/last-scan.json --json
+wrkr regress init --baseline ./.wrkr/last-scan.json --output ./.tmp/wrkr-regress-baseline.json --json
+wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/last-scan.json --json
+```
+
+This curated path is the recommended fallback and demo workflow when hosted prerequisites are not ready yet or when you want to show the shipped wedge without repo-root fixture noise from Wrkr's own scenario, docs, and test fixtures.
+`--path` is explicit now: point it at a repo root when the selected directory itself carries repo-root signals such as `.git`, `go.mod`, `AGENTS.md`, `.codex/`, or `.github/`; point it at `./scenarios/wrkr/scan-mixed-org/repos` or another bundle root when you want Wrkr to scan immediate child repos as a deterministic repo-set.
+Low or zero first-run `framework_coverage` in this evaluator path is still an evidence-gap signal. It means the current state lacks documented controls or approvals, not that the framework mapping is unsupported.
+
+If hosted prerequisites are still not ready yet after the evaluator-safe scenario, start with one of these deterministic local fallback paths:
 
 ```bash
 wrkr scan --path ./your-repo --json

--- a/core/cli/evidence.go
+++ b/core/cli/evidence.go
@@ -62,6 +62,7 @@ func runEvidence(args []string, stdout io.Writer, stderr io.Writer) int {
 			"manifest_path":      result.ManifestPath,
 			"chain_path":         result.ChainPath,
 			"framework_coverage": result.FrameworkCoverage,
+			"coverage_note":      result.CoverageNote,
 			"report_artifacts":   result.ReportArtifacts,
 		})
 		return exitSuccess

--- a/core/cli/init.go
+++ b/core/cli/init.go
@@ -144,7 +144,7 @@ func buildInitNextStep(configPath string, target config.Target, hostedConfigured
 		if hostedConfigured {
 			return scanCommand
 		}
-		return fmt.Sprintf("Configure hosted acquisition with --github-api, config hosted_source.github_api_base, or WRKR_GITHUB_API_BASE, then run %s", scanCommand)
+		return fmt.Sprintf("Configure hosted acquisition with --github-api, config github_api_base, or WRKR_GITHUB_API_BASE, then run %s", scanCommand)
 	default:
 		return scanCommand
 	}

--- a/core/cli/init.go
+++ b/core/cli/init.go
@@ -27,6 +27,7 @@ func runInit(args []string, stdout io.Writer, stderr io.Writer) int {
 	repo := fs.String("repo", "", "default scan target owner/repo")
 	org := fs.String("org", "", "default scan target org")
 	path := fs.String("path", "", "default scan target local path")
+	githubAPI := fs.String("github-api", "", "github api base url for hosted repo/org scans")
 	scanToken := fs.String("scan-token", "", "read-only token for scan profile")
 	fixToken := fs.String("fix-token", "", "read-write token for fix profile")
 	configPathFlag := fs.String("config", "", "config file path override")
@@ -68,12 +69,14 @@ func runInit(args []string, stdout io.Writer, stderr io.Writer) int {
 	cfg.Auth.Scan.Token = strings.TrimSpace(*scanToken)
 	cfg.Auth.Fix.Token = strings.TrimSpace(*fixToken)
 	cfg.DefaultTarget = config.Target{Mode: mode, Value: strings.TrimSpace(value)}
+	cfg.GitHubAPIBase = strings.TrimSpace(*githubAPI)
 
 	if err := config.Save(configPath, cfg); err != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
 	}
 
 	if *jsonOut {
+		hostedConfigured := cfg.GitHubAPIBase != ""
 		_ = json.NewEncoder(stdout).Encode(map[string]any{
 			"status":      "ok",
 			"config_path": configPath,
@@ -85,6 +88,11 @@ func runInit(args []string, stdout io.Writer, stderr io.Writer) int {
 				"scan": map[string]any{"token_configured": cfg.Auth.Scan.Token != ""},
 				"fix":  map[string]any{"token_configured": cfg.Auth.Fix.Token != ""},
 			},
+			"hosted_source": map[string]any{
+				"github_api_base":       cfg.GitHubAPIBase,
+				"github_api_configured": hostedConfigured,
+			},
+			"next_step": buildInitNextStep(configPath, cfg.DefaultTarget, hostedConfigured),
 		})
 		return exitSuccess
 	}
@@ -127,4 +135,17 @@ func resolveTarget(repo, org, path string) (config.TargetMode, string, error) {
 		return "", "", err
 	}
 	return targets[0].Mode, targets[0].Value, nil
+}
+
+func buildInitNextStep(configPath string, target config.Target, hostedConfigured bool) string {
+	scanCommand := fmt.Sprintf("wrkr scan --config %s --json", configPath)
+	switch target.Mode {
+	case config.TargetRepo, config.TargetOrg:
+		if hostedConfigured {
+			return scanCommand
+		}
+		return fmt.Sprintf("Configure hosted acquisition with --github-api, config hosted_source.github_api_base, or WRKR_GITHUB_API_BASE, then run %s", scanCommand)
+	default:
+		return scanCommand
+	}
 }

--- a/core/cli/root_test.go
+++ b/core/cli/root_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	proof "github.com/Clyra-AI/proof"
+	"github.com/Clyra-AI/wrkr/core/config"
 	"github.com/Clyra-AI/wrkr/core/lifecycle"
 	"github.com/Clyra-AI/wrkr/core/manifest"
 	"github.com/Clyra-AI/wrkr/core/proofemit"
@@ -507,6 +508,65 @@ func TestInitNonInteractiveWritesConfig(t *testing.T) {
 	}
 	if payload["status"] != "ok" {
 		t.Fatalf("unexpected status: %v", payload["status"])
+	}
+	hostedSource, ok := payload["hosted_source"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected hosted_source payload, got %T", payload["hosted_source"])
+	}
+	if hostedSource["github_api_configured"] != false {
+		t.Fatalf("expected github_api_configured=false, got %v", hostedSource["github_api_configured"])
+	}
+	nextStep, _ := payload["next_step"].(string)
+	if !strings.Contains(nextStep, "Configure hosted acquisition") {
+		t.Fatalf("expected missing hosted-source guidance, got %q", nextStep)
+	}
+}
+
+func TestInitNonInteractiveWritesHostedGitHubAPIBase(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.json")
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"init",
+		"--non-interactive",
+		"--org", "acme",
+		"--github-api", "https://api.github.com",
+		"--config", configPath,
+		"--json",
+	}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d with stderr %q", code, errOut.String())
+	}
+
+	loaded, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if loaded.GitHubAPIBase != "https://api.github.com" {
+		t.Fatalf("unexpected github api base: %q", loaded.GitHubAPIBase)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse json output: %v", err)
+	}
+	hostedSource, ok := payload["hosted_source"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected hosted_source payload, got %T", payload["hosted_source"])
+	}
+	if hostedSource["github_api_configured"] != true {
+		t.Fatalf("expected github_api_configured=true, got %v", hostedSource["github_api_configured"])
+	}
+	if hostedSource["github_api_base"] != "https://api.github.com" {
+		t.Fatalf("unexpected hosted source payload: %v", hostedSource)
+	}
+	nextStep, _ := payload["next_step"].(string)
+	if !strings.Contains(nextStep, "wrkr scan --config") {
+		t.Fatalf("expected next_step to point at config-backed scan, got %q", nextStep)
 	}
 }
 
@@ -1877,6 +1937,16 @@ func TestVerifyAndEvidenceCommands(t *testing.T) {
 	}
 	if evidencePayload["status"] != "ok" {
 		t.Fatalf("unexpected evidence status: %v", evidencePayload["status"])
+	}
+	coverageNote, ok := evidencePayload["coverage_note"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected coverage_note payload, got %T", evidencePayload["coverage_note"])
+	}
+	if coverageNote["basis"] != "evidenced_controls_only" {
+		t.Fatalf("unexpected coverage note: %v", coverageNote)
+	}
+	if coverageNote["low_coverage_means"] != "evidence_gap" {
+		t.Fatalf("unexpected low coverage meaning: %v", coverageNote["low_coverage_means"])
 	}
 	if _, err := os.Stat(filepath.Join(outputDir, "manifest.json")); err != nil {
 		t.Fatalf("expected manifest.json in evidence output: %v", err)

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -75,7 +75,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	productionTargetsPath := fs.String("production-targets", "", "optional production target rules file")
 	productionTargetsStrict := fs.Bool("production-targets-strict", false, "fail scan when production target rules cannot be loaded")
 	profileName := fs.String("profile", "standard", "posture profile [baseline|standard|strict|assessment]")
-	githubBaseURL := fs.String("github-api", strings.TrimSpace(os.Getenv("WRKR_GITHUB_API_BASE")), "github api base url")
+	githubBaseURL := fs.String("github-api", "", "github api base url")
 	githubToken := fs.String("github-token", "", "github token override")
 	reportMD := fs.Bool("report-md", false, "emit deterministic markdown summary artifact after scan")
 	reportMDPath := fs.String("report-md-path", "wrkr-scan-summary.md", "scan summary markdown output path")
@@ -116,14 +116,16 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	}
 	if hasLoadedCfg {
 		cfg.Auth = loadedCfg.Auth
+		cfg.GitHubAPIBase = loadedCfg.GitHubAPIBase
 	}
+	*githubBaseURL = resolveScanGitHubAPIBase(*githubBaseURL, cfg)
 	*githubToken = resolveScanGitHubToken(*githubToken, cfg)
 	if *enrich && strings.TrimSpace(*githubBaseURL) == "" {
 		return emitError(
 			stderr,
 			jsonRequested || *jsonOut,
 			"dependency_missing",
-			"--enrich requires a reachable network source; set --github-api or WRKR_GITHUB_API_BASE",
+			"--enrich requires a reachable network source; set --github-api, configure github_api_base in wrkr init config, or set WRKR_GITHUB_API_BASE",
 			exitDependencyMissing,
 		)
 	}
@@ -132,7 +134,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 			stderr,
 			jsonRequested || *jsonOut,
 			"dependency_missing",
-			"--repo and --org scans require --github-api or WRKR_GITHUB_API_BASE",
+			"--repo and --org scans require --github-api, config github_api_base, or WRKR_GITHUB_API_BASE",
 			exitDependencyMissing,
 		)
 	}
@@ -715,6 +717,19 @@ func resolveScanGitHubToken(explicit string, cfg config.Config) string {
 		strings.TrimSpace(cfg.Auth.Scan.Token),
 		strings.TrimSpace(os.Getenv("WRKR_GITHUB_TOKEN")),
 		strings.TrimSpace(os.Getenv("GITHUB_TOKEN")),
+	} {
+		if candidate != "" {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func resolveScanGitHubAPIBase(explicit string, cfg config.Config) string {
+	for _, candidate := range []string{
+		strings.TrimSpace(explicit),
+		strings.TrimSpace(cfg.GitHubAPIBase),
+		strings.TrimSpace(os.Getenv("WRKR_GITHUB_API_BASE")),
 	} {
 		if candidate != "" {
 			return candidate

--- a/core/cli/scan_github_auth_test.go
+++ b/core/cli/scan_github_auth_test.go
@@ -123,6 +123,99 @@ func TestScanHostedRateLimitFailureMessageIncludesAuthGuidance(t *testing.T) {
 	}
 }
 
+func TestScanGitHubAPIBasePrecedenceFlagOverConfigAndEnv(t *testing.T) {
+	t.Setenv("WRKR_GITHUB_API_BASE", "http://127.0.0.1:1")
+	flagServer := newHostedScanBaseServer(t)
+	defer flagServer.Close()
+
+	configPath := writeScanConfigWithHostedBase(t, "", "http://127.0.0.1:2")
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"scan",
+		"--repo", "acme/backend",
+		"--github-api", flagServer.URL,
+		"--config", configPath,
+		"--state", filepath.Join(t.TempDir(), "state.json"),
+		"--json",
+	}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("scan failed: code=%d stderr=%s", code, errOut.String())
+	}
+}
+
+func TestScanGitHubAPIBasePrecedenceConfigOverEnv(t *testing.T) {
+	t.Setenv("WRKR_GITHUB_API_BASE", "http://127.0.0.1:1")
+	configServer := newHostedScanBaseServer(t)
+	defer configServer.Close()
+
+	configPath := writeScanConfigWithHostedBase(t, "", configServer.URL)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"scan",
+		"--repo", "acme/backend",
+		"--config", configPath,
+		"--state", filepath.Join(t.TempDir(), "state.json"),
+		"--json",
+	}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("scan failed: code=%d stderr=%s", code, errOut.String())
+	}
+}
+
+func TestScanUsesConfigHostedGitHubAPIBaseForDefaultTarget(t *testing.T) {
+	configServer := newHostedScanBaseServer(t)
+	defer configServer.Close()
+
+	configPath := writeScanConfigWithHostedBase(t, "", configServer.URL)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"scan",
+		"--config", configPath,
+		"--state", filepath.Join(t.TempDir(), "state.json"),
+		"--json",
+	}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("scan failed: code=%d stderr=%s", code, errOut.String())
+	}
+}
+
+func TestScanHostedDependencyMissingMentionsConfigGitHubAPIBase(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"scan",
+		"--repo", "acme/backend",
+		"--json",
+	}, &out, &errOut)
+	if code != exitDependencyMissing {
+		t.Fatalf("expected exit %d, got %d (%s)", exitDependencyMissing, code, errOut.String())
+	}
+
+	var envelope map[string]any
+	if err := json.Unmarshal(errOut.Bytes(), &envelope); err != nil {
+		t.Fatalf("parse error payload: %v", err)
+	}
+	errorPayload := envelope["error"].(map[string]any)
+	message := errorPayload["message"].(string)
+	for _, want := range []string{
+		"--github-api",
+		"config github_api_base",
+		"WRKR_GITHUB_API_BASE",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("expected dependency guidance %q, got %q", want, message)
+		}
+	}
+}
+
 func newHostedScanAuthServer(t *testing.T, wantAuth string) *httptest.Server {
 	t.Helper()
 
@@ -147,6 +240,35 @@ func writeScanConfig(t *testing.T, token string) string {
 	cfg := config.Default()
 	cfg.Auth.Scan.Token = token
 	cfg.DefaultTarget = config.Target{Mode: config.TargetRepo, Value: "acme/backend"}
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := config.Save(path, cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	return path
+}
+
+func newHostedScanBaseServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/acme/backend":
+			_, _ = fmt.Fprint(w, `{"full_name":"acme/backend","default_branch":"main"}`)
+		case "/repos/acme/backend/git/trees/main":
+			_, _ = fmt.Fprint(w, `{"tree":[]}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+}
+
+func writeScanConfigWithHostedBase(t *testing.T, token string, githubAPIBase string) string {
+	t.Helper()
+
+	cfg := config.Default()
+	cfg.Auth.Scan.Token = token
+	cfg.DefaultTarget = config.Target{Mode: config.TargetRepo, Value: "acme/backend"}
+	cfg.GitHubAPIBase = githubAPIBase
 	path := filepath.Join(t.TempDir(), "config.json")
 	if err := config.Save(path, cfg); err != nil {
 		t.Fatalf("save config: %v", err)

--- a/core/cli/wave3_compliance_test.go
+++ b/core/cli/wave3_compliance_test.go
@@ -113,3 +113,44 @@ func TestScanAndReportExplainIncludeComplianceRollupLines(t *testing.T) {
 		t.Fatalf("expected report explain output to include next-action guidance, got %q", reportExplain.String())
 	}
 }
+
+func TestEvidenceJSONCoverageNoteClarifiesEvidenceGapState(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "policy-check", "repos")
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	outputDir := filepath.Join(tmp, "evidence")
+
+	var scanOut bytes.Buffer
+	var scanErr bytes.Buffer
+	if code := Run([]string{"scan", "--path", scanPath, "--state", statePath, "--json"}, &scanOut, &scanErr); code != 0 {
+		t.Fatalf("scan failed: %d %s", code, scanErr.String())
+	}
+
+	var evidenceOut bytes.Buffer
+	var evidenceErr bytes.Buffer
+	if code := Run([]string{"evidence", "--frameworks", "eu-ai-act,soc2", "--state", statePath, "--output", outputDir, "--json"}, &evidenceOut, &evidenceErr); code != 0 {
+		t.Fatalf("evidence failed: %d %s", code, evidenceErr.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(evidenceOut.Bytes(), &payload); err != nil {
+		t.Fatalf("parse evidence payload: %v", err)
+	}
+	coverageNote, ok := payload["coverage_note"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected coverage_note object, got %T", payload["coverage_note"])
+	}
+	message, _ := coverageNote["message"].(string)
+	for _, want := range []string{
+		"framework_coverage reflects only controls evidenced in the current scanned state",
+		"evidence gaps",
+		"unsupported framework parsing",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("expected coverage note message to contain %q, got %q", want, message)
+		}
+	}
+}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	Version       string       `json:"version"`
 	Auth          AuthProfiles `json:"auth"`
 	DefaultTarget Target       `json:"default_target"`
+	GitHubAPIBase string       `json:"github_api_base,omitempty"`
 }
 
 func Default() Config {
@@ -58,6 +59,7 @@ func Default() Config {
 }
 
 func Validate(cfg Config) error {
+	cfg.GitHubAPIBase = strings.TrimSpace(cfg.GitHubAPIBase)
 	if cfg.Version == "" {
 		return errors.New("config version is required")
 	}
@@ -114,6 +116,7 @@ func ResolvePath(explicit string) (string, error) {
 
 // Save writes config deterministically.
 func Save(path string, cfg Config) error {
+	cfg.GitHubAPIBase = strings.TrimSpace(cfg.GitHubAPIBase)
 	if err := Validate(cfg); err != nil {
 		return err
 	}

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -44,6 +44,7 @@ func TestSaveLoadDeterministicRoundTrip(t *testing.T) {
 	cfg.DefaultTarget = Target{Mode: TargetRepo, Value: "acme/backend"}
 	cfg.Auth.Scan.Token = "scan-token"
 	cfg.Auth.Fix.Token = "fix-token"
+	cfg.GitHubAPIBase = "https://api.github.com"
 
 	if err := Save(path, cfg); err != nil {
 		t.Fatalf("save config: %v", err)
@@ -57,6 +58,9 @@ func TestSaveLoadDeterministicRoundTrip(t *testing.T) {
 	}
 	if loaded.DefaultTarget.Mode != TargetRepo || loaded.DefaultTarget.Value != "acme/backend" {
 		t.Fatalf("unexpected default target: %+v", loaded.DefaultTarget)
+	}
+	if loaded.GitHubAPIBase != "https://api.github.com" {
+		t.Fatalf("unexpected github api base: %q", loaded.GitHubAPIBase)
 	}
 
 	first, err := os.ReadFile(path)
@@ -83,5 +87,27 @@ func TestResolvePathWithEnv(t *testing.T) {
 	}
 	if path != "/tmp/wrkr-config.json" {
 		t.Fatalf("unexpected env path: %q", path)
+	}
+}
+
+func TestLoadOlderConfigWithoutGitHubAPIBase(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.json")
+	payload := []byte("{\n  \"version\": \"v1\",\n  \"auth\": {\n    \"scan\": {},\n    \"fix\": {}\n  },\n  \"default_target\": {\n    \"mode\": \"org\",\n    \"value\": \"acme\"\n  }\n}\n")
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if loaded.GitHubAPIBase != "" {
+		t.Fatalf("expected empty github api base, got %q", loaded.GitHubAPIBase)
+	}
+	if loaded.DefaultTarget.Mode != TargetOrg || loaded.DefaultTarget.Value != "acme" {
+		t.Fatalf("unexpected default target: %+v", loaded.DefaultTarget)
 	}
 }

--- a/core/evidence/evidence.go
+++ b/core/evidence/evidence.go
@@ -37,7 +37,15 @@ type BuildResult struct {
 	ManifestPath      string             `json:"manifest_path"`
 	ChainPath         string             `json:"chain_path"`
 	FrameworkCoverage map[string]float64 `json:"framework_coverage"`
+	CoverageNote      CoverageNote       `json:"coverage_note"`
 	ReportArtifacts   []string           `json:"report_artifacts"`
+}
+
+type CoverageNote struct {
+	Basis              string   `json:"basis"`
+	LowCoverageMeans   string   `json:"low_coverage_means"`
+	Message            string   `json:"message"`
+	RecommendedActions []string `json:"recommended_actions"`
 }
 
 const outputDirMarkerFile = ".wrkr-evidence-managed"
@@ -386,8 +394,21 @@ func Build(in BuildInput) (BuildResult, error) {
 		ManifestPath:      filepath.Join(targetOutputDir, "manifest.json"),
 		ChainPath:         chainPath,
 		FrameworkCoverage: coverage,
+		CoverageNote:      defaultCoverageNote(),
 		ReportArtifacts:   reportArtifacts,
 	}, nil
+}
+
+func defaultCoverageNote() CoverageNote {
+	return CoverageNote{
+		Basis:            "evidenced_controls_only",
+		LowCoverageMeans: "evidence_gap",
+		Message:          "framework_coverage reflects only controls evidenced in the current scanned state; low or zero first-run coverage indicates evidence gaps rather than unsupported framework parsing.",
+		RecommendedActions: []string{
+			"Run wrkr report --top 5 --json to prioritize missing controls and approvals.",
+			"Remediate the highest-priority gaps and rerun wrkr scan, wrkr evidence, and wrkr report with the same deterministic inputs.",
+		},
+	}
 }
 
 func normalizeFrameworks(in []string) []string {

--- a/core/evidence/evidence_test.go
+++ b/core/evidence/evidence_test.go
@@ -88,6 +88,15 @@ func TestBuildEvidenceBundle(t *testing.T) {
 	if len(result.ReportArtifacts) == 0 {
 		t.Fatal("expected report artifacts to be recorded in build result")
 	}
+	if result.CoverageNote.Basis != "evidenced_controls_only" {
+		t.Fatalf("unexpected coverage note basis: %+v", result.CoverageNote)
+	}
+	if result.CoverageNote.LowCoverageMeans != "evidence_gap" {
+		t.Fatalf("unexpected coverage note low_coverage_means: %+v", result.CoverageNote)
+	}
+	if len(result.CoverageNote.RecommendedActions) == 0 {
+		t.Fatalf("expected recommended actions in coverage note, got %+v", result.CoverageNote)
+	}
 }
 
 func TestBuildEvidenceBundleIncludesPersonalInventoryAndMCPCatalogWhenPresent(t *testing.T) {

--- a/docs-site/public/llm/faq.md
+++ b/docs-site/public/llm/faq.md
@@ -14,7 +14,7 @@ No. Core scan and evidence workflows are local/file-based by default.
 
 ## Does Wrkr require setup for repo or org scans?
 
-Hosted `--repo` and `--org` scans require explicit GitHub API configuration and usually a token for private repos or rate-limit avoidance. `--my-setup` and `--path` remain the zero-integration local paths.
+Hosted `--repo` and `--org` scans require explicit GitHub API configuration and usually a token for private repos or rate-limit avoidance. `wrkr init` can persist the hosted GitHub API base together with the default org target, and `--my-setup`, `--path`, and the curated scenario remain the zero-integration fallback paths.
 
 ## Can Wrkr enforce runtime tool calls?
 
@@ -38,4 +38,4 @@ Use `wrkr evidence --frameworks ... --json` and verify with `wrkr verify --chain
 
 ## Why can framework coverage be low on the first run?
 
-`framework_coverage` reflects the controls and approvals currently evidenced in the scanned state. Low or zero coverage means more evidence work is needed; it does not mean the framework is unsupported.
+`framework_coverage` reflects the controls and approvals currently evidenced in the scanned state. Low or zero coverage means more evidence work is needed; it does not mean the framework is unsupported. `wrkr evidence --json` also emits additive `coverage_note` guidance with the same interpretation.

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -13,20 +13,26 @@ go install github.com/Clyra-AI/wrkr/cmd/wrkr@latest
 wrkr version --json
 ```
 
-For the current public launch, the recommended first path is the curated scenario flow below, then security/platform org posture and evidence. Repo-local and local-machine fallbacks remain available later in the flow when hosted setup is not ready yet.
+For the current public launch, the recommended first path is the hosted org posture flow below when hosted prerequisites are ready. If they are not, use the curated scenario fallback and then return to the org path once GitHub access is configured.
 When concrete local tool, MCP, or secret signals exist, `scan --my-setup --json` also emits additive `activation.items` so the local-machine path stays concrete without mutating the raw risk ranking.
 
 ```bash
+# Hosted org posture first when prerequisites are ready
+wrkr init --non-interactive --org acme --github-api https://api.github.com --json
+wrkr scan --config ~/.wrkr/config.json --json
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence --json
+wrkr verify --chain --json
+
+# Low or zero first-run framework_coverage means the current state is evidence sparse, not that parsing is broken
+
+# Evaluator-safe scenario fallback when hosted prerequisites are not ready yet
 wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json
 wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/wrkr-scenario-evidence --json
 wrkr verify --chain --state ./.wrkr/last-scan.json --json
 wrkr regress init --baseline ./.wrkr/last-scan.json --output ./.tmp/wrkr-regress-baseline.json --json
 wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/last-scan.json --json
 
-# Hosted prerequisites: set --github-api and usually a GitHub token for private repos or rate limits
-wrkr scan --github-org acme --github-api https://api.github.com --json
-wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence --json
-wrkr verify --chain --json
+# If hosted prerequisites are still not ready yet, use a deterministic local fallback
 wrkr scan --path ./your-repo --json
 wrkr scan --my-setup --json
 wrkr mcp-list --state ./.wrkr/last-scan.json --json
@@ -35,7 +41,7 @@ wrkr inventory --diff --baseline ./.wrkr/inventory-baseline.json --state ./.wrkr
 ```
 
 `wrkr evidence` now fails closed when the saved proof chain is malformed or tampered, and `wrkr verify --chain --json` remains the explicit machine gate for integrity.
-Use the curated scenario first when you want the evaluator-safe path because it avoids repo-root fixture noise from Wrkr's own scenarios, docs, and test fixtures. That scenario path is the canonical `repo_set` example for `--path`: Wrkr scans the immediate child repos in the bundle instead of treating the bundle root as one repo.
+The hosted org path is the primary launch workflow when prerequisites are ready. Use the curated scenario when you want the evaluator-safe fallback because it avoids repo-root fixture noise from Wrkr's own scenarios, docs, and test fixtures. That scenario path is the canonical `repo_set` example for `--path`: Wrkr scans the immediate child repos in the bundle instead of treating the bundle root as one repo.
 Use `wrkr scan --path ./your-repo --json` when the selected directory itself is the repo root and carries repo-root signals such as `.git`, `go.mod`, `AGENTS.md`, or `.codex/`. Use a bundle root like `./scenarios/wrkr/scan-mixed-org/repos` when you want immediate child repos scanned as a deterministic repo-set.
 
 Use these next when you want deeper triage:
@@ -46,7 +52,7 @@ Use these next when you want deeper triage:
 `wrkr verify --chain --json` now reports whether the result was structural-only (`chain_only` / `unavailable`) or authenticated (`chain_and_attestation` or `chain_and_signature` with `verified` authenticity status).
 Resumed hosted org scans also revalidate checkpoint files and reused materialized repo roots before detector execution, so symlink-swapped resume state is blocked as unsafe.
 
-Low or zero `framework_coverage` on a first run means the scanned state still lacks documented controls or approvals. It is an evidence gap, not a parser failure.
+Low or zero `framework_coverage` on a first run means the scanned state still lacks documented controls or approvals. It is an evidence gap, not a parser failure, and `wrkr evidence --json` also emits additive `coverage_note` guidance with the same interpretation.
 
 Use these intent guides next:
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -7,6 +7,7 @@
 - https://clyra-ai.github.io/wrkr/
 
 ## Core Commands
+- wrkr init --org <org> --github-api <url> --json
 - wrkr --help
 - wrkr help <command>
 - wrkr scan --my-setup --json
@@ -24,7 +25,7 @@
 - wrkr fix --top <n> --json
 
 ## When To Use
-- You need a security/platform-led view of AI tooling posture across repos or orgs, with a secondary local-machine path available for developers.
+- You need a security/platform-led view of AI tooling posture across repos or orgs, with hosted org posture as the primary path and deterministic scenario/local fallbacks when hosted setup is not ready yet.
 - You need deterministic inventory and evidence outputs for AI tooling declared across machines, repos, or org surfaces.
 - You need compliance-ready evidence outputs with explicit verification workflows.
 - You need CI gates for drift and regression with stable machine-readable reasons.
@@ -41,9 +42,9 @@
 - Deterministic JSON contracts and stable exit-code semantics.
 - No secret-value extraction; only risk context signals.
 - Proof-chain verification support for evidence integrity checks; `wrkr evidence` now fails closed on malformed or tampered saved proof chains, while `verify --chain --json` remains the explicit machine gate and reports `chain.verification_mode` and `chain.authenticity_status`.
-- Local `--my-setup` and `--path` scans are the no-integration first-value paths; `--repo`, `--org`, and `--github-org` require explicit GitHub API configuration.
+- Hosted org posture is the primary first-run path when prerequisites are ready; local `--my-setup`, repo-local `--path`, and the curated scenario remain deterministic fallback paths when hosted setup is not ready yet.
 - Resumed hosted org scans revalidate checkpoint files and reused materialized repo roots before detector execution, so symlink-swapped resume state is blocked as unsafe.
-- Low or zero `framework_coverage` reflects the controls currently evidenced in the scanned state, not missing parser support.
+- Low or zero `framework_coverage` reflects the controls currently evidenced in the scanned state, not missing parser support, and `wrkr evidence --json` emits additive `coverage_note` guidance with the same interpretation.
 - Evidence bundles include deterministic inventory artifacts: inventory.json, inventory-snapshot.json, inventory.yaml.
 - Wrkr runs standalone; Gait is the optional control-layer counterpart.
 - Wrkr does not replace vulnerability scanners such as Snyk.

--- a/docs-site/src/app/page.tsx
+++ b/docs-site/src/app/page.tsx
@@ -11,20 +11,22 @@ export const metadata: Metadata = {
   },
 };
 
-const QUICKSTART = `# Evaluator-safe first pass: use the curated scenario
+const QUICKSTART = `# Security and platform teams: use hosted org posture first when prerequisites are ready
+wrkr init --non-interactive --org acme --github-api https://api.github.com --json
+wrkr scan --config ~/.wrkr/config.json --json
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence --json
+wrkr verify --chain --state ./.wrkr/last-scan.json --json
+
+# Low or zero first-run framework_coverage means the current state is evidence sparse, not that parsing is broken
+
+# Evaluator-safe scenario fallback when hosted prerequisites are not ready yet
 wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json
 wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/wrkr-scenario-evidence --json
 wrkr verify --chain --state ./.wrkr/last-scan.json --json
 wrkr regress init --baseline ./.wrkr/last-scan.json --output ./.tmp/wrkr-regress-baseline.json --json
 wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/last-scan.json --json
 
-# Security and platform teams: widen to org posture next
-# Hosted prerequisites: set --github-api and usually a GitHub token for private repos or rate limits
-wrkr scan --github-org acme --github-api https://api.github.com --json
-wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence --json
-wrkr verify --chain --state ./.wrkr/last-scan.json --json
-
-# If hosted prerequisites are not ready yet after the scenario run, use a deterministic fallback
+# If hosted prerequisites are still not ready yet, use a deterministic local fallback
 wrkr scan --path ./your-repo --json
 
 # Developers: use the secondary local-machine hygiene path
@@ -144,7 +146,7 @@ export default function HomePage() {
           Wrkr gives security and platform teams an evidence-ready view of org-wide AI tooling posture and keeps a deterministic local-machine hygiene path available for developers.
         </p>
         <p className="text-base text-gray-500 max-w-3xl mx-auto mb-8">
-          Discover supported AI dev tools, MCP servers, and agent frameworks, map what they can touch, show what changed, and emit proof artifacts for audits and CI. Start with the curated scenario when you want the evaluator-safe path, then widen to org posture when hosted prerequisites are ready; use repo-local or local-machine fallback paths when you need zero-integration first value and want to avoid repo-root fixture noise in the Wrkr repo itself.
+          Discover supported AI dev tools, MCP servers, and agent frameworks, map what they can touch, show what changed, and emit proof artifacts for audits and CI. Start with hosted org posture when GitHub access is ready; use the curated scenario and local fallback paths when hosted prerequisites are not ready yet or when you want an evaluator-safe demo that avoids repo-root fixture noise in the Wrkr repo itself.
         </p>
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
           <Link href="/docs/examples/security-team" className="px-6 py-3 bg-emerald-400 hover:bg-emerald-300 text-gray-950 font-semibold rounded-lg transition-colors">
@@ -237,8 +239,8 @@ export default function HomePage() {
       </div>
 
       <div className="text-center py-12 border-t border-gray-800">
-        <h2 className="text-2xl font-bold text-white mb-4">Start with your machine. Widen to your org only when you need posture and proof.</h2>
-        <p className="text-gray-400 mb-6">Use command-first docs that developers, security teams, and assistants can all validate against the same deterministic CLI outputs.</p>
+        <h2 className="text-2xl font-bold text-white mb-4">Start with your org when hosted access is ready. Fall back to the scenario or local paths when it is not.</h2>
+        <p className="text-gray-400 mb-6">Use command-first docs that developers, security teams, and assistants can all validate against the same deterministic CLI outputs and the same evidence-gap framing.</p>
         <Link href="/docs" className="inline-block px-6 py-3 bg-cyan-500 hover:bg-cyan-400 text-gray-900 font-semibold rounded-lg transition-colors">
           Open Documentation
         </Link>

--- a/docs/commands/evidence.md
+++ b/docs/commands/evidence.md
@@ -65,7 +65,8 @@ wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json
 Pair this with the saved-state `wrkr report` and explicit proof-chain verification flow documented in [`docs/examples/security-team.md`](../examples/security-team.md).
 `wrkr evidence` now requires the saved proof chain to be intact before it will stage or publish a bundle; it does not replace the explicit operator or CI proof-chain verification gate.
 
-Expected JSON keys: `status`, `output_dir`, `frameworks`, `manifest_path`, `chain_path`, `framework_coverage`, `report_artifacts`.
+Expected JSON keys: `status`, `output_dir`, `frameworks`, `manifest_path`, `chain_path`, `framework_coverage`, additive `coverage_note`, `report_artifacts`.
+`coverage_note` is the machine-readable interpretation companion for `framework_coverage`: it states that coverage reflects only controls evidenced in the current scanned state and that low or zero first-run coverage indicates evidence gaps rather than unsupported framework parsing.
 Evidence bundle includes deterministic inventory exports at `inventory.json`, `inventory-snapshot.json`, and `inventory.yaml`.
 Evidence bundle includes deterministic compliance rollup export at `compliance-summary.json`.
 Evidence bundle includes deterministic attack-path artifact export at `attack-paths.json` when attack-path scoring is present in scan state.

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -3,7 +3,7 @@
 ## Synopsis
 
 ```bash
-wrkr init [--non-interactive] (--repo <owner/repo> | --org <org> | --path <dir>) [--scan-token <token>] [--fix-token <token>] [--config <path>] [--json]
+wrkr init [--non-interactive] (--repo <owner/repo> | --org <org> | --path <dir>) [--github-api <url>] [--scan-token <token>] [--fix-token <token>] [--config <path>] [--json]
 ```
 
 `wrkr init` still persists one default target in config in this wave.
@@ -16,6 +16,7 @@ Multi-target scans are driven explicitly at runtime through the `wrkr scan` targ
 - `--repo`
 - `--org`
 - `--path`
+- `--github-api`
 - `--scan-token`
 - `--fix-token`
 - `--config`
@@ -24,8 +25,11 @@ Multi-target scans are driven explicitly at runtime through the `wrkr scan` targ
 
 ```bash
 wrkr init --non-interactive --path ./scenarios/wrkr/scan-mixed-org/repos --json
+wrkr init --non-interactive --org acme --github-api https://api.github.com --json
 ```
 
-Expected JSON keys: `status`, `config_path`, `default_target`, `auth_profiles`.
+Expected JSON keys: `status`, `config_path`, `default_target`, `auth_profiles`, additive `hosted_source`, additive `next_step`.
 
 `auth_profiles.scan.token_configured` and `auth_profiles.fix.token_configured` report only tokens persisted in config by `wrkr init`. Ambient runtime fallback tokens from `WRKR_GITHUB_TOKEN` or `GITHUB_TOKEN` are not reflected in that JSON response.
+`hosted_source.github_api_configured` and `hosted_source.github_api_base` report whether Wrkr persisted a hosted GitHub API base for repo/org scans. Ambient runtime fallback from `WRKR_GITHUB_API_BASE` is not reflected in that JSON response.
+For repo/org defaults, `next_step` points at the config-backed `wrkr scan --config ... --json` flow. If no hosted GitHub API base was persisted, the guidance stays fail closed and tells you to set `--github-api`, persist `github_api_base` via `wrkr init`, or export `WRKR_GITHUB_API_BASE` before running the hosted scan.

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -20,7 +20,8 @@ Acquisition behavior is fail-closed by target:
 - `repo_set` child repos are enumerated in deterministic lexical order by repo name.
 - `--my-setup` runs fully local/offline against the local machine setup rooted at the current user home directory.
   It inspects supported user-home tool configs, selected environment key names, and common workspace roots for local agent project markers without emitting raw secret values.
-- `--repo` and `--org` require real GitHub acquisition via `--github-api` or `WRKR_GITHUB_API_BASE`.
+- `--repo` and `--org` require real GitHub acquisition via `--github-api`, config `github_api_base`, or `WRKR_GITHUB_API_BASE`.
+- Hosted GitHub API base resolution order is: `--github-api`, config `github_api_base`, then `WRKR_GITHUB_API_BASE`.
 - Hosted GitHub token resolution order is: `--github-token`, config `auth.scan.token`, `WRKR_GITHUB_TOKEN`, then `GITHUB_TOKEN`.
 - `--github-org` is an additive alias for `--org`.
 - Explicit multi-target scans set `target.mode=multi` and add deterministic `targets[]` arrays to the top-level scan payload, saved state snapshot, and `source_manifest`.
@@ -91,6 +92,13 @@ wrkr scan --github-org acme --github-api https://api.github.com --json --json-pa
 
 `--github-org` is the additive alias for `--org`. Use it when security or platform teams need the deterministic saved-state input for `wrkr report`, `wrkr evidence`, `wrkr mcp-list`, or `wrkr inventory --diff`.
 Private repos and public API rate-limit avoidance usually require a GitHub token even when `--github-api` is set.
+If you already configured the hosted source and target with `wrkr init`, you can reuse them:
+
+```bash
+wrkr init --org acme --github-api https://api.github.com --json
+wrkr scan --config ~/.wrkr/config.json --json
+```
+
 Wrkr's hosted connector currently calls these GitHub REST endpoints:
 
 - `GET /orgs/{org}/repos?per_page=100&page=N`

--- a/docs/contracts/readme_contract.md
+++ b/docs/contracts/readme_contract.md
@@ -66,12 +66,14 @@ Section requirements:
 - Start Here
   - Make the current launch persona explicit at the top of the section.
   - For the current Wrkr launch, foreground the security/platform-led org posture workflow.
+  - If an evaluator-safe scenario is shown, present it as an explicit fallback/demo path after the hosted org posture workflow rather than as the primary launch path.
   - Keep developer-machine hygiene as the secondary path.
   - Place hosted prerequisites (`--github-api` and token guidance) adjacent to the first hosted org workflow.
+  - If `wrkr init` is used for hosted onboarding, keep it immediately adjacent to the first hosted scan command and make the `wrkr scan --config ...` follow-on path explicit.
   - Include explicit deterministic fallback commands before hosted setup can dead-end (`wrkr scan --path` and/or `wrkr scan --my-setup`).
   - Explain the dual `wrkr scan --path` contract: repo-root fallback for one selected repo, and bundle-root repo-set behavior for paths such as `./scenarios/wrkr/*/repos`.
   - Include `wrkr scan --my-setup`, `wrkr mcp-list`, and `wrkr inventory --diff`.
-  - Include `wrkr scan --github-org`, `wrkr evidence`, and `wrkr verify` when security/platform-led launch copy is used.
+  - Include `wrkr init`, `wrkr scan --github-org` or `wrkr scan --config ...`, `wrkr evidence`, and `wrkr verify` when security/platform-led launch copy is used.
   - Keep deterministic `--json` command anchors.
   - Show one personal-setup output example and one org-scan output example.
   - Clarify that environment-key presence and source bookkeeping remain finding-only signals, not approvable lifecycle identities.

--- a/docs/examples/operator-playbooks.md
+++ b/docs/examples/operator-playbooks.md
@@ -37,10 +37,11 @@ Check `remediation_count`, deterministic `fingerprint`, `apply_supported`, and u
 wrkr evidence --frameworks eu-ai-act,soc2 --output ./.tmp/evidence --json
 ```
 
-Check `framework_coverage`, `report_artifacts`, and manifest/chain paths.
+Check `framework_coverage`, additive `coverage_note`, `report_artifacts`, and manifest/chain paths.
 When risk state includes attack-path scoring, evidence output includes deterministic `attack-paths.json`.
 
 `framework_coverage` reflects evidence currently present in scanned state.
+`coverage_note` is the additive machine-readable interpretation of that value and should be preferred when you need to explain low/zero first-run coverage to operators or downstream automation.
 
 - Low/0% coverage indicates documented control gaps in current evidence.
 - Low/0% does not imply Wrkr lacks support for that framework.

--- a/docs/examples/quickstart.md
+++ b/docs/examples/quickstart.md
@@ -2,7 +2,7 @@
 
 Know what AI tools, agents, and MCP servers are configured on your machine and in your org before they become unreviewed access.
 
-Wrkr gives security and platform teams an evidence-ready view of org-wide AI tooling posture and keeps deterministic zero-integration fallback paths available when hosted prerequisites are not ready yet. This quickstart leads with the evaluator-safe scenario flow, then widens to the org posture path and local fallback flows.
+Wrkr gives security and platform teams an evidence-ready view of org-wide AI tooling posture and keeps deterministic zero-integration fallback paths available when hosted prerequisites are not ready yet. This quickstart leads with the hosted org posture path, then falls back to the evaluator-safe scenario and local flows when hosted setup is not ready yet.
 
 ## Positioning
 
@@ -12,24 +12,9 @@ Wrkr is an AI-DSPM discovery and posture tool in the See -> Prove -> Control seq
 - Prove: proof-ready artifacts can flow into downstream evidence consumers.
 - Control: Gait is the optional runtime enforcement counterpart.
 
-The fastest minimum-now public value is the curated scenario path below. If hosted prerequisites are not ready yet after that, use the repo-local or local-machine fallback section later in this guide.
+The fastest minimum-now public value for the current launch is the hosted org posture path below when prerequisites are ready. If they are not, use the evaluator-safe scenario fallback and then return to the org posture workflow once GitHub access is configured.
 
 Canonical local artifact paths are documented in [`docs/state_lifecycle.md`](../state_lifecycle.md).
-
-## Evaluator-safe scenario first
-
-Use the curated scenario bundle when you want a clean first pass through discovery, evidence, verify, and regress without the repo-root fixture noise in the Wrkr repository itself.
-
-```bash
-wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json
-wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/wrkr-scenario-evidence --json
-wrkr verify --chain --state ./.wrkr/last-scan.json --json
-wrkr regress init --baseline ./.wrkr/last-scan.json --output ./.tmp/wrkr-regress-baseline.json --json
-wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/last-scan.json --json
-```
-
-Use this flow first when you want the evaluator-safe path. It avoids repo-root fixture noise from Wrkr's own scenarios, docs, and tests while still exercising the shipped wedge.
-This is the canonical `repo_set` path example: Wrkr scans the immediate child repos under `./scenarios/wrkr/scan-mixed-org/repos` in deterministic order instead of treating that bundle root as one repo.
 
 ## Security/platform posture first
 
@@ -42,23 +27,42 @@ Hosted prerequisites for this path:
 - connector endpoints: `GET /orgs/{org}/repos`, `GET /repos/{owner}/{repo}`, `GET /repos/{owner}/{repo}/git/trees/{default_branch}?recursive=1`, `GET /repos/{owner}/{repo}/git/blobs/{sha}`
 
 ```bash
-wrkr scan --github-org acme --github-api https://api.github.com --state ./.wrkr/last-scan.json --timeout 30m --json --json-path ./.wrkr/scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
+wrkr init --non-interactive --org acme --github-api https://api.github.com --json
+wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --timeout 30m --json --json-path ./.wrkr/scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
 wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --output ./.tmp/evidence --json
 wrkr verify --chain --json
 ```
 
 `wrkr evidence` now fails closed when the saved proof chain is malformed or tampered, and `wrkr verify --chain --json` remains the explicit integrity gate for CI and operator workflows.
+`wrkr init` can now persist the hosted GitHub API base together with the default org target, so follow-on hosted scans can reuse `--config` instead of repeating `--github-api` each time.
+Low or zero first-run `framework_coverage` means the current hosted scan state still lacks documented controls or approvals. It is an evidence gap, not a parser failure, and the additive `coverage_note` in `wrkr evidence --json` carries the same interpretation for automation.
 
 If a hosted run is interrupted, rerun the same target with `--resume`. Retry/cooldown/resume progress stays on stderr in `--json` mode, and `partial_result` / `source_errors` means the posture output is incomplete until the run is repeated successfully.
 Resumed hosted scans also revalidate checkpoint files and reused materialized repo roots before detector execution, so symlink-swapped resume state is blocked as unsafe.
 
-If you scan the Wrkr repo root during evaluation, expect repo-root fixture noise because the repo includes intentionally noisy scenario and test fixtures. Use the curated scenario path above first, then move to your own repo or org target.
+If you scan the Wrkr repo root during evaluation, expect repo-root fixture noise because the repo includes intentionally noisy scenario and test fixtures. Use the curated scenario fallback below first, then move to your own repo or org target.
 
 Expected outputs:
 
-- `scan --github-org`: `status`, `target`, `findings`, `ranked_findings`, `top_findings`, `inventory`, `repo_exposure_summaries`, `profile`, `posture_score`
+- `scan` (hosted org mode): `status`, `target`, `findings`, `ranked_findings`, `top_findings`, `inventory`, `repo_exposure_summaries`, `profile`, `posture_score`
 - `evidence`: `output_dir`, `manifest_path`, `chain_path`, `framework_coverage`
 - `verify`: `chain.intact=true`
+
+## Evaluator-safe scenario fallback
+
+Use the curated scenario bundle when hosted prerequisites are not ready yet, or when you want a clean first pass through discovery, evidence, verify, and regress without the repo-root fixture noise in the Wrkr repository itself.
+
+```bash
+wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/wrkr-scenario-evidence --json
+wrkr verify --chain --state ./.wrkr/last-scan.json --json
+wrkr regress init --baseline ./.wrkr/last-scan.json --output ./.tmp/wrkr-regress-baseline.json --json
+wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/last-scan.json --json
+```
+
+Use this flow when you want the evaluator-safe fallback. It avoids repo-root fixture noise from Wrkr's own scenarios, docs, and tests while still exercising the shipped wedge.
+This is the canonical `repo_set` path example: Wrkr scans the immediate child repos under `./scenarios/wrkr/scan-mixed-org/repos` in deterministic order instead of treating that bundle root as one repo.
+Low or zero first-run `framework_coverage` in this path is still an evidence-gap signal. It means the current state lacks documented controls or approvals, not that the framework mapping is unsupported.
 
 ## If hosted prerequisites are not ready yet
 
@@ -101,6 +105,7 @@ wrkr verify --chain --json
 ```
 
 `wrkr evidence` does not replace `wrkr verify --chain --json`; it now reuses the same proof-chain prerequisite and aborts before publish when saved proof state is malformed or tampered.
+`wrkr evidence --json` also emits additive `coverage_note` guidance so automation and operator UX can explain low or zero first-run coverage as an evidence-state gap rather than a parser failure.
 
 Expected outputs:
 

--- a/docs/examples/security-team.md
+++ b/docs/examples/security-team.md
@@ -14,17 +14,19 @@ Hosted prerequisites for this path:
 - if hosted prerequisites are not ready yet, start with `wrkr scan --path ./your-repo --json` or `wrkr scan --my-setup --json` first and return to this flow when GitHub access is configured; `--path` scans the selected directory itself when it is the repo root and uses bundle roots like `./scenarios/wrkr/scan-mixed-org/repos` when you want a deterministic repo-set
 
 ```bash
-wrkr scan --github-org acme --github-api https://api.github.com --state ./.wrkr/last-scan.json --timeout 30m --profile assessment --json --json-path ./.wrkr/scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
+wrkr init --non-interactive --org acme --github-api https://api.github.com --json
+wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --timeout 30m --profile assessment --json --json-path ./.wrkr/scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
 wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./wrkr-evidence --json
 wrkr verify --chain --state ./.wrkr/last-scan.json --json
 ```
 
 `wrkr evidence` now requires the saved proof chain to be intact before it stages or publishes a bundle, and `wrkr verify --chain --json` remains the explicit operator/CI integrity gate.
+`wrkr init` can now persist the hosted GitHub API base together with the default org target, so the follow-on `wrkr scan --config ...` path stays copy-pasteable without repeating `--github-api` on every run.
 
 If a hosted org scan is interrupted, rerun the same target with `--resume` to reuse checkpointed materialization state under the scan-state directory:
 
 ```bash
-wrkr scan --github-org acme --github-api https://api.github.com --state ./.wrkr/last-scan.json --resume --json --json-path ./.wrkr/scan.json
+wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --resume --json --json-path ./.wrkr/scan.json
 ```
 
 Interpretation notes:
@@ -43,10 +45,11 @@ wrkr report --top 5 --json
 
 ## Expected JSON keys
 
-- `scan --github-org`: `status`, `target`, `findings`, `ranked_findings`, `top_findings`, `inventory`, `repo_exposure_summaries`, `profile`, `posture_score`
+- `scan` (hosted org mode): `status`, `target`, `findings`, `ranked_findings`, `top_findings`, `inventory`, `repo_exposure_summaries`, `profile`, `posture_score`
   - `inventory.security_visibility_summary` gives you the additive `unknown_to_security` counts and reference basis for that run
   - `agent_privilege_map[*]` is instance-scoped and includes `agent_instance_id`, `write_capable`, and `security_visibility_status`
 - `evidence`: `status`, `output_dir`, `frameworks`, `manifest_path`, `chain_path`, `framework_coverage`
+- `evidence.coverage_note`: additive interpretation for low/zero first-run coverage; treat it as an evidence-gap signal, not unsupported framework parsing
 - `verify`: `status`, `chain`
 - `mcp-list`: `status`, `generated_at`, `rows`, optional `warnings`
 - `report`: `status`, `generated_at`, `top_findings`, `total_tools`, `summary`
@@ -59,6 +62,7 @@ wrkr report --top 5 --json
 - `report` gives the ranked operator summary for triage.
 - `report` is a saved-state renderer for static posture and offline proof artifacts; it is not a live observation surface.
 - `evidence` packages the saved posture into portable proof artifacts only when the saved proof chain is intact, and `verify` remains the explicit machine gate for proof integrity.
+- `coverage_note` is the machine-readable companion to `framework_coverage`; use it when handing results to operators or downstream automation so sparse first-run evidence is framed as a remediation queue instead of a parser failure.
 
 ## Scope boundary
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -21,7 +21,14 @@ No. Core operation is local and file-based by default.
 
 ### Does Wrkr require setup for repo or org scans?
 
-`--path` is the zero-integration first-value path. Hosted `--repo` and `--org` scans require explicit GitHub API configuration via `--github-api` or `WRKR_GITHUB_API_BASE`, and they usually also need a GitHub token for private repos or to avoid public API rate limits. Token resolution order is `--github-token`, config `auth.scan.token`, `WRKR_GITHUB_TOKEN`, then `GITHUB_TOKEN`.
+`--path` is the zero-integration first-value path. Hosted `--repo` and `--org` scans require explicit GitHub API configuration via `--github-api`, config `github_api_base`, or `WRKR_GITHUB_API_BASE`, and they usually also need a GitHub token for private repos or to avoid public API rate limits. Token resolution order is `--github-token`, config `auth.scan.token`, `WRKR_GITHUB_TOKEN`, then `GITHUB_TOKEN`.
+
+`wrkr init` can now persist both the default hosted target and the hosted GitHub API base, so org-first onboarding can be:
+
+```bash
+wrkr init --non-interactive --org acme --github-api https://api.github.com --json
+wrkr scan --config ~/.wrkr/config.json --json
+```
 
 For hosted org runs, the least-privilege fine-grained PAT recipe is: select only the target repositories, grant read-only repository metadata, and grant read-only repository contents. That matches the exact endpoints Wrkr calls: `GET /orgs/{org}/repos`, `GET /repos/{owner}/{repo}`, `GET /repos/{owner}/{repo}/git/trees/{default_branch}?recursive=1`, and `GET /repos/{owner}/{repo}/git/blobs/{sha}`.
 
@@ -41,14 +48,15 @@ Wrkr does not perform live MCP probing or package vulnerability assessment in th
 
 ### Should I start with `wrkr scan --my-setup` or `wrkr scan --github-org`?
 
-For the current public launch, start with `wrkr scan --github-org ... --github-api ... --json` when the goal is org posture, shared inventory review, or compliance handoff.
+For the current public launch, start with `wrkr init --org ... --github-api ... --json`, then run `wrkr scan --config ... --json` when the goal is org posture, shared inventory review, or compliance handoff.
 If hosted prerequisites are not ready yet, use `wrkr scan --path ./your-repo --json` as the zero-integration repo-local fallback or `wrkr scan --my-setup --json` for developer-machine hygiene. `--path` scans the selected directory itself when that directory is the repo root with signals such as `.git`, `go.mod`, `AGENTS.md`, or `.codex/`; it scans immediate child repos instead when you point it at a bundle root such as `./scenarios/wrkr/scan-mixed-org/repos`.
 Developers doing only local checks can still start with `wrkr scan --my-setup --json`.
 
 For larger orgs, prefer the opinionated path:
 
 ```bash
-wrkr scan --github-org acme --github-api https://api.github.com --state ./.wrkr/last-scan.json --timeout 30m --json --json-path ./.wrkr/scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
+wrkr init --non-interactive --org acme --github-api https://api.github.com --json
+wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --timeout 30m --json --json-path ./.wrkr/scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
 ```
 
 If the run is interrupted, rerun the same target with `--resume`. If `partial_result`, `source_errors`, or `source_degraded` is present, treat the result as incomplete until the hosted scan finishes cleanly.
@@ -67,4 +75,4 @@ Use `wrkr evidence --frameworks ... --json` and verify chain integrity with `wrk
 
 ### Why can framework coverage be low on the first run?
 
-`framework_coverage` reflects the controls and approvals currently evidenced in the scanned state. Low or zero coverage means more evidence work is needed; it does not mean Wrkr lacks support for that framework.
+`framework_coverage` reflects the controls and approvals currently evidenced in the scanned state. Low or zero coverage means more evidence work is needed; it does not mean Wrkr lacks support for that framework. `wrkr evidence --json` now emits additive `coverage_note` guidance with the same interpretation for automation and operator handoffs.

--- a/docs/install/minimal-dependencies.md
+++ b/docs/install/minimal-dependencies.md
@@ -37,7 +37,14 @@ wrkr version --json
 
 ## Recommended first-value after install
 
-Start with the curated scenario when you want the evaluator-safe first path and want to avoid repo-root fixture noise from Wrkr's own scenarios and tests:
+Start with hosted org posture when GitHub access is ready:
+
+```bash
+wrkr init --non-interactive --org acme --github-api https://api.github.com --json
+wrkr scan --config ~/.wrkr/config.json --json
+```
+
+If hosted prerequisites are not ready yet, use the evaluator-safe scenario fallback and return to the hosted org path later:
 
 ```bash
 wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -36,7 +36,7 @@ Wrkr is the discovery/posture layer in the See -> Prove -> Control sequence.
 
 ## Persona Fit
 
-- Security/platform team: start with `wrkr scan --github-org`, `wrkr evidence`, `wrkr verify`, and optional `wrkr report` / `wrkr mcp-list` for org posture and compliance-ready handoff.
+- Security/platform team: start with `wrkr init --org ... --github-api ...`, then `wrkr scan --config ...`, `wrkr evidence`, `wrkr verify`, and optional `wrkr report` / `wrkr mcp-list` for org posture and compliance-ready handoff.
 - Developer: use `wrkr scan --path`, `wrkr scan --my-setup`, `wrkr mcp-list`, and `wrkr inventory --diff` when you want repo-local or machine-local hygiene before moving to the hosted org flow.
 - Buyer: CISO / VP Engineering
 - Consumer: CI pipelines and audit workflows
@@ -44,14 +44,15 @@ Wrkr is the discovery/posture layer in the See -> Prove -> Control sequence.
 ## Proof Point Workflow
 
 ```bash
-wrkr scan --github-org acme --github-api https://api.github.com --json
+wrkr init --non-interactive --org acme --github-api https://api.github.com --json
+wrkr scan --config ~/.wrkr/config.json --json
 wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --json
 wrkr verify --chain --json
 ```
 
 If hosted prerequisites are not ready yet, start with `wrkr scan --path ./your-repo --json` or `wrkr scan --my-setup --json` and return to the org posture flow once GitHub access is configured. `--path` scans the selected directory itself when it is the repo root and uses bundle roots such as `./scenarios/wrkr/scan-mixed-org/repos` when you want immediate child repos scanned as a repo-set.
 
-Low first-run `framework_coverage` is an evidence-state signal, not a parser failure. Wrkr measures what is currently documented in the scanned state.
+Low first-run `framework_coverage` is an evidence-state signal, not a parser failure. Wrkr measures what is currently documented in the scanned state, and `wrkr evidence --json` now emits additive `coverage_note` guidance with the same interpretation for operator and automation handoffs.
 
 ## Boundary With Gait and Vulnerability Scanners
 

--- a/internal/acceptance/v1_acceptance_test.go
+++ b/internal/acceptance/v1_acceptance_test.go
@@ -40,12 +40,16 @@ func TestV1AcceptanceMatrix(t *testing.T) {
 		statePath := filepath.Join(tmp, "state.json")
 		githubAPI := newAcceptanceGitHubAPIServer(t)
 
-		initPayload := runJSONOK(t, "init", "--non-interactive", "--org", "acme", "--config", configPath, "--json")
+		initPayload := runJSONOK(t, "init", "--non-interactive", "--org", "acme", "--github-api", githubAPI, "--config", configPath, "--json")
 		if initPayload["status"] != "ok" {
 			t.Fatalf("unexpected init payload: %v", initPayload)
 		}
+		hostedSource, ok := initPayload["hosted_source"].(map[string]any)
+		if !ok || hostedSource["github_api_configured"] != true {
+			t.Fatalf("expected configured hosted source payload, got %v", initPayload["hosted_source"])
+		}
 
-		scanPayload := runJSONOK(t, "scan", "--org", "acme", "--github-api", githubAPI, "--state", statePath, "--json")
+		scanPayload := runJSONOK(t, "scan", "--config", configPath, "--state", statePath, "--json")
 		requireKey(t, scanPayload, "inventory")
 		topFindings, ok := scanPayload["top_findings"].([]any)
 		if !ok || len(topFindings) == 0 {
@@ -69,6 +73,7 @@ func TestV1AcceptanceMatrix(t *testing.T) {
 		payload := runJSONOK(t, "evidence", "--frameworks", "eu-ai-act,soc2", "--state", statePath, "--output", evidenceDir, "--json")
 		requireKey(t, payload, "manifest_path")
 		requireKey(t, payload, "chain_path")
+		requireKey(t, payload, "coverage_note")
 
 		verifyPayload := runJSONOK(t, "verify", "--chain", "--state", statePath, "--json")
 		chain, ok := verifyPayload["chain"].(map[string]any)
@@ -768,7 +773,7 @@ func allowJSONProgressStderr(args []string, stderr string) bool {
 	if !hasArg(args, "--json") {
 		return false
 	}
-	if !hasArg(args, "--org") && !hasArg(args, "--github-org") {
+	if !hasArg(args, "--org") && !hasArg(args, "--github-org") && !hasArg(args, "--config") {
 		return false
 	}
 

--- a/internal/e2e/init/init_e2e_test.go
+++ b/internal/e2e/init/init_e2e_test.go
@@ -33,11 +33,10 @@ func TestE2EInitThenScanWithRepoTarget(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
-	t.Setenv("WRKR_GITHUB_API_BASE", server.URL)
 
 	var initOut bytes.Buffer
 	var initErr bytes.Buffer
-	code := cli.Run([]string{"init", "--non-interactive", "--repo", "acme/backend", "--config", configPath, "--json"}, &initOut, &initErr)
+	code := cli.Run([]string{"init", "--non-interactive", "--repo", "acme/backend", "--github-api", server.URL, "--config", configPath, "--json"}, &initOut, &initErr)
 	if code != 0 {
 		t.Fatalf("init failed exit=%d stderr=%s", code, initErr.String())
 	}
@@ -55,6 +54,54 @@ func TestE2EInitThenScanWithRepoTarget(t *testing.T) {
 	}
 	if payload["status"] != "ok" {
 		t.Fatalf("unexpected payload: %v", payload)
+	}
+}
+
+func TestE2EInitThenScanWithOrgTargetAndConfigBackedGitHubAPIBase(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.json")
+	statePath := filepath.Join(tmp, "state.json")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme/repos":
+			_, _ = fmt.Fprint(w, `[{"full_name":"acme/backend"}]`)
+		case "/repos/acme/backend":
+			_, _ = fmt.Fprint(w, `{"full_name":"acme/backend","default_branch":"main"}`)
+		case "/repos/acme/backend/git/trees/main":
+			_, _ = fmt.Fprint(w, `{"tree":[{"path":"AGENTS.md","type":"blob","sha":"blob-1"}]}`)
+		case "/repos/acme/backend/git/blobs/blob-1":
+			blob := base64.StdEncoding.EncodeToString([]byte("# agents\n"))
+			_, _ = fmt.Fprintf(w, `{"content":"%s","encoding":"base64"}`, blob)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	var initOut bytes.Buffer
+	var initErr bytes.Buffer
+	code := cli.Run([]string{"init", "--non-interactive", "--org", "acme", "--github-api", server.URL, "--config", configPath, "--json"}, &initOut, &initErr)
+	if code != 0 {
+		t.Fatalf("init failed exit=%d stderr=%s", code, initErr.String())
+	}
+
+	var scanOut bytes.Buffer
+	var scanErr bytes.Buffer
+	code = cli.Run([]string{"scan", "--config", configPath, "--state", statePath, "--json"}, &scanOut, &scanErr)
+	if code != 0 {
+		t.Fatalf("scan failed exit=%d stderr=%s", code, scanErr.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(scanOut.Bytes(), &payload); err != nil {
+		t.Fatalf("parse scan output: %v", err)
+	}
+	if payload["status"] != "ok" {
+		t.Fatalf("unexpected payload: %v", payload)
+	}
+	target := payload["target"].(map[string]any)
+	if target["mode"] != "org" || target["value"] != "acme" {
+		t.Fatalf("unexpected target: %v", target)
 	}
 }
 

--- a/product/PLAN_NEXT.md
+++ b/product/PLAN_NEXT.md
@@ -1,417 +1,547 @@
-# PLAN Adhoc: scan path contract hardening, managed artifact safety, and repo-local toolchain alignment
+# PLAN Adhoc: launch onboarding alignment, evidence framing, and hosted org activation
 
-Date: 2026-04-13
+Date: 2026-04-14
 Source of truth:
-- user-provided full-repo code review findings in this run
+- user-provided 2026-04-14 launch audit findings and recommendations for this run
 - `product/dev_guides.md`
 - `product/architecture_guides.md`
-Scope: Planning only for the release-blocking `scan --path` contract mismatch, scan sidecar artifact collision safety, and the AGENTS/go toolchain drift. No implementation work is performed in this plan.
+Scope: Planning only for the current launch-risk follow-up backlog in Wrkr OSS. This plan converts the audit recommendations into implementation-ready waves covering onboarding taxonomy drift, low first-run evidence coverage optics, and hosted org setup friction. No implementation work is performed in this plan.
 
 ## Global Decisions (Locked)
 
-- Treat the two scan findings as Wave 1 release blockers. They change real command behavior today and must land before any new outward-facing scan/report/evidence work.
-- Preserve Wrkr's core contracts:
-  - deterministic behavior
-  - offline-first defaults for local path scans
-  - fail-closed behavior for unsafe or ambiguous artifact/output configurations
-  - stable exit code integers and machine-readable envelopes
-- Keep existing numeric exit codes unchanged. For scan artifact aliasing, use the existing `invalid_input` envelope and exit code `6` rather than inventing a new exit code.
-- Preserve the public repo-local fallback `wrkr scan --path ./your-repo --json`.
-- Preserve current local repo-set workflows and shipped scenario bundle usage under `scenarios/wrkr/*/repos`.
-- Define one explicit `--path` contract that supports both:
-  - `repo_root`: the selected directory itself is scanned as one repo when it contains qualifying root-level repo signals
-  - `repo_set`: the selected directory is scanned as a set of immediate child repos only when it lacks qualifying root-level repo signals and contains one or more non-hidden child directories
-- Centralize the `repo_root` vs `repo_set` classifier in the Source layer and back it with deterministic fixtures. Do not spread heuristic decisions into detector code.
-- Preflight all managed and optional scan artifact paths as one canonical set before the first write:
-  - state snapshot
-  - manifest
-  - lifecycle chain
-  - proof chain
-  - proof attestation
-  - signing key
-  - optional `--json-path`
-  - optional `--report-md-path`
-  - optional `--sarif-path`
-- Any collision among those paths, or between optional outputs themselves, must fail before mutation.
-- Do not change schema versions in this plan. Any behavior change must fit the current `v1` scan/state/inventory/proof contracts.
-- Replace the stale literal Go floor in `AGENTS.md` with a single-source-of-truth model: the repo-local guide should delegate to `go.mod` and `product/dev_guides.md`, and enforcement must catch future drift.
+- Treat the current repo as technically launchable. This backlog is adoption-leverage and launch-clarity work, not release-blocking defect triage.
+- Preserve Wrkr's non-negotiable contracts:
+  - deterministic scan/risk/proof behavior by default
+  - offline-first local fallback paths
+  - fail-closed behavior on ambiguous or unsafe paths
+  - stable numeric exit codes and machine-readable envelopes
+  - file-based, offline-verifiable proof artifacts
+- Keep the product boundary truthful:
+  - Wrkr remains static posture, discovery, evidence, and regress
+  - no runtime enforcement, no control-plane dependency, no vuln-scanner positioning
+- Canonical launch taxonomy for minimum-now OSS:
+  - security/platform-led hosted org posture is the primary public path when prerequisites are available
+  - evaluator-safe scenario is an explicit demo and hosted-prereq fallback path
+  - developer-machine hygiene remains secondary and local
+- Reduce hosted-org friction through the existing CLI/config surface only. Do not add any dashboard-first, control-plane, or background-service scope.
+- Keep `framework_coverage` semantics unchanged. Improve interpretation and placement, not the underlying math.
+- Any config changes must be additive and backward compatible within current config version `v1`.
+- Do not expand `wrkr init` into multi-target persistence in this plan. One default target remains the locked config model.
+- Runtime and contract stories must land before docs/onboarding/distribution stories that depend on them.
+- Every story in this plan is user-visible or OSS-governance-visible, so every story requires a changelog decision and a `CHANGELOG.md` update during implementation.
 
 ## Current Baseline (Observed)
 
-- [core/source/local/local.go](/Users/tr/wrkr/core/source/local/local.go:13) treats `--path` as a directory of repos and enumerates immediate child directories only.
-- [core/source/local/local_test.go](/Users/tr/wrkr/core/source/local/local_test.go:9) validates only the repo-set behavior; there is no single-repo-root coverage.
-- Public docs repeatedly advertise single-repo-root usage:
-  - [README.md](/Users/tr/wrkr/README.md:91)
-  - [docs/commands/scan.md](/Users/tr/wrkr/docs/commands/scan.md:35)
-  - [docs/examples/quickstart.md](/Users/tr/wrkr/docs/examples/quickstart.md:65)
-  - [docs/faq.md](/Users/tr/wrkr/docs/faq.md:45)
-  - [docs/examples/security-team.md](/Users/tr/wrkr/docs/examples/security-team.md:14)
-- The existing shipped scenario path `./scenarios/wrkr/scan-mixed-org/repos` relies on the current repo-set interpretation, so the fix must preserve that supported workflow.
-- [core/cli/scan.go](/Users/tr/wrkr/core/cli/scan.go:94) resolves optional sidecar outputs, but [core/cli/scan.go](/Users/tr/wrkr/core/cli/scan.go:349) does not reject alias collisions with managed artifacts before writes begin.
-- [core/cli/jsonmode.go](/Users/tr/wrkr/core/cli/jsonmode.go:37) and [core/cli/report.go](/Users/tr/wrkr/core/cli/report.go:262) validate file-path shape, not artifact identity uniqueness.
-- Reproduced failure path:
-  - `wrkr scan --path "$tmp/root" --state "$tmp/state.json" --json-path "$tmp/state.json" --json` exits `0`
-  - the saved `state.json` is overwritten with final scan payload keys like `status` and `top_findings`
-  - `wrkr evidence --frameworks soc2 --state "$tmp/state.json" --output "$tmp/evidence" --json` then fails because `risk_report` is missing
-- [AGENTS.md](/Users/tr/wrkr/AGENTS.md:108) still says Go `1.26.1`, while [go.mod](/Users/tr/wrkr/go.mod:3), [product/dev_guides.md](/Users/tr/wrkr/product/dev_guides.md:135), and CI pins are already on `1.26.2`.
-- Working tree baseline is clean, so follow-on implementation can branch cleanly from the generated plan.
+- The end-to-end shipped loop is real and working today:
+  - `wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json`
+  - `wrkr evidence --frameworks eu-ai-act,soc2 --state <state> --output <dir> --json`
+  - `wrkr verify --chain --state <state> --json`
+  - `wrkr regress init/run --json`
+- The audit run on the curated scenario produced:
+  - `19` tools
+  - `19` identities
+  - `131` findings
+  - posture score `56.74` (`F`)
+  - profile compliance `43.75% fail`
+  - `19` unknown-to-security tools
+  - `3` unknown-to-security write-capable agents
+- Full-repo validation succeeded in the audit run:
+  - `go test ./...`
+  - acceptance
+  - e2e
+  - integration
+  - scenarios
+- Public launch surfaces are split today:
+  - `README.md` leads with the evaluator-safe scenario path and only then widens to the security-team org path
+  - `docs/examples/quickstart.md` also foregrounds evaluator-safe scenario first
+  - `docs/install/minimal-dependencies.md` recommends the scenario path as first value after install
+  - `product/wrkr.md` describes Sam's workflow and AC1 as `wrkr init` -> `wrkr scan --org`
+  - `docs/contracts/readme_contract.md` says the current Wrkr launch should foreground the security/platform-led org posture workflow
+- Hosted org friction is real in the current contract:
+  - `wrkr scan --org` and `wrkr scan --github-org` require `--github-api` or `WRKR_GITHUB_API_BASE`
+  - `core/cli/init.go` only persists `default_target`, `scan-token`, and `fix-token`
+  - `core/config/config.go` has no hosted acquisition config beyond tokens
+  - `docs/commands/init.md` has no `--github-api` support today
+- Evidence coverage explanation exists, but it is unevenly placed:
+  - `docs/commands/evidence.md`
+  - `docs/examples/quickstart.md`
+  - `docs/faq.md`
+  - `docs/positioning.md`
+  already clarify that low/zero `framework_coverage` is an evidence-gap signal
+  - `README.md` and the first hosted-org evidence touchpoints do not place that explanation adjacent to the first evidence command
+  - `core/cli/evidence.go` emits only numeric `framework_coverage` in `--json`, with no additive interpretation fields
+- Existing compliance explain/report behavior already contains the right wording:
+  - `core/cli/wave3_compliance_test.go` asserts that explain output says coverage reflects only controls evidenced in current scan state and should trigger remediation/rescan
+- Safety posture is strong and should not be weakened:
+  - proof-chain prerequisite checks in `core/evidence/evidence.go`
+  - managed-marker and staged publish safety in `core/evidence/stage.go`
+  - managed-root and symlink rejection in `internal/e2e/source/source_e2e_test.go`
+- Working tree baseline is clean, so follow-on implementation can start from the generated plan file without hidden unrelated edits.
 
 ## Exit Criteria
 
-- `wrkr scan --path <single-repo-root> --json` emits one repo in `source_manifest.repos`, detects root-level config files such as `AGENTS.md`, and no longer returns an empty false-negative result for qualifying repo roots.
-- Existing repo-set fixtures and scenario bundle paths still scan as multiple repos with deterministic repo naming and order.
-- `wrkr scan` rejects any collision among managed artifact paths and optional output paths with `invalid_input` and exit code `6` before mutating state/proof/manifest artifacts.
-- Rejected collision runs preserve the previous committed managed artifact generation, or preserve artifact absence if no prior generation existed.
-- README and command docs explain the final `--path` contract without ambiguity and keep the repo-local fallback first-value path copy-pasteable.
-- `AGENTS.md` no longer conflicts with the enforced Go floor, and an automated check prevents recurrence.
-- Validation passes on the mapped lanes:
-  - `make lint-fast`
-  - `make test-fast`
-  - `make test-contracts`
-  - `make test-scenarios`
-  - `make prepush-full`
-  - `make test-hardening`
-  - `make test-chaos`
-  - docs consistency/storyline/smoke checks for touched flows
+- `wrkr init` can persist hosted-org scan defaults needed for the primary launch path:
+  - default org target
+  - hosted GitHub API base
+  - scan/fix auth profile tokens
+- `wrkr scan --config <path> --json` can resolve the default org target and hosted GitHub API base from config when flags are omitted.
+- Hosted source precedence is deterministic, documented, and tested.
+- Missing hosted acquisition config still fails closed with the same machine-readable class and numeric exit code family; the error guidance becomes more actionable without weakening the gate.
+- `wrkr evidence --json` preserves the current `framework_coverage` numbers and adds an explicit additive interpretation surface so low/zero first-run coverage is not misread as unsupported framework coverage.
+- README, install docs, quickstart, security-team docs, FAQ, positioning, and PRD all use one canonical launch taxonomy:
+  - org posture first when prerequisites are available
+  - evaluator-safe scenario as explicit fallback/demo path
+  - `--my-setup` as secondary local hygiene
+- Evidence-gap guidance appears immediately adjacent to the first evidence touchpoints in first-screen docs and examples.
+- Docs, CLI contract, acceptance, and release-smoke gates pass on the touched surfaces.
 
 ## Public API and Contract Map
 
 - Stable public surfaces:
+  - `wrkr init`
   - `wrkr scan`
-  - the `--path` flag itself
-  - existing exit code integers `0..8`
-  - scan JSON top-level contract for valid runs
-  - saved scan state/proof artifact locations beside `--state`
-  - downstream command flow: `scan -> report/evidence/regress/verify`
-- Changed public surfaces in this plan:
-  - `--path` now has an explicit dual contract: deterministic `repo_root` or deterministic `repo_set`
-  - previously accepted aliasing sidecar configurations become hard `invalid_input` failures before mutation
+  - `wrkr evidence`
+  - `wrkr report`
+  - `wrkr verify`
+  - `wrkr regress`
+  - exit code integers and existing error classes
+  - `framework_coverage` numeric semantics
+  - state/proof lifecycle rooted at `--state`
+  - local fallback paths `--path` and `--my-setup`
+- Additive public surfaces planned in this backlog:
+  - `wrkr init --github-api <url>`
+  - additive config field for hosted GitHub API base
+  - additive `init --json` fields exposing hosted-source configuration state and next-step guidance
+  - additive `evidence --json` coverage interpretation fields
 - Internal surfaces:
-  - local path classifier logic in `core/source/local`
-  - managed artifact collision preflight helper(s) in `core/cli`
-  - AGENTS/toolchain drift enforcement in hygiene scripts/tests
-- Shim/deprecation path:
-  - no new scan flags are introduced
-  - no deprecation notice is added for current repo-set usage
-  - repo-set behavior remains supported under `--path` for shipped scenarios and local multi-repo roots
-- Schema/versioning policy:
-  - stay on current scan/state/inventory/proof schema versions
-  - no JSON keys are removed
-  - no schema bump is allowed for these fixes
-  - if any additive metadata is proposed during implementation, it must be acceptance-backed and documented as additive only
+  - `core/config/*`
+  - `core/cli/init.go`
+  - `core/cli/scan.go`
+  - `core/cli/scan_helpers.go`
+  - `core/cli/evidence.go`
+  - docs parity/storyline/hygiene checks
+- Shim and deprecation path:
+  - existing explicit `--github-api` usage remains valid
+  - `WRKR_GITHUB_API_BASE` remains valid
+  - scenario-first evaluator flow remains supported as an explicit fallback/demo path
+  - no existing flag is removed in this plan
+- Schema and versioning policy:
+  - remain on current CLI/state/evidence schema versions
+  - config stays at version `v1`
+  - config additions must be backward compatible when loading older configs
+  - no JSON key removals or meaning changes for existing keys
 - Machine-readable error expectations:
-  - artifact path alias collision -> `invalid_input`, exit `6`
-  - invalid sidecar path shape stays `invalid_input`, exit `6`
-  - valid repo-root `--path` scan still exits `0` and returns the standard scan payload
-  - valid repo-set `--path` scan still exits `0` and returns the standard scan payload
+  - missing hosted GitHub API base after all allowed resolution sources remain exhausted -> fail closed with existing dependency-missing contract
+  - missing/invalid state or proof-chain prerequisites for `evidence` remain runtime failures
+  - low/zero `framework_coverage` remains success-path output, not an error-path output
 
 ## Docs and OSS Readiness Baseline
 
-- README first screen must continue to present `wrkr scan --path ./your-repo --json` as the local/offline fallback.
-- `docs/commands/scan.md` is the command-contract source of truth for:
-  - `repo_root` vs `repo_set` path semantics
-  - sidecar uniqueness/fail-closed rules
-  - downstream lifecycle path from saved scan state into evidence/report/regress
-- `docs/examples/quickstart.md`, `docs/examples/security-team.md`, `docs/faq.md`, and `docs/positioning.md` mirror the command contract but must not redefine it.
-- Integration-first flow for touched docs:
-  - show the working `scan --path` repo-root flow first
-  - explain repo-set/scenario-bundle usage second
-  - explain fail-closed output-path rules before report/evidence examples
-- Lifecycle path model for touched docs:
+- README first-screen contract:
+  - must state what Wrkr is, who the current launch is for, and which workflow to run first
+  - must keep hosted prerequisites adjacent to the first hosted org example
+  - must preserve explicit deterministic fallback commands before hosted setup can dead-end
+- Integration-first docs flow for touched surfaces:
+  - install
+  - first run
+  - evidence/verify
+  - regress
+  - only then deeper concepts
+- Lifecycle path model:
   - saved scan state is the canonical handoff artifact
-  - optional sidecars are additive and must never replace or alias that handoff artifact
-- OSS/governance trust baseline:
-  - `CHANGELOG.md`: required updates for all three stories
-  - `AGENTS.md`: updated as repo-local contributor/agent guidance
-  - `CONTRIBUTING.md`: verify no content change is required; explicitly defer if unchanged
-  - `SECURITY.md`: verify no content change is required; explicitly defer if unchanged
+  - report/evidence/verify/regress are downstream of saved state
+  - optional JSON/markdown/SARIF sidecars are additive, not canonical
+- Docs source-of-truth expectations:
+  - `docs/commands/*.md` are command contract anchors
+  - `docs/examples/*.md` are workflow anchors
+  - `docs/contracts/readme_contract.md` governs README first-screen behavior
+  - `docs/install/minimal-dependencies.md` governs install/release parity guidance
+- OSS trust baseline files for touched behavior:
+  - `CHANGELOG.md` is required for every story in this plan
+  - `CONTRIBUTING.md` must be checked for impact and updated only if contributor workflow meaning changes
+  - `SECURITY.md` must be checked for impact and updated only if security-reporting expectations change
+  - no maintainer-support promises are expanded in this plan
 
 ## Recommendation Traceability
 
-| Recommendation | Why | Story IDs |
-|---|---|---|
-| Fix the public `scan --path` contract so it actually scans the supplied repo root | Current implementation silently misses root-level files while docs tell users to scan a repo root directly | W1-S1 |
-| Reject sidecar output paths that alias managed scan artifacts | Current scan can succeed while clobbering its own saved state and breaking downstream commands | W1-S2 |
-| Align the repo-local toolchain contract in `AGENTS.md` with the enforced Go floor | Current repo-local guidance conflicts with `go.mod`, CI, and the normative dev guide | W2-S1 |
+| Rec ID | Recommendation | Why | Strategic direction | Expected moat/benefit | Story IDs |
+|---|---|---|---|---|---|
+| R1 | Unify the launch taxonomy so the public story stops oscillating between evaluator-safe scenario first and hosted org posture first | The current split weakens buyer confidence and makes self-serve evaluation feel inconsistent | One canonical OSS onboarding story with honest fallback paths | Sharper category wedge and lower evaluator confusion | W1-S1, W2-S1 |
+| R2 | Make low/zero first-run `framework_coverage` unmistakably read as an evidence gap, not a parser/capability failure | The current math is correct, but the interpretation is not adjacent enough to first evidence touchpoints | Evidence-state clarity without changing score/coverage semantics | Higher trust in proof artifacts and better remediation follow-through | W1-S2, W2-S2 |
+| R3 | Reduce hosted org setup friction on the primary path using existing CLI/config surfaces | The current primary path requires more manual setup than the smoother local/synthetic flows | Self-serve hosted-org onboarding through additive config and exact next-step guidance | Better AC1 credibility and better expansion from evaluator to team/org usage | W1-S1 |
 
 ## Test Matrix Wiring
 
 - Fast lane:
+  - targeted Go tests in `core/config`, `core/cli`, and any focused docs/hygiene checks
   - `make lint-fast`
-  - focused unit tests in `core/source/local`, `core/cli`, and hygiene tests
-  - docs parity/storyline checks for touched command/docs flows
+  - docs parity/storyline checks for touched README/commands/examples
 - Core CI lane:
   - `make prepush`
   - `make test-contracts`
-  - `make test-scenarios`
+  - targeted scenario or CLI contract suites as applicable
 - Acceptance lane:
-  - targeted `internal/e2e/cli_contract` coverage for repo-root `--path`
-  - targeted end-to-end safety coverage proving rejected alias collisions do not poison downstream evidence/report/regress flows
+  - targeted `internal/acceptance` subtests for AC01 and AC03
+  - targeted `internal/e2e/init` and CLI contract coverage for touched flows
 - Cross-platform lane:
-  - `windows-smoke`
-  - targeted path-classification and path-collision tests must avoid POSIX-only assumptions
+  - `windows-smoke` for any Go/config/CLI behavior change
+  - avoid platform-specific path assumptions in config/init tests
 - Risk lane:
-  - `make prepush-full`
-  - `make test-hardening`
-  - `make test-chaos`
+  - `make prepush-full` for runtime/contract stories
+  - add `make test-hardening` and `make test-chaos` only if implementation changes failure-class behavior beyond the documented hosted-source resolution and evidence-note additions
 - Merge/release gating rule:
-  - both Wave 1 stories are required before the next release candidate or release tag
-  - no CLI/docs/contract story closes without docs and changelog landing in the same PR
-  - no fail-closed artifact safety story closes without hardening/chaos coverage
+  - Wave 1 stories must land before Wave 2 docs stories that depend on them
+  - no public docs story closes without docs parity/storyline/smoke coverage
+  - no runtime story closes without acceptance or e2e coverage on the touched path
+  - if install guidance changes, release smoke/UAT parity must be rerun before merge or release cut
 
-## Epic W1: Scan Contract and State-Safety Blockers
+## Epic W1: Hosted Org Activation Contract and Evidence Interpretation
 
-Objective: remove the two release-blocking scan defects without weakening deterministic local/offline behavior or the existing repo-set scenario workflows.
+Objective: reduce real friction on the primary security/platform launch path and make first-run evidence semantics explicit in machine-readable output, without changing Wrkr's deterministic evidence math or exit behavior.
 
-### Story W1-S1: Make `scan --path` deterministic for both single repo roots and repo-set directories
+### Story W1-S1: Persist hosted org acquisition defaults in `init` and consume them in `scan`
 
-Priority: P0
+Priority: P1
 Tasks:
-- Add an explicit path-target classifier in the Source layer that determines `repo_root` vs `repo_set` from deterministic root-level signals.
-- Scan the selected directory itself as one repo when it qualifies as a repo root.
-- Preserve immediate-child repo-set enumeration when the selected directory is a shipped or user-managed repo bundle root.
-- Keep deterministic repo naming, ordering, and deduplication across both modes.
-- Add contract fixtures for:
-  - root-level `AGENTS.md` / `.codex` repo-root scans
-  - existing multi-repo bundle directories under `scenarios/wrkr/*/repos`
-- Update README and command/example docs so repo-root and repo-set semantics are explicit and non-conflicting.
+- Extend persisted config with an additive hosted GitHub API base field.
+- Add `--github-api` to `wrkr init` so the primary hosted-org path can be configured once.
+- Keep config backward compatible and deterministic under current config version `v1`.
+- Update `wrkr scan` hosted-source resolution so it can consume:
+  - explicit `--github-api`
+  - config-persisted hosted API base
+  - `WRKR_GITHUB_API_BASE`
+- Align precedence with the existing token-resolution style and document it explicitly.
+- Add additive `init --json` fields that expose hosted-source configuration state and deterministic next-step guidance for the chosen target.
+- Keep existing explicit `--github-api` and env-driven workflows fully valid.
+- Improve missing-hosted-source guidance so a fail-closed run points users to the valid flag/config/env remedies without changing the fail-closed class.
+- Update PRD, command docs, and workflow examples to reflect the new hosted-org setup contract.
 Repo paths:
-- `core/source/local/local.go`
-- `core/source/local/local_test.go`
+- `core/config/config.go`
+- `core/config/config_test.go`
+- `core/cli/init.go`
+- `core/cli/scan.go`
+- `core/cli/scan_helpers.go`
+- `core/cli/root.go`
 - `core/cli/root_test.go`
-- `core/cli/scan_contract_fix_test.go`
-- `internal/e2e/cli_contract/cli_contract_e2e_test.go`
-- `README.md`
+- `core/cli/scan_github_auth_test.go`
+- `internal/e2e/init/init_e2e_test.go`
+- `internal/acceptance/v1_acceptance_test.go`
+- `docs/commands/init.md`
 - `docs/commands/scan.md`
+- `docs/examples/security-team.md`
+- `docs/examples/quickstart.md`
+- `docs/faq.md`
+- `README.md`
+- `product/wrkr.md`
+- `CHANGELOG.md`
+Run commands:
+- `go test ./core/config ./core/cli ./internal/e2e/init -count=1`
+- `go test ./internal/acceptance -count=1 -run 'TestV1AcceptanceMatrix/AC01_org_scan_flow_outputs_inventory_and_top_findings'`
+- `make test-contracts`
+- `make prepush-full`
+- `scripts/check_docs_cli_parity.sh`
+- `scripts/check_docs_storyline.sh`
+Test requirements:
+- Schema/artifact changes:
+  - config round-trip and byte-stability tests
+  - backward-compat load tests for older config files without the new hosted field
+- CLI behavior changes:
+  - help/usage coverage for `init`
+  - `--json` stability tests for additive `init --json` fields
+  - exit-code and error-envelope tests for hosted-source resolution when config/flag/env are present or missing
+- Acceptance/E2E:
+  - `init` followed by hosted `scan` using config-backed API base
+  - AC01 org scan flow remains green
+- Docs/examples changes:
+  - docs consistency checks
+  - storyline checks
+  - README first-screen checks for hosted prerequisites
+Matrix wiring:
+- Fast lane: targeted `core/config`, `core/cli`, `internal/e2e/init`, docs parity
+- Core CI lane: `make prepush`, `make test-contracts`
+- Acceptance lane: targeted AC01 plus `internal/e2e/init`
+- Cross-platform lane: `windows-smoke`
+- Risk lane: `make prepush-full`
+Acceptance criteria:
+- `wrkr init --non-interactive --org acme --github-api https://api.github.com --config <path> --json` succeeds and persists the hosted API base in config.
+- `wrkr scan --config <path> --state <state> --json` can resolve the default org target and hosted API base without needing `--github-api` again.
+- Explicit `--github-api` still overrides config when both are present.
+- Existing configs without the new field still load and behave correctly.
+- Hosted scans with no usable API base anywhere still fail closed with the existing dependency-missing contract family.
+Changelog impact: required
+Changelog section: Changed
+Draft changelog entry: Added config-backed hosted GitHub API base support to `wrkr init` and `wrkr scan` so org-first onboarding can be configured once without weakening the existing fail-closed hosted-scan contract.
+Semver marker override: none
+Contract/API impact:
+- Additive `init` flag: `--github-api`
+- Additive config field for hosted GitHub API base
+- Additive `init --json` fields for hosted-source config state and next-step guidance
+- Additive hosted-source resolution path in `scan`
+Versioning/migration impact:
+- Config remains version `v1`
+- Existing config files must continue to load without migration steps
+- No existing JSON keys or exit codes are removed or renumbered
+Architecture constraints:
+- Keep hosted-source resolution in thin CLI/config orchestration; do not leak hosted-config logic into source or detector packages.
+- Preserve explicit side-effect semantics in API naming and precedence handling.
+- Keep cancellation and timeout propagation unchanged through hosted scan flows.
+- Keep the config extension narrow enough to avoid enterprise-fork pressure for basic onboarding defaults.
+ADR required: yes
+TDD first failing test(s):
+- `core/config/config_test.go` config round-trip with additive hosted API base
+- `internal/e2e/init/init_e2e_test.go` config-backed org scan without env-provided API base
+- `core/cli/scan_github_auth_test.go` precedence and missing-hosted-source failure guidance
+Cost/perf impact: low
+Chaos/failure hypothesis:
+- If precedence is wrong, stale config could override explicit user intent or hide missing hosted prerequisites.
+- If config compatibility breaks, previously initialized installs could fail before scan starts.
+
+### Story W1-S2: Add explicit coverage interpretation to `wrkr evidence --json` without changing `framework_coverage`
+
+Priority: P1
+Tasks:
+- Add additive machine-readable interpretation fields to `wrkr evidence --json` that explain what `framework_coverage` means.
+- Reuse the already-shipped coverage guidance wording so CLI JSON, docs, and report/explain language stay aligned.
+- Keep `framework_coverage` values and framework ordering unchanged.
+- Keep success/failure classes unchanged for low/zero first-run coverage.
+- Update command docs and examples to consume the new additive interpretation keys.
+- Add contract tests so the new keys remain additive and deterministic.
+Repo paths:
+- `core/cli/evidence.go`
+- `core/evidence/evidence.go`
+- `core/cli/root_test.go`
+- `core/cli/wave3_compliance_test.go`
+- `internal/scenarios/epic4_scenario_test.go`
+- `internal/acceptance/v1_acceptance_test.go`
+- `docs/commands/evidence.md`
+- `docs/examples/quickstart.md`
+- `docs/examples/security-team.md`
+- `docs/examples/operator-playbooks.md`
+- `docs/faq.md`
+- `docs/positioning.md`
+- `CHANGELOG.md`
+Run commands:
+- `go test ./core/cli ./core/evidence -count=1`
+- `go test ./internal/scenarios -count=1 -tags=scenario -run 'TestScenarioEvidenceBundleIncludesProfileAndPosture'`
+- `go test ./internal/acceptance -count=1 -run 'TestV1AcceptanceMatrix/AC03_evidence_bundle_signed_and_verifiable'`
+- `make test-contracts`
+- `scripts/check_docs_cli_parity.sh`
+- `scripts/check_docs_storyline.sh`
+Test requirements:
+- CLI behavior changes:
+  - `--json` stability tests for additive evidence keys
+  - exit-code invariants proving low/zero coverage remains a success-path result
+  - machine-readable envelope tests for malformed/tampered chain prerequisites remain unchanged
+- Contract changes:
+  - additive JSON-key assertions only
+  - determinism tests proving repeat runs emit the same coverage interpretation wording for the same state
+- Scenario/spec tests:
+  - evidence bundle output still carries profile/posture artifacts
+  - coverage interpretation remains consistent with explain/report wording
+- Docs/examples changes:
+  - docs consistency checks
+  - workflow docs use the same interpretation sentence as the JSON note
+Matrix wiring:
+- Fast lane: targeted `core/cli`, `core/evidence`, docs parity
+- Core CI lane: `make prepush`, `make test-contracts`
+- Acceptance lane: targeted AC03 and the scenario evidence suite
+- Cross-platform lane: `windows-smoke`
+- Risk lane: `make prepush-full`
+Acceptance criteria:
+- `wrkr evidence --frameworks eu-ai-act,soc2 --state <state> --output <dir> --json` still emits the current numeric `framework_coverage` map.
+- The same JSON payload now also emits additive interpretation fields that explicitly say coverage reflects controls evidenced in the current scanned state and that low/zero first-run coverage indicates evidence gaps rather than unsupported framework parsing.
+- Existing low-coverage runs still exit `0`.
+- Malformed/tampered chain runs still fail with the same runtime/verification behavior they have today.
+Changelog impact: required
+Changelog section: Changed
+Draft changelog entry: Added explicit coverage-interpretation fields to `wrkr evidence --json` so low first-run framework coverage is framed as an evidence gap rather than a parser or framework-support failure.
+Semver marker override: none
+Contract/API impact:
+- Additive `evidence --json` output fields only
+- No existing key removal or exit-code change
+Versioning/migration impact:
+- No schema/version bump
+- Existing automation that ignores unknown JSON keys remains compatible
+Architecture constraints:
+- Keep interpretation logic close to CLI/report contract surfaces; do not change compliance-rollup math or proof generation.
+- Preserve deterministic wording and field ordering for identical inputs.
+- Avoid thresholds or heuristics that could imply unsupported new policy logic.
+ADR required: yes
+TDD first failing test(s):
+- `core/cli/root_test.go` or a dedicated evidence JSON contract test for additive coverage interpretation fields
+- `core/cli/wave3_compliance_test.go` alignment checks between explain wording and the new JSON note
+- `internal/acceptance/v1_acceptance_test.go` targeted AC03 assertion for additive interpretation fields
+Cost/perf impact: low
+Chaos/failure hypothesis:
+- If the additive note diverges from numeric coverage semantics, automation and operator trust will drift.
+- If interpretation fields are emitted inconsistently across equivalent runs, the CLI JSON contract becomes noisy.
+
+## Epic W2: Launch Taxonomy and First-Run Docs Alignment
+
+Objective: remove the public-message split, keep the evaluator-safe fallback honest and explicit, and place evidence-gap interpretation exactly where new users first encounter it.
+
+### Story W2-S1: Reconcile first-screen launch taxonomy across README, install docs, quickstart, security-team docs, FAQ, and PRD
+
+Priority: P1
+Tasks:
+- Make one canonical launch ordering explicit across public surfaces:
+  - org posture first when hosted prerequisites are ready
+  - evaluator-safe scenario fallback/demo path second
+  - `--my-setup` secondary local hygiene path
+- Align README, install docs, quickstart, security-team docs, FAQ, positioning, and PRD so they no longer contradict one another.
+- Keep the evaluator-safe scenario path prominent as a fallback, but stop presenting it as the unconditional first-screen recommendation when the launch persona is security/platform-led.
+- Update any README first-screen contract checks that still encode the old story.
+- Verify install-path wording and `wrkr version --json` discoverability remain intact when editing first-screen docs.
+Repo paths:
+- `README.md`
+- `docs/install/minimal-dependencies.md`
 - `docs/examples/quickstart.md`
 - `docs/examples/security-team.md`
 - `docs/faq.md`
 - `docs/positioning.md`
 - `docs/contracts/readme_contract.md`
+- `product/wrkr.md`
 - `CHANGELOG.md`
 Run commands:
-- `go test ./core/source/local ./core/cli ./internal/e2e/cli_contract -count=1`
-- `make test-contracts`
-- `make test-scenarios`
-- `scripts/check_docs_cli_parity.sh`
-- `scripts/check_docs_storyline.sh`
-- `scripts/run_docs_smoke.sh --subset`
+- `go test ./testinfra/hygiene -count=1`
+- `make test-docs-consistency`
+- `make test-docs-storyline`
+- `scripts/run_docs_smoke.sh`
+- `scripts/test_uat_local.sh --skip-global-gates`
 Test requirements:
-- CLI behavior changes:
-  - `--json` stability tests for repo-root and repo-set path scans
-  - exit-code contract tests remain `0` for valid repo-root and repo-set scans
-  - machine-readable scan payload assertions for `source_manifest.repos`
-- Scenario/spec tests:
-  - outside-in fixture validating a single repo root with only root-level signals
-  - regression fixture validating existing multi-repo bundle behavior
 - Docs/examples changes:
   - docs consistency checks
-  - README first-screen contract checks
-  - integration-before-internals guidance checks for the updated fallback flow
+  - storyline/smoke checks when the user flow changes
+  - README first-screen checks
+  - integration-before-internals guidance checks
+  - version/install discoverability checks for `wrkr version` and minimal-dependency guidance
+- OSS readiness changes:
+  - verify `CHANGELOG.md` updates
+  - verify no additional maintainer/support-policy file change is needed
 Matrix wiring:
-- Fast lane: focused `core/source/local` and `core/cli` tests plus docs parity
-- Core CI lane: `make prepush`, `make test-contracts`, `make test-scenarios`
-- Acceptance lane: `go test ./internal/e2e/cli_contract -count=1`
-- Cross-platform lane: `windows-smoke` plus targeted path-behavior assertions that avoid platform-specific separators in expectations
-- Risk lane: `make prepush-full`
-Acceptance criteria:
-- A temp repo with only a root `AGENTS.md` scanned via `wrkr scan --path <repo-root> --json` produces one repo manifest entry and at least one root-level finding.
-- Existing scenario-bundle paths under `scenarios/wrkr/*/repos` still produce per-child repo manifests with deterministic ordering.
-- No detector-layer code is required to guess path mode.
-- README and docs no longer describe `--path` in conflicting ways.
-Changelog impact: required
-Changelog section: Fixed
-Draft changelog entry: Made `wrkr scan --path` honor single-repo root inputs while preserving deterministic repo-set scans for scenario bundles and local multi-repo roots.
-Semver marker override: none
-Contract/API impact:
-- Public `--path` behavior is corrected and explicitly defined.
-- No new flags or exit codes are introduced.
-Versioning/migration impact:
-- No schema/version bump.
-- Automation that accidentally relied on false-negative empty results from single-repo-root scans will now receive the correct repo findings and state.
-Architecture constraints:
-- Keep path-mode classification inside the Source boundary.
-- Use thin orchestration with focused packages; do not leak path classification into detectors or reporting.
-- Preserve explicit side-effect semantics and deterministic ordering.
-- Preserve cancellation/timeout propagation through the local acquisition path.
-- Keep the classifier extensible so future repo-root signal additions do not require broad detector rewrites.
-ADR required: yes
-TDD first failing test(s):
-- `core/source/local/local_test.go` single-repo-root fixture
-- `core/cli/root_test.go` or a dedicated scan path contract test for `wrkr scan --path <repo-root> --json`
-- `internal/e2e/cli_contract/cli_contract_e2e_test.go` repo-root fallback example
-Cost/perf impact: low
-Chaos/failure hypothesis:
-- If the classifier over-classifies repo bundles as single repos, per-repo ownership/risk output collapses.
-- If it under-classifies single repo roots as bundles, the public fallback remains a silent false negative.
-
-### Story W1-S2: Fail closed when scan sidecar outputs alias managed artifacts
-
-Priority: P0
-Tasks:
-- Add one canonical scan-artifact preflight that resolves every managed and optional artifact path before the first write.
-- Reject collisions among:
-  - `--state`
-  - manifest path
-  - lifecycle chain
-  - proof chain
-  - proof attestation
-  - proof signing key
-  - `--json-path`
-  - `--report-md-path`
-  - `--sarif-path`
-- Return a deterministic `invalid_input` error that identifies the conflicting path pair(s).
-- Preserve the existing atomic rollback model for late write failures after successful preflight.
-- Add regression tests proving a rejected collision does not poison downstream `evidence`, `report`, `inventory`, or `regress` flows.
-Repo paths:
-- `core/cli/scan.go`
-- `core/cli/jsonmode.go`
-- `core/cli/managed_artifacts.go`
-- `core/cli/report.go`
-- `core/cli/scan_json_path_test.go`
-- `core/cli/scan_transaction_test.go`
-- `core/cli/root_test.go`
-- `internal/e2e/cli_contract/cli_contract_e2e_test.go`
-- `docs/commands/scan.md`
-- `README.md`
-- `CHANGELOG.md`
-Run commands:
-- `go test ./core/cli ./internal/e2e/cli_contract -count=1`
-- `make test-contracts`
-- `make test-hardening`
-- `make test-chaos`
-- `make prepush-full`
-Test requirements:
-- CLI behavior changes:
-  - `--json` stability tests for rejected alias collisions
-  - exit-code contract tests for `invalid_input` / exit `6`
-  - machine-readable error envelope tests naming the collision
-- Gate/policy/fail-closed changes:
-  - deterministic alias-collision fixtures for state/json/report/SARIF/proof path pairs
-  - tests proving rejection happens before managed artifact mutation
-- Job runtime/state/concurrency changes:
-  - rollback preservation tests for preexisting state/proof artifacts
-  - interrupted/failing write tests must still preserve the previous generation after successful preflight
-- Docs/examples changes:
-  - docs consistency checks for updated sidecar rules
-Matrix wiring:
-- Fast lane: focused `core/cli` tests
-- Core CI lane: `make test-contracts`
-- Acceptance lane: targeted CLI/e2e flow proving rejected collisions do not break a follow-on `wrkr evidence` or `wrkr inventory`
-- Cross-platform lane: path-collision tests must normalize absolute/canonical path handling across Windows and POSIX
-- Risk lane: `make prepush-full`, `make test-hardening`, `make test-chaos`
-Acceptance criteria:
-- `wrkr scan --json-path <state-path>` fails with `invalid_input` and exit `6` before mutating scan state.
-- Sidecar-to-sidecar duplicates such as `--json-path` == `--report-md-path` also fail closed.
-- Valid unique sidecar paths continue to work without JSON/exit-code drift.
-- A previously valid saved state remains usable by downstream commands after a rejected collision run.
-Changelog impact: required
-Changelog section: Fixed
-Draft changelog entry: Blocked scan sidecar output paths from aliasing managed state and proof artifacts, so invalid configurations now fail fast instead of corrupting saved scan state.
-Semver marker override: none
-Contract/API impact:
-- Previously accepted but unsafe aliasing output configurations now return `invalid_input` with exit `6`.
-- Valid scan contracts are unchanged.
-Versioning/migration impact:
-- No schema/version bump.
-- Automation using colliding output paths must switch to unique sidecar paths.
-Architecture constraints:
-- Keep collision detection in CLI orchestration, not in lower-level state/proof writers.
-- Resolve and compare canonical paths once up front.
-- Preserve explicit plan/apply style semantics: preflight first, mutate second.
-- Keep the atomic-write and rollback boundaries authoritative.
-- Preserve cancellation/timeout propagation and deterministic error reporting.
-ADR required: yes
-TDD first failing test(s):
-- `core/cli/scan_json_path_test.go` alias collision case
-- `core/cli/scan_transaction_test.go` preservation case for preexisting managed artifacts
-- `internal/e2e/cli_contract/cli_contract_e2e_test.go` rejected-collision then downstream-command sanity flow
-Cost/perf impact: low
-Chaos/failure hypothesis:
-- If any managed/optional alias escapes preflight, a nominally successful scan can still overwrite its own canonical handoff artifact and break downstream evidence/report/regress commands.
-
-## Epic W2: Repo-Local Toolchain Contract Hygiene
-
-Objective: remove contributor/agent guidance drift and prevent the repo-local Go floor from diverging again from authoritative enforcement surfaces.
-
-### Story W2-S1: Delegate AGENTS toolchain authority to enforced sources and add a drift check
-
-Priority: P2
-Tasks:
-- Replace the stale literal Go `1.26.1` declaration in `AGENTS.md` with repo-local guidance that points to `go.mod` and `product/dev_guides.md` as the authoritative toolchain floor.
-- Add an enforcement check so `AGENTS.md` cannot drift back to a conflicting explicit Go floor without failing CI/local hygiene.
-- Keep the guidance readable for both human contributors and repo-local coding agents.
-Repo paths:
-- `AGENTS.md`
-- `scripts/check_toolchain_pins.sh`
-- `testinfra/hygiene/toolchain_pins_test.go`
-- `CHANGELOG.md`
-Run commands:
-- `scripts/check_toolchain_pins.sh`
-- `go test ./testinfra/hygiene -count=1`
-- `make lint-fast`
-Test requirements:
-- Docs/governance changes:
-  - enforcement-first drift check for AGENTS vs authoritative toolchain sources
-  - no runtime or schema contract changes
-- Toolchain/runtime/security scanner changes:
-  - none beyond contributor guidance alignment and enforcement
-Matrix wiring:
-- Fast lane: `make lint-fast`, `go test ./testinfra/hygiene -count=1`
-- Core CI lane: covered by `make prepush`
-- Acceptance lane: not required
-- Cross-platform lane: keep the drift check in portable shell or Go test logic
+- Fast lane: docs parity and hygiene checks
+- Core CI lane: docs consistency and storyline
+- Acceptance lane: not required beyond docs/storyline because no runtime behavior changes in this story
+- Cross-platform lane: not required beyond existing docs smoke because no platform-sensitive runtime changes are introduced
 - Risk lane: not required
 Acceptance criteria:
-- `AGENTS.md` no longer claims Go `1.26.1`.
-- CI/local hygiene fails if AGENTS introduces a conflicting explicit Go floor in the future.
-- No runtime behavior, JSON payload, schema, or exit code changes occur.
+- README, quickstart, install docs, security-team docs, FAQ, and PRD all describe the same canonical launch ordering.
+- The evaluator-safe scenario path remains present and explicit, but is clearly labeled as fallback/demo rather than the canonical security/platform first path.
+- Hosted prerequisites sit adjacent to the first hosted org example on the public first-screen surfaces.
+- `wrkr version --json` verification remains on the first install screen.
 Changelog impact: required
 Changelog section: Changed
-Draft changelog entry: Clarified repo-local contributor and agent guidance so Wrkr now delegates Go toolchain authority to the enforced 1.26.2 floor in `go.mod` and the development standards.
+Draft changelog entry: Reconciled the public launch docs so hosted org posture is the primary first-screen path, with the evaluator-safe scenario preserved as the explicit fallback and demo flow.
 Semver marker override: none
 Contract/API impact:
-- Contributor/agent governance guidance only.
-- No runtime public API change.
+- Docs-only clarification of existing and newly-additive runtime behavior
+- No CLI or schema change in this story
 Versioning/migration impact:
-- None.
+- None
 Architecture constraints:
-- Keep one authoritative toolchain source of truth.
-- Prefer enforceable delegation over duplicated mutable version strings across governance docs.
+- Do not introduce docs claims that exceed the actual CLI/runtime contract.
+- Keep README and docs examples aligned with `docs/commands/*.md` command sources of truth.
 ADR required: no
 TDD first failing test(s):
-- `testinfra/hygiene/toolchain_pins_test.go` or a dedicated AGENTS/toolchain drift fixture
+- `go test ./testinfra/hygiene -count=1`
+- docs storyline checks that encode the first-screen ordering
 Cost/perf impact: low
 Chaos/failure hypothesis:
-- If AGENTS drifts again, contributors and local agents can debug under an unsupported Go floor and reproduce different outcomes than CI.
+- None; docs-only story. The failure mode is contract drift between public surfaces, which must be caught by docs/hygiene checks.
+
+### Story W2-S2: Put evidence-gap framing directly beside the first evidence touchpoints and operator handoff paths
+
+Priority: P1
+Tasks:
+- Update README, quickstart, security-team docs, operator playbooks, and command docs so the first evidence touchpoints explain low/zero first-run coverage immediately.
+- Mirror the additive `evidence --json` interpretation wording from W1-S2 in the docs so public copy, machine-readable output, and operator playbooks use one sentence.
+- Add explicit next-step guidance near the first evidence examples:
+  - review top risks
+  - remediate missing controls/approvals
+  - rerun scan/evidence/report
+- Make sure no touched doc implies low coverage means missing parser support or missing framework support.
+- Add or tighten docs/hygiene checks so this guidance stays adjacent to first evidence workflows.
+Repo paths:
+- `README.md`
+- `docs/examples/quickstart.md`
+- `docs/examples/security-team.md`
+- `docs/commands/evidence.md`
+- `docs/examples/operator-playbooks.md`
+- `docs/faq.md`
+- `docs/positioning.md`
+- `docs/intent/generate-compliance-evidence-from-scans.md`
+- `CHANGELOG.md`
+Run commands:
+- `go test ./testinfra/hygiene -count=1`
+- `make test-docs-consistency`
+- `make test-docs-storyline`
+- `scripts/run_docs_smoke.sh`
+Test requirements:
+- Docs/examples changes:
+  - docs consistency checks
+  - storyline/smoke checks for evidence workflow changes
+  - README and quickstart checks for first evidence command adjacency
+  - docs source-of-truth mapping checks when both commands and examples are touched
+- API/contract lifecycle changes:
+  - confirm docs examples reflect the additive `evidence --json` fields from W1-S2 exactly
+Matrix wiring:
+- Fast lane: docs parity and hygiene checks
+- Core CI lane: docs consistency and storyline
+- Acceptance lane: not required beyond docs/hygiene because runtime acceptance coverage lands in W1-S2
+- Cross-platform lane: not required
+- Risk lane: not required
+Acceptance criteria:
+- The first evidence command shown in README, quickstart, and security-team docs is immediately followed by evidence-gap interpretation and next actions.
+- Operator playbooks and evidence command docs use the same wording as the shipped additive JSON note.
+- No touched doc frames low/zero `framework_coverage` as parser failure or unsupported framework support.
+Changelog impact: required
+Changelog section: Changed
+Draft changelog entry: Updated first-run evidence docs to explain low framework coverage as an evidence-state gap and to place remediation guidance directly beside the first evidence workflows.
+Semver marker override: none
+Contract/API impact:
+- Docs-only clarification of the additive evidence JSON interpretation shipped in W1-S2
+Versioning/migration impact:
+- None
+Architecture constraints:
+- Keep docs claims strictly downstream of the shipped CLI contract.
+- Do not fork wording across docs surfaces; use one stable interpretation sentence.
+ADR required: no
+TDD first failing test(s):
+- `go test ./testinfra/hygiene -count=1`
+- docs storyline checks that assert evidence-gap guidance adjacency
+Cost/perf impact: low
+Chaos/failure hypothesis:
+- None; docs-only story. The failure mode is message drift across README, examples, and command docs.
 
 ## Minimum-Now Sequence
 
-1. Wave 1, Story W1-S2: block artifact-path alias collisions before any further scan contract work lands. This removes the state-clobbering failure mode immediately.
-2. Wave 1, Story W1-S1: fix the public `--path` contract while preserving repo-set behavior used by shipped scenarios and existing docs.
-3. Wave 2, Story W2-S1: clean up AGENTS toolchain drift and add recurrence protection after the runtime blockers are gone.
+1. Wave 1
+   - W1-S1 first. The hosted-org onboarding contract must exist before public docs can honestly foreground it.
+   - W1-S2 second. The additive evidence interpretation must ship before docs can rely on it.
+2. Wave 2
+   - W2-S1 after W1-S1. Public first-screen docs should describe the real hosted onboarding contract, not the old split story.
+   - W2-S2 after W1-S2 and W2-S1. The evidence framing should quote the shipped runtime interpretation and sit inside the canonical launch ordering.
 
 ## Explicit Non-Goals
 
-- No new scan flags or schema versions.
-- No change to hosted GitHub acquisition behavior, rate limiting, or PR publishing.
-- No docs-site redesign or broader docs IA rewrite.
-- No changes to proof formats, lifecycle state model, or report templates beyond what is required to keep docs/flows accurate.
-- No Go toolchain uplift work in runtime/CI surfaces; the authoritative floor is already `1.26.2` and this plan only fixes repo-local drift.
+- No dashboard, browser handoff redesign, or SaaS control plane work
+- No change to risk scoring math, posture score weights, or `framework_coverage` calculation
+- No new scanner surfaces, no live probing by default, and no runtime enforcement scope
+- No multi-target persistence in `wrkr init`
+- No package- or server-vulnerability scanning scope expansion
+- No release engineering/toolchain pin work unless it is directly required by implementation of the above stories
 
 ## Definition of Done
 
-- Every recommendation maps to at least one shipped story outcome.
-- Wave 1 stories land with:
-  - code
-  - tests
-  - docs
-  - changelog
-  - CI wiring
-- `--path` repo-root and repo-set behavior are both deterministic and acceptance-backed.
-- Artifact-path aliasing fails fast before mutation and is covered by hardening/chaos-aware tests.
-- `AGENTS.md` no longer conflicts with enforced toolchain authority and future drift is automatically caught.
-- Required PR checks remain green:
-  - `fast-lane`
-  - `windows-smoke`
-- No dirty files remain beyond the intended implementation changes and the updated plan/changelog/docs artifacts.
+- Every audit recommendation in this run maps to one or more completed stories in this plan.
+- Runtime/contract stories land before the docs stories that describe them.
+- Every story ships with:
+  - explicit changelog intent
+  - tests at the right level
+  - matrix wiring
+  - acceptance criteria proven by commands or gated checks
+- Public docs, install docs, examples, and PRD no longer contradict one another on the minimum-now launch path.
+- Hosted org onboarding is materially simpler through existing CLI/config surfaces and remains fail closed when prerequisites are missing.
+- Evidence coverage semantics are explicit in both machine-readable output and first-run docs.
+- `CHANGELOG.md` is updated in the same implementation PRs.
+- If follow-on implementation with `adhoc-implement` finds additional dirty files beyond the generated plan file, scope/clean that state before proceeding on a new branch.

--- a/product/wrkr.md
+++ b/product/wrkr.md
@@ -260,8 +260,8 @@ Sam owns the internal developer platform. 180 engineers. Sam standardized on Cla
 **Sam's workflow with Wrkr:**
 
 1. `brew install Clyra-AI/tap/wrkr`
-2. `wrkr init` (configure GitHub org, scan targets)
-3. `wrkr scan` (10 minutes)
+2. `wrkr init --github-api https://api.github.com` (configure GitHub org, hosted scan source, scan targets)
+3. `wrkr scan --config ...` (10 minutes)
 4. Reviews inventory and risk report in terminal
 5. `wrkr fix --top 3` (opens 3 PRs)
 6. `wrkr evidence --frameworks eu-ai-act,soc2` (generates bundle with proof records)
@@ -395,7 +395,7 @@ Alex heard about Wrkr on Reddit or at a meetup. Runs `wrkr scan` on a Friday aft
 
 ### FR8: CLI Experience
 
-- `wrkr init` — interactive setup (GitHub token, default scan target, scan preferences)
+- `wrkr init` — interactive setup (GitHub token profiles, default scan target, hosted GitHub API base)
 - `wrkr scan --repo <owner/repo>` — single-repo scan, produces inventory + risk report + proof records
 - `wrkr scan --org <org>` — full org scan across all repositories, produces inventory + risk report + proof records
 - `wrkr scan` — scan using configured default target from `wrkr init` (repo or org). Errors if no default is configured and no target flag is provided.
@@ -568,8 +568,8 @@ Every discovered AI tool receives a persistent identity that tracks its lifecycl
 A new user with a GitHub org of 50+ repos can:
 
 - Install Wrkr (`brew install Clyra-AI/tap/wrkr`)
-- Run `wrkr init` with a GitHub token
-- Run `wrkr scan --org <org>`
+- Run `wrkr init --org <org> --github-api https://api.github.com`
+- Run `wrkr scan --config <path>`
 - See a complete AI tool inventory in their terminal
 - See a ranked risk report with top 5 findings (configurable via `--top N`)
 - Total elapsed time: under 10 minutes

--- a/testinfra/hygiene/wave2_docs_contracts_test.go
+++ b/testinfra/hygiene/wave2_docs_contracts_test.go
@@ -90,7 +90,7 @@ func TestLandingReadmeStartHerePersonaAndFallback(t *testing.T) {
 		"### Security Teams (Recommended first path)",
 		"Hosted prerequisites for this path:",
 		"`--github-api https://api.github.com`",
-		"If hosted prerequisites are not ready yet, start with one of these deterministic fallback paths:",
+		"If hosted prerequisites are still not ready yet after the evaluator-safe scenario, start with one of these deterministic local fallback paths:",
 		"wrkr scan --path ./your-repo --json",
 		"wrkr scan --my-setup --json",
 		"### Developers (Secondary local hygiene)",
@@ -98,6 +98,9 @@ func TestLandingReadmeStartHerePersonaAndFallback(t *testing.T) {
 		if !strings.Contains(readme, required) {
 			t.Fatalf("landing README missing persona/fallback requirement %q", required)
 		}
+	}
+	if strings.Index(readme, "### Security Teams (Recommended first path)") > strings.Index(readme, "### Evaluators") {
+		t.Fatal("landing README must foreground the security-team org posture path before the evaluator fallback")
 	}
 
 	for _, required := range []string{
@@ -109,6 +112,9 @@ func TestLandingReadmeStartHerePersonaAndFallback(t *testing.T) {
 		if !strings.Contains(quickstart, required) {
 			t.Fatalf("quickstart missing persona/fallback requirement %q", required)
 		}
+	}
+	if strings.Index(quickstart, "## Security/platform posture first") > strings.Index(quickstart, "## Evaluator-safe scenario fallback") {
+		t.Fatal("quickstart must foreground the security/platform org posture flow before the evaluator fallback")
 	}
 
 	if !strings.Contains(securityTeam, "if hosted prerequisites are not ready yet, start with `wrkr scan --path ./your-repo --json` or `wrkr scan --my-setup --json` first") {
@@ -138,6 +144,7 @@ func TestDocsSiteQuickstartMirrorInstallAndFallback(t *testing.T) {
 		"brew install Clyra-AI/tap/wrkr",
 		"go install github.com/Clyra-AI/wrkr/cmd/wrkr@\"${WRKR_VERSION}\"",
 		"wrkr version --json",
+		"wrkr init --non-interactive --org acme --github-api https://api.github.com --json",
 		"wrkr scan --path ./your-repo --json",
 		"wrkr scan --my-setup --json",
 	} {


### PR DESCRIPTION
## Problem
- Hosted org onboarding required repeating `--github-api` even after `wrkr init`, which weakened the org-first launch path.
- `wrkr evidence --json` exposed numeric `framework_coverage` without a machine-readable interpretation, making sparse first-run evidence easy to misread.
- Public docs and docs-site mirrors were split between scenario-first and org-first onboarding narratives.

## Changes
- Added config-backed hosted GitHub API base support to `wrkr init` and `wrkr scan`, with precedence tests and config-backed org-scan acceptance coverage.
- Added additive `coverage_note` output to `wrkr evidence --json` without changing `framework_coverage` semantics.
- Reconciled README, docs, docs-site, and hygiene checks around an org-first launch story with explicit evaluator-safe and local fallback paths.

## Validation
- `go test ./core/config ./core/cli ./internal/e2e/init -count=1`
- `go test ./internal/acceptance -count=1 -run 'TestV1AcceptanceMatrix/AC01_org_scan_flow_outputs_inventory_and_top_findings|TestV1AcceptanceMatrix/AC03_evidence_bundle_signed_and_verifiable'`
- `go test ./core/cli ./core/evidence -count=1`
- `go test ./internal/scenarios -count=1 -tags=scenario -run 'TestScenarioEvidenceBundleIncludesProfileAndPosture'`
- `make test-contracts`
- `go test ./testinfra/hygiene -count=1`
- `make test-docs-consistency`
- `make test-docs-storyline`
- `scripts/run_docs_smoke.sh`
- `scripts/test_uat_local.sh --skip-global-gates`
- `make prepush-full`
- `GOOS=windows GOARCH=amd64 go build -o .tmp/wrkr.exe ./cmd/wrkr`
