### PR TITLE
Fix scan progress and release tag fallback

### DIFF
--- a/.agents/skills/commit-push/SKILL.md
+++ b/.agents/skills/commit-push/SKILL.md
@@ -79,6 +79,14 @@ If preconditions fail, stop and report.
 - Poll PR reviews, review comments, issue comments, and relevant reactions every `15s`, preferring signals tied to the latest PR head SHA.
 - Never post `@codex review` or any other comment solely to solicit review.
 - Default reviewer identity for this gate: `chatgpt-codex-connector` (GitHub UI may render as `chatgpt-codex-connector bot`).
+- Build a Codex review inventory before severity filtering:
+- fetch PR reviews, inline review comments, issue comments, and relevant reactions with `gh api`
+- include latest-head Codex inline comments from `repos/<owner>/<repo>/pulls/<pr>/comments` where `commit_id == headRefOid`
+- include Codex issue comments and PR/review-comment reactions even when they are not tied to a commit SHA
+- do not discard a latest-head Codex inline comment because priority parsing fails; surface it for triage as `unclassified`
+- Treat priority parsing as advisory, not as the inventory filter.
+- Recognize Codex priority markers in all common renderings, including `[P0]`, `[P1]`, `[P2]`, `[P3]`, `P0 Badge`, `P1 Badge`, `P2 Badge`, `P3 Badge`, shield URLs such as `badge/P2-`, and text such as `priority: 2`.
+- A suitable priority regex is `(?i)(\[P[0-3]\]|\bP[0-3]\s+Badge\b|badge/P[0-3]-|priority[: ]*[0-3])`.
 - Accepted settle signals on the latest PR head:
 - actionable Codex review comments or suggestions -> proceed to pre-merge fix loop
 - explicit approval or all-good signal -> review gate satisfied
@@ -102,6 +110,8 @@ If preconditions fail, stop and report.
 
 9. Pre-merge unresolved comment triage and fix loop:
 - Fetch unresolved PR review threads and comments, preferring latest-head Codex items first, then latest-head GitHub Advanced Security items, then any still-open carry-forward `P0/P1` items from earlier heads.
+- Start from the full Codex review inventory built in the settle gate; do not rely on priority-regex matches as the source of truth for which Codex comments exist.
+- Triage latest-head Codex inline comments even when their priority is `unclassified`; missing or unfamiliar priority markup is not evidence that the comment is non-actionable.
 - Triage each unresolved item as `implement`, `blocked`, `defer`, `reject`, or `already_satisfied`.
 - Resolve the corresponding GitHub review thread for `implement` or `already_satisfied` items once they are satisfied on the current head.
 - Do not resolve threads for `blocked`, `defer`, or `reject`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- (none yet)
+- Release version tooling now ignores unrelated non-ancestor semantic tags when falling back to historic release tags, limiting fallback selection to the documented changelog release lineage.
+- `wrkr scan --path` now preserves nested local repositories named `build`, `dist`, or `target` instead of pruning those valid repo roots as generated directories.
 
 ### Security
 

--- a/core/source/local/local.go
+++ b/core/source/local/local.go
@@ -179,6 +179,9 @@ func discoverRepoRoots(ctx context.Context, root string) ([]source.RepoManifest,
 			return fmt.Errorf("classify path target %s: %w", path, signalErr)
 		}
 		if !hasSignals {
+			if shouldSkipGeneratedLocalTraversal(d.Name()) {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		manifests = append(manifests, repoManifestForDiscoveredRoot(root, path))
@@ -199,7 +202,7 @@ func discoverRepoRoots(ctx context.Context, root string) ([]source.RepoManifest,
 func shouldSkipLocalTraversal(rel, name string) bool {
 	lowerName := strings.ToLower(strings.TrimSpace(name))
 	switch lowerName {
-	case "", ".git", "node_modules", "vendor", "dist", "build", "target", ".venv", "venv", ".next", "coverage":
+	case "", ".git", "node_modules", "vendor", ".venv", "venv", ".next", "coverage":
 		return true
 	}
 	for _, part := range strings.Split(strings.Trim(filepath.ToSlash(strings.TrimSpace(rel)), "/"), "/") {
@@ -208,6 +211,15 @@ func shouldSkipLocalTraversal(rel, name string) bool {
 		}
 	}
 	return false
+}
+
+func shouldSkipGeneratedLocalTraversal(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "dist", "build", "target":
+		return true
+	default:
+		return false
+	}
 }
 
 func repoDiscoveryDepth(rel string) int {

--- a/core/source/local/local_test.go
+++ b/core/source/local/local_test.go
@@ -81,7 +81,13 @@ func TestAcquireDiscoversNestedOrgCloneRepos(t *testing.T) {
 	t.Parallel()
 
 	tmp := t.TempDir()
-	for _, repo := range []string{"Activity-Insights/api", "Activity-Insights/web"} {
+	for _, repo := range []string{
+		"Activity-Insights/api",
+		"Activity-Insights/build",
+		"Activity-Insights/dist",
+		"Activity-Insights/target",
+		"Activity-Insights/web",
+	} {
 		if err := os.MkdirAll(filepath.Join(tmp, repo, ".codex"), 0o755); err != nil {
 			t.Fatalf("mkdir repo %s: %v", repo, err)
 		}
@@ -103,11 +109,19 @@ func TestAcquireDiscoversNestedOrgCloneRepos(t *testing.T) {
 	if err != nil {
 		t.Fatalf("acquire nested org clone: %v", err)
 	}
-	if len(repos) != 2 {
+	if len(repos) != 5 {
 		t.Fatalf("expected nested repo roots, got %+v", repos)
 	}
-	if repos[0].Repo != "Activity-Insights/api" || repos[1].Repo != "Activity-Insights/web" {
-		t.Fatalf("unexpected nested repo identities: %+v", repos)
+	for idx, want := range []string{
+		"Activity-Insights/api",
+		"Activity-Insights/build",
+		"Activity-Insights/dist",
+		"Activity-Insights/target",
+		"Activity-Insights/web",
+	} {
+		if repos[idx].Repo != want {
+			t.Fatalf("expected repo %d to be %s, got %+v", idx, want, repos)
+		}
 	}
 }
 

--- a/core/source/org/acquire_resume_test.go
+++ b/core/source/org/acquire_resume_test.go
@@ -192,6 +192,7 @@ func TestAcquireMaterializedReportsMaterializeProgressInDispatchOrder(t *testing
 	}
 
 	var starts []string
+	startPositions := make(map[string]int)
 	for _, event := range strings.Split(progress.joined(), "\n") {
 		if strings.HasPrefix(event, "repo_materialize org=") {
 			starts = append(starts, event)
@@ -205,6 +206,35 @@ func TestAcquireMaterializedReportsMaterializeProgressInDispatchOrder(t *testing
 	if strings.Join(starts, "\n") != strings.Join(want, "\n") {
 		t.Fatalf("expected dispatch-ordered materialize progress, got:\n%s", strings.Join(starts, "\n"))
 	}
+
+	events := strings.Split(progress.joined(), "\n")
+	for idx, event := range events {
+		if strings.HasPrefix(event, "repo_materialize org=") {
+			startPositions[repoFromProgressEvent(event)] = idx
+		}
+	}
+	for idx, event := range events {
+		if !strings.HasPrefix(event, "repo_materialize_done org=") {
+			continue
+		}
+		repo := repoFromProgressEvent(event)
+		startIdx, ok := startPositions[repo]
+		if !ok {
+			t.Fatalf("expected materialize start before done for %s, got:\n%s", repo, progress.joined())
+		}
+		if startIdx > idx {
+			t.Fatalf("expected materialize start before done for %s, got:\n%s", repo, progress.joined())
+		}
+	}
+}
+
+func repoFromProgressEvent(event string) string {
+	for _, field := range strings.Fields(event) {
+		if strings.HasPrefix(field, "repo=") {
+			return strings.TrimPrefix(field, "repo=")
+		}
+	}
+	return ""
 }
 
 func TestAcquireMaterializedProgressReportsCompletedRepos(t *testing.T) {

--- a/core/source/org/acquire_resume_test.go
+++ b/core/source/org/acquire_resume_test.go
@@ -68,6 +68,12 @@ type recordingProgress struct {
 	events []string
 }
 
+type delayingStartProgress struct {
+	recordingProgress
+	delayRepo string
+	delay     time.Duration
+}
+
 func (p *recordingProgress) RepoDiscovery(org string, total int) {
 	p.add("repo_discovery org=" + org + " total=" + strconv.Itoa(total))
 }
@@ -98,6 +104,13 @@ func (p *recordingProgress) joined() string {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return strings.Join(p.events, "\n")
+}
+
+func (p *delayingStartProgress) RepoMaterialize(org string, index, total int, repo string) {
+	if repo == p.delayRepo {
+		time.Sleep(p.delay)
+	}
+	p.recordingProgress.RepoMaterialize(org, index, total, repo)
 }
 
 func TestAcquireMaterializedUsesBoundedConcurrencyAndDeterministicOrder(t *testing.T) {
@@ -144,6 +157,53 @@ func TestAcquireMaterializedUsesBoundedConcurrencyAndDeterministicOrder(t *testi
 	}
 	if materializer.maxConcurrent != 2 {
 		t.Fatalf("expected bounded concurrency of 2, got %d", materializer.maxConcurrent)
+	}
+}
+
+func TestAcquireMaterializedReportsMaterializeProgressInDispatchOrder(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	materializedRoot := filepath.Join(tmp, "materialized-sources")
+	progress := &delayingStartProgress{
+		delayRepo: "acme/a",
+		delay:     30 * time.Millisecond,
+	}
+	materializer := &trackingMaterializer{t: t, root: materializedRoot}
+
+	_, failures, err := AcquireMaterialized(
+		context.Background(),
+		"acme",
+		fakeLister{repos: []string{"acme/c", "acme/a", "acme/b"}},
+		materializer,
+		AcquireMaterializedOptions{
+			StatePath:        statePath,
+			MaterializedRoot: materializedRoot,
+			WorkerCount:      3,
+			Progress:         progress,
+		},
+	)
+	if err != nil {
+		t.Fatalf("acquire materialized: %v", err)
+	}
+	if len(failures) != 0 {
+		t.Fatalf("expected no failures, got %+v", failures)
+	}
+
+	var starts []string
+	for _, event := range strings.Split(progress.joined(), "\n") {
+		if strings.HasPrefix(event, "repo_materialize org=") {
+			starts = append(starts, event)
+		}
+	}
+	want := []string{
+		"repo_materialize org=acme repo=acme/a index=1 total=3",
+		"repo_materialize org=acme repo=acme/b index=2 total=3",
+		"repo_materialize org=acme repo=acme/c index=3 total=3",
+	}
+	if strings.Join(starts, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("expected dispatch-ordered materialize progress, got:\n%s", strings.Join(starts, "\n"))
 	}
 }
 

--- a/core/source/org/materialized.go
+++ b/core/source/org/materialized.go
@@ -125,9 +125,6 @@ func AcquireMaterialized(
 		go func() {
 			defer wg.Done()
 			for job := range jobs {
-				if opts.Progress != nil {
-					opts.Progress.RepoMaterialize(org, job.index, totalRepos, job.repo)
-				}
 				manifest, materializeErr := materializer.MaterializeRepo(ctx, job.repo, opts.MaterializedRoot)
 				if materializeErr != nil {
 					if errors.Is(materializeErr, context.Canceled) || errors.Is(materializeErr, context.DeadlineExceeded) {
@@ -161,6 +158,9 @@ func AcquireMaterialized(
 			case <-ctx.Done():
 				return
 			case jobs <- job:
+				if opts.Progress != nil {
+					opts.Progress.RepoMaterialize(org, job.index, totalRepos, job.repo)
+				}
 			}
 		}
 	}()

--- a/core/source/org/materialized.go
+++ b/core/source/org/materialized.go
@@ -36,6 +36,7 @@ type AcquireMaterializedOptions struct {
 type materializeJob struct {
 	repo  string
 	index int
+	start chan struct{}
 }
 
 type materializeResult struct {
@@ -125,6 +126,12 @@ func AcquireMaterialized(
 		go func() {
 			defer wg.Done()
 			for job := range jobs {
+				select {
+				case <-ctx.Done():
+					results <- materializeResult{fatalErr: ctx.Err(), repo: job.repo}
+					continue
+				case <-job.start:
+				}
 				manifest, materializeErr := materializer.MaterializeRepo(ctx, job.repo, opts.MaterializedRoot)
 				if materializeErr != nil {
 					if errors.Is(materializeErr, context.Canceled) || errors.Is(materializeErr, context.DeadlineExceeded) {
@@ -150,10 +157,12 @@ func AcquireMaterialized(
 
 	go func() {
 		defer close(jobs)
-		for _, job := range pendingJobs {
+		for _, pendingJob := range pendingJobs {
 			if ctx.Err() != nil {
 				return
 			}
+			job := pendingJob
+			job.start = make(chan struct{})
 			select {
 			case <-ctx.Done():
 				return
@@ -161,6 +170,7 @@ func AcquireMaterialized(
 				if opts.Progress != nil {
 					opts.Progress.RepoMaterialize(org, job.index, totalRepos, job.repo)
 				}
+				close(job.start)
 			}
 		}
 	}()

--- a/scripts/release_changelog.py
+++ b/scripts/release_changelog.py
@@ -56,21 +56,69 @@ def run_git(repo_root: Path, *args: str) -> str:
 
 def latest_semver_tag(repo_root: Path, exclude: set[str] | None = None) -> str:
     excluded = exclude or set()
+    excluded_versions = normalized_versions(excluded)
     output = run_git(repo_root, "tag", "--merged", "HEAD", "--sort=-version:refname")
     for line in output.splitlines():
         candidate = line.strip()
-        if candidate in excluded:
+        if not SEMVER_RE.fullmatch(candidate) or tag_is_excluded(candidate, excluded, excluded_versions):
             continue
-        if SEMVER_RE.fullmatch(candidate):
+        return candidate
+
+    all_semver_tags = [
+        tag for tag in semantic_tags(repo_root) if not tag_is_excluded(tag, excluded, excluded_versions)
+    ]
+    lineage_versions = changelog_release_versions(repo_root)
+    if not lineage_versions:
+        if all_semver_tags:
+            raise RuntimeError(
+                "semantic version tags exist but none are reachable from HEAD or documented in CHANGELOG.md release lineage"
+            )
+        return ""
+    for candidate in all_semver_tags:
+        normalized, _ = normalize_version(candidate)
+        if normalized in lineage_versions:
             return candidate
-    output = run_git(repo_root, "tag", "--sort=-version:refname")
-    for line in output.splitlines():
-        candidate = line.strip()
-        if candidate in excluded:
-            continue
-        if SEMVER_RE.fullmatch(candidate):
-            return candidate
+    if all_semver_tags:
+        raise RuntimeError(
+            "semantic version tags exist but none are reachable from HEAD or documented in CHANGELOG.md release lineage"
+        )
     return ""
+
+
+def semantic_tags(repo_root: Path) -> list[str]:
+    output = run_git(repo_root, "tag", "--sort=-version:refname")
+    return [line.strip() for line in output.splitlines() if SEMVER_RE.fullmatch(line.strip())]
+
+
+def changelog_release_versions(repo_root: Path) -> set[str]:
+    changelog_path = repo_root / "CHANGELOG.md"
+    if not changelog_path.is_file():
+        return set()
+    versions: set[str] = set()
+    for raw_line in read_lines(changelog_path):
+        match = VERSION_SECTION_RE.match(raw_line.strip())
+        if not match:
+            continue
+        normalized, _ = normalize_version(match.group(1))
+        versions.add(normalized)
+    return versions
+
+
+def normalized_versions(tags: set[str]) -> set[str]:
+    versions: set[str] = set()
+    for tag in tags:
+        if not SEMVER_RE.fullmatch(tag):
+            continue
+        normalized, _ = normalize_version(tag)
+        versions.add(normalized)
+    return versions
+
+
+def tag_is_excluded(candidate: str, excluded: set[str], excluded_versions: set[str]) -> bool:
+    if candidate in excluded:
+        return True
+    normalized, _ = normalize_version(candidate)
+    return normalized in excluded_versions
 
 
 def has_changes_since(repo_root: Path, ref: str) -> bool:

--- a/testinfra/hygiene/release_version_test.go
+++ b/testinfra/hygiene/release_version_test.go
@@ -210,10 +210,11 @@ func TestResolveReleaseVersionFallsBackToExistingTagsWithoutMergedTags(t *testin
 
 	runCommand(t, repoRoot, "git", "checkout", "main")
 	writeFixtureFile(t, repoRoot, "README.md", "mainline release prep\n")
-	writeFixtureFile(t, repoRoot, "CHANGELOG.md", fixtureChangelog(
+	writeFixtureFile(t, repoRoot, "CHANGELOG.md", fixtureChangelogWithRelease(
 		map[string][]string{
 			"Fixed": {"keep release numbering when historic tags are not merged into main"},
 		},
+		"v1.1.1",
 	))
 	commitAll(t, repoRoot, "fix: keep release numbering after lineage reset")
 
@@ -223,6 +224,98 @@ func TestResolveReleaseVersionFallsBackToExistingTagsWithoutMergedTags(t *testin
 	}
 	if result.BaseTag != "v1.1.1" {
 		t.Fatalf("expected fallback base tag v1.1.1, got %s", result.BaseTag)
+	}
+}
+
+func TestResolveReleaseVersionFallbackIgnoresTagsOutsideChangelogLineage(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := initReleaseFixtureRepo(t)
+
+	runCommand(t, repoRoot, "git", "checkout", "--orphan", "release-history")
+	writeFixtureFile(t, repoRoot, "README.md", "prior release history\n")
+	writeFixtureFile(t, repoRoot, "CHANGELOG.md", fixtureChangelog(nil))
+	commitAll(t, repoRoot, "chore: prior release history")
+	runCommand(t, repoRoot, "git", "tag", "v1.1.1")
+
+	runCommand(t, repoRoot, "git", "checkout", "main")
+	runCommand(t, repoRoot, "git", "checkout", "-b", "release-preview")
+	writeFixtureFile(t, repoRoot, "preview.txt", "preview branch only\n")
+	commitAll(t, repoRoot, "chore: preview-only release")
+	runCommand(t, repoRoot, "git", "tag", "v9.9.9")
+
+	runCommand(t, repoRoot, "git", "checkout", "main")
+	writeFixtureFile(t, repoRoot, "README.md", "mainline release prep\n")
+	writeFixtureFile(t, repoRoot, "CHANGELOG.md", fixtureChangelogWithRelease(
+		map[string][]string{
+			"Fixed": {"keep release numbering on the documented release lineage"},
+		},
+		"v1.1.1",
+	))
+	commitAll(t, repoRoot, "fix: keep release numbering on release lineage")
+
+	result := runReleaseVersionResolver(t, repoRoot)
+	if result.Version != "v1.1.2" {
+		t.Fatalf("expected changelog-lineage fallback to yield v1.1.2, got %s", result.Version)
+	}
+	if result.BaseTag != "v1.1.1" {
+		t.Fatalf("expected changelog-lineage base tag v1.1.1, got %s", result.BaseTag)
+	}
+}
+
+func TestResolveReleaseVersionFailsClosedForUnreachableTagsOutsideChangelogLineage(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := initReleaseFixtureRepo(t)
+
+	runCommand(t, repoRoot, "git", "checkout", "-b", "release-preview")
+	writeFixtureFile(t, repoRoot, "preview.txt", "preview branch only\n")
+	commitAll(t, repoRoot, "chore: preview-only release")
+	runCommand(t, repoRoot, "git", "tag", "v9.9.9")
+
+	runCommand(t, repoRoot, "git", "checkout", "main")
+	writeFixtureFile(t, repoRoot, "README.md", "mainline release prep\n")
+	writeFixtureFile(t, repoRoot, "CHANGELOG.md", fixtureChangelog(
+		map[string][]string{
+			"Fixed": {"refuse unreachable preview tags outside release lineage"},
+		},
+	))
+	commitAll(t, repoRoot, "fix: refuse preview release tag fallback")
+
+	_, stderr, err := runReleaseVersionResolverRaw(t, repoRoot)
+	if err == nil {
+		t.Fatal("expected resolver to fail closed for unreachable tags outside changelog lineage")
+	}
+	if !strings.Contains(stderr, "semantic version tags exist but none are reachable from HEAD or documented in CHANGELOG.md release lineage") {
+		t.Fatalf("expected release-lineage failure, got %q", stderr)
+	}
+}
+
+func TestValidateReleaseChangelogFallbackIgnoresTagsOutsideChangelogLineage(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := initReleaseFixtureRepo(t)
+
+	runCommand(t, repoRoot, "git", "checkout", "--orphan", "release-history")
+	writeFixtureFile(t, repoRoot, "README.md", "prior release history\n")
+	writeFixtureFile(t, repoRoot, "CHANGELOG.md", fixtureChangelog(nil))
+	commitAll(t, repoRoot, "chore: prior release history")
+	runCommand(t, repoRoot, "git", "tag", "v1.1.1")
+
+	runCommand(t, repoRoot, "git", "checkout", "main")
+	runCommand(t, repoRoot, "git", "checkout", "-b", "release-preview")
+	writeFixtureFile(t, repoRoot, "preview.txt", "preview branch only\n")
+	commitAll(t, repoRoot, "chore: preview-only release")
+	runCommand(t, repoRoot, "git", "tag", "v9.9.9")
+
+	runCommand(t, repoRoot, "git", "checkout", "main")
+	writeFixtureFile(t, repoRoot, "CHANGELOG.md", fixtureFinalizedChangelog("v1.1.2", "v1.1.1"))
+	commitAll(t, repoRoot, "chore: finalize changelog")
+	runCommand(t, repoRoot, "git", "tag", "v1.1.2")
+
+	result := runValidateReleaseChangelog(t, repoRoot, "v1.1.2")
+	if result.BaseTag != "v1.1.1" {
+		t.Fatalf("expected changelog-lineage validation base tag v1.1.1, got %s", result.BaseTag)
 	}
 }
 
@@ -488,6 +581,44 @@ func fixtureChangelog(entries map[string][]string) string {
 	)
 
 	return strings.Join(lines, "\n")
+}
+
+func fixtureChangelogWithRelease(entries map[string][]string, releaseVersion string) string {
+	return fixtureChangelog(entries) + "\n\n" + fixtureReleaseBlock(releaseVersion)
+}
+
+func fixtureFinalizedChangelog(releaseVersion string, previousVersion string) string {
+	sections := []string{"Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"}
+	lines := []string{
+		"# Changelog",
+		"",
+		"## [Unreleased]",
+		"",
+	}
+	for _, section := range sections {
+		lines = append(lines, "### "+section, "", "- (none yet)", "")
+	}
+	lines = append(lines, "## Changelog maintenance process", "")
+	lines = append(lines,
+		"1. Update `## [Unreleased]` in every PR that changes user-visible behavior, contracts, or governance process.",
+		"2. Before release tagging, run `python3 scripts/finalize_release_changelog.py --json` to promote releasable `Unreleased` entries into a dated versioned section and land that change through a release-prep PR.",
+		"3. Validate the prepared release changelog with `python3 scripts/validate_release_changelog.py --release-version vX.Y.Z --json` on merged main before or during the tag workflow.",
+		"",
+	)
+	lines = append(lines, strings.Split(fixtureReleaseBlock(releaseVersion), "\n")...)
+	lines = append(lines, strings.Split(fixtureReleaseBlock(previousVersion), "\n")...)
+	return strings.Join(lines, "\n")
+}
+
+func fixtureReleaseBlock(version string) string {
+	return strings.Join([]string{
+		"## [" + version + "] - 2026-04-01",
+		"<!-- release-semver: patch -->",
+		"",
+		"### Fixed",
+		"",
+		"- keep release numbering on the documented release lineage",
+	}, "\n")
 }
 
 func TestReleaseDocsReferenceReleasePrepPRFlow(t *testing.T) {


### PR DESCRIPTION
## Problem

Large scan and release-prep paths still had a few deterministic edge cases:

- Local org-clone discovery could skip valid nested repositories named `build`, `dist`, or `target` before checking repo-root signals.
- Remote org materialization progress emitted `repo_materialize` from worker goroutines, so start-event ordering could vary with scheduler timing.
- Release tooling fallback could choose unrelated high-version semantic tags from non-release branches when no tag was merged into `HEAD`.

## Changes

- Preserve nested local repositories named `build`, `dist`, or `target` by checking repo-root signals before pruning those generated-directory names.
- Emit remote org `repo_materialize` progress from the dispatcher immediately after enqueue for deterministic ordering.
- Restrict non-ancestor release tag fallback to semantic tags documented in the current changelog release lineage, and fail closed when only unrelated semantic tags exist.
- Added focused regressions for local repo discovery, org materialization progress ordering, and release version/changelog validation fallback behavior.

## Validation

- `python3 -m py_compile scripts/release_changelog.py`
- `go test ./core/source/local ./core/source/org ./testinfra/hygiene -run 'TestAcquireDiscoversNestedOrgCloneRepos|TestAcquireMaterializedReportsMaterializeProgressInDispatchOrder|TestAcquireMaterializedProgressReportsCompletedRepos|TestResolveReleaseVersion|TestValidateReleaseChangelog' -count=1`
- `make lint-fast`
- `make test-fast`
- `make prepush-full`
