### PR TITLE
ci: separate release acceptance from perf budgets

### DIFF
--- a/scripts/run_v1_acceptance.sh
+++ b/scripts/run_v1_acceptance.sh
@@ -124,10 +124,14 @@ fi
 
 risk_cmd="make test-contracts && scripts/validate_scenarios.sh && go test ./internal/scenarios -count=1 -tags=scenario && go test ./internal/integration/interop -count=1"
 if [[ "$mode" == "nightly" || "$mode" == "release" ]]; then
-  risk_cmd+=" && scripts/test_hardening_core.sh && scripts/test_perf_budgets.sh"
+  # Nightly/release pipelines enforce performance budgets as a separate
+  # dedicated gate after acceptance. Keep the acceptance risk lane focused on
+  # functional risk-path coverage and hardening so perf measurements do not run
+  # inside a compounded long-running lane and then immediately rerun again.
+  risk_cmd+=" && scripts/test_hardening_core.sh"
 fi
 if run_cmd "lane_risk" "$risk_cmd"; then
-  lane_risk="pass"
+ lane_risk="pass"
 fi
 
 scorecard_json=".tmp/release/v1-scorecard.json"


### PR DESCRIPTION
## Problem
The `v1.1.1` release flow was still intermittently blocking in `scripts/run_v1_acceptance.sh --mode=release` because the acceptance risk lane embedded `scripts/test_perf_budgets.sh`, even though release/nightly workflows and the release preflight already run the perf budget gate again as a dedicated standalone step.

## Root Cause
Release acceptance and the explicit perf gate were both measuring performance back-to-back in the same overall flow. That duplicated perf enforcement inside a long-running acceptance lane, which made the acceptance scorecard sensitive to noisy runtime measurements that were already enforced separately.

## Fix
Keep the release/nightly acceptance risk lane focused on contracts, scenarios, interop, and hardening, and leave runtime perf budgets to the standalone dedicated perf step that still runs later in the release/nightly flows.

## Validation
- `scripts/run_v1_acceptance.sh --mode=release`
- `scripts/test_perf_budgets.sh`
