### PR TITLE
score: fix merged PR review follow-up

### DIFF
--- a/core/cli/score.go
+++ b/core/cli/score.go
@@ -42,10 +42,8 @@ func runScore(args []string, stdout io.Writer, stderr io.Writer) int {
 	result := snapshot.PostureScore
 	var attackPaths any
 	var topAttackPaths any
-	if len(snapshot.AttackPaths) != 0 {
+	if snapshot.HasRiskReport {
 		attackPaths = snapshot.AttackPaths
-	}
-	if len(snapshot.TopAttackPaths) != 0 {
 		topAttackPaths = snapshot.TopAttackPaths
 	}
 	if result == nil {

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -176,7 +176,7 @@ func LoadScoreView(path string) (ScoreView, error) {
 }
 
 func validateCachedScoreSnapshot(envelope scoreSnapshotEnvelope) (*scoreRiskReportEnvelope, error) {
-	if err := validateRequiredRawShape(envelope.Target, rawObject, rawNull); err != nil {
+	if err := validateRequiredRawShape(envelope.Target, rawObject); err != nil {
 		return nil, err
 	}
 	if err := validateRawShape(envelope.Targets, rawArray, rawNull); err != nil {

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -304,3 +304,25 @@ func TestLoadScoreViewRejectsMalformedIdentitiesPrimitive(t *testing.T) {
 		t.Fatal("expected malformed identities to fail score view load")
 	}
 }
+
+func TestLoadScoreViewRejectsNullTargetInCachedSnapshot(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state.json")
+	payload := []byte(`{
+  "version": "v1",
+  "target": null,
+  "findings": [],
+  "posture_score": {
+    "score": 82.5,
+    "grade": "B"
+  }
+}`)
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatalf("write malformed snapshot: %v", err)
+	}
+
+	if _, err := LoadScoreView(path); err == nil {
+		t.Fatal("expected null target to fail score view load")
+	}
+}


### PR DESCRIPTION
## Problem
Merged PR `#142` still had unresolved Codex review comments covering cached-score snapshot validation and score JSON key stability. Those issues were small but real, so they need a follow-up patch from `main`.

## Changes
- reject `target: null` on the cached-score fail-closed validation path
- preserve stable `attack_paths` / `top_attack_paths` key presence in `wrkr score --json` when a saved `risk_report` exists
- add regression coverage for the null-target malformed-state case

## Validation
- `go test ./core/state ./core/cli -count=1`
- `go test ./internal/e2e/score -count=1`
- `make prepush-full`
