### PR TITLE
chore: finalize changelog for v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed
 
-- Clarified the `wrkr score` command contract so malformed saved state is documented as a fail-closed runtime failure while valid cached-score output remains unchanged.
+- (none yet)
 
 ### Deprecated
 
@@ -24,7 +24,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- `wrkr score` now validates the full saved scan snapshot before reusing cached posture scores, so malformed state files fail closed instead of returning stale success output.
+- (none yet)
 
 ### Security
 
@@ -37,6 +37,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 3. Validate the prepared release changelog with `python3 scripts/validate_release_changelog.py --release-version vX.Y.Z --json` on merged `main` before or during the tag workflow.
 4. Keep entries concise and operator-facing: what changed, why it matters, and any migration/action notes.
 5. Link release notes and tag artifacts to the finalized changelog section.
+
+## [v1.1.2] - 2026-04-21
+<!-- release-semver: patch -->
+
+### Changed
+
+- Clarified the `wrkr score` command contract so malformed saved state is documented as a fail-closed runtime failure while valid cached-score output remains unchanged.
+
+### Fixed
+
+- `wrkr score` now validates the full saved scan snapshot before reusing cached posture scores, so malformed state files fail closed instead of returning stale success output.
 
 ## [v1.1.1] - 2026-04-14
 <!-- release-semver: patch -->

--- a/scripts/release_changelog.py
+++ b/scripts/release_changelog.py
@@ -63,6 +63,13 @@ def latest_semver_tag(repo_root: Path, exclude: set[str] | None = None) -> str:
             continue
         if SEMVER_RE.fullmatch(candidate):
             return candidate
+    output = run_git(repo_root, "tag", "--sort=-version:refname")
+    for line in output.splitlines():
+        candidate = line.strip()
+        if candidate in excluded:
+            continue
+        if SEMVER_RE.fullmatch(candidate):
+            return candidate
     return ""
 
 

--- a/testinfra/hygiene/release_version_test.go
+++ b/testinfra/hygiene/release_version_test.go
@@ -197,6 +197,35 @@ func TestResolveReleaseVersionIgnoresUnmergedTags(t *testing.T) {
 	}
 }
 
+func TestResolveReleaseVersionFallsBackToExistingTagsWithoutMergedTags(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := initReleaseFixtureRepo(t)
+
+	runCommand(t, repoRoot, "git", "checkout", "--orphan", "release-history")
+	writeFixtureFile(t, repoRoot, "README.md", "prior release history\n")
+	writeFixtureFile(t, repoRoot, "CHANGELOG.md", fixtureChangelog(nil))
+	commitAll(t, repoRoot, "chore: prior release history")
+	runCommand(t, repoRoot, "git", "tag", "v1.1.1")
+
+	runCommand(t, repoRoot, "git", "checkout", "main")
+	writeFixtureFile(t, repoRoot, "README.md", "mainline release prep\n")
+	writeFixtureFile(t, repoRoot, "CHANGELOG.md", fixtureChangelog(
+		map[string][]string{
+			"Fixed": {"keep release numbering when historic tags are not merged into main"},
+		},
+	))
+	commitAll(t, repoRoot, "fix: keep release numbering after lineage reset")
+
+	result := runReleaseVersionResolver(t, repoRoot)
+	if result.Version != "v1.1.2" {
+		t.Fatalf("expected fallback tag to yield v1.1.2, got %s", result.Version)
+	}
+	if result.BaseTag != "v1.1.1" {
+		t.Fatalf("expected fallback base tag v1.1.1, got %s", result.BaseTag)
+	}
+}
+
 func TestResolveReleaseVersionFailsClosedWithoutSignal(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Problem
- The manual v1.1.2 release needs a finalized changelog section before tagging.
- Existing semantic release tags are present but not ancestors of current main, causing the release helper to incorrectly treat main as an initial bootstrap release.

Root cause
- The release helper only selected semantic tags merged into HEAD.
- Current main has no merged semantic release tag even though v1.1.1 is the latest existing release tag.

Fix
- Finalize CHANGELOG.md for v1.1.2 as a patch release.
- Keep merged tag lineage as the preferred release base, but fall back to the highest existing semantic tag when no merged semantic tag exists.
- Add hygiene coverage for the lineage-reset fallback.

Validation
- python3 scripts/validate_release_changelog.py --release-version v1.1.2 --json
- go test ./testinfra/hygiene -run 'TestResolveReleaseVersion|TestValidateReleaseChangelog' -count=1
- make prepush-full
