### PR TITLE
scan: add governance control backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Added
 
-- (none yet)
+- Added the versioned control backlog contract for governance-first scan output while preserving existing raw finding JSON surfaces.
+- Added deterministic recommended-action, evidence-quality, confidence, and SLA fields to governance backlog items.
 
 ### Changed
 
-- (none yet)
+- Made governance scan mode the default, added quick/deep scan modes, and moved generated/package noise into a deterministic scan-quality appendix.
 
 ### Deprecated
 
@@ -28,7 +29,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Security
 
-- (none yet)
+- Refined secret-bearing automation semantics so Wrkr distinguishes secret references, leaked values, ownership/scope gaps, and rotation evidence gaps without exposing secret values.
 
 ## Changelog maintenance process
 

--- a/PLAN_NEXT.md
+++ b/PLAN_NEXT.md
@@ -1,0 +1,1319 @@
+# PLAN NEXT: Govern-First Control-Path Governance
+
+Date: 2026-04-22
+
+Source of truth:
+- User-provided PM change list after the IBM scan.
+- `AGENTS.md` repository instructions.
+- `product/wrkr.md`.
+- `product/dev_guides.md`.
+- `product/architecture_guides.md`.
+
+Scope:
+- Wrkr only.
+- Planning only. No implementation is included in this plan.
+- Convert Wrkr from broad scanner posture toward AI and automation control-path governance for engineering environments.
+- Preserve deterministic, offline-first, file-based evidence behavior and existing CLI/exit-code contracts.
+
+## Global Decisions (Locked)
+
+- Product position: Wrkr is "governance and proof for unknown AI and automation control paths across engineering environments."
+- Default customer outcome: answer "What should security review first?" through a short prioritized control backlog.
+- Product umbrella term: `control_surface`.
+- Control surface subtypes: `ai_agent`, `coding_assistant_config`, `mcp_server_tool`, `ci_automation`, `release_automation`, `dependency_agent_surface`, `secret_bearing_workflow`, `non_human_identity`.
+- Primary Wrkr signal is separate from supporting security signal in all new governance outputs.
+- Raw findings remain available as machine-readable evidence but are not the default human/operator decision surface.
+- Default scan mode becomes governance-oriented while keeping existing stable JSON keys additive and backward compatible.
+- Secret semantics classify references, value evidence, scope gaps, owner gaps, rotation evidence gaps, and write-capable usage separately.
+- No scan/risk/proof path may call an LLM or exfiltrate scan data by default.
+- Structured parsing remains mandatory for structured configs; regex-only parsing is allowed only for unstructured text or a narrowly bounded reference detector.
+- Enterprise integrations such as Jira, ServiceNow, GitHub Issues, Slack, or Teams must default to local dry-run/export artifacts unless explicit opt-in network execution is provided.
+- Contract/runtime waves must land before docs/report/ticket polish waves.
+
+## Current Baseline (Observed)
+
+- `core/model/finding.go` is the canonical detector/policy finding contract. It has severity, remediation, permissions, evidence, and parse error metadata, but no native control backlog fields, action taxonomy, evidence quality, signal class, confidence level, control-path type, SLA, or explicit secret-reference subtype.
+- `core/cli/scan.go` emits `findings`, `ranked_findings`, `top_findings`, `action_paths`, `inventory`, `privilege_budget`, profile, posture score, and compliance summary. It does not expose `--mode quick|governance|deep`.
+- `core/aggregate/inventory` already models tools, agents, owner metadata, approval summary, security visibility summary, privilege budget, and agent privilege map. Security visibility currently has `approved`, `known_unapproved`, and `unknown_to_security`.
+- `core/owners` supports CODEOWNERS and deterministic repo fallback ownership. It does not yet support service catalog, Backstage, GitHub teams, repo topics, explicit custom owner mappings, or conflicting owner resolution.
+- `core/detect/workflowcap` already parses GitHub workflow YAML and derives write/deploy/db/IaC capabilities, headless execution, secret access, and gate/proof hints.
+- `core/detect/secrets` redacts values and detects env files plus workflow/Jenkins secret references, but current finding type is still generic `secret_presence`.
+- `core/regress` already supports deterministic baselines, drift exit code `5`, permission expansion, revoked-tool reappearance, and critical attack-path drift. Drift reasons do not yet map to governance-first categories like new secret-bearing workflow or approval expired.
+- `core/report` supports `exec`, `operator`, `audit`, and `public` templates with deterministic Markdown/PDF generation. It does not yet provide native CISO/AppSec/platform/customer-draft bundles led by a control backlog.
+- `core/export` supports inventory and appendix export. It does not yet export tickets.
+- Scenario, e2e, acceptance, contract, hardening, chaos, and perf gates already exist and must be wired into implementation stories.
+- `PLAN_NEXT.md` did not exist before this planning run.
+
+## Exit Criteria
+
+- `wrkr scan --json` includes a deterministic `control_backlog` led by unique Wrkr signals and keeps existing raw finding surfaces available for compatibility.
+- `wrkr scan` defaults to governance mode, with explicit `--mode quick`, `--mode governance`, and `--mode deep`.
+- Generated, vendored, package-manager, minified, and build-output noise is suppressed or moved to a scan-quality appendix by default.
+- Every control backlog item includes repo, path, control-path type, capability, owner, evidence source, approval status, security visibility, recommended action, confidence, evidence gaps, confidence-raising guidance, SLA, and closure criteria.
+- Every finding/control item has a fixed action taxonomy value or deterministic equivalent accepted by the schema.
+- Secret-bearing workflows distinguish secret references from leaked values and explain owner/scope/rotation/proof evidence gaps.
+- Inventory workflows can approve, attach evidence, accept risk, deprecate, exclude, and expire/renew approvals with deterministic proof records.
+- Drift views answer what new or changed AI/automation control paths appeared since the last approved baseline.
+- Ownership resolution distinguishes explicit, inferred, conflicting, and missing owners with confidence.
+- Large-org scans keep JSON stdout clean, progress on stderr, phase timing visible, partial results explicit, and status inspectable after interruptions.
+- Native reports and ticket exports lead with the control backlog and keep raw findings in appendices.
+
+## Public API and Contract Map
+
+Stable existing public surfaces:
+- CLI commands in `core/cli/root.go`: `scan`, `inventory`, `regress`, `report`, `export`, `evidence`, `verify`, `identity`, `lifecycle`, `manifest`, `score`, `fix`, `campaign`, `mcp-list`, `action`, `version`.
+- Exit codes in `core/cli/root.go`: `0` success, `1` runtime failure, `2` verification failure, `3` policy/schema violation, `4` approval required, `5` regression drift, `6` invalid input, `7` dependency missing, `8` unsafe operation blocked.
+- Existing `wrkr scan --json` keys must remain present unless explicitly deprecated by a future major version: `findings`, `ranked_findings`, `top_findings`, `inventory`, `profile`, `posture_score`, `compliance_summary`.
+- Existing proof chain, lifecycle manifest, state snapshot, report, appendix, SARIF, and regress baseline artifacts remain portable and verifiable.
+
+New public surfaces to add:
+- `wrkr scan --mode quick|governance|deep`.
+- `control_backlog` object in scan state and scan JSON, versioned as `control_backlog_version`.
+- `scan_quality` appendix containing suppressed generated/package noise, parser errors, detector errors, and completeness warnings.
+- Finding/control item enums: `signal_class`, `control_surface_type`, `control_path_type`, `recommended_action`, `confidence`, `evidence_basis`, `security_visibility_state`, `write_path_class`, `secret_signal_type`.
+- Inventory lifecycle commands: `wrkr inventory approve`, `wrkr inventory attach-evidence`, `wrkr inventory accept-risk`, `wrkr inventory deprecate`, `wrkr inventory exclude`.
+- Drift categories for control-path changes in `wrkr regress run --json` and `wrkr inventory --diff --json`.
+- Report templates: `ciso`, `appsec`, `platform`, `audit`, `customer-draft`, with compatibility alias for current `exec|operator|audit|public`.
+- Ticket export command surface under `wrkr export tickets`.
+
+Internal surfaces:
+- New aggregation packages may live under `core/aggregate/controlbacklog`, `core/aggregate/scanquality`, and focused helper packages for classification. Keep orchestration thin in `core/cli`.
+- Detector logic remains under `core/detect/*`; risk logic remains under `core/risk/*`; ownership logic remains under `core/owners`; evidence/proof stays under `core/evidence`, `core/proofemit`, and `core/proofmap`.
+
+Shim and deprecation path:
+- Keep existing finding JSON fields and report templates. Add new fields additively.
+- Map existing security visibility value `approved` to new display value `known_approved` only in new governance surfaces; do not mutate old inventory fields without a schema/version note.
+- Keep current `top_findings` while adding `control_backlog.items`. Do not remove `top_findings` during this plan.
+- Existing `secret_presence` findings may continue for compatibility, but governance outputs must derive and expose new secret signal semantics.
+
+Schema/versioning policy:
+- Add explicit version fields for new artifacts: `control_backlog_version`, `scan_quality_version`, `approval_inventory_version`, `ticket_export_version`.
+- Enum additions are minor-version compatible when old fields remain. Enum renames or removals require shim logic, docs, and compatibility tests.
+- New artifacts must be byte-stable across repeated runs except explicit timestamp/version fields.
+
+Machine-readable error expectations:
+- Invalid scan mode, report template, ticket format, or inventory action arguments: exit `6`, JSON error code `invalid_input`.
+- Invalid governance policy/config schema: exit `3`, JSON error code `policy_schema_violation`.
+- Approval-required enforcement paths: exit `4`, JSON error code `approval_required`.
+- Drift found by regress/inventory diff: exit `5`, JSON status `drift`.
+- Missing optional network adapter configuration: exit `7`, JSON error code `dependency_missing`.
+- Unsafe output path, symlink marker abuse, or unmanaged destructive write: exit `8`, JSON error code `unsafe_operation_blocked`.
+
+## Docs and OSS Readiness Baseline
+
+- README first screen must say what Wrkr does, who it is for, how to get first value, and why it is governance/proof for control paths rather than generic AppSec scanning.
+- Docs must introduce the lifecycle path model: discover -> classify -> attach evidence -> approve -> monitor drift -> prove control.
+- Integration-first docs flow must lead with `wrkr scan --mode governance --json`, `wrkr inventory approve`, `wrkr regress init/run --json`, `wrkr report --template ciso`, and `wrkr export tickets --dry-run --json`.
+- Docs source of truth: command docs in `docs/commands/*.md`, product positioning in `docs/positioning.md`, trust/security docs in `docs/trust/*.md`, examples in `docs/examples/*.md`, decisions in `docs/decisions/*.md`.
+- OSS trust baseline must remain aligned: `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `SECURITY.md`, `.github/CODEOWNERS`, `.github/ISSUE_TEMPLATE/*`, `.github/pull_request_template.md`, and release/trust docs.
+- Any CLI/help/JSON/schema/exit-code change must update docs and pass docs parity gates in the same implementation story.
+
+## Recommendation Traceability
+
+| Rec | Normalized recommendation | Epic/story coverage |
+|---|---|---|
+| R1 | Reposition Wrkr around AI and automation control-path governance | W1-S1, W5-S1 |
+| R2 | Make govern-first control backlog the default output | W1-S1, W2-S1 |
+| R3 | Split unique Wrkr signals from supporting security signals | W1-S1, W2-S1, W5-S1 |
+| R4 | Add fixed finding action taxonomy | W1-S2, W3-S1 |
+| R5 | Add evidence quality and confidence | W1-S2, W4-S1 |
+| R6 | Add approval inventory workflow | W3-S1, W3-S2 |
+| R7 | Make drift recurring value | W3-S3 |
+| R8 | Add scan modes quick/governance/deep | W1-S4, W2-S1 |
+| R9 | Suppress generated/package noise by default | W1-S4 |
+| R10 | Improve secret reference semantics | W1-S3, W2-S2 |
+| R11 | Add control mapping | W2-S2, W3-S2 |
+| R12 | Add native customer reports | W5-S1 |
+| R13 | Add ticket export | W5-S2 |
+| R14 | Add enterprise ownership resolution | W4-S1 |
+| R15 | Add security visibility state | W2-S3 |
+| R16 | Add write-path classification | W2-S2 |
+| R17 | Add large-org operator UX | W4-S2 |
+| R18 | Add baseline and approval expiration | W3-S1, W3-S3 |
+| R19 | Tighten agent vs automation model around control surfaces | W1-S1, W2-S2 |
+| R20 | Productize proof | W3-S2, W5-S1 |
+
+## Test Matrix Wiring
+
+Fast lane:
+- `make lint-fast`
+- `make test-fast`
+- Targeted `go test` commands named by each story.
+- Docs parity checks for touched command docs: `scripts/check_docs_cli_parity.sh`.
+
+Core CI lane:
+- `make prepush`
+- `go test ./internal/e2e -count=1`
+- `go test ./internal/integration -count=1`
+- `.github/required-checks.json` and branch-protection contract validation remain aligned.
+
+Acceptance lane:
+- `scripts/run_v1_acceptance.sh --mode=local`
+- `go test ./internal/acceptance -count=1`
+- `go test ./internal/scenarios -count=1 -tags=scenario`
+- New scenario fixtures under `scenarios/wrkr/**` for each governance behavior.
+
+Cross-platform lane:
+- Required PR checks remain `fast-lane` and `windows-smoke`.
+- Windows/macOS smoke must cover path filtering, JSON stdout cleanliness, and report/ticket artifact path behavior when touched.
+
+Risk lane:
+- `make prepush-full` for architecture, risk, adapter, or failure-semantics changes.
+- `make test-contracts` for schema/artifact/CLI JSON changes.
+- `make test-scenarios` for outside-in behavior changes.
+- `make test-hardening` and `make test-chaos` for approval persistence, baseline/drift, long-running scan status, and unsafe output behavior.
+- `make test-perf` for generated-path filtering, scan modes, control backlog construction, large-org progress/status, and report/ticket export scaling.
+
+Merge/release gating rule:
+- No implementation wave may merge with failing fast/core/contract/scenario gates.
+- Stories touching proof, evidence, regress drift, approval state, or failure handling require risk lane green before merge.
+- Report/ticket/docs waves may not merge before Wave 1 through Wave 3 contracts are green.
+
+## Epic Wave 1: Control-Surface Contract And Signal Quality
+
+Objective:
+- Establish the contract vocabulary that lets Wrkr speak in control surfaces, signal classes, actions, confidence, secret semantics, scan modes, and noise policy without collapsing detector/risk/inventory boundaries.
+
+### Story W1-S1: Add Control Surface And Backlog Contract
+
+Priority: P0
+
+Tasks:
+- Add a focused control backlog model with deterministic item sorting and a stable version field.
+- Define fields for repo, path, control surface type, control-path type, capability, owner, owner source, ownership status, evidence source, approval status, security visibility, signal class, recommended action, confidence, evidence gaps, SLA, closure criteria, and linked raw finding IDs.
+- Add enum validation helpers for `unique_wrkr_signal` vs `supporting_security_signal`.
+- Keep raw detector findings unchanged and derive backlog items in aggregation.
+- Add fixture/golden output for a mixed org scan with CI workflow, MCP config, coding assistant config, dependency surface, and supporting secret reference.
+
+Repo paths:
+- `core/model/finding.go`
+- `core/aggregate/controlbacklog/`
+- `core/aggregate/inventory/`
+- `core/risk/`
+- `core/state/`
+- `internal/scenarios/`
+- `scenarios/wrkr/control-backlog-governance/`
+
+Run commands:
+- `go test ./core/aggregate/controlbacklog ./core/aggregate/inventory ./core/model -count=1`
+- `go test ./internal/scenarios -run 'TestControlBacklogGovernance' -count=1 -tags=scenario`
+- `make test-contracts`
+- `make prepush-full`
+
+Test requirements:
+- Schema validation tests for the new backlog artifact.
+- Golden JSON repeat-run byte stability tests.
+- Compatibility tests proving existing `findings`, `top_findings`, and `inventory` JSON remain available.
+- Scenario fixture proving primary Wrkr signals rank before supporting security signals.
+
+Matrix wiring:
+- Fast lane: targeted package tests.
+- Core CI lane: `make prepush`.
+- Acceptance lane: new scenario fixture.
+- Risk lane: `make test-contracts`, `make prepush-full`.
+
+Acceptance criteria:
+- `wrkr scan --path scenarios/wrkr/control-backlog-governance/repos --json` emits `control_backlog.control_backlog_version`.
+- Backlog item order is deterministic across two runs with distinct state paths.
+- Each backlog item has a valid signal class and links back to raw finding evidence.
+- Existing scan JSON consumers can still read `findings`, `top_findings`, and `inventory`.
+
+Changelog impact: required
+
+Changelog section: Added
+
+Draft changelog entry: Added the versioned control backlog contract for governance-first scan output while preserving existing raw finding JSON surfaces.
+
+Semver marker override: none
+
+Contract/API impact:
+- Adds stable scan JSON fields and artifact schema. Existing fields remain stable.
+
+Versioning/migration impact:
+- Add `control_backlog_version: "1"`. No migration required for old state files; old snapshots produce an empty or derived backlog when read.
+
+Architecture constraints:
+- Keep detector output as raw evidence and backlog aggregation as a separate package.
+- Thin CLI orchestration only; no risk logic embedded in `core/cli`.
+- Explicit side-effect-free API naming for backlog build functions.
+- Deterministic sort order by priority, confidence, repo, path, control type, and linked finding ID.
+
+ADR required: yes
+
+TDD first failing test(s):
+- `TestBuildControlBacklogSplitsSignalClassesAndSortsDeterministically`.
+- `TestScanJSONRetainsLegacyFindingSurfacesWithControlBacklog`.
+
+Cost/perf impact: medium
+
+Chaos/failure hypothesis:
+- If a raw finding has incomplete owner/evidence metadata, backlog construction emits a low-confidence item with explicit gaps instead of dropping it or panicking.
+
+### Story W1-S2: Add Action Taxonomy, Evidence Quality, And Confidence
+
+Priority: P0
+
+Tasks:
+- Define fixed recommended actions: `attach_evidence`, `approve`, `remediate`, `downgrade`, `deprecate`, `exclude`, `monitor`, `inventory_review`, `suppress`, `debug_only`.
+- Add evidence quality fields: confidence, evidence basis, evidence gaps, and what would raise confidence.
+- Map existing finding classes into default actions without changing detector semantics.
+- Add deterministic SLA assignment rules by action, capability, write-path class, security visibility, and confidence.
+- Add contract tests for every taxonomy value and reason-code stability.
+
+Repo paths:
+- `core/model/finding.go`
+- `core/aggregate/controlbacklog/`
+- `core/risk/`
+- `core/report/`
+- `docs/trust/contracts-and-schemas.md`
+
+Run commands:
+- `go test ./core/aggregate/controlbacklog ./core/risk ./core/report -count=1`
+- `go test ./internal/e2e/cli_contract -count=1`
+- `make test-contracts`
+- `make prepush-full`
+
+Test requirements:
+- Enum validation tests.
+- Golden JSON tests for each action.
+- CLI `--json` stability tests for error envelopes and valid/invalid action filters when filters are introduced.
+- Deterministic SLA rule tests.
+
+Matrix wiring:
+- Fast lane: targeted package tests.
+- Core CI lane: e2e CLI contract.
+- Risk lane: `make test-contracts`, `make prepush-full`.
+
+Acceptance criteria:
+- Every backlog item has exactly one allowed recommended action.
+- Secret-bearing workflows with only references default to `attach_evidence` or `approve`, not automatic `remediate`, unless unsafe value evidence exists.
+- Generated parse errors can be marked `suppress` or `debug_only` in scan quality surfaces.
+- Confidence basis and confidence-raising guidance are deterministic and non-empty for medium/low confidence items.
+
+Changelog impact: required
+
+Changelog section: Added
+
+Draft changelog entry: Added deterministic recommended-action, evidence-quality, confidence, and SLA fields to governance backlog items.
+
+Semver marker override: none
+
+Contract/API impact:
+- Adds stable enum values and backlog JSON fields.
+
+Versioning/migration impact:
+- Backlog schema remains version `1` if added before release; otherwise bump minor artifact version and preserve old readers.
+
+Architecture constraints:
+- Taxonomy mapping must live in aggregation/risk packages, not detectors.
+- Reason codes and action values must be stable and documented.
+- Fail closed on unknown configured taxonomy values.
+
+ADR required: yes
+
+TDD first failing test(s):
+- `TestRecommendedActionTaxonomyCoversKnownFindingFamilies`.
+- `TestEvidenceQualityExplainsOwnerFallbackConfidence`.
+
+Cost/perf impact: low
+
+Chaos/failure hypothesis:
+- If evidence basis is missing or contradictory, item confidence falls to low and the evidence gap is surfaced instead of silently treating the item as controlled.
+
+### Story W1-S3: Split Secret Reference Semantics From Secret Value Risk
+
+Priority: P0
+
+Tasks:
+- Introduce secret signal types: `secret_reference_detected`, `secret_value_detected`, `secret_scope_unknown`, `secret_rotation_evidence_missing`, `secret_owner_missing`, `secret_used_by_write_capable_workflow`.
+- Update secret detector and workflow capability aggregation so workflow references remain redacted and classified as references.
+- Add control backlog language that says rotation/owner/scope/proof evidence is missing rather than implying a leaked secret.
+- Add tests proving raw values are never emitted and workflow secret reference names are handled deterministically.
+
+Repo paths:
+- `core/detect/secrets/`
+- `core/detect/workflowcap/`
+- `core/aggregate/controlbacklog/`
+- `core/risk/`
+- `core/report/`
+- `scenarios/wrkr/secret-reference-semantics/`
+
+Run commands:
+- `go test ./core/detect/secrets ./core/detect/workflowcap ./core/aggregate/controlbacklog ./core/risk -count=1`
+- `go test ./internal/scenarios -run 'TestSecretReferenceSemantics' -count=1 -tags=scenario`
+- `make test-contracts`
+- `make prepush-full`
+
+Test requirements:
+- Unit tests for secret signal classification.
+- Redaction tests proving secret values are absent from JSON, Markdown, PDF, CSV, and ticket exports.
+- Scenario tests for rotation evidence attached vs missing.
+- Contract tests for secret signal enum stability.
+
+Matrix wiring:
+- Fast lane: detector and backlog tests.
+- Acceptance lane: new secret-reference scenario.
+- Risk lane: `make test-contracts`, `make prepush-full`.
+
+Acceptance criteria:
+- A GitHub workflow with `secrets.MY_TOKEN` produces `secret_reference_detected`, not `secret_value_detected`.
+- If the same workflow is write-capable, backlog item includes `secret_used_by_write_capable_workflow`.
+- If control evidence is attached, the item can close as controlled without remediation language.
+- No output contains raw secret values.
+
+Changelog impact: required
+
+Changelog section: Security
+
+Draft changelog entry: Refined secret-bearing automation semantics so Wrkr distinguishes secret references, leaked values, ownership/scope gaps, and rotation evidence gaps without exposing secret values.
+
+Semver marker override: none
+
+Contract/API impact:
+- Adds secret signal enum values and changes governance wording for secret findings. Legacy raw finding compatibility remains.
+
+Versioning/migration impact:
+- Existing `secret_presence` findings are still accepted and mapped to the new secret signal types in governance outputs.
+
+Architecture constraints:
+- Secret detectors may flag presence and references only; no raw value extraction.
+- Workflow-derived secret context must be merged in aggregation, not duplicated across detectors.
+- Default behavior remains offline and deterministic.
+
+ADR required: yes
+
+TDD first failing test(s):
+- `TestWorkflowSecretReferenceDoesNotClaimLeakedSecret`.
+- `TestSecretValueNeverAppearsInGovernanceOutputs`.
+
+Cost/perf impact: low
+
+Chaos/failure hypothesis:
+- If a workflow file cannot be parsed, Wrkr moves the parse failure to scan quality and does not invent secret risk from unreadable content.
+
+### Story W1-S4: Add Scan Modes And Generated-Path Noise Policy
+
+Priority: P0
+
+Tasks:
+- Add `--mode quick|governance|deep` to `wrkr scan`.
+- Make `governance` the default mode.
+- Define mode-specific detector/path scope: quick scans high-signal repo/CI/agent/MCP files, governance scans control backlog evidence surfaces, deep runs exhaustive detector/debug scope.
+- Add default generated/package suppression for `dist/`, `build/`, nested `target/`, `.yarn/sdks/`, `node_modules/`, generated SDK folders, vendored dependency trees, minified JS, and package-manager internals.
+- Move parse errors from suppressed/generated paths into `scan_quality` instead of top-level governance backlog.
+- Preserve deterministic ordering and explicit inclusion behavior for deep mode.
+
+Repo paths:
+- `core/cli/scan.go`
+- `core/detect/`
+- `core/source/local/`
+- `core/source/github/`
+- `core/aggregate/scanquality/`
+- `internal/e2e/source/`
+- `scenarios/wrkr/first-offer-noise-pack/`
+- `docs/commands/scan.md`
+
+Run commands:
+- `go test ./core/detect/... ./core/source/local ./core/source/github ./core/aggregate/scanquality -count=1`
+- `go test ./internal/e2e/source -count=1`
+- `go test ./internal/acceptance -run 'TestV1Acceptance/AC06_scan_diff_no_noise' -count=1`
+- `make test-perf`
+- `make prepush-full`
+
+Test requirements:
+- CLI help/usage tests for `--mode`.
+- Invalid mode exit-code and JSON error envelope tests.
+- Fixture/golden tests for quick/governance/deep output differences.
+- Generated path suppression tests including symlink and nested-root safety.
+- Perf regression tests for large path sets.
+
+Matrix wiring:
+- Fast lane: source/detect/scanquality package tests.
+- Core CI lane: e2e source tests.
+- Acceptance lane: noise scenario and acceptance no-noise check.
+- Cross-platform lane: Windows path separator smoke.
+- Risk lane: `make test-perf`, `make prepush-full`.
+
+Acceptance criteria:
+- `wrkr scan --path <repos> --json` behaves as governance mode.
+- `wrkr scan --mode deep --json` can include debug/raw parse errors that governance mode suppresses from the backlog.
+- Suppressed paths are represented in `scan_quality` with counts and rationale, sorted deterministically.
+- Invalid `--mode` exits `6` with JSON error code `invalid_input`.
+
+Changelog impact: required
+
+Changelog section: Changed
+
+Draft changelog entry: Made governance scan mode the default, added quick/deep scan modes, and moved generated/package noise into a deterministic scan-quality appendix.
+
+Semver marker override: none
+
+Contract/API impact:
+- Adds CLI flag and scan JSON fields. Changes default prioritization and human output, but keeps legacy raw JSON fields.
+
+Versioning/migration impact:
+- No state migration required. New state snapshots include mode and scan-quality metadata.
+
+Architecture constraints:
+- Path filtering must be a reusable deterministic source/detector scope layer.
+- Mode selection must not be hidden global state.
+- Long-running scan loops must propagate context cancellation.
+
+ADR required: yes
+
+TDD first failing test(s):
+- `TestScanModeGovernanceSuppressesGeneratedPathNoise`.
+- `TestScanModeDeepKeepsDebugParseErrorsInScanQuality`.
+- `TestInvalidScanModeJSONErrorEnvelope`.
+
+Cost/perf impact: medium
+
+Chaos/failure hypothesis:
+- If suppression encounters unreadable paths or unsafe symlinks, scan quality records deterministic warnings and high-risk unreadable control paths fail closed when applicable.
+
+## Epic Wave 2: Govern-First Runtime Output
+
+Objective:
+- Make the new contracts visible in operator output, write-path classification, control mapping, and security visibility without removing existing scanner evidence.
+
+### Story W2-S1: Make Control Backlog The Default Scan Decision Surface
+
+Priority: P0
+
+Tasks:
+- Emit `control_backlog` in scan JSON and persist it in scan state.
+- Update human `wrkr scan --explain` to lead with top backlog items and rationale.
+- Keep stdout clean JSON when `--json` is set; send progress and warnings to stderr only.
+- Put raw findings, parse errors, detector errors, and generated-path issues in appendix-style JSON surfaces.
+- Add `--top` or reuse existing report top behavior only if needed for backlog count; otherwise default to top 10 backlog items.
+
+Repo paths:
+- `core/cli/scan.go`
+- `core/state/`
+- `core/report/activation.go`
+- `core/report/render_markdown.go`
+- `docs/commands/scan.md`
+- `internal/e2e/cli_contract/`
+- `internal/acceptance/`
+
+Run commands:
+- `go test ./core/cli ./core/state ./core/report -count=1`
+- `go test ./internal/e2e/cli_contract -count=1`
+- `go test ./internal/acceptance -run 'TestV1Acceptance' -count=1`
+- `scripts/check_docs_cli_parity.sh`
+- `make test-contracts`
+
+Test requirements:
+- CLI `--json` stdout-only stability tests.
+- Help/usage tests for new mode/default wording.
+- Golden scan JSON tests for backlog and raw appendix.
+- Exit-code invariants for unchanged success/failure paths.
+
+Matrix wiring:
+- Fast lane: CLI/report package tests.
+- Core CI lane: e2e CLI contract.
+- Acceptance lane: V1 acceptance with new governance assertions.
+- Risk lane: `make test-contracts`.
+
+Acceptance criteria:
+- `wrkr scan --json` has valid `control_backlog.items` and no non-JSON stdout.
+- `wrkr scan --explain` answers which items security should review first.
+- Raw findings are still emitted in JSON for downstream compatibility.
+- Warnings, progress, and scan-quality notes do not corrupt JSON stdout.
+
+Changelog impact: required
+
+Changelog section: Changed
+
+Draft changelog entry: Changed scan output to lead with a prioritized control backlog while keeping raw findings available for compatibility.
+
+Semver marker override: none
+
+Contract/API impact:
+- Adds new default JSON and human output surfaces. Existing JSON fields remain.
+
+Versioning/migration impact:
+- Existing state files remain readable. New state files include backlog and scan quality.
+
+Architecture constraints:
+- CLI should call aggregation/report builders, not rank backlog inline.
+- Output writers must keep stdout/stderr separation explicit.
+- Context cancellation must flush partial progress safely.
+
+ADR required: yes
+
+TDD first failing test(s):
+- `TestScanJSONStdoutContainsOnlyJSONWithControlBacklog`.
+- `TestScanExplainLeadsWithTopControlBacklogItems`.
+
+Cost/perf impact: medium
+
+Chaos/failure hypothesis:
+- If report/backlog artifact writing fails after state save begins, managed artifact rollback preserves previous state and emits deterministic runtime error.
+
+### Story W2-S2: Add Write-Path Classification And Control Mapping
+
+Priority: P0
+
+Tasks:
+- Define write-path classes: `read`, `write`, `pr_write`, `repo_write`, `release_write`, `package_publish`, `deploy_write`, `infra_write`, `secret_bearing_execution`, `production_adjacent_write`.
+- Derive write-path class from workflow permissions, workflow steps, MCP/tool config, non-human identities, and dependency agent surfaces.
+- Map backlog items to controls: owner assigned, approval recorded, least privilege verified, rotation evidence attached, deployment gate present, production access classified, proof artifact generated, review cadence set.
+- Ensure write-path classification is visible in scan JSON, inventory, reports, regress drift, and ticket exports.
+
+Repo paths:
+- `core/detect/workflowcap/`
+- `core/aggregate/inventory/privileges.go`
+- `core/aggregate/controlbacklog/`
+- `core/risk/attackpath/`
+- `core/risk/classify/`
+- `core/compliance/`
+- `core/proofmap/`
+- `internal/scenarios/workflow_capabilities_scenario_test.go`
+- `scenarios/wrkr/write-path-classification/`
+
+Run commands:
+- `go test ./core/detect/workflowcap ./core/aggregate/inventory ./core/aggregate/controlbacklog ./core/risk/... ./core/compliance ./core/proofmap -count=1`
+- `go test ./internal/scenarios -run 'TestWorkflowCapabilities|TestWritePathClassification' -count=1 -tags=scenario`
+- `make test-contracts`
+- `make test-scenarios`
+- `make prepush-full`
+
+Test requirements:
+- Unit tests for each write-path class.
+- Scenario fixtures for PR write plus secret reference, deploy workflow with environment gate, package publish, and infra write.
+- Contract tests proving enum names remain stable.
+- Compliance/proof mapping tests for each governance control.
+
+Matrix wiring:
+- Fast lane: detector/risk/compliance targeted tests.
+- Acceptance lane: workflow capability and new write-path scenario.
+- Risk lane: `make test-contracts`, `make test-scenarios`, `make prepush-full`.
+
+Acceptance criteria:
+- A workflow with `pull-requests: write` and `secrets.*` produces `pr_write` plus `secret_bearing_execution`.
+- A release workflow with publish/deploy steps produces release/deploy/package classes as applicable.
+- Control mappings are deterministic and explain which evidence is present or missing.
+- Existing attack/action path output includes write-path class references without breaking prior fields.
+
+Changelog impact: required
+
+Changelog section: Added
+
+Draft changelog entry: Added explicit engineering write-path classification and governance control mappings across scan, inventory, risk, and proof outputs.
+
+Semver marker override: none
+
+Contract/API impact:
+- Adds enum fields to scan, inventory, backlog, and report JSON.
+
+Versioning/migration impact:
+- Additive schema changes only. Old snapshots derive write-path classes when possible.
+
+Architecture constraints:
+- Detection extracts evidence; classification and control mapping happen in risk/aggregation/compliance layers.
+- No workflow execution or remote lookup is introduced.
+- Structured YAML parser behavior remains `gopkg.in/yaml.v3` compatible.
+
+ADR required: yes
+
+TDD first failing test(s):
+- `TestWritePathClassifiesPRWriteSecretBearingWorkflow`.
+- `TestControlMappingRequiresLeastPrivilegeAndProofEvidence`.
+
+Cost/perf impact: medium
+
+Chaos/failure hypothesis:
+- If workflow permissions are ambiguous or inherited, classify confidence as medium/low and surface evidence gaps rather than assuming least privilege.
+
+### Story W2-S3: Expand Security Visibility States
+
+Priority: P1
+
+Tasks:
+- Add governance-native states: `known_approved`, `known_unapproved`, `unknown_to_security`, `accepted_risk`, `deprecated`, `revoked`, `needs_review`.
+- Preserve old inventory status compatibility with shim mapping.
+- Update rollups for tools, agents, write-capable agents, and backlog items.
+- Add drift behavior for expired approvals and revoked/deprecated reappearance.
+- Update docs and schema contract references.
+
+Repo paths:
+- `core/aggregate/inventory/`
+- `core/lifecycle/`
+- `core/manifest/`
+- `core/regress/`
+- `core/aggregate/controlbacklog/`
+- `docs/state_lifecycle.md`
+- `docs/commands/inventory.md`
+- `docs/trust/contracts-and-schemas.md`
+
+Run commands:
+- `go test ./core/aggregate/inventory ./core/lifecycle ./core/manifest ./core/regress ./core/aggregate/controlbacklog -count=1`
+- `go test ./internal/e2e/regress -count=1`
+- `scripts/check_docs_cli_parity.sh`
+- `make test-contracts`
+- `make prepush-full`
+
+Test requirements:
+- Compatibility tests for old `approved` state.
+- Lifecycle transition tests for accepted risk, deprecated, revoked, and needs review.
+- Drift tests for approval expiry and deprecated reappearance.
+- Schema/golden updates for visibility rollups.
+
+Matrix wiring:
+- Fast lane: inventory/lifecycle/regress package tests.
+- Core CI lane: e2e regress.
+- Risk lane: `make test-contracts`, `make prepush-full`.
+
+Acceptance criteria:
+- New governance backlog uses `known_approved` for approved controls.
+- Existing inventory readers still accept current `approved` status where emitted historically.
+- Expired approvals move affected items to `needs_review`.
+- Revoked or deprecated paths that reappear produce deterministic drift reasons.
+
+Changelog impact: required
+
+Changelog section: Changed
+
+Draft changelog entry: Expanded security visibility into governance-native states for approved, unapproved, accepted-risk, deprecated, revoked, and needs-review control paths.
+
+Semver marker override: none
+
+Contract/API impact:
+- Adds/changes visibility enum in new governance surfaces and shims old values.
+
+Versioning/migration impact:
+- Old manifests and state snapshots are migrated in-memory through compatibility mapping.
+
+Architecture constraints:
+- Lifecycle state transitions remain deterministic and proof-record-backed.
+- Visibility rollups must not borrow approval across orgs or repos.
+- Fail closed on invalid manually supplied visibility state.
+
+ADR required: yes
+
+TDD first failing test(s):
+- `TestSecurityVisibilityMapsApprovedToKnownApprovedInBacklog`.
+- `TestExpiredApprovalMovesBacklogItemToNeedsReview`.
+
+Cost/perf impact: low
+
+Chaos/failure hypothesis:
+- If lifecycle manifest has invalid approval metadata, state becomes `needs_review` or `revoked` according to deterministic rules rather than silently staying approved.
+
+## Epic Wave 3: Approval Inventory, Evidence, And Drift
+
+Objective:
+- Turn discovery into lifecycle governance: attach evidence, approve, accept risk, deprecate, exclude, expire approvals, and monitor drift from approved baselines.
+
+### Story W3-S1: Add Approval Inventory Workflow Commands
+
+Priority: P1
+
+Tasks:
+- Add `wrkr inventory approve <id> --owner <team> --evidence <ticket-or-url> --expires <date> --json`.
+- Add `wrkr inventory attach-evidence <id> --control <control-id> --url <url> --json`.
+- Add `wrkr inventory accept-risk <id> --expires <duration-or-date> --json`.
+- Add `wrkr inventory deprecate <id> --reason <reason> --json`.
+- Add `wrkr inventory exclude <id> --reason <reason> --json`.
+- Store approval owner, evidence URL, control ID, approval expiry, review cadence, last reviewed date, exclusion reason, and renewal state in deterministic state/manifest artifacts.
+- Require regular-file markers and safe managed output paths for state mutations.
+
+Repo paths:
+- `core/cli/inventory.go`
+- `core/lifecycle/`
+- `core/manifest/`
+- `core/state/`
+- `core/evidence/`
+- `core/proofemit/`
+- `internal/atomicwrite/`
+- `internal/e2e/cli_contract/`
+- `docs/commands/inventory.md`
+
+Run commands:
+- `go test ./core/cli ./core/lifecycle ./core/manifest ./core/state ./core/evidence ./core/proofemit ./internal/atomicwrite -count=1`
+- `go test ./internal/e2e/cli_contract -count=1`
+- `make test-contracts`
+- `make test-hardening`
+- `make test-chaos`
+- `make prepush-full`
+
+Test requirements:
+- CLI help/usage tests.
+- `--json` stability tests.
+- Exit-code tests for missing id, invalid expiry, invalid evidence URL/path, unknown action, and unsafe output path.
+- Crash-safe atomic write and rollback tests.
+- Marker trust tests: marker must be regular file; reject symlink/directory.
+- Approval expiry and renewal lifecycle tests.
+
+Matrix wiring:
+- Fast lane: targeted CLI/lifecycle/state tests.
+- Core CI lane: e2e CLI contract.
+- Risk lane: `make test-contracts`, `make test-hardening`, `make test-chaos`, `make prepush-full`.
+
+Acceptance criteria:
+- Each inventory mutation emits a deterministic JSON response and proof/lifecycle transition record.
+- Invalid or unsafe state mutation exits with the correct machine-readable error envelope.
+- Approval expiry is enforced in subsequent scan/regress output.
+- Excluded items remain in evidence appendices but leave the active governance backlog with explicit rationale.
+
+Changelog impact: required
+
+Changelog section: Added
+
+Draft changelog entry: Added inventory governance commands for approvals, evidence attachments, accepted risk, deprecation, exclusion, and time-bound review state.
+
+Semver marker override: none
+
+Contract/API impact:
+- Adds inventory subcommands and state/proof artifact fields.
+
+Versioning/migration impact:
+- Add `approval_inventory_version`. Old manifests read with missing approvals as `missing` or `needs_review`.
+
+Architecture constraints:
+- Use plan/apply style APIs for mutating lifecycle state.
+- Mutations must be atomic and rollback-safe.
+- Proof emission remains file-based and verifiable.
+- No network validation of evidence URLs by default.
+
+ADR required: yes
+
+TDD first failing test(s):
+- `TestInventoryApproveWritesApprovalProofRecordAtomically`.
+- `TestInventoryAcceptRiskRequiresExpiry`.
+- `TestInventoryMutationRejectsUnsafeManagedMarker`.
+
+Cost/perf impact: medium
+
+Chaos/failure hypothesis:
+- If the process crashes during approval write, previous state remains readable and no partial proof chain is treated as valid.
+
+### Story W3-S2: Productize Proof And Evidence Lifecycle
+
+Priority: P1
+
+Tasks:
+- Define evidence/control proof records for owner assigned, approval recorded, least privilege verified, rotation evidence attached, deployment gate present, production access classified, proof artifact generated, and review cadence set.
+- Map backlog closure criteria to proof requirements.
+- Ensure `wrkr evidence --json`, `wrkr verify --chain --json`, and reports can show whether proof exists for each control.
+- Keep `Clyra-AI/proof` primitives authoritative for proof record creation and verification.
+- Add compatibility assertions for proof chain integrity and mixed scan/evidence records.
+
+Repo paths:
+- `core/evidence/`
+- `core/proofemit/`
+- `core/proofmap/`
+- `core/compliance/`
+- `core/verify/`
+- `core/cli/evidence.go`
+- `core/cli/verify.go`
+- `scenarios/cross-product/proof-record-interop/`
+- `docs/trust/proof-chain-verification.md`
+- `docs/evidence_templates.md`
+
+Run commands:
+- `go test ./core/evidence ./core/proofemit ./core/proofmap ./core/compliance ./core/verify ./core/cli -count=1`
+- `go test ./internal/integration/interop -count=1`
+- `go test ./internal/scenarios -run 'TestPolicyComplianceMapping|TestWave3Compliance' -count=1 -tags=scenario`
+- `make test-contracts`
+- `make test-scenarios`
+- `make prepush-full`
+
+Test requirements:
+- Proof record schema validation tests.
+- Chain integrity tests with mixed scan/evidence records.
+- Golden tests for evidence bundle closure criteria.
+- CLI JSON tests for evidence and verify output.
+
+Matrix wiring:
+- Fast lane: proof/evidence/compliance package tests.
+- Core CI lane: interop integration.
+- Acceptance lane: compliance/proof scenarios.
+- Risk lane: `make test-contracts`, `make test-scenarios`, `make prepush-full`.
+
+Acceptance criteria:
+- Every control backlog item can explain which proof artifacts exist and which are missing.
+- Attached evidence creates verifiable proof records with stable record types.
+- `wrkr verify --chain --json` validates the resulting proof chain.
+- Compliance mapping can consume the same evidence without product-specific hacks.
+
+Changelog impact: required
+
+Changelog section: Added
+
+Draft changelog entry: Added proof and evidence lifecycle mapping so governance controls can show verifiable approval, least-privilege, rotation, deployment-gate, and review evidence.
+
+Semver marker override: none
+
+Contract/API impact:
+- Adds proof/evidence record fields and evidence JSON surfaces.
+
+Versioning/migration impact:
+- Existing proof chains remain valid; new records append with stable types.
+
+Architecture constraints:
+- Do not duplicate proof primitive semantics outside `Clyra-AI/proof`.
+- Compliance mapping consumes evidence abstractions, not raw detector internals.
+- Verification failure remains exit `2`.
+
+ADR required: yes
+
+TDD first failing test(s):
+- `TestControlEvidenceRecordVerifiesInProofChain`.
+- `TestBacklogClosureCriteriaMapsToProofRequirements`.
+
+Cost/perf impact: low
+
+Chaos/failure hypothesis:
+- If proof append fails after state mutation planning, mutation apply is blocked or rolled back and verification remains fail-closed.
+
+### Story W3-S3: Add Drift-First Approved Baseline Monitoring
+
+Priority: P1
+
+Tasks:
+- Extend regress baselines with approved control-path state, security visibility, owner, evidence expiry, write-path class, secret-bearing status, and confidence.
+- Add drift categories: `new_unknown_automation`, `new_repo_write_path`, `new_secret_bearing_workflow`, `new_mcp_tool_config`, `approval_expired`, `owner_changed`, `approved_path_risk_increased`, `deprecated_path_reappeared`.
+- Update `wrkr regress init --baseline <state> --json`, `wrkr regress run --baseline <baseline> --state <state> --json`, and `wrkr inventory --diff --json` outputs.
+- Keep drift exit code `5`.
+- Add summary markdown/report integration for drift categories.
+
+Repo paths:
+- `core/regress/`
+- `core/diff/`
+- `core/cli/regress.go`
+- `core/cli/inventory.go`
+- `core/report/`
+- `core/aggregate/controlbacklog/`
+- `internal/e2e/regress/`
+- `scenarios/wrkr/drift-first-baseline/`
+- `docs/commands/regress.md`
+
+Run commands:
+- `go test ./core/regress ./core/diff ./core/cli ./core/report ./core/aggregate/controlbacklog -count=1`
+- `go test ./internal/e2e/regress -count=1`
+- `go test ./internal/scenarios -run 'TestDriftFirstBaseline' -count=1 -tags=scenario`
+- `make test-contracts`
+- `make test-scenarios`
+- `make prepush-full`
+
+Test requirements:
+- Baseline schema compatibility tests.
+- Drift reason-code stability tests.
+- Exit-code `5` contract tests.
+- Golden JSON for every new drift category.
+- Scenario tests for approved path becoming higher risk and deprecated path reappearing.
+
+Matrix wiring:
+- Fast lane: regress/diff/report package tests.
+- Core CI lane: e2e regress.
+- Acceptance lane: new drift scenario.
+- Risk lane: `make test-contracts`, `make test-scenarios`, `make prepush-full`.
+
+Acceptance criteria:
+- Regress output leads with new/changed unknown control paths since approved baseline.
+- Approval expiry creates `approval_expired` drift and moves visibility to `needs_review`.
+- Owner changes are reported with old/new owner and source.
+- Drift output remains sorted and byte-stable.
+
+Changelog impact: required
+
+Changelog section: Changed
+
+Draft changelog entry: Changed regress and inventory drift to focus on new or changed AI/automation control paths, approval expiry, owner changes, and risk increases from approved baselines.
+
+Semver marker override: none
+
+Contract/API impact:
+- Extends regress baseline schema and drift JSON reasons while preserving exit code `5`.
+
+Versioning/migration impact:
+- Add baseline compatibility reader for prior `BaselineVersion`. Bump baseline version only with migration tests.
+
+Architecture constraints:
+- Regress compares persisted state and backlog summaries; it must not rescan or call detectors.
+- Drift reason codes are stable public contract.
+- Ambiguous baseline reads fail closed with machine-readable errors.
+
+ADR required: yes
+
+TDD first failing test(s):
+- `TestRegressDetectsNewSecretBearingWriteWorkflow`.
+- `TestRegressDetectsApprovalExpiredAndOwnerChanged`.
+
+Cost/perf impact: medium
+
+Chaos/failure hypothesis:
+- If baseline is partially written or schema-invalid, regress exits fail-closed with deterministic error and does not produce misleading no-drift output.
+
+## Epic Wave 4: Ownership And Large-Org Operator UX
+
+Objective:
+- Make governance scalable for hundreds of repos by resolving owners better and making long-running scans observable without violating offline-first defaults.
+
+### Story W4-S1: Add Enterprise Ownership Resolution
+
+Priority: P1
+
+Tasks:
+- Extend `core/owners` to support CODEOWNERS, custom owner mapping files, service catalog exports, Backstage catalog files, GitHub teams/repo topics when available from source metadata, and fallback owner rules.
+- Add owner source states: `explicit_owner`, `inferred_owner`, `conflicting_owner`, `missing_owner`.
+- Add ownership confidence and evidence basis.
+- Keep all network ownership lookups tied to already configured source acquisition; no standalone network calls by default.
+- Surface owner quality in backlog, inventory, reports, and ticket exports.
+
+Repo paths:
+- `core/owners/`
+- `core/source/github/`
+- `core/source/org/`
+- `core/aggregate/inventory/`
+- `core/aggregate/controlbacklog/`
+- `docs/examples/`
+- `scenarios/wrkr/ownership-quality/`
+- `internal/scenarios/ownership_quality_scenario_test.go`
+
+Run commands:
+- `go test ./core/owners ./core/source/github ./core/source/org ./core/aggregate/inventory ./core/aggregate/controlbacklog -count=1`
+- `go test ./internal/scenarios -run 'TestOwnershipQuality' -count=1 -tags=scenario`
+- `make test-contracts`
+- `make prepush-full`
+
+Test requirements:
+- Parser tests for CODEOWNERS, custom mappings, Backstage/service catalog fixtures.
+- Conflict resolution tests with deterministic tie-breaking.
+- Source adapter parity tests for available GitHub ownership metadata.
+- Scenario tests for explicit, inferred, conflicting, and missing owners.
+
+Matrix wiring:
+- Fast lane: owners/source/inventory tests.
+- Acceptance lane: ownership quality scenario.
+- Risk lane: `make test-contracts`, `make prepush-full`.
+
+Acceptance criteria:
+- Backlog items distinguish explicit, inferred, conflicting, and missing owners.
+- Ownership confidence drives backlog evidence gaps and SLA.
+- Local/offline scans work without GitHub owner metadata.
+- Conflicting owner data is surfaced as a governance gap, not silently resolved.
+
+Changelog impact: required
+
+Changelog section: Added
+
+Draft changelog entry: Added enterprise ownership resolution with explicit, inferred, conflicting, and missing owner states plus ownership confidence in governance outputs.
+
+Semver marker override: none
+
+Contract/API impact:
+- Adds ownership fields and optional owner mapping config surfaces.
+
+Versioning/migration impact:
+- Existing owner fields remain; new owner quality metadata is additive.
+
+Architecture constraints:
+- Vendor/source schemas must be isolated behind owner/source adapter boundaries.
+- Fallback owner rules must be deterministic and documented.
+- Optional network-derived metadata must not alter offline default behavior.
+
+ADR required: yes
+
+TDD first failing test(s):
+- `TestResolveOwnershipFromCustomMappingBeforeFallback`.
+- `TestConflictingOwnersLowerConfidenceAndCreateEvidenceGap`.
+
+Cost/perf impact: medium
+
+Chaos/failure hypothesis:
+- If external ownership metadata is unavailable or stale, Wrkr falls back deterministically and marks confidence/evidence gaps rather than failing the entire scan.
+
+### Story W4-S2: Improve Large-Org Operator UX And Scan Status
+
+Priority: P1
+
+Tasks:
+- Add phase timing and current phase/repo count to scan progress on stderr.
+- Persist last successful phase and partial result marker for interrupted org scans.
+- Add `wrkr scan status --state <path> --json` or equivalent subcommand with deterministic status output.
+- Document `nohup`/background pattern if `--background` is not implemented; avoid hidden daemons.
+- Ensure `--quiet`, `--json`, and `--explain` interactions remain contract-tested.
+- Add failure footer with last successful phase and artifact paths.
+
+Repo paths:
+- `core/cli/scan.go`
+- `core/cli/scan_progress_test.go`
+- `core/state/`
+- `core/source/org/`
+- `internal/e2e/source/`
+- `docs/commands/scan.md`
+- `docs/examples/operator-playbooks.md`
+
+Run commands:
+- `go test ./core/cli ./core/state ./core/source/org -count=1`
+- `go test ./internal/e2e/source -count=1`
+- `make test-hardening`
+- `make test-chaos`
+- `make test-perf`
+- `make prepush-full`
+
+Test requirements:
+- CLI stdout/stderr separation tests.
+- Lifecycle/status tests for completed, running, interrupted, partial, and failed scans.
+- Crash-safe/atomic status update tests.
+- Contention/concurrency tests for status reads during scan writes.
+- Perf tests on large synthetic org manifests.
+
+Matrix wiring:
+- Fast lane: CLI/state/source tests.
+- Core CI lane: e2e source tests.
+- Cross-platform lane: Windows status-path smoke.
+- Risk lane: `make test-hardening`, `make test-chaos`, `make test-perf`, `make prepush-full`.
+
+Acceptance criteria:
+- JSON stdout remains clean for `wrkr scan --json`.
+- Progress, phase timing, warnings, and failure footer go to stderr.
+- Interrupted scans preserve a deterministic partial state marker and last successful phase.
+- `wrkr scan status --json` can describe the last scan without rescanning.
+
+Changelog impact: required
+
+Changelog section: Added
+
+Draft changelog entry: Added large-org scan progress, phase timing, partial-result status, and scan status inspection without changing JSON stdout contracts.
+
+Semver marker override: none
+
+Contract/API impact:
+- Adds scan status command/subcommand and status JSON fields.
+
+Versioning/migration impact:
+- Existing state files report status as unknown or completed based on available snapshot fields.
+
+Architecture constraints:
+- No hidden background daemon by default.
+- Status writes must be atomic and readable under contention.
+- Cancellation/timeouts must propagate through source acquisition and detector execution.
+
+ADR required: yes
+
+TDD first failing test(s):
+- `TestScanJSONProgressOnlyOnStderr`.
+- `TestScanStatusReportsInterruptedPartialPhase`.
+
+Cost/perf impact: medium
+
+Chaos/failure hypothesis:
+- If an org scan is interrupted while writing state, the next status read returns partial/interrupted metadata and does not corrupt the prior completed snapshot.
+
+## Epic Wave 5: Reports And Work Export
+
+Objective:
+- Turn governance outputs into customer-ready artifacts and work items after the core contract/runtime behavior is stable.
+
+### Story W5-S1: Add Native Customer Report Templates Led By Control Backlog
+
+Priority: P2
+
+Tasks:
+- Add report templates: `ciso`, `appsec`, `platform`, `audit`, `customer-draft`.
+- Generate PDF, Markdown, JSON evidence bundle, and CSV backlog from a single report command.
+- Lead every report with the control backlog and move raw findings to an appendix.
+- Add redaction/public share-profile handling for customer-draft reports.
+- Update report docs, examples, and acceptance fixtures.
+
+Repo paths:
+- `core/cli/report.go`
+- `core/report/`
+- `core/report/templates/`
+- `core/export/appendix/`
+- `core/export/inventory/`
+- `internal/acceptance/report_pdf_acceptance_test.go`
+- `internal/scenarios/epic9_scenario_test.go`
+- `docs/commands/report.md`
+- `docs/examples/security-team.md`
+
+Run commands:
+- `go test ./core/report ./core/export/appendix ./core/export/inventory ./core/cli -count=1`
+- `go test ./internal/acceptance -run 'TestReportPDFAcceptance|TestV1Acceptance/AC21' -count=1`
+- `go test ./internal/scenarios -run 'TestEpic9' -count=1 -tags=scenario`
+- `scripts/check_docs_cli_parity.sh`
+- `make test-perf`
+- `make prepush-full`
+
+Test requirements:
+- Template parsing tests.
+- Deterministic PDF/Markdown repeat-run tests.
+- CSV backlog golden tests.
+- Redaction tests for public/customer-draft share profile.
+- Docs consistency checks.
+
+Matrix wiring:
+- Fast lane: report/export/CLI package tests.
+- Acceptance lane: PDF and report scenarios.
+- Cross-platform lane: artifact path smoke.
+- Risk lane: `make test-perf`, `make prepush-full`.
+
+Acceptance criteria:
+- `wrkr report --template ciso --pdf --md --json` returns artifact paths and deterministic summary payload.
+- Report starts with control backlog, not raw findings.
+- CSV backlog includes owner, evidence, recommended action, SLA, and closure criteria.
+- Public/customer-draft reports do not leak secret values or sensitive local paths.
+
+Changelog impact: required
+
+Changelog section: Added
+
+Draft changelog entry: Added customer-ready CISO, AppSec, platform, audit, and customer-draft report templates led by the governance control backlog.
+
+Semver marker override: none
+
+Contract/API impact:
+- Adds report template enum values and artifact bundle JSON fields.
+
+Versioning/migration impact:
+- Existing report templates continue to work as compatibility aliases.
+
+Architecture constraints:
+- Report rendering consumes state/backlog summaries and does not call detectors.
+- Artifact writes use managed path safety and deterministic rendering.
+- Raw findings must stay appendix-only for these templates.
+
+ADR required: no
+
+TDD first failing test(s):
+- `TestReportTemplateCISOLeadsWithControlBacklog`.
+- `TestCustomerDraftReportRedactsSensitiveEvidence`.
+
+Cost/perf impact: medium
+
+Chaos/failure hypothesis:
+- If one artifact in a report bundle fails to write, the command returns a deterministic error and does not claim the bundle is complete.
+
+### Story W5-S2: Add Ticket Export With Offline Dry-Run First
+
+Priority: P2
+
+Tasks:
+- Add `wrkr export tickets --top <n> --format jira|github|servicenow --dry-run --json`.
+- Export ticket payloads with owner, repo, path, control-path type, capability, evidence, recommended action, SLA, closure criteria, confidence, and proof requirements.
+- Add explicit opt-in adapter execution later or behind separate flags; default is local JSON/CSV/Markdown payload generation.
+- Add deterministic grouping/deduping by owner/repo/control path.
+- Add simulated adapter fixtures only if network execution is included in implementation scope.
+
+Repo paths:
+- `core/cli/export.go`
+- `core/export/tickets/`
+- `core/aggregate/controlbacklog/`
+- `internal/e2e/cli_contract/`
+- `docs/commands/export.md`
+- `docs/examples/operator-playbooks.md`
+- `scenarios/wrkr/ticket-export/`
+
+Run commands:
+- `go test ./core/export/tickets ./core/aggregate/controlbacklog ./core/cli -count=1`
+- `go test ./internal/e2e/cli_contract -count=1`
+- `go test ./internal/scenarios -run 'TestTicketExport' -count=1 -tags=scenario`
+- `make test-contracts`
+- `make prepush-full`
+
+Test requirements:
+- CLI help/usage tests.
+- JSON schema/golden tests for Jira/GitHub/ServiceNow payload formats.
+- Deterministic grouping/deduping tests.
+- Invalid format and missing backlog error-envelope tests.
+- Dry-run no-network tests.
+
+Matrix wiring:
+- Fast lane: export/CLI package tests.
+- Core CI lane: e2e CLI contract.
+- Acceptance lane: ticket export scenario.
+- Risk lane: `make test-contracts`, `make prepush-full`.
+
+Acceptance criteria:
+- `wrkr export tickets --top 10 --format jira --dry-run --json` emits deterministic local ticket payloads and makes no network calls.
+- Each ticket includes owner, evidence, recommended action, SLA, and closure criteria.
+- Unsupported formats exit `6` with `invalid_input`.
+- Ticket exports can be generated from saved state without rescanning.
+
+Changelog impact: required
+
+Changelog section: Added
+
+Draft changelog entry: Added offline-first ticket export payloads for Jira, GitHub Issues, and ServiceNow from top governance backlog items.
+
+Semver marker override: none
+
+Contract/API impact:
+- Adds export subcommand/format and ticket export JSON schema.
+
+Versioning/migration impact:
+- Add `ticket_export_version: "1"` to exported payloads.
+
+Architecture constraints:
+- Exporters consume control backlog state and never run detectors.
+- Network adapters must be explicit opt-in and fail closed on missing credentials.
+- Default dry-run path is deterministic and offline.
+
+ADR required: yes
+
+TDD first failing test(s):
+- `TestExportTicketsDryRunDoesNotUseNetwork`.
+- `TestTicketPayloadIncludesClosureCriteriaAndSLA`.
+
+Cost/perf impact: low
+
+Chaos/failure hypothesis:
+- If adapter configuration is missing or unavailable, dry-run remains usable and opt-in send mode fails closed with a machine-readable dependency error.
+
+## Minimum-Now Sequence
+
+Wave 1:
+- Implement W1-S1, W1-S2, W1-S3, and W1-S4.
+- This wave creates the public vocabulary and suppresses the IBM-scan-style noise before changing downstream reports or workflows.
+- Required gates: targeted tests, `make test-contracts`, scenario fixtures, `make prepush-full`, and `make test-perf` for scan modes/noise.
+
+Wave 2:
+- Implement W2-S1, W2-S2, and W2-S3.
+- This wave makes governance backlog visible by default and adds write-path/control/visibility semantics.
+- Required gates: CLI contract, acceptance, scenarios, contract tests, and risk lane.
+
+Wave 3:
+- Implement W3-S1, W3-S2, and W3-S3.
+- This wave turns backlog items into lifecycle-managed controls with proof and drift.
+- Required gates: hardening, chaos, contract, scenario, interop, and prepush-full.
+
+Wave 4:
+- Implement W4-S1 and W4-S2.
+- This wave improves enterprise accuracy and scan operability for large orgs.
+- Required gates: source/owner scenarios, hardening, chaos, perf, and cross-platform smoke.
+
+Wave 5:
+- Implement W5-S1 and W5-S2.
+- This wave packages governance output into customer reports and work exports after the underlying contracts are stable.
+- Required gates: report acceptance, ticket export scenarios, docs parity, perf, and contract tests.
+
+## Explicit Non-Goals
+
+- No dashboard-first scope in this backlog.
+- No Axym or Gait product feature implementation in this repository.
+- No LLM calls in scan, risk, proof, reporting, or ticket export paths.
+- No default network ticket creation or notification sending.
+- No secret value extraction or secret value output.
+- No replacement of SAST, SCA, or secret scanning as Wrkr's product lane.
+- No removal of existing raw finding JSON fields during this plan.
+- No broad refactor that collapses source, detection, aggregation, identity, risk, proof, and compliance boundaries.
+- No generated binary, transient scan report, or customer data commit.
+
+## Definition of Done
+
+- Every recommendation R1-R20 maps to at least one merged story.
+- Every new CLI surface has help text, command docs, JSON tests, and exit-code tests.
+- Every schema/artifact change has versioning, compatibility, and golden tests.
+- Every governance output is deterministic across repeated runs except explicit timestamp/version fields.
+- Every risk-bearing story has failure-mode tests and runs `make prepush-full`.
+- Approval and evidence mutations are atomic, rollback-safe, and proof-verifiable.
+- Raw findings remain accessible while default operator/customer views lead with the control backlog.
+- Secret-bearing automation language distinguishes references from leaked values and never emits secret values.
+- Generated/package noise is suppressed by default or moved to scan quality.
+- Reports and ticket exports are offline-first and backlog-led.
+- Docs, README positioning, trust docs, and command references match implemented behavior.
+- `CHANGELOG.md` `## [Unreleased]` can be updated from the story-level changelog fields without re-deciding semver intent.

--- a/core/aggregate/controlbacklog/controlbacklog.go
+++ b/core/aggregate/controlbacklog/controlbacklog.go
@@ -46,7 +46,7 @@ const (
 	ConfidenceLow                    = "low"
 	SecretReferenceDetected          = "secret_reference_detected"
 	SecretValueDetected              = "secret_value_detected"
-	SecretScopeUnknown               = "secret_scope_unknown"
+	SecretScopeUnknown               = "secret_scope_unknown" // #nosec G101 -- governance enum label, not credential material.
 	SecretRotationEvidenceMissing    = "secret_rotation_evidence_missing"
 	SecretOwnerMissing               = "secret_owner_missing"
 	SecretUsedByWriteCapableWorkflow = "secret_used_by_write_capable_workflow"

--- a/core/aggregate/controlbacklog/controlbacklog.go
+++ b/core/aggregate/controlbacklog/controlbacklog.go
@@ -1,0 +1,863 @@
+package controlbacklog
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/detect"
+	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/risk"
+)
+
+const BacklogVersion = "1"
+
+const (
+	SignalClassUniqueWrkrSignal      = "unique_wrkr_signal"
+	SignalClassSupportingSecurity    = "supporting_security_signal"
+	ControlSurfaceAIAgent            = "ai_agent"
+	ControlSurfaceCodingAssistant    = "coding_assistant_config"
+	ControlSurfaceMCPServerTool      = "mcp_server_tool"
+	ControlSurfaceCIAutomation       = "ci_automation"
+	ControlSurfaceReleaseAutomation  = "release_automation"
+	ControlSurfaceDependencyAgent    = "dependency_agent_surface"
+	ControlSurfaceSecretWorkflow     = "secret_bearing_workflow"
+	ControlSurfaceNonHumanIdentity   = "non_human_identity"
+	ControlPathAgentConfig           = "agent_config"
+	ControlPathMCPTool               = "mcp_tool"
+	ControlPathCIAutomation          = "ci_automation"
+	ControlPathReleaseWorkflow       = "release_workflow"
+	ControlPathDependencyAgent       = "dependency_agent_surface"
+	ControlPathSecretWorkflow        = "secret_bearing_workflow"
+	ActionAttachEvidence             = "attach_evidence"
+	ActionApprove                    = "approve"
+	ActionRemediate                  = "remediate"
+	ActionDowngrade                  = "downgrade"
+	ActionDeprecate                  = "deprecate"
+	ActionExclude                    = "exclude"
+	ActionMonitor                    = "monitor"
+	ActionInventoryReview            = "inventory_review"
+	ActionSuppress                   = "suppress"
+	ActionDebugOnly                  = "debug_only"
+	ConfidenceHigh                   = "high"
+	ConfidenceMedium                 = "medium"
+	ConfidenceLow                    = "low"
+	SecretReferenceDetected          = "secret_reference_detected"
+	SecretValueDetected              = "secret_value_detected"
+	SecretScopeUnknown               = "secret_scope_unknown"
+	SecretRotationEvidenceMissing    = "secret_rotation_evidence_missing"
+	SecretOwnerMissing               = "secret_owner_missing"
+	SecretUsedByWriteCapableWorkflow = "secret_used_by_write_capable_workflow"
+)
+
+type Backlog struct {
+	ControlBacklogVersion string  `json:"control_backlog_version"`
+	Summary               Summary `json:"summary"`
+	Items                 []Item  `json:"items"`
+}
+
+type Summary struct {
+	TotalItems                int `json:"total_items"`
+	UniqueWrkrSignalItems     int `json:"unique_wrkr_signal_items"`
+	SupportingSecurityItems   int `json:"supporting_security_signal_items"`
+	AttachEvidenceActionItems int `json:"attach_evidence_action_items"`
+	ApproveActionItems        int `json:"approve_action_items"`
+	RemediateActionItems      int `json:"remediate_action_items"`
+}
+
+type Item struct {
+	ID                 string   `json:"id"`
+	Repo               string   `json:"repo"`
+	Path               string   `json:"path"`
+	ControlSurfaceType string   `json:"control_surface_type"`
+	ControlPathType    string   `json:"control_path_type"`
+	Capability         string   `json:"capability"`
+	Capabilities       []string `json:"capabilities,omitempty"`
+	Owner              string   `json:"owner,omitempty"`
+	OwnerSource        string   `json:"owner_source,omitempty"`
+	OwnershipStatus    string   `json:"ownership_status,omitempty"`
+	EvidenceSource     string   `json:"evidence_source"`
+	EvidenceBasis      []string `json:"evidence_basis"`
+	ApprovalStatus     string   `json:"approval_status"`
+	SecurityVisibility string   `json:"security_visibility"`
+	SignalClass        string   `json:"signal_class"`
+	RecommendedAction  string   `json:"recommended_action"`
+	Confidence         string   `json:"confidence"`
+	EvidenceGaps       []string `json:"evidence_gaps,omitempty"`
+	ConfidenceRaise    []string `json:"confidence_raise,omitempty"`
+	SLA                string   `json:"sla"`
+	ClosureCriteria    string   `json:"closure_criteria"`
+	SecretSignalTypes  []string `json:"secret_signal_types,omitempty"`
+	LinkedFindingIDs   []string `json:"linked_finding_ids,omitempty"`
+	LinkedActionPathID string   `json:"linked_action_path_id,omitempty"`
+}
+
+type Input struct {
+	Mode        string
+	Findings    []model.Finding
+	Inventory   *agginventory.Inventory
+	ActionPaths []risk.ActionPath
+}
+
+func Build(input Input) Backlog {
+	builder := newBuilder(input)
+	for _, path := range input.ActionPaths {
+		builder.addActionPath(path)
+	}
+	for _, finding := range input.Findings {
+		builder.addFinding(finding, input.Mode)
+	}
+	items := builder.items()
+	return Backlog{
+		ControlBacklogVersion: BacklogVersion,
+		Summary:               summarize(items),
+		Items:                 items,
+	}
+}
+
+func ValidSignalClass(value string) bool {
+	switch strings.TrimSpace(value) {
+	case SignalClassUniqueWrkrSignal, SignalClassSupportingSecurity:
+		return true
+	default:
+		return false
+	}
+}
+
+func ValidRecommendedAction(value string) bool {
+	switch strings.TrimSpace(value) {
+	case ActionAttachEvidence, ActionApprove, ActionRemediate, ActionDowngrade, ActionDeprecate, ActionExclude, ActionMonitor, ActionInventoryReview, ActionSuppress, ActionDebugOnly:
+		return true
+	default:
+		return false
+	}
+}
+
+func ValidConfidence(value string) bool {
+	switch strings.TrimSpace(value) {
+	case ConfidenceHigh, ConfidenceMedium, ConfidenceLow:
+		return true
+	default:
+		return false
+	}
+}
+
+type builder struct {
+	findingsByLocation map[string][]model.Finding
+	toolByLocation     map[string]agginventory.Tool
+	locationByKey      map[string]agginventory.ToolLocation
+	writeByLocation    map[string]bool
+	itemsByKey         map[string]Item
+}
+
+func newBuilder(input Input) *builder {
+	b := &builder{
+		findingsByLocation: map[string][]model.Finding{},
+		toolByLocation:     map[string]agginventory.Tool{},
+		locationByKey:      map[string]agginventory.ToolLocation{},
+		writeByLocation:    map[string]bool{},
+		itemsByKey:         map[string]Item{},
+	}
+	for _, finding := range input.Findings {
+		key := locationKey(finding.Org, finding.Repo, finding.Location)
+		b.findingsByLocation[key] = append(b.findingsByLocation[key], finding)
+		if findingWriteCapable(finding) {
+			b.writeByLocation[key] = true
+		}
+	}
+	if input.Inventory != nil {
+		for _, tool := range input.Inventory.Tools {
+			for _, loc := range tool.Locations {
+				key := locationKey(tool.Org, loc.Repo, loc.Location)
+				b.toolByLocation[key] = tool
+				b.locationByKey[key] = loc
+			}
+		}
+	}
+	return b
+}
+
+func (b *builder) addActionPath(path risk.ActionPath) {
+	item := Item{
+		ID:                 backlogID("action_path", path.Org, path.Repo, path.Location, path.PathID),
+		Repo:               strings.TrimSpace(path.Repo),
+		Path:               strings.TrimSpace(path.Location),
+		ControlSurfaceType: controlSurfaceType(path.ToolType, path.Location, path.CredentialAccess, false),
+		ControlPathType:    controlPathType(path.ToolType, path.Location, path.CredentialAccess, false),
+		Capabilities:       capabilitiesFromActionPath(path),
+		Owner:              strings.TrimSpace(path.OperationalOwner),
+		OwnerSource:        strings.TrimSpace(path.OwnerSource),
+		OwnershipStatus:    strings.TrimSpace(path.OwnershipStatus),
+		EvidenceSource:     "risk_action_path",
+		EvidenceBasis:      evidenceBasisFromActionPath(path),
+		ApprovalStatus:     approvalStatus(path.ApprovalGap, path.SecurityVisibilityStatus),
+		SecurityVisibility: fallback(path.SecurityVisibilityStatus, agginventory.SecurityVisibilityUnknownToSecurity),
+		SignalClass:        SignalClassUniqueWrkrSignal,
+		RecommendedAction:  actionFromActionPath(path.RecommendedAction, path),
+		LinkedActionPathID: path.PathID,
+	}
+	item.LinkedFindingIDs = b.linkedFindingIDs(path.Org, path.Repo, path.Location)
+	item.SecretSignalTypes = secretSignalTypesForActionPath(path)
+	item.Capability = capabilitySummary(item.Capabilities)
+	item.Confidence, item.EvidenceGaps, item.ConfidenceRaise = qualityForItem(item)
+	item.SLA = slaForAction(item.RecommendedAction)
+	item.ClosureCriteria = closureCriteriaForAction(item.RecommendedAction)
+	b.merge(item)
+}
+
+func (b *builder) addFinding(finding model.Finding, mode string) {
+	if !includeFinding(finding, mode) {
+		return
+	}
+	key := locationKey(finding.Org, finding.Repo, finding.Location)
+	tool := b.toolByLocation[key]
+	loc := b.locationByKey[key]
+	writeCapable := b.writeByLocation[key]
+	isSecret := isSecretFinding(finding)
+	item := Item{
+		ID:                 backlogID("finding", finding.Org, finding.Repo, finding.Location, finding.FindingType, finding.RuleID, finding.Detector),
+		Repo:               strings.TrimSpace(finding.Repo),
+		Path:               strings.TrimSpace(finding.Location),
+		ControlSurfaceType: controlSurfaceType(finding.ToolType, finding.Location, writeCapable, isSecret),
+		ControlPathType:    controlPathType(finding.ToolType, finding.Location, writeCapable, isSecret),
+		Capabilities:       capabilitiesFromFinding(finding, writeCapable),
+		Owner:              strings.TrimSpace(loc.Owner),
+		OwnerSource:        strings.TrimSpace(loc.OwnerSource),
+		OwnershipStatus:    strings.TrimSpace(loc.OwnershipStatus),
+		EvidenceSource:     evidenceSourceForFinding(finding),
+		EvidenceBasis:      evidenceBasisForFinding(finding),
+		ApprovalStatus:     fallback(tool.ApprovalClass, "unknown"),
+		SecurityVisibility: fallback(tool.SecurityVisibilityStatus, agginventory.SecurityVisibilityUnknownToSecurity),
+		SignalClass:        signalClassForFinding(finding, writeCapable),
+		RecommendedAction:  actionForFinding(finding, writeCapable),
+		LinkedFindingIDs:   []string{findingID(finding)},
+		SecretSignalTypes:  secretSignalTypesForFinding(finding, writeCapable),
+	}
+	item.Capability = capabilitySummary(item.Capabilities)
+	item.Confidence, item.EvidenceGaps, item.ConfidenceRaise = qualityForItem(item)
+	item.SLA = slaForAction(item.RecommendedAction)
+	item.ClosureCriteria = closureCriteriaForAction(item.RecommendedAction)
+	b.merge(item)
+}
+
+func (b *builder) merge(item Item) {
+	if strings.TrimSpace(item.Path) == "" && strings.TrimSpace(item.Repo) == "" {
+		return
+	}
+	key := mergeKey(item)
+	current, exists := b.itemsByKey[key]
+	if !exists {
+		b.itemsByKey[key] = normalizeItem(item)
+		return
+	}
+	current.Capabilities = mergeStrings(current.Capabilities, item.Capabilities)
+	current.Capability = capabilitySummary(current.Capabilities)
+	current.EvidenceBasis = mergeStrings(current.EvidenceBasis, item.EvidenceBasis)
+	current.EvidenceGaps = mergeStrings(current.EvidenceGaps, item.EvidenceGaps)
+	current.ConfidenceRaise = mergeStrings(current.ConfidenceRaise, item.ConfidenceRaise)
+	current.SecretSignalTypes = mergeStrings(current.SecretSignalTypes, item.SecretSignalTypes)
+	current.LinkedFindingIDs = mergeStrings(current.LinkedFindingIDs, item.LinkedFindingIDs)
+	if actionPriority(item.RecommendedAction) < actionPriority(current.RecommendedAction) {
+		current.RecommendedAction = item.RecommendedAction
+		current.SLA = slaForAction(item.RecommendedAction)
+		current.ClosureCriteria = closureCriteriaForAction(item.RecommendedAction)
+	}
+	if signalPriority(item.SignalClass) < signalPriority(current.SignalClass) {
+		current.SignalClass = item.SignalClass
+	}
+	if confidencePriority(item.Confidence) < confidencePriority(current.Confidence) {
+		current.Confidence = item.Confidence
+	}
+	if current.Owner == "" {
+		current.Owner = item.Owner
+		current.OwnerSource = item.OwnerSource
+		current.OwnershipStatus = item.OwnershipStatus
+	}
+	if current.LinkedActionPathID == "" {
+		current.LinkedActionPathID = item.LinkedActionPathID
+	}
+	b.itemsByKey[key] = normalizeItem(current)
+}
+
+func (b *builder) items() []Item {
+	items := make([]Item, 0, len(b.itemsByKey))
+	for _, item := range b.itemsByKey {
+		items = append(items, normalizeItem(item))
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if signalPriority(items[i].SignalClass) != signalPriority(items[j].SignalClass) {
+			return signalPriority(items[i].SignalClass) < signalPriority(items[j].SignalClass)
+		}
+		if actionPriority(items[i].RecommendedAction) != actionPriority(items[j].RecommendedAction) {
+			return actionPriority(items[i].RecommendedAction) < actionPriority(items[j].RecommendedAction)
+		}
+		if confidencePriority(items[i].Confidence) != confidencePriority(items[j].Confidence) {
+			return confidencePriority(items[i].Confidence) < confidencePriority(items[j].Confidence)
+		}
+		if items[i].Repo != items[j].Repo {
+			return items[i].Repo < items[j].Repo
+		}
+		if items[i].Path != items[j].Path {
+			return items[i].Path < items[j].Path
+		}
+		if items[i].ControlPathType != items[j].ControlPathType {
+			return items[i].ControlPathType < items[j].ControlPathType
+		}
+		return items[i].ID < items[j].ID
+	})
+	return items
+}
+
+func summarize(items []Item) Summary {
+	summary := Summary{TotalItems: len(items)}
+	for _, item := range items {
+		switch item.SignalClass {
+		case SignalClassUniqueWrkrSignal:
+			summary.UniqueWrkrSignalItems++
+		case SignalClassSupportingSecurity:
+			summary.SupportingSecurityItems++
+		}
+		switch item.RecommendedAction {
+		case ActionAttachEvidence:
+			summary.AttachEvidenceActionItems++
+		case ActionApprove:
+			summary.ApproveActionItems++
+		case ActionRemediate:
+			summary.RemediateActionItems++
+		}
+	}
+	return summary
+}
+
+func includeFinding(finding model.Finding, mode string) bool {
+	if strings.TrimSpace(mode) != "deep" && findingGeneratedPath(finding) {
+		return false
+	}
+	switch strings.TrimSpace(finding.FindingType) {
+	case "", "policy_check", "source_discovery":
+		return false
+	default:
+		return true
+	}
+}
+
+func parseErrorPath(finding model.Finding) string {
+	if finding.ParseError == nil {
+		return ""
+	}
+	return finding.ParseError.Path
+}
+
+func findingGeneratedPath(finding model.Finding) bool {
+	return detect.IsGeneratedPath(finding.Location) || detect.IsGeneratedPath(parseErrorPath(finding))
+}
+
+func controlSurfaceType(toolType, location string, writeCapable bool, secret bool) string {
+	tool := strings.ToLower(strings.TrimSpace(toolType))
+	loc := strings.ToLower(strings.TrimSpace(location))
+	switch {
+	case secret && (writeCapable || strings.Contains(loc, ".github/workflows") || strings.Contains(loc, "jenkinsfile")):
+		return ControlSurfaceSecretWorkflow
+	case strings.Contains(loc, ".github/workflows") || strings.Contains(loc, "jenkinsfile") || tool == "ci_agent":
+		if strings.Contains(loc, "release") || strings.Contains(loc, "deploy") {
+			return ControlSurfaceReleaseAutomation
+		}
+		return ControlSurfaceCIAutomation
+	case tool == "mcp" || strings.Contains(tool, "mcp"):
+		return ControlSurfaceMCPServerTool
+	case tool == "dependency" || strings.Contains(tool, "dependency"):
+		return ControlSurfaceDependencyAgent
+	case tool == "non_human_identity":
+		return ControlSurfaceNonHumanIdentity
+	case tool == "claude" || tool == "cursor" || tool == "codex" || tool == "copilot" || strings.Contains(loc, ".claude") || strings.Contains(loc, ".cursor") || strings.Contains(loc, ".codex") || strings.Contains(loc, "agents.md"):
+		return ControlSurfaceCodingAssistant
+	default:
+		return ControlSurfaceAIAgent
+	}
+}
+
+func controlPathType(toolType, location string, writeCapable bool, secret bool) string {
+	surface := controlSurfaceType(toolType, location, writeCapable, secret)
+	switch surface {
+	case ControlSurfaceSecretWorkflow:
+		return ControlPathSecretWorkflow
+	case ControlSurfaceMCPServerTool:
+		return ControlPathMCPTool
+	case ControlSurfaceCIAutomation:
+		return ControlPathCIAutomation
+	case ControlSurfaceReleaseAutomation:
+		return ControlPathReleaseWorkflow
+	case ControlSurfaceDependencyAgent:
+		return ControlPathDependencyAgent
+	default:
+		return ControlPathAgentConfig
+	}
+}
+
+func capabilitiesFromActionPath(path risk.ActionPath) []string {
+	values := make([]string, 0)
+	if path.PullRequestWrite {
+		values = append(values, "pr_write")
+	}
+	if path.MergeExecute {
+		values = append(values, "repo_write")
+	}
+	if path.DeployWrite {
+		values = append(values, "deploy")
+	}
+	if path.ProductionWrite {
+		values = append(values, "production_write")
+	}
+	if path.WriteCapable {
+		values = append(values, "write")
+	}
+	if path.CredentialAccess {
+		values = append(values, "secret_access")
+	}
+	return mergeStrings(values, nil)
+}
+
+func capabilitiesFromFinding(finding model.Finding, writeCapable bool) []string {
+	values := make([]string, 0)
+	if writeCapable {
+		values = append(values, "write")
+	}
+	for _, permission := range finding.Permissions {
+		normalized := strings.ToLower(strings.TrimSpace(permission))
+		switch {
+		case normalized == "pull_request.write":
+			values = append(values, "pr_write")
+		case normalized == "repo.write" || normalized == "filesystem.write":
+			values = append(values, "repo_write")
+		case normalized == "deploy.write":
+			values = append(values, "deploy")
+		case normalized == "iac.write":
+			values = append(values, "infra_write")
+		case normalized == "secret.read" || strings.Contains(normalized, "secret"):
+			values = append(values, "secret_access")
+		case normalized == "proc.exec" || normalized == "headless.execute":
+			values = append(values, "execution")
+		case strings.Contains(normalized, ".read"):
+			values = append(values, "read")
+		}
+	}
+	if isSecretFinding(finding) {
+		values = append(values, "secret_access")
+	}
+	if len(values) == 0 {
+		values = append(values, "read")
+	}
+	return mergeStrings(values, nil)
+}
+
+func evidenceBasisFromActionPath(path risk.ActionPath) []string {
+	basis := []string{"risk_action_path"}
+	if path.PullRequestWrite || path.WriteCapable {
+		basis = append(basis, "workflow_permission")
+	}
+	if path.CredentialAccess {
+		basis = append(basis, "secret_reference")
+	}
+	if path.OwnerSource != "" {
+		basis = append(basis, path.OwnerSource)
+	}
+	return mergeStrings(basis, nil)
+}
+
+func evidenceBasisForFinding(finding model.Finding) []string {
+	basis := make([]string, 0)
+	switch {
+	case finding.ParseError != nil:
+		basis = append(basis, "parse_error")
+	case strings.Contains(strings.ToLower(finding.Location), ".github/workflows"):
+		basis = append(basis, "workflow_permission")
+	case isSecretFinding(finding):
+		basis = append(basis, "secret_reference")
+	case strings.TrimSpace(finding.Detector) != "":
+		basis = append(basis, "direct_config")
+	default:
+		basis = append(basis, "static_finding")
+	}
+	for _, evidence := range finding.Evidence {
+		key := strings.TrimSpace(evidence.Key)
+		if key != "" {
+			basis = append(basis, key)
+		}
+	}
+	return mergeStrings(basis, nil)
+}
+
+func evidenceSourceForFinding(finding model.Finding) string {
+	switch {
+	case finding.ParseError != nil:
+		return "parse_error"
+	case isSecretFinding(finding):
+		return "secret_reference"
+	case strings.TrimSpace(finding.Detector) != "":
+		return strings.TrimSpace(finding.Detector)
+	default:
+		return "static_analysis"
+	}
+}
+
+func signalClassForFinding(finding model.Finding, writeCapable bool) string {
+	if finding.ParseError != nil || detect.IsGeneratedPath(finding.Location) {
+		return SignalClassSupportingSecurity
+	}
+	if isSecretFinding(finding) {
+		if writeCapable {
+			return SignalClassUniqueWrkrSignal
+		}
+		return SignalClassSupportingSecurity
+	}
+	switch strings.TrimSpace(finding.FindingType) {
+	case "secret_presence", "dependency_manifest", "dependency_signal", "parse_error":
+		return SignalClassSupportingSecurity
+	default:
+		return SignalClassUniqueWrkrSignal
+	}
+}
+
+func actionForFinding(finding model.Finding, writeCapable bool) string {
+	if finding.ParseError != nil {
+		if detect.IsGeneratedPath(finding.Location) {
+			return ActionSuppress
+		}
+		return ActionDebugOnly
+	}
+	if isSecretFinding(finding) {
+		if hasSecretValueEvidence(finding) {
+			return ActionRemediate
+		}
+		return ActionAttachEvidence
+	}
+	if detect.IsGeneratedPath(finding.Location) {
+		return ActionInventoryReview
+	}
+	switch strings.TrimSpace(finding.FindingType) {
+	case "policy_violation", "skill_policy_conflict":
+		return ActionRemediate
+	case "dependency_manifest", "dependency_signal":
+		return ActionInventoryReview
+	}
+	if writeCapable {
+		return ActionApprove
+	}
+	return ActionAttachEvidence
+}
+
+func actionFromActionPath(action string, path risk.ActionPath) string {
+	switch strings.TrimSpace(action) {
+	case "control":
+		if path.CredentialAccess && !path.ProductionWrite {
+			return ActionAttachEvidence
+		}
+		return ActionRemediate
+	case "approval":
+		return ActionApprove
+	case "proof":
+		return ActionAttachEvidence
+	case "inventory":
+		return ActionInventoryReview
+	default:
+		if path.ApprovalGap {
+			return ActionApprove
+		}
+		return ActionAttachEvidence
+	}
+}
+
+func secretSignalTypesForActionPath(path risk.ActionPath) []string {
+	if !path.CredentialAccess {
+		return nil
+	}
+	values := []string{SecretReferenceDetected, SecretScopeUnknown, SecretRotationEvidenceMissing}
+	if path.WriteCapable || path.PullRequestWrite || path.DeployWrite || path.MergeExecute {
+		values = append(values, SecretUsedByWriteCapableWorkflow)
+	}
+	if strings.TrimSpace(path.OperationalOwner) == "" || strings.TrimSpace(path.OwnershipStatus) == "unresolved" {
+		values = append(values, SecretOwnerMissing)
+	}
+	return mergeStrings(values, nil)
+}
+
+func secretSignalTypesForFinding(finding model.Finding, writeCapable bool) []string {
+	if !isSecretFinding(finding) {
+		return nil
+	}
+	values := []string{SecretReferenceDetected, SecretScopeUnknown, SecretRotationEvidenceMissing}
+	if hasSecretValueEvidence(finding) {
+		values = append(values, SecretValueDetected)
+	}
+	if writeCapable {
+		values = append(values, SecretUsedByWriteCapableWorkflow)
+	}
+	return mergeStrings(values, nil)
+}
+
+func qualityForItem(item Item) (string, []string, []string) {
+	gaps := make([]string, 0)
+	raise := make([]string, 0)
+	confidence := ConfidenceHigh
+	switch {
+	case strings.TrimSpace(item.Owner) == "":
+		gaps = append(gaps, "owner_missing")
+		raise = append(raise, "add CODEOWNERS or service ownership record")
+		confidence = ConfidenceLow
+	case strings.TrimSpace(item.OwnershipStatus) == "unresolved":
+		gaps = append(gaps, "owner_missing")
+		raise = append(raise, "add CODEOWNERS or service ownership record")
+		confidence = ConfidenceLow
+	case strings.TrimSpace(item.OwnershipStatus) == "inferred" || strings.TrimSpace(item.OwnerSource) == "repo_fallback":
+		gaps = append(gaps, "explicit_owner_evidence_missing")
+		raise = append(raise, "replace fallback owner with CODEOWNERS or service catalog evidence")
+		confidence = ConfidenceMedium
+	}
+	if strings.TrimSpace(item.ApprovalStatus) == "" || strings.TrimSpace(item.ApprovalStatus) == "unknown" || strings.TrimSpace(item.ApprovalStatus) == "unapproved" {
+		gaps = append(gaps, "approval_evidence_missing")
+		raise = append(raise, "attach an approval record with owner and expiry")
+		if confidence == ConfidenceHigh {
+			confidence = ConfidenceMedium
+		}
+	}
+	if len(item.SecretSignalTypes) > 0 {
+		gaps = append(gaps, "secret_scope_evidence_missing", "secret_rotation_evidence_missing")
+		raise = append(raise, "attach secret scope and rotation evidence")
+	}
+	if item.RecommendedAction == ActionDebugOnly || item.RecommendedAction == ActionSuppress {
+		confidence = ConfidenceLow
+	}
+	return confidence, mergeStrings(gaps, nil), mergeStrings(raise, nil)
+}
+
+func approvalStatus(approvalGap bool, visibility string) string {
+	if approvalGap {
+		return "unapproved"
+	}
+	if strings.TrimSpace(visibility) == agginventory.SecurityVisibilityApproved {
+		return "approved"
+	}
+	return "unknown"
+}
+
+func findingWriteCapable(finding model.Finding) bool {
+	for _, permission := range finding.Permissions {
+		normalized := strings.ToLower(strings.TrimSpace(permission))
+		if strings.Contains(normalized, ".write") ||
+			strings.Contains(normalized, "write") ||
+			strings.Contains(normalized, "deploy") ||
+			strings.Contains(normalized, "exec") {
+			return true
+		}
+	}
+	return false
+}
+
+func isSecretFinding(finding model.Finding) bool {
+	if strings.TrimSpace(finding.FindingType) == "secret_presence" {
+		return true
+	}
+	for _, evidence := range finding.Evidence {
+		key := strings.ToLower(strings.TrimSpace(evidence.Key))
+		if strings.Contains(key, "secret") || strings.Contains(key, "credential") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSecretValueEvidence(finding model.Finding) bool {
+	for _, evidence := range finding.Evidence {
+		key := strings.ToLower(strings.TrimSpace(evidence.Key))
+		value := strings.ToLower(strings.TrimSpace(evidence.Value))
+		if key == "secret_value_detected" && value == "true" {
+			return true
+		}
+		if key == "value_redacted" && value != "true" {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *builder) linkedFindingIDs(org, repo, location string) []string {
+	findings := b.findingsByLocation[locationKey(org, repo, location)]
+	ids := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		ids = append(ids, findingID(finding))
+	}
+	return mergeStrings(ids, nil)
+}
+
+func locationKey(org, repo, location string) string {
+	return strings.Join([]string{strings.TrimSpace(org), strings.TrimSpace(repo), strings.TrimSpace(location)}, "|")
+}
+
+func mergeKey(item Item) string {
+	return strings.Join([]string{item.Repo, item.Path, item.ControlPathType, item.SignalClass}, "|")
+}
+
+func backlogID(parts ...string) string {
+	joined := strings.Join(parts, "|")
+	sum := sha256.Sum256([]byte(joined))
+	return "cb-" + hex.EncodeToString(sum[:6])
+}
+
+func findingID(finding model.Finding) string {
+	parts := []string{
+		finding.Org,
+		finding.Repo,
+		finding.Location,
+		finding.FindingType,
+		finding.RuleID,
+		finding.ToolType,
+		finding.Detector,
+	}
+	return backlogID(parts...)
+}
+
+func normalizeItem(item Item) Item {
+	item.Repo = strings.TrimSpace(item.Repo)
+	item.Path = strings.TrimSpace(item.Path)
+	item.ControlSurfaceType = fallback(item.ControlSurfaceType, ControlSurfaceAIAgent)
+	item.ControlPathType = fallback(item.ControlPathType, ControlPathAgentConfig)
+	item.Capabilities = mergeStrings(item.Capabilities, nil)
+	item.Capability = capabilitySummary(item.Capabilities)
+	item.EvidenceBasis = mergeStrings(item.EvidenceBasis, nil)
+	item.ApprovalStatus = fallback(item.ApprovalStatus, "unknown")
+	item.SecurityVisibility = fallback(item.SecurityVisibility, agginventory.SecurityVisibilityUnknownToSecurity)
+	if !ValidSignalClass(item.SignalClass) {
+		item.SignalClass = SignalClassSupportingSecurity
+	}
+	if !ValidRecommendedAction(item.RecommendedAction) {
+		item.RecommendedAction = ActionAttachEvidence
+	}
+	if !ValidConfidence(item.Confidence) {
+		item.Confidence = ConfidenceMedium
+	}
+	item.SLA = fallback(item.SLA, slaForAction(item.RecommendedAction))
+	item.ClosureCriteria = fallback(item.ClosureCriteria, closureCriteriaForAction(item.RecommendedAction))
+	item.EvidenceGaps = mergeStrings(item.EvidenceGaps, nil)
+	item.ConfidenceRaise = mergeStrings(item.ConfidenceRaise, nil)
+	item.SecretSignalTypes = mergeStrings(item.SecretSignalTypes, nil)
+	item.LinkedFindingIDs = mergeStrings(item.LinkedFindingIDs, nil)
+	return item
+}
+
+func capabilitySummary(values []string) string {
+	values = mergeStrings(values, nil)
+	if len(values) == 0 {
+		return "read"
+	}
+	return strings.Join(values, " + ")
+}
+
+func slaForAction(action string) string {
+	switch action {
+	case ActionRemediate:
+		return "7d"
+	case ActionAttachEvidence, ActionApprove:
+		return "14d"
+	case ActionInventoryReview, ActionDowngrade, ActionDeprecate, ActionMonitor:
+		return "30d"
+	default:
+		return "none"
+	}
+}
+
+func closureCriteriaForAction(action string) string {
+	switch action {
+	case ActionAttachEvidence:
+		return "Attach owner, scope, approval, and proof evidence for this control path."
+	case ActionApprove:
+		return "Record owner-approved, time-bounded approval evidence and rescan."
+	case ActionRemediate:
+		return "Remove or reduce the unsafe control path and rescan until the backlog item closes."
+	case ActionInventoryReview:
+		return "Confirm owner, scope, production relevance, and whether to approve, deprecate, or exclude."
+	case ActionSuppress:
+		return "Confirm generated or out-of-scope evidence and keep it in scan quality, not active backlog."
+	case ActionDebugOnly:
+		return "Review parser/debug context and fix only if it affects control-path visibility."
+	case ActionDowngrade:
+		return "Document non-production or low-criticality context and rescan."
+	case ActionDeprecate:
+		return "Record deprecation reason and confirm the path no longer executes."
+	case ActionExclude:
+		return "Record false-positive or out-of-scope rationale with review owner."
+	default:
+		return "Monitor for drift and rescan on owner, approval, or capability change."
+	}
+}
+
+func signalPriority(value string) int {
+	if value == SignalClassUniqueWrkrSignal {
+		return 0
+	}
+	return 1
+}
+
+func actionPriority(value string) int {
+	switch value {
+	case ActionRemediate:
+		return 0
+	case ActionAttachEvidence:
+		return 1
+	case ActionApprove:
+		return 2
+	case ActionInventoryReview:
+		return 3
+	case ActionMonitor:
+		return 4
+	case ActionDowngrade, ActionDeprecate:
+		return 5
+	case ActionExclude, ActionSuppress:
+		return 6
+	case ActionDebugOnly:
+		return 7
+	default:
+		return 99
+	}
+}
+
+func confidencePriority(value string) int {
+	switch value {
+	case ConfidenceHigh:
+		return 0
+	case ConfidenceMedium:
+		return 1
+	default:
+		return 2
+	}
+}
+
+func mergeStrings(a, b []string) []string {
+	set := map[string]struct{}{}
+	for _, values := range [][]string{a, b} {
+		for _, value := range values {
+			trimmed := strings.TrimSpace(value)
+			if trimmed == "" {
+				continue
+			}
+			set[trimmed] = struct{}{}
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func fallback(value, fallbackValue string) string {
+	if strings.TrimSpace(value) != "" {
+		return strings.TrimSpace(value)
+	}
+	return strings.TrimSpace(fallbackValue)
+}

--- a/core/aggregate/controlbacklog/controlbacklog_test.go
+++ b/core/aggregate/controlbacklog/controlbacklog_test.go
@@ -1,0 +1,240 @@
+package controlbacklog
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/risk"
+)
+
+func TestBuildControlBacklogSplitsSignalClassesAndSortsDeterministically(t *testing.T) {
+	t.Parallel()
+
+	findings := []model.Finding{
+		{
+			FindingType: "dependency_manifest",
+			Severity:    model.SeverityLow,
+			ToolType:    "dependency",
+			Location:    "package.json",
+			Repo:        "app",
+			Org:         "acme",
+			Detector:    "dependency",
+		},
+		{
+			FindingType: "mcp_server",
+			Severity:    model.SeverityMedium,
+			ToolType:    "mcp",
+			Location:    ".cursor/mcp.json",
+			Repo:        "app",
+			Org:         "acme",
+			Detector:    "mcp",
+		},
+	}
+	inventory := &agginventory.Inventory{
+		Tools: []agginventory.Tool{
+			{
+				ToolID:                   "mcp:.cursor/mcp.json",
+				ToolType:                 "mcp",
+				Org:                      "acme",
+				ApprovalClass:            "unapproved",
+				SecurityVisibilityStatus: agginventory.SecurityVisibilityUnknownToSecurity,
+				Locations: []agginventory.ToolLocation{{
+					Repo:            "app",
+					Location:        ".cursor/mcp.json",
+					Owner:           "@acme/app",
+					OwnerSource:     "codeowners",
+					OwnershipStatus: "explicit",
+				}},
+			},
+			{
+				ToolID:                   "dependency:package.json",
+				ToolType:                 "dependency",
+				Org:                      "acme",
+				ApprovalClass:            "unknown",
+				SecurityVisibilityStatus: agginventory.SecurityVisibilityUnknownToSecurity,
+				Locations: []agginventory.ToolLocation{{
+					Repo:            "app",
+					Location:        "package.json",
+					Owner:           "@acme/app",
+					OwnerSource:     "repo_fallback",
+					OwnershipStatus: "inferred",
+				}},
+			},
+		},
+	}
+	actionPaths := []risk.ActionPath{{
+		PathID:                   "apc-test",
+		Org:                      "acme",
+		Repo:                     "app",
+		ToolType:                 "mcp",
+		Location:                 ".cursor/mcp.json",
+		WriteCapable:             true,
+		OperationalOwner:         "@acme/app",
+		OwnerSource:              "codeowners",
+		OwnershipStatus:          "explicit",
+		ApprovalGap:              true,
+		SecurityVisibilityStatus: agginventory.SecurityVisibilityUnknownToSecurity,
+		RecommendedAction:        "approval",
+		RiskScore:                7.2,
+	}}
+
+	first := Build(Input{Findings: findings, Inventory: inventory, ActionPaths: actionPaths})
+	second := Build(Input{Findings: append([]model.Finding(nil), findings...), Inventory: inventory, ActionPaths: append([]risk.ActionPath(nil), actionPaths...)})
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("expected deterministic backlog\nfirst=%+v\nsecond=%+v", first, second)
+	}
+	if first.ControlBacklogVersion != BacklogVersion {
+		t.Fatalf("unexpected backlog version: %s", first.ControlBacklogVersion)
+	}
+	if len(first.Items) < 2 {
+		t.Fatalf("expected at least two backlog items, got %+v", first.Items)
+	}
+	if first.Items[0].SignalClass != SignalClassUniqueWrkrSignal {
+		t.Fatalf("expected unique Wrkr signal first, got %+v", first.Items)
+	}
+	if first.Summary.UniqueWrkrSignalItems == 0 || first.Summary.SupportingSecurityItems == 0 {
+		t.Fatalf("expected split signal summary, got %+v", first.Summary)
+	}
+	if len(first.Items[0].LinkedFindingIDs) == 0 {
+		t.Fatalf("expected linked raw finding IDs, got %+v", first.Items[0])
+	}
+	if _, err := json.Marshal(first); err != nil {
+		t.Fatalf("marshal backlog: %v", err)
+	}
+}
+
+func TestRecommendedActionTaxonomyCoversKnownFindingFamilies(t *testing.T) {
+	t.Parallel()
+
+	for _, action := range []string{
+		ActionAttachEvidence,
+		ActionApprove,
+		ActionRemediate,
+		ActionDowngrade,
+		ActionDeprecate,
+		ActionExclude,
+		ActionMonitor,
+		ActionInventoryReview,
+		ActionSuppress,
+		ActionDebugOnly,
+	} {
+		if !ValidRecommendedAction(action) {
+			t.Fatalf("expected valid action %s", action)
+		}
+	}
+	if ValidRecommendedAction("control") {
+		t.Fatal("legacy action-path action must not be a backlog action")
+	}
+
+	backlog := Build(Input{Mode: "deep", Findings: []model.Finding{
+		{FindingType: "parse_error", ToolType: "dependency", Location: "dist/generated.js", Repo: "app", Org: "acme", ParseError: &model.ParseError{Kind: "parse_error", Path: "dist/generated.js"}},
+		{FindingType: "dependency_manifest", ToolType: "dependency", Location: "package.json", Repo: "app", Org: "acme"},
+		{FindingType: "policy_violation", ToolType: "policy", Location: "WRKR-004", Repo: "app", Org: "acme"},
+	}})
+	seen := map[string]bool{}
+	for _, item := range backlog.Items {
+		seen[item.RecommendedAction] = true
+	}
+	for _, want := range []string{ActionSuppress, ActionInventoryReview, ActionRemediate} {
+		if !seen[want] {
+			t.Fatalf("expected action %s in %+v", want, backlog.Items)
+		}
+	}
+}
+
+func TestEvidenceQualityExplainsOwnerFallbackConfidence(t *testing.T) {
+	t.Parallel()
+
+	backlog := Build(Input{
+		Findings: []model.Finding{{
+			FindingType: "mcp_server",
+			ToolType:    "mcp",
+			Location:    ".mcp.json",
+			Repo:        "payments-api",
+			Org:         "acme",
+		}},
+		Inventory: &agginventory.Inventory{Tools: []agginventory.Tool{{
+			ToolType:                 "mcp",
+			Org:                      "acme",
+			ApprovalClass:            "unapproved",
+			SecurityVisibilityStatus: agginventory.SecurityVisibilityUnknownToSecurity,
+			Locations: []agginventory.ToolLocation{{
+				Repo:            "payments-api",
+				Location:        ".mcp.json",
+				Owner:           "@acme/payments",
+				OwnerSource:     "repo_fallback",
+				OwnershipStatus: "inferred",
+			}},
+		}}},
+	})
+	if len(backlog.Items) != 1 {
+		t.Fatalf("expected one item, got %+v", backlog.Items)
+	}
+	item := backlog.Items[0]
+	if item.Confidence != ConfidenceMedium {
+		t.Fatalf("expected medium confidence from fallback owner, got %+v", item)
+	}
+	if !contains(item.EvidenceGaps, "explicit_owner_evidence_missing") {
+		t.Fatalf("expected owner evidence gap, got %+v", item.EvidenceGaps)
+	}
+	if len(item.ConfidenceRaise) == 0 {
+		t.Fatalf("expected confidence raising guidance, got %+v", item)
+	}
+}
+
+func TestWorkflowSecretReferenceDoesNotClaimLeakedSecret(t *testing.T) {
+	t.Parallel()
+
+	backlog := Build(Input{Findings: []model.Finding{
+		{
+			FindingType: "ci_autonomy",
+			ToolType:    "ci_agent",
+			Location:    ".github/workflows/pr.yml",
+			Repo:        "app",
+			Org:         "acme",
+			Permissions: []string{"pull_request.write", "secret.read"},
+		},
+		{
+			FindingType: "secret_presence",
+			ToolType:    "secret",
+			Location:    ".github/workflows/pr.yml",
+			Repo:        "app",
+			Org:         "acme",
+			Evidence:    []model.Evidence{{Key: "workflow_secret_refs", Value: "GH_TOKEN"}},
+		},
+	}})
+	var secretItem *Item
+	for idx := range backlog.Items {
+		if backlog.Items[idx].ControlPathType == ControlPathSecretWorkflow {
+			secretItem = &backlog.Items[idx]
+			break
+		}
+	}
+	if secretItem == nil {
+		t.Fatalf("expected secret-bearing workflow item, got %+v", backlog.Items)
+	}
+	if !contains(secretItem.SecretSignalTypes, SecretReferenceDetected) {
+		t.Fatalf("expected secret reference signal, got %+v", secretItem.SecretSignalTypes)
+	}
+	if contains(secretItem.SecretSignalTypes, SecretValueDetected) {
+		t.Fatalf("did not expect secret value signal, got %+v", secretItem.SecretSignalTypes)
+	}
+	if !contains(secretItem.SecretSignalTypes, SecretUsedByWriteCapableWorkflow) {
+		t.Fatalf("expected write-capable workflow signal, got %+v", secretItem.SecretSignalTypes)
+	}
+	if secretItem.RecommendedAction != ActionAttachEvidence {
+		t.Fatalf("expected attach_evidence, got %+v", secretItem)
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/core/aggregate/scanquality/scanquality.go
+++ b/core/aggregate/scanquality/scanquality.go
@@ -1,0 +1,200 @@
+package scanquality
+
+import (
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Clyra-AI/wrkr/core/detect"
+	"github.com/Clyra-AI/wrkr/core/model"
+)
+
+const ReportVersion = "1"
+
+type Report struct {
+	ScanQualityVersion string                 `json:"scan_quality_version"`
+	Mode               string                 `json:"mode"`
+	SuppressedPaths    []SuppressedPath       `json:"suppressed_paths,omitempty"`
+	ParseErrors        []ParseIssue           `json:"parse_errors,omitempty"`
+	DetectorErrors     []detect.DetectorError `json:"detector_errors,omitempty"`
+}
+
+type SuppressedPath struct {
+	Org    string `json:"org,omitempty"`
+	Repo   string `json:"repo,omitempty"`
+	Path   string `json:"path"`
+	Kind   string `json:"kind"`
+	Reason string `json:"reason"`
+}
+
+type ParseIssue struct {
+	Org               string `json:"org,omitempty"`
+	Repo              string `json:"repo,omitempty"`
+	Path              string `json:"path"`
+	Detector          string `json:"detector,omitempty"`
+	Kind              string `json:"kind"`
+	Format            string `json:"format,omitempty"`
+	Message           string `json:"message,omitempty"`
+	Reason            string `json:"reason,omitempty"`
+	RecommendedAction string `json:"recommended_action,omitempty"`
+}
+
+type Input struct {
+	Mode           string
+	Scopes         []detect.Scope
+	Findings       []model.Finding
+	DetectorErrors []detect.DetectorError
+}
+
+func Build(input Input) Report {
+	report := Report{
+		ScanQualityVersion: ReportVersion,
+		Mode:               normalizeMode(input.Mode),
+		DetectorErrors:     cloneDetectorErrors(input.DetectorErrors),
+	}
+	if report.Mode != "deep" {
+		report.SuppressedPaths = collectSuppressedPaths(input.Scopes)
+	}
+	report.ParseErrors = collectParseIssues(input.Findings)
+	return report
+}
+
+func collectSuppressedPaths(scopes []detect.Scope) []SuppressedPath {
+	items := make([]SuppressedPath, 0)
+	seen := map[string]struct{}{}
+	for _, scope := range scopes {
+		root := strings.TrimSpace(scope.Root)
+		if root == "" {
+			continue
+		}
+		_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return nil
+			}
+			rel, relErr := filepath.Rel(root, path)
+			if relErr != nil {
+				return nil
+			}
+			rel = filepath.ToSlash(rel)
+			if rel == "." || rel == "" {
+				return nil
+			}
+			if !detect.IsGeneratedPath(rel) {
+				return nil
+			}
+			kind := "file"
+			if d != nil && d.IsDir() {
+				kind = "directory"
+			}
+			key := strings.Join([]string{scope.Org, scope.Repo, rel, kind}, "|")
+			if _, exists := seen[key]; !exists {
+				seen[key] = struct{}{}
+				items = append(items, SuppressedPath{
+					Org:    strings.TrimSpace(scope.Org),
+					Repo:   strings.TrimSpace(scope.Repo),
+					Path:   rel,
+					Kind:   kind,
+					Reason: "generated_or_package_noise",
+				})
+			}
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Org != items[j].Org {
+			return items[i].Org < items[j].Org
+		}
+		if items[i].Repo != items[j].Repo {
+			return items[i].Repo < items[j].Repo
+		}
+		if items[i].Path != items[j].Path {
+			return items[i].Path < items[j].Path
+		}
+		return items[i].Kind < items[j].Kind
+	})
+	return items
+}
+
+func collectParseIssues(findings []model.Finding) []ParseIssue {
+	items := make([]ParseIssue, 0)
+	for _, finding := range findings {
+		if finding.ParseError == nil {
+			continue
+		}
+		reason := "detector_parse_error"
+		recommendedAction := "debug_only"
+		if detect.IsGeneratedPath(finding.Location) || detect.IsGeneratedPath(finding.ParseError.Path) {
+			reason = "generated_or_package_noise"
+			recommendedAction = "suppress"
+		}
+		items = append(items, ParseIssue{
+			Org:               strings.TrimSpace(finding.Org),
+			Repo:              strings.TrimSpace(finding.Repo),
+			Path:              firstNonEmpty(finding.ParseError.Path, finding.Location),
+			Detector:          strings.TrimSpace(finding.ParseError.Detector),
+			Kind:              strings.TrimSpace(finding.ParseError.Kind),
+			Format:            strings.TrimSpace(finding.ParseError.Format),
+			Message:           strings.TrimSpace(finding.ParseError.Message),
+			Reason:            reason,
+			RecommendedAction: recommendedAction,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Org != items[j].Org {
+			return items[i].Org < items[j].Org
+		}
+		if items[i].Repo != items[j].Repo {
+			return items[i].Repo < items[j].Repo
+		}
+		if items[i].Path != items[j].Path {
+			return items[i].Path < items[j].Path
+		}
+		if items[i].Detector != items[j].Detector {
+			return items[i].Detector < items[j].Detector
+		}
+		return items[i].Message < items[j].Message
+	})
+	return items
+}
+
+func cloneDetectorErrors(in []detect.DetectorError) []detect.DetectorError {
+	if len(in) == 0 {
+		return nil
+	}
+	out := append([]detect.DetectorError(nil), in...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Org != out[j].Org {
+			return out[i].Org < out[j].Org
+		}
+		if out[i].Repo != out[j].Repo {
+			return out[i].Repo < out[j].Repo
+		}
+		if out[i].Detector != out[j].Detector {
+			return out[i].Detector < out[j].Detector
+		}
+		return out[i].Message < out[j].Message
+	})
+	return out
+}
+
+func normalizeMode(mode string) string {
+	switch strings.TrimSpace(mode) {
+	case "quick", "deep":
+		return strings.TrimSpace(mode)
+	default:
+		return "governance"
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/core/aggregate/scanquality/scanquality_test.go
+++ b/core/aggregate/scanquality/scanquality_test.go
@@ -1,0 +1,65 @@
+package scanquality
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/detect"
+	"github.com/Clyra-AI/wrkr/core/model"
+)
+
+func TestBuildScanQualityReportsGeneratedSuppressionAndParseErrors(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "node_modules", "pkg"), 0o755); err != nil {
+		t.Fatalf("mkdir node_modules: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "node_modules", "pkg", "package.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write package: %v", err)
+	}
+
+	report := Build(Input{
+		Mode:   "governance",
+		Scopes: []detect.Scope{{Org: "acme", Repo: "app", Root: root}},
+		Findings: []model.Finding{{
+			FindingType: "parse_error",
+			Location:    "node_modules/pkg/package.json",
+			Repo:        "app",
+			Org:         "acme",
+			ParseError:  &model.ParseError{Kind: "parse_error", Path: "node_modules/pkg/package.json", Detector: "dependency", Message: "broken"},
+		}},
+	})
+	if report.ScanQualityVersion != ReportVersion {
+		t.Fatalf("unexpected version: %s", report.ScanQualityVersion)
+	}
+	if len(report.SuppressedPaths) == 0 {
+		t.Fatalf("expected suppressed generated/package path, got %+v", report)
+	}
+	if len(report.ParseErrors) != 1 || report.ParseErrors[0].Reason != "generated_or_package_noise" {
+		t.Fatalf("expected generated parse issue, got %+v", report.ParseErrors)
+	}
+	if report.ParseErrors[0].RecommendedAction != "suppress" {
+		t.Fatalf("expected suppress action for generated parse issue, got %+v", report.ParseErrors[0])
+	}
+}
+
+func TestDeepModeDoesNotReportSuppressedPathSet(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "dist"), 0o755); err != nil {
+		t.Fatalf("mkdir dist: %v", err)
+	}
+	report := Build(Input{
+		Mode:   "deep",
+		Scopes: []detect.Scope{{Repo: "app", Root: root}},
+	})
+	if report.Mode != "deep" {
+		t.Fatalf("expected deep mode, got %s", report.Mode)
+	}
+	if len(report.SuppressedPaths) != 0 {
+		t.Fatalf("deep mode should not report generated suppression as active, got %+v", report.SuppressedPaths)
+	}
+}

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -12,9 +12,11 @@ import (
 
 	"github.com/Clyra-AI/wrkr/core/aggregate/agentdeploy"
 	"github.com/Clyra-AI/wrkr/core/aggregate/agentresolver"
+	"github.com/Clyra-AI/wrkr/core/aggregate/controlbacklog"
 	aggexposure "github.com/Clyra-AI/wrkr/core/aggregate/exposure"
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/aggregate/privilegebudget"
+	"github.com/Clyra-AI/wrkr/core/aggregate/scanquality"
 	"github.com/Clyra-AI/wrkr/core/compliance"
 	"github.com/Clyra-AI/wrkr/core/config"
 	"github.com/Clyra-AI/wrkr/core/detect"
@@ -65,6 +67,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	var explicitTargets repeatedStringFlag
 	fs.Var(&explicitTargets, "target", "repeatable scan target <mode>:<value>")
 	timeout := fs.Duration("timeout", 0, "optional scan timeout (0 disables)")
+	scanModeRaw := fs.String("mode", "governance", "scan mode [quick|governance|deep]")
 	diffMode := fs.Bool("diff", false, "show only changes since previous scan")
 	enrich := fs.Bool("enrich", false, "enable non-deterministic enrichment lookups (network required)")
 	baselinePath := fs.String("baseline", "", "optional fallback baseline when local state is absent")
@@ -90,6 +93,10 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	}
 	if *timeout < 0 {
 		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", "--timeout must be >= 0", exitInvalidInput)
+	}
+	scanMode, scanModeErr := parseScanMode(*scanModeRaw)
+	if scanModeErr != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", scanModeErr.Error(), exitInvalidInput)
 	}
 	productionTargetsFile := strings.TrimSpace(*productionTargetsPath)
 	if *productionTargetsStrict && productionTargetsFile == "" {
@@ -197,12 +204,12 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	scopes := detectorScopes(manifestOut)
 	detectorErrors := []detect.DetectorError{}
 	if len(scopes) > 0 {
-		registry, regErr := detectdefaults.Registry()
+		registry, regErr := detectdefaults.RegistryForMode(scanMode)
 		if regErr != nil {
 			return emitScanFailure(regErr)
 		}
 		progress.ScanPhase(progressTargetMode, progressTargetValue, "detectors_start")
-		detected, runErr := registry.Run(ctx, scopes, detect.Options{Enrich: *enrich})
+		detected, runErr := registry.Run(ctx, scopes, detect.Options{Enrich: *enrich, ScanMode: scanMode})
 		if runErr != nil {
 			return emitScanFailure(runErr)
 		}
@@ -354,6 +361,18 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	if err := checkScanContext(); err != nil {
 		return emitScanFailure(err)
 	}
+	scanQuality := scanquality.Build(scanquality.Input{
+		Mode:           scanMode,
+		Scopes:         scopes,
+		Findings:       findings,
+		DetectorErrors: detectorErrors,
+	})
+	controlBacklog := controlbacklog.Build(controlbacklog.Input{
+		Mode:        scanMode,
+		Findings:    findings,
+		Inventory:   &inventoryOut,
+		ActionPaths: riskReport.ActionPaths,
+	})
 
 	weights, weightErr := score.LoadWeights(strings.TrimSpace(*policyPath), repoRootFromScopes(scopes))
 	if weightErr != nil {
@@ -377,16 +396,19 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	}
 
 	snapshot := state.Snapshot{
-		Version:      state.SnapshotVersion,
-		Target:       manifestOut.Target,
-		Targets:      manifestOut.Targets,
-		Findings:     findings,
-		Inventory:    &inventoryOut,
-		RiskReport:   &riskReport,
-		Profile:      &profileResult,
-		PostureScore: &postureScore,
-		Identities:   nextManifest.Identities,
-		Transitions:  transitions,
+		Version:        state.SnapshotVersion,
+		Target:         manifestOut.Target,
+		Targets:        manifestOut.Targets,
+		Findings:       findings,
+		Inventory:      &inventoryOut,
+		ControlBacklog: &controlBacklog,
+		ScanQuality:    &scanQuality,
+		ScanMode:       scanMode,
+		RiskReport:     &riskReport,
+		Profile:        &profileResult,
+		PostureScore:   &postureScore,
+		Identities:     nextManifest.Identities,
+		Transitions:    transitions,
 	}
 	chainPath := artifactPreflight.LifecyclePath
 	proofChainPath := artifactPreflight.ProofChainPath
@@ -472,6 +494,8 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		"status":          "ok",
 		"target":          manifestOut.Target,
 		"source_manifest": manifestOut,
+		"scan_mode":       scanMode,
+		"scan_quality":    scanQuality,
 	}
 	if len(manifestOut.Targets) > 0 {
 		payload["targets"] = manifestOut.Targets
@@ -503,6 +527,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		payload["diff_empty"] = diff.Empty(result)
 	} else {
 		payload["findings"] = findings
+		payload["control_backlog"] = controlBacklog
 		payload["ranked_findings"] = riskReport.Ranked
 		payload["top_findings"] = riskReport.TopN
 		payload["attack_paths"] = riskReport.AttackPaths
@@ -833,6 +858,19 @@ func scanRateLimitedMessage(err error) string {
 		return ""
 	}
 	return err.Error() + "; authenticate hosted scans with --github-token, config auth.scan.token, WRKR_GITHUB_TOKEN, or GITHUB_TOKEN; wait for the reported GitHub reset window before retrying"
+}
+
+func parseScanMode(raw string) (string, error) {
+	switch strings.TrimSpace(raw) {
+	case "", "governance":
+		return "governance", nil
+	case "quick":
+		return "quick", nil
+	case "deep":
+		return "deep", nil
+	default:
+		return "", fmt.Errorf("--mode must be one of quick, governance, or deep")
+	}
 }
 
 func hasIncompleteFilesystemVisibility(detectorErrors []detect.DetectorError, sourceFailures []source.RepoFailure) bool {

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -236,6 +236,9 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	if loadPreviousErr != nil {
 		return emitScanFailure(loadPreviousErr)
 	}
+	if *diffMode && previousSnapshot != nil && !scanModesCompatible(previousSnapshot.ScanMode, scanMode) {
+		return emitScanError("invalid_input", fmt.Sprintf("--diff requires matching scan modes: previous=%s current=%s", previousSnapshot.ScanMode, scanMode), exitInvalidInput)
+	}
 
 	now := time.Now().UTC().Truncate(time.Second)
 	scanMethodology := buildScanMethodology(manifestOut, findings, scanStartedAt, now)
@@ -871,6 +874,12 @@ func parseScanMode(raw string) (string, error) {
 	default:
 		return "", fmt.Errorf("--mode must be one of quick, governance, or deep")
 	}
+}
+
+func scanModesCompatible(previous, current string) bool {
+	previous = strings.TrimSpace(previous)
+	current = strings.TrimSpace(current)
+	return previous == "" || previous == current
 }
 
 func hasIncompleteFilesystemVisibility(detectorErrors []detect.DetectorError, sourceFailures []source.RepoFailure) bool {

--- a/core/cli/scan_control_backlog_test.go
+++ b/core/cli/scan_control_backlog_test.go
@@ -123,6 +123,34 @@ func TestScanModeGovernanceSuppressesGeneratedPathNoiseAndDeepKeepsDebugEvidence
 	}
 }
 
+func TestScanDiffRejectsMismatchedScanModes(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := filepath.Join(t.TempDir(), "app")
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, "AGENTS.md"), []byte("agent instructions\n"), 0o600); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	_ = runScanPayloadWithArgs(t, []string{"scan", "--path", repoRoot, "--mode", "deep", "--state", statePath, "--json"})
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{"scan", "--path", repoRoot, "--mode", "governance", "--state", statePath, "--diff", "--json"}, &out, &errOut)
+	if code != exitInvalidInput {
+		t.Fatalf("expected exit %d, got %d stdout=%q stderr=%q", exitInvalidInput, code, out.String(), errOut.String())
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected no stdout on invalid diff mode mismatch, got %q", out.String())
+	}
+	assertErrorEnvelopeCode(t, errOut.Bytes(), "invalid_input", exitInvalidInput)
+	if !bytes.Contains(errOut.Bytes(), []byte("requires matching scan modes")) {
+		t.Fatalf("expected scan mode mismatch message, got %s", errOut.String())
+	}
+}
+
 func runScanPayload(t *testing.T, repoRoot, statePath string) map[string]any {
 	t.Helper()
 

--- a/core/cli/scan_control_backlog_test.go
+++ b/core/cli/scan_control_backlog_test.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+func TestScanJSONRetainsLegacyFindingSurfacesWithControlBacklog(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := filepath.Join(t.TempDir(), "app")
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".codex"), 0o755); err != nil {
+		t.Fatalf("mkdir codex: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, ".codex", "config.toml"), []byte("approval_policy = \"never\"\n"), 0o600); err != nil {
+		t.Fatalf("write codex config: %v", err)
+	}
+
+	first := runScanPayload(t, repoRoot, filepath.Join(t.TempDir(), "state-a.json"))
+	second := runScanPayload(t, repoRoot, filepath.Join(t.TempDir(), "state-b.json"))
+
+	for _, key := range []string{"findings", "top_findings", "inventory", "control_backlog", "scan_quality"} {
+		if _, ok := first[key]; !ok {
+			t.Fatalf("expected key %s in scan payload: %v", key, first)
+		}
+	}
+	backlog, ok := first["control_backlog"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected control_backlog object, got %T", first["control_backlog"])
+	}
+	if backlog["control_backlog_version"] != "1" {
+		t.Fatalf("unexpected backlog version: %v", backlog["control_backlog_version"])
+	}
+	items, ok := backlog["items"].([]any)
+	if !ok || len(items) == 0 {
+		t.Fatalf("expected backlog items, got %v", backlog["items"])
+	}
+	firstItems := normalizeBacklogItemsForDeterminism(first)
+	secondItems := normalizeBacklogItemsForDeterminism(second)
+	if string(firstItems) != string(secondItems) {
+		t.Fatalf("expected deterministic backlog items\nfirst=%s\nsecond=%s", firstItems, secondItems)
+	}
+}
+
+func TestScanSavesControlBacklogAndQualityInState(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := filepath.Join(t.TempDir(), "app")
+	if err := os.WriteFile(filepath.Join(repoRoot, "AGENTS.md"), []byte("agent instructions\n"), 0o600); err != nil {
+		if mkErr := os.MkdirAll(repoRoot, 0o755); mkErr != nil {
+			t.Fatalf("mkdir repo: %v", mkErr)
+		}
+		if writeErr := os.WriteFile(filepath.Join(repoRoot, "AGENTS.md"), []byte("agent instructions\n"), 0o600); writeErr != nil {
+			t.Fatalf("write AGENTS.md: %v", writeErr)
+		}
+	}
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	_ = runScanPayload(t, repoRoot, statePath)
+	snapshot, err := state.Load(statePath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if snapshot.ScanMode != "governance" {
+		t.Fatalf("expected default governance scan mode, got %q", snapshot.ScanMode)
+	}
+	if snapshot.ControlBacklog == nil || snapshot.ControlBacklog.ControlBacklogVersion != "1" {
+		t.Fatalf("expected saved control backlog, got %+v", snapshot.ControlBacklog)
+	}
+	if snapshot.ScanQuality == nil || snapshot.ScanQuality.ScanQualityVersion != "1" {
+		t.Fatalf("expected saved scan quality, got %+v", snapshot.ScanQuality)
+	}
+}
+
+func TestInvalidScanModeJSONErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{"scan", "--mode", "wide", "--json"}, &out, &errOut)
+	if code != exitInvalidInput {
+		t.Fatalf("expected exit %d, got %d stdout=%q stderr=%q", exitInvalidInput, code, out.String(), errOut.String())
+	}
+	assertErrorEnvelopeCode(t, errOut.Bytes(), "invalid_input", exitInvalidInput)
+}
+
+func TestScanModeGovernanceSuppressesGeneratedPathNoiseAndDeepKeepsDebugEvidence(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := filepath.Join(t.TempDir(), "app")
+	if err := os.MkdirAll(filepath.Join(repoRoot, "node_modules", "pkg"), 0o755); err != nil {
+		t.Fatalf("mkdir generated dependency path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, "package.json"), []byte(`{"dependencies":{}}`), 0o600); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, "node_modules", "pkg", "package.json"), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write generated package.json: %v", err)
+	}
+
+	governance := runScanPayloadWithArgs(t, []string{"scan", "--path", repoRoot, "--state", filepath.Join(t.TempDir(), "state-governance.json"), "--json"})
+	if payloadContainsPath(governance["findings"], "node_modules/pkg/package.json") {
+		t.Fatalf("governance findings should suppress generated package parse evidence: %v", governance["findings"])
+	}
+	if payloadContainsPath(governance["control_backlog"], "node_modules/pkg/package.json") {
+		t.Fatalf("governance backlog should suppress generated package parse evidence: %v", governance["control_backlog"])
+	}
+	if !payloadContainsPath(governance["scan_quality"], "node_modules") {
+		t.Fatalf("governance scan_quality should report generated/package suppression: %v", governance["scan_quality"])
+	}
+
+	deep := runScanPayloadWithArgs(t, []string{"scan", "--path", repoRoot, "--mode", "deep", "--state", filepath.Join(t.TempDir(), "state-deep.json"), "--json"})
+	if !payloadContainsPath(deep["findings"], "node_modules/pkg/package.json") {
+		t.Fatalf("deep findings should keep generated package parse evidence: %v", deep["findings"])
+	}
+	if !payloadContainsAction(deep["scan_quality"], "suppress") {
+		t.Fatalf("deep scan_quality should mark generated parse issue as suppress: %v", deep["scan_quality"])
+	}
+}
+
+func runScanPayload(t *testing.T, repoRoot, statePath string) map[string]any {
+	t.Helper()
+
+	return runScanPayloadWithArgs(t, []string{"scan", "--path", repoRoot, "--state", statePath, "--json"})
+}
+
+func runScanPayloadWithArgs(t *testing.T, args []string) map[string]any {
+	t.Helper()
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run(args, &out, &errOut)
+	if code != exitSuccess {
+		t.Fatalf("scan failed: %d stderr=%s", code, errOut.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse scan payload: %v", err)
+	}
+	return payload
+}
+
+func normalizeBacklogItemsForDeterminism(payload map[string]any) []byte {
+	backlog, _ := payload["control_backlog"].(map[string]any)
+	items := backlog["items"]
+	encoded, _ := json.Marshal(items)
+	return encoded
+}
+
+func payloadContainsPath(value any, path string) bool {
+	encoded, _ := json.Marshal(value)
+	return bytes.Contains(encoded, []byte(path))
+}
+
+func payloadContainsAction(value any, action string) bool {
+	encoded, _ := json.Marshal(value)
+	return bytes.Contains(encoded, []byte(`"recommended_action":"`+action+`"`))
+}

--- a/core/detect/a2a/detector.go
+++ b/core/detect/a2a/detector.go
@@ -28,7 +28,7 @@ type agentCard struct {
 	InteractionPatterns []string `json:"interaction_patterns"`
 }
 
-func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) ([]model.Finding, error) {
+func (Detector) Detect(_ context.Context, scope detect.Scope, options detect.Options) ([]model.Finding, error) {
 	if err := detect.ValidateScopeRoot(scope.Root); err != nil {
 		return nil, err
 	}
@@ -36,12 +36,12 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 		return nil, nil
 	}
 
-	policy, _, policyErr := mcpgateway.LoadPolicy(scope.Root)
+	policy, _, policyErr := mcpgateway.LoadPolicyWithOptions(scope.Root, options)
 	if policyErr != nil {
 		return nil, policyErr
 	}
 
-	files, err := detect.WalkFiles(scope.Root)
+	files, err := detect.WalkFilesWithOptions(scope.Root, options)
 	if err != nil {
 		return nil, err
 	}

--- a/core/detect/agentautogen/detector.go
+++ b/core/detect/agentautogen/detector.go
@@ -16,9 +16,9 @@ func New() Detector { return Detector{} }
 
 func (Detector) ID() string { return detectorID }
 
-func (Detector) Detect(ctx context.Context, scope detect.Scope, _ detect.Options) ([]model.Finding, error) {
+func (Detector) Detect(ctx context.Context, scope detect.Scope, options detect.Options) ([]model.Finding, error) {
 	_ = ctx
-	return agentframework.DetectMany(scope, []agentframework.DetectorConfig{
+	return agentframework.DetectManyWithOptions(scope, []agentframework.DetectorConfig{
 		{
 			DetectorID: detectorID,
 			Framework:  "autogen",
@@ -43,5 +43,5 @@ func (Detector) Detect(ctx context.Context, scope detect.Scope, _ detect.Options
 			ConfigPath: ".wrkr/agents/autogen.toml",
 			Format:     "toml",
 		},
-	})
+	}, options)
 }

--- a/core/detect/agentcrewai/detector.go
+++ b/core/detect/agentcrewai/detector.go
@@ -16,11 +16,11 @@ func New() Detector { return Detector{} }
 
 func (Detector) ID() string { return detectorID }
 
-func (Detector) Detect(ctx context.Context, scope detect.Scope, _ detect.Options) ([]model.Finding, error) {
-	return agentframework.Detect(ctx, scope, agentframework.DetectorConfig{
+func (Detector) Detect(ctx context.Context, scope detect.Scope, options detect.Options) ([]model.Finding, error) {
+	return agentframework.DetectWithOptions(ctx, scope, agentframework.DetectorConfig{
 		DetectorID: detectorID,
 		Framework:  "crewai",
 		ConfigPath: ".wrkr/agents/crewai.yaml",
 		Format:     "yaml",
-	})
+	}, options)
 }

--- a/core/detect/agentcustom/detector.go
+++ b/core/detect/agentcustom/detector.go
@@ -52,7 +52,7 @@ func New() Detector { return Detector{} }
 
 func (Detector) ID() string { return detectorID }
 
-func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) ([]model.Finding, error) {
+func (Detector) Detect(_ context.Context, scope detect.Scope, options detect.Options) ([]model.Finding, error) {
 	if err := detect.ValidateScopeRoot(scope.Root); err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 		}
 	}
 
-	sourceFindings, err := detectSourceAnnotations(scope, workspaceSignals)
+	sourceFindings, err := detectSourceAnnotations(scope, workspaceSignals, options)
 	if err != nil {
 		return nil, err
 	}
@@ -208,8 +208,8 @@ func detectWorkspaceSignals(scope detect.Scope) (signalSet, error) {
 	return signals, nil
 }
 
-func detectSourceAnnotations(scope detect.Scope, workspace signalSet) ([]model.Finding, error) {
-	files, err := detect.WalkFiles(scope.Root)
+func detectSourceAnnotations(scope detect.Scope, workspace signalSet, options detect.Options) ([]model.Finding, error) {
+	files, err := detect.WalkFilesWithOptions(scope.Root, options)
 	if err != nil {
 		return nil, err
 	}

--- a/core/detect/agentframework/detector.go
+++ b/core/detect/agentframework/detector.go
@@ -45,7 +45,15 @@ func Detect(_ context.Context, scope detect.Scope, cfg DetectorConfig) ([]model.
 	return DetectMany(scope, []DetectorConfig{cfg})
 }
 
+func DetectWithOptions(_ context.Context, scope detect.Scope, cfg DetectorConfig, options detect.Options) ([]model.Finding, error) {
+	return DetectManyWithOptions(scope, []DetectorConfig{cfg}, options)
+}
+
 func DetectMany(scope detect.Scope, configs []DetectorConfig) ([]model.Finding, error) {
+	return DetectManyWithOptions(scope, configs, detect.Options{})
+}
+
+func DetectManyWithOptions(scope detect.Scope, configs []DetectorConfig, options detect.Options) ([]model.Finding, error) {
 	if err := detect.ValidateScopeRoot(scope.Root); err != nil {
 		return nil, err
 	}
@@ -71,7 +79,7 @@ func DetectMany(scope detect.Scope, configs []DetectorConfig) ([]model.Finding, 
 
 	sourcePlans := buildSourcePlans(normalized)
 	if len(sourcePlans) > 0 {
-		sourceFindings, err := detectFromSource(scope, sourcePlans)
+		sourceFindings, err := detectFromSource(scope, sourcePlans, options)
 		if err != nil {
 			return nil, err
 		}

--- a/core/detect/agentframework/source.go
+++ b/core/detect/agentframework/source.go
@@ -83,12 +83,12 @@ func buildSourcePlans(configs []DetectorConfig) []sourcePlan {
 	return out
 }
 
-func detectFromSource(scope detect.Scope, plans []sourcePlan) ([]model.Finding, error) {
+func detectFromSource(scope detect.Scope, plans []sourcePlan, options detect.Options) ([]model.Finding, error) {
 	if len(plans) == 0 {
 		return nil, nil
 	}
 
-	files, err := detect.WalkFiles(scope.Root)
+	files, err := detect.WalkFilesWithOptions(scope.Root, options)
 	if err != nil {
 		return nil, err
 	}

--- a/core/detect/agentlangchain/detector.go
+++ b/core/detect/agentlangchain/detector.go
@@ -16,11 +16,11 @@ func New() Detector { return Detector{} }
 
 func (Detector) ID() string { return detectorID }
 
-func (Detector) Detect(ctx context.Context, scope detect.Scope, _ detect.Options) ([]model.Finding, error) {
-	return agentframework.Detect(ctx, scope, agentframework.DetectorConfig{
+func (Detector) Detect(ctx context.Context, scope detect.Scope, options detect.Options) ([]model.Finding, error) {
+	return agentframework.DetectWithOptions(ctx, scope, agentframework.DetectorConfig{
 		DetectorID: detectorID,
 		Framework:  "langchain",
 		ConfigPath: ".wrkr/agents/langchain.json",
 		Format:     "json",
-	})
+	}, options)
 }

--- a/core/detect/agentllamaindex/detector.go
+++ b/core/detect/agentllamaindex/detector.go
@@ -16,9 +16,9 @@ func New() Detector { return Detector{} }
 
 func (Detector) ID() string { return detectorID }
 
-func (Detector) Detect(ctx context.Context, scope detect.Scope, _ detect.Options) ([]model.Finding, error) {
+func (Detector) Detect(ctx context.Context, scope detect.Scope, options detect.Options) ([]model.Finding, error) {
 	_ = ctx
-	return agentframework.DetectMany(scope, []agentframework.DetectorConfig{
+	return agentframework.DetectManyWithOptions(scope, []agentframework.DetectorConfig{
 		{
 			DetectorID: detectorID,
 			Framework:  "llamaindex",
@@ -43,5 +43,5 @@ func (Detector) Detect(ctx context.Context, scope detect.Scope, _ detect.Options
 			ConfigPath: ".wrkr/agents/llamaindex.toml",
 			Format:     "toml",
 		},
-	})
+	}, options)
 }

--- a/core/detect/agentmcpclient/detector.go
+++ b/core/detect/agentmcpclient/detector.go
@@ -16,8 +16,8 @@ func New() Detector { return Detector{} }
 
 func (Detector) ID() string { return detectorID }
 
-func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) ([]model.Finding, error) {
-	return agentframework.DetectMany(scope, []agentframework.DetectorConfig{
+func (Detector) Detect(_ context.Context, scope detect.Scope, options detect.Options) ([]model.Finding, error) {
+	return agentframework.DetectManyWithOptions(scope, []agentframework.DetectorConfig{
 		{
 			DetectorID: detectorID,
 			Framework:  "mcp_client",
@@ -42,5 +42,5 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 			ConfigPath: ".wrkr/agents/mcp-client.toml",
 			Format:     "toml",
 		},
-	})
+	}, options)
 }

--- a/core/detect/agentopenai/detector.go
+++ b/core/detect/agentopenai/detector.go
@@ -16,11 +16,11 @@ func New() Detector { return Detector{} }
 
 func (Detector) ID() string { return detectorID }
 
-func (Detector) Detect(ctx context.Context, scope detect.Scope, _ detect.Options) ([]model.Finding, error) {
-	return agentframework.Detect(ctx, scope, agentframework.DetectorConfig{
+func (Detector) Detect(ctx context.Context, scope detect.Scope, options detect.Options) ([]model.Finding, error) {
+	return agentframework.DetectWithOptions(ctx, scope, agentframework.DetectorConfig{
 		DetectorID: detectorID,
 		Framework:  "openai_agents",
 		ConfigPath: ".wrkr/agents/openai-agents.json",
 		Format:     "json",
-	})
+	}, options)
 }

--- a/core/detect/compiledaction/detector.go
+++ b/core/detect/compiledaction/detector.go
@@ -31,7 +31,7 @@ type actionDoc struct {
 	ApprovalSource string   `json:"approval_source" yaml:"approval_source"`
 }
 
-func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) ([]model.Finding, error) {
+func (Detector) Detect(_ context.Context, scope detect.Scope, options detect.Options) ([]model.Finding, error) {
 	if err := detect.ValidateScopeRoot(scope.Root); err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 		return nil, nil
 	}
 
-	files, walkErr := detect.WalkFiles(scope.Root)
+	files, walkErr := detect.WalkFilesWithOptions(scope.Root, options)
 	if walkErr != nil {
 		return nil, walkErr
 	}

--- a/core/detect/defaults/defaults.go
+++ b/core/detect/defaults/defaults.go
@@ -30,38 +30,62 @@ import (
 )
 
 func Registry() (*detect.Registry, error) {
+	return RegistryForMode("governance")
+}
+
+func RegistryForMode(mode string) (*detect.Registry, error) {
 	registry := detect.NewRegistry()
-	detectorList := []detect.Detector{
-		a2a.New(),
-		agentlangchain.New(),
-		agentcrewai.New(),
-		agentopenai.New(),
-		agentautogen.New(),
-		agentllamaindex.New(),
-		agentmcpclient.New(),
-		agentcustom.New(),
-		claude.New(),
-		cursor.New(),
-		codex.New(),
-		copilot.New(),
-		mcp.New(),
-		workstation.New(),
-		mcpgateway.New(),
-		nonhumanidentity.New(),
-		webmcp.New(),
-		promptchannel.New(),
-		skills.New(),
-		gaitpolicy.New(),
-		dependency.New(),
-		extension.New(),
-		secrets.New(),
-		compiledaction.New(),
-		ciagent.New(),
-	}
+	detectorList := detectorsForMode(mode)
 	for _, detector := range detectorList {
 		if err := registry.Register(detector); err != nil {
 			return nil, err
 		}
 	}
 	return registry, nil
+}
+
+func detectorsForMode(mode string) []detect.Detector {
+	switch mode {
+	case "quick":
+		return []detect.Detector{
+			claude.New(),
+			cursor.New(),
+			codex.New(),
+			copilot.New(),
+			mcp.New(),
+			mcpgateway.New(),
+			skills.New(),
+			gaitpolicy.New(),
+			secrets.New(),
+			ciagent.New(),
+		}
+	default:
+		return []detect.Detector{
+			a2a.New(),
+			agentlangchain.New(),
+			agentcrewai.New(),
+			agentopenai.New(),
+			agentautogen.New(),
+			agentllamaindex.New(),
+			agentmcpclient.New(),
+			agentcustom.New(),
+			claude.New(),
+			cursor.New(),
+			codex.New(),
+			copilot.New(),
+			mcp.New(),
+			workstation.New(),
+			mcpgateway.New(),
+			nonhumanidentity.New(),
+			webmcp.New(),
+			promptchannel.New(),
+			skills.New(),
+			gaitpolicy.New(),
+			dependency.New(),
+			extension.New(),
+			secrets.New(),
+			compiledaction.New(),
+			ciagent.New(),
+		}
+	}
 }

--- a/core/detect/dependency/detector.go
+++ b/core/detect/dependency/detector.go
@@ -70,16 +70,19 @@ var projectSignalKeywords = []string{
 }
 
 var ignoredDirectoryNames = map[string]struct{}{
-	".git":         {},
-	"node_modules": {},
-	"vendor":       {},
-	"dist":         {},
-	"build":        {},
-	"target":       {},
-	".venv":        {},
+	".git":           {},
+	"node_modules":   {},
+	"vendor":         {},
+	"dist":           {},
+	"build":          {},
+	"target":         {},
+	".venv":          {},
+	".yarn":          {},
+	"generated":      {},
+	"generated-sdks": {},
 }
 
-func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) ([]model.Finding, error) {
+func (Detector) Detect(_ context.Context, scope detect.Scope, options detect.Options) ([]model.Finding, error) {
 	if err := detect.ValidateScopeRoot(scope.Root); err != nil {
 		return nil, err
 	}
@@ -87,7 +90,7 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 		return nil, nil
 	}
 
-	files, err := collectDependencyManifests(scope.Root)
+	files, err := collectDependencyManifests(scope.Root, options)
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +345,7 @@ func normalizeDependencyToken(value string) string {
 	return normalized
 }
 
-func collectDependencyManifests(root string) ([]string, error) {
+func collectDependencyManifests(root string, options detect.Options) ([]string, error) {
 	files := make([]string, 0)
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
 		rel, relErr := filepath.Rel(root, path)
@@ -354,13 +357,13 @@ func collectDependencyManifests(root string) ([]string, error) {
 			rel = ""
 		}
 		if walkErr != nil {
-			if shouldSkipTraversal(rel) {
+			if shouldSkipTraversal(rel, options) {
 				return filepath.SkipDir
 			}
 			return walkErr
 		}
 		if d != nil && d.IsDir() {
-			if shouldSkipTraversal(rel) {
+			if shouldSkipTraversal(rel, options) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -389,12 +392,18 @@ func isDependencyManifest(rel string) bool {
 	}
 }
 
-func shouldSkipTraversal(rel string) bool {
+func shouldSkipTraversal(rel string, options detect.Options) bool {
 	if strings.TrimSpace(rel) == "" {
 		return false
 	}
+	if strings.TrimSpace(options.ScanMode) != "deep" && detect.IsGeneratedPath(rel) {
+		return true
+	}
 	parts := strings.Split(strings.ToLower(filepath.ToSlash(rel)), "/")
 	for _, part := range parts {
+		if strings.TrimSpace(options.ScanMode) == "deep" && part != ".git" && part != ".venv" {
+			continue
+		}
 		if _, ok := ignoredDirectoryNames[part]; ok {
 			return true
 		}

--- a/core/detect/dependency/detector_test.go
+++ b/core/detect/dependency/detector_test.go
@@ -81,6 +81,42 @@ func TestProjectSignalMatchesExplicitToken(t *testing.T) {
 	}
 }
 
+func TestGeneratedDependencyNoiseSuppressedUnlessDeepMode(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, root, "node_modules/pkg/package.json", "{")
+
+	governance, err := New().Detect(context.Background(), detect.Scope{
+		Org:  "acme",
+		Repo: "repo",
+		Root: root,
+	}, detect.Options{ScanMode: "governance"})
+	if err != nil {
+		t.Fatalf("governance detect returned error: %v", err)
+	}
+	for _, finding := range governance {
+		if finding.Location == "node_modules/pkg/package.json" {
+			t.Fatalf("governance mode should suppress generated dependency evidence, got %+v", governance)
+		}
+	}
+
+	deep, err := New().Detect(context.Background(), detect.Scope{
+		Org:  "acme",
+		Repo: "repo",
+		Root: root,
+	}, detect.Options{ScanMode: "deep"})
+	if err != nil {
+		t.Fatalf("deep detect returned error: %v", err)
+	}
+	if len(deep) != 1 {
+		t.Fatalf("expected one deep parse finding, got %+v", deep)
+	}
+	if deep[0].FindingType != "parse_error" || deep[0].Location != "node_modules/pkg/package.json" {
+		t.Fatalf("expected generated package parse error in deep mode, got %+v", deep)
+	}
+}
+
 func writeFile(t *testing.T, root, rel, content string) {
 	t.Helper()
 	path := filepath.Join(root, filepath.FromSlash(rel))

--- a/core/detect/detect.go
+++ b/core/detect/detect.go
@@ -25,7 +25,8 @@ func IsLocalMachineScope(scope Scope) bool {
 
 // Options toggles optional detector behavior.
 type Options struct {
-	Enrich bool
+	Enrich   bool
+	ScanMode string
 }
 
 // Detector emits canonical findings for one repo scope.

--- a/core/detect/mcpgateway/detector.go
+++ b/core/detect/mcpgateway/detector.go
@@ -274,10 +274,6 @@ func EvaluateCoverage(policy Policy, declarationName string) Result {
 	}
 }
 
-func discoverDeclarations(root string) ([]declaration, error) {
-	return discoverDeclarationsWithOptions(root, detect.Options{})
-}
-
 func discoverDeclarationsWithOptions(root string, options detect.Options) ([]declaration, error) {
 	files, err := detect.WalkFilesWithOptions(root, options)
 	if err != nil {

--- a/core/detect/mcpgateway/detector.go
+++ b/core/detect/mcpgateway/detector.go
@@ -75,7 +75,7 @@ func New() Detector { return Detector{} }
 
 func (Detector) ID() string { return detectorID }
 
-func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) ([]model.Finding, error) {
+func (Detector) Detect(_ context.Context, scope detect.Scope, options detect.Options) ([]model.Finding, error) {
 	if err := detect.ValidateScopeRoot(scope.Root); err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 		return nil, nil
 	}
 
-	policy, parseErrors, err := LoadPolicy(scope.Root)
+	policy, parseErrors, err := LoadPolicyWithOptions(scope.Root, options)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 		})
 	}
 
-	declarations, declErr := discoverDeclarations(scope.Root)
+	declarations, declErr := discoverDeclarationsWithOptions(scope.Root, options)
 	if declErr != nil {
 		return nil, declErr
 	}
@@ -151,7 +151,11 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 
 // LoadPolicy parses all recognized gateway config files in root and returns one normalized policy.
 func LoadPolicy(root string) (Policy, []fileParseError, error) {
-	files, err := detect.WalkFiles(root)
+	return LoadPolicyWithOptions(root, detect.Options{})
+}
+
+func LoadPolicyWithOptions(root string, options detect.Options) (Policy, []fileParseError, error) {
+	files, err := detect.WalkFilesWithOptions(root, options)
 	if err != nil {
 		return Policy{}, nil, err
 	}
@@ -271,7 +275,11 @@ func EvaluateCoverage(policy Policy, declarationName string) Result {
 }
 
 func discoverDeclarations(root string) ([]declaration, error) {
-	files, err := detect.WalkFiles(root)
+	return discoverDeclarationsWithOptions(root, detect.Options{})
+}
+
+func discoverDeclarationsWithOptions(root string, options detect.Options) ([]declaration, error) {
+	files, err := detect.WalkFilesWithOptions(root, options)
 	if err != nil {
 		return nil, err
 	}

--- a/core/detect/nonhumanidentity/detector.go
+++ b/core/detect/nonhumanidentity/detector.go
@@ -25,7 +25,7 @@ func New() Detector { return Detector{} }
 
 func (Detector) ID() string { return detectorID }
 
-func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) ([]model.Finding, error) {
+func (Detector) Detect(_ context.Context, scope detect.Scope, options detect.Options) ([]model.Finding, error) {
 	if err := detect.ValidateScopeRoot(scope.Root); err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 		return nil, nil
 	}
 
-	files, err := detect.WalkFiles(scope.Root)
+	files, err := detect.WalkFilesWithOptions(scope.Root, options)
 	if err != nil {
 		return nil, err
 	}

--- a/core/detect/parse.go
+++ b/core/detect/parse.go
@@ -223,17 +223,33 @@ func globLiteralPrefix(pattern string) string {
 }
 
 func WalkFiles(root string) ([]string, error) {
+	return WalkFilesWithOptions(root, Options{})
+}
+
+func WalkFilesWithOptions(root string, options Options) ([]string, error) {
 	files := make([]string, 0)
+	includeGenerated := strings.TrimSpace(options.ScanMode) == "deep"
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
+			rel, relErr := filepath.Rel(root, path)
+			if relErr != nil {
+				return relErr
+			}
+			rel = filepath.ToSlash(rel)
+			if rel != "." && !includeGenerated && IsGeneratedPath(rel) {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		rel, relErr := filepath.Rel(root, path)
 		if relErr != nil {
 			return relErr
+		}
+		if !includeGenerated && IsGeneratedPath(rel) {
+			return nil
 		}
 		files = append(files, filepath.ToSlash(rel))
 		return nil

--- a/core/detect/pathfilter.go
+++ b/core/detect/pathfilter.go
@@ -1,0 +1,33 @@
+package detect
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func IsGeneratedPath(rel string) bool {
+	normalized := strings.ToLower(filepath.ToSlash(strings.TrimSpace(rel)))
+	if normalized == "" || normalized == "." {
+		return false
+	}
+	if strings.HasSuffix(normalized, ".min.js") {
+		return true
+	}
+	parts := strings.Split(normalized, "/")
+	for idx, part := range parts {
+		switch part {
+		case "node_modules", "dist", "build", "vendor", ".venv", "generated", "generated-sdks", "generated-sdk":
+			return true
+		case "target":
+			return true
+		case ".yarn":
+			if idx+1 < len(parts) && parts[idx+1] == "sdks" {
+				return true
+			}
+		}
+		if strings.Contains(part, "generated-sdk") || strings.Contains(part, "generated_client") {
+			return true
+		}
+	}
+	return false
+}

--- a/core/detect/pathfilter_test.go
+++ b/core/detect/pathfilter_test.go
@@ -1,0 +1,81 @@
+package detect
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsGeneratedPathClassifiesPackageAndGeneratedNoise(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"node_modules/pkg/package.json",
+		"dist/app.min.js",
+		".yarn/sdks/typescript/lib.js",
+		"clients/generated-sdk/openapi.json",
+		"target/classes/app.jar",
+	} {
+		if !IsGeneratedPath(path) {
+			t.Fatalf("expected generated path: %s", path)
+		}
+	}
+	for _, path := range []string{
+		".github/workflows/release.yml",
+		".cursor/mcp.json",
+		"AGENTS.md",
+	} {
+		if IsGeneratedPath(path) {
+			t.Fatalf("did not expect generated path: %s", path)
+		}
+	}
+}
+
+func TestWalkFilesHonorsDeepModeGeneratedInclusion(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writePathFilterTestFile(t, root, "src/app.go", "package main\n")
+	writePathFilterTestFile(t, root, "node_modules/pkg/package.json", "{}\n")
+	writePathFilterTestFile(t, root, "dist/app.min.js", "console.log('generated')\n")
+
+	governanceFiles, err := WalkFilesWithOptions(root, Options{ScanMode: "governance"})
+	if err != nil {
+		t.Fatalf("walk governance files: %v", err)
+	}
+	for _, rel := range governanceFiles {
+		if IsGeneratedPath(rel) {
+			t.Fatalf("governance walk should suppress generated path %s in %v", rel, governanceFiles)
+		}
+	}
+
+	deepFiles, err := WalkFilesWithOptions(root, Options{ScanMode: "deep"})
+	if err != nil {
+		t.Fatalf("walk deep files: %v", err)
+	}
+	for _, want := range []string{"node_modules/pkg/package.json", "dist/app.min.js"} {
+		if !pathFilterTestContains(deepFiles, want) {
+			t.Fatalf("deep walk should include %s in %v", want, deepFiles)
+		}
+	}
+}
+
+func writePathFilterTestFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", rel, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func pathFilterTestContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/core/detect/promptchannel/detector.go
+++ b/core/detect/promptchannel/detector.go
@@ -36,7 +36,7 @@ func New() Detector { return Detector{} }
 
 func (Detector) ID() string { return detectorID }
 
-func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) ([]model.Finding, error) {
+func (Detector) Detect(_ context.Context, scope detect.Scope, options detect.Options) ([]model.Finding, error) {
 	if err := detect.ValidateScopeRoot(scope.Root); err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 		return nil, nil
 	}
 
-	files, err := detect.WalkFiles(scope.Root)
+	files, err := detect.WalkFilesWithOptions(scope.Root, options)
 	if err != nil {
 		return nil, err
 	}

--- a/core/detect/skills/detector.go
+++ b/core/detect/skills/detector.go
@@ -27,7 +27,7 @@ type frontmatter struct {
 	AllowedTools []string `yaml:"allowed-tools"`
 }
 
-func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) ([]model.Finding, error) {
+func (Detector) Detect(_ context.Context, scope detect.Scope, options detect.Options) ([]model.Finding, error) {
 	if err := detect.ValidateScopeRoot(scope.Root); err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 		return nil, nil
 	}
 
-	files, walkErr := detect.WalkFiles(scope.Root)
+	files, walkErr := detect.WalkFilesWithOptions(scope.Root, options)
 	if walkErr != nil {
 		return nil, walkErr
 	}

--- a/core/detect/webmcp/detector.go
+++ b/core/detect/webmcp/detector.go
@@ -31,7 +31,7 @@ type declaration struct {
 	rel    string
 }
 
-func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) ([]model.Finding, error) {
+func (Detector) Detect(_ context.Context, scope detect.Scope, options detect.Options) ([]model.Finding, error) {
 	if err := detect.ValidateScopeRoot(scope.Root); err != nil {
 		return nil, err
 	}
@@ -39,12 +39,12 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 		return nil, nil
 	}
 
-	policy, _, policyErr := mcpgateway.LoadPolicy(scope.Root)
+	policy, _, policyErr := mcpgateway.LoadPolicyWithOptions(scope.Root, options)
 	if policyErr != nil {
 		return nil, policyErr
 	}
 
-	files, err := detect.WalkFiles(scope.Root)
+	files, err := detect.WalkFilesWithOptions(scope.Root, options)
 	if err != nil {
 		return nil, err
 	}

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -7,7 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Clyra-AI/wrkr/core/aggregate/controlbacklog"
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/aggregate/scanquality"
 	"github.com/Clyra-AI/wrkr/core/lifecycle"
 	"github.com/Clyra-AI/wrkr/core/manifest"
 	profileeval "github.com/Clyra-AI/wrkr/core/policy/profileeval"
@@ -23,16 +25,19 @@ const SnapshotVersion = "v1"
 
 // Snapshot stores deterministic scan material for diff mode.
 type Snapshot struct {
-	Version      string                    `json:"version"`
-	Target       source.Target             `json:"target"`
-	Targets      []source.Target           `json:"targets,omitempty"`
-	Findings     []source.Finding          `json:"findings"`
-	Inventory    *agginventory.Inventory   `json:"inventory,omitempty"`
-	RiskReport   *risk.Report              `json:"risk_report,omitempty"`
-	Profile      *profileeval.Result       `json:"profile,omitempty"`
-	PostureScore *score.Result             `json:"posture_score,omitempty"`
-	Identities   []manifest.IdentityRecord `json:"identities,omitempty"`
-	Transitions  []lifecycle.Transition    `json:"lifecycle_transitions,omitempty"`
+	Version        string                    `json:"version"`
+	Target         source.Target             `json:"target"`
+	Targets        []source.Target           `json:"targets,omitempty"`
+	Findings       []source.Finding          `json:"findings"`
+	Inventory      *agginventory.Inventory   `json:"inventory,omitempty"`
+	ControlBacklog *controlbacklog.Backlog   `json:"control_backlog,omitempty"`
+	ScanQuality    *scanquality.Report       `json:"scan_quality,omitempty"`
+	ScanMode       string                    `json:"scan_mode,omitempty"`
+	RiskReport     *risk.Report              `json:"risk_report,omitempty"`
+	Profile        *profileeval.Result       `json:"profile,omitempty"`
+	PostureScore   *score.Result             `json:"posture_score,omitempty"`
+	Identities     []manifest.IdentityRecord `json:"identities,omitempty"`
+	Transitions    []lifecycle.Transition    `json:"lifecycle_transitions,omitempty"`
 }
 
 type ScoreView struct {

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -3,7 +3,7 @@
 ## Synopsis
 
 ```bash
-wrkr scan [--repo <owner/repo> | --org <org> | --github-org <org> | --path <dir> | --my-setup | --target <mode>:<value> ...] [--timeout <duration>] [--diff] [--enrich] [--baseline <path>] [--config <path>] [--state <path>] [--policy <path>] [--approved-tools <path>] [--production-targets <path>] [--production-targets-strict] [--profile baseline|standard|strict|assessment] [--github-api <url>] [--github-token <token>] [--report-md] [--report-md-path <path>] [--report-template exec|operator|audit|public] [--report-share-profile internal|public] [--report-top <n>] [--sarif] [--sarif-path <path>] [--json] [--json-path <path>] [--resume] [--quiet] [--explain]
+wrkr scan [--repo <owner/repo> | --org <org> | --github-org <org> | --path <dir> | --my-setup | --target <mode>:<value> ...] [--mode quick|governance|deep] [--timeout <duration>] [--diff] [--enrich] [--baseline <path>] [--config <path>] [--state <path>] [--policy <path>] [--approved-tools <path>] [--production-targets <path>] [--production-targets-strict] [--profile baseline|standard|strict|assessment] [--github-api <url>] [--github-token <token>] [--report-md] [--report-md-path <path>] [--report-template exec|operator|audit|public] [--report-share-profile internal|public] [--report-top <n>] [--sarif] [--sarif-path <path>] [--json] [--json-path <path>] [--resume] [--quiet] [--explain]
 ```
 
 Use either one legacy target source (`--repo`, `--org`, `--github-org`, `--path`, or `--my-setup`) or one or more repeatable `--target <mode>:<value>` flags.
@@ -41,6 +41,13 @@ Acquisition behavior is fail-closed by target:
 - Late write failures after preflight still fail closed and roll managed artifacts back to the previous committed generation instead of leaving mixed state/proof/manifest outputs behind.
 - For `--path` scans, detector file reads stay bounded to the selected repo root. Root-escaping symlinked config, env, workflow, and MCP files are rejected with deterministic `parse_error.kind=unsafe_path` diagnostics instead of being read.
 
+Scan mode behavior is explicit:
+
+- `--mode governance` is the default enterprise posture. It emits the versioned `control_backlog`, keeps raw findings for compatibility, and reports generated/package-manager noise in `scan_quality`.
+- `--mode quick` runs the highest-signal governance detectors for coding assistant configs, MCP, skills, CI automation, secret references, and policy files.
+- `--mode deep` runs the full detector set and marks `scan_quality.mode=deep`; generated/package paths remain available to raw/debug investigation instead of being treated as active governance suppression.
+- Invalid mode values fail closed with `invalid_input` (exit `6`) and the normal JSON error envelope in `--json` mode.
+
 ## Flags
 
 - `--json`
@@ -54,6 +61,7 @@ Acquisition behavior is fail-closed by target:
 - `--path`
 - `--my-setup`
 - `--target`
+- `--mode`
 - `--timeout`
 - `--diff`
 - `--enrich`
@@ -137,8 +145,10 @@ wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --profile assessment --re
 ```
 
 This is the canonical `repo_set` example for `--path`: the selected directory is a bundle of immediate child repos, so Wrkr preserves per-child repo manifests and deterministic ordering instead of collapsing the bundle into one repo.
-Expected JSON keys include `status`, `target`, `findings`, `ranked_findings`, `top_findings`, `attack_paths`, `top_attack_paths`, additive `action_paths`, additive `action_path_to_control_first`, `inventory`, `privilege_budget`, `agent_privilege_map`, `repo_exposure_summaries`, `profile`, `posture_score`, `compliance_summary`, additive `activation`, and optional `report` when summary output is requested.
+Expected JSON keys include `status`, `target`, `scan_mode`, `scan_quality`, `findings`, additive `control_backlog`, `ranked_findings`, `top_findings`, `attack_paths`, `top_attack_paths`, additive `action_paths`, additive `action_path_to_control_first`, `inventory`, `privilege_budget`, `agent_privilege_map`, `repo_exposure_summaries`, `profile`, `posture_score`, `compliance_summary`, additive `activation`, and optional `report` when summary output is requested.
 Explicit multi-target runs also emit additive `targets[]` arrays at the top level and inside `source_manifest`, and saved state snapshots preserve the same additive `targets[]` contract.
+`control_backlog.control_backlog_version` is the stable backlog schema version. `control_backlog.items[*]` includes repo, path, control surface/path type, capability, owner/source/status, evidence source/basis, approval status, security visibility, signal class (`unique_wrkr_signal|supporting_security_signal`), recommended action (`attach_evidence|approve|remediate|downgrade|deprecate|exclude|monitor|inventory_review|suppress|debug_only`), confidence (`high|medium|low`), evidence gaps, confidence-raising guidance, SLA, closure criteria, optional secret signal types, and linked raw finding IDs. Raw `findings` remain the compatibility evidence surface.
+`scan_quality.scan_quality_version` is the stable scan-quality schema version. In governance mode, generated/package-manager surfaces such as `node_modules/`, `dist/`, `build/`, nested generated SDK folders, `.yarn/sdks/`, minified JavaScript, and other package internals are reported as scan-quality context instead of active backlog items. Parser diagnostics in `scan_quality.parse_errors[*]` include deterministic `recommended_action` values such as `suppress` for generated/package noise and `debug_only` for non-generated diagnostics.
 For local-machine scans, `target.mode` is `my_setup`.
 When `target.mode=my_setup`, `activation.items` projects concrete local tool, MCP, secret, and parse-error signals first without mutating the raw `top_findings` ranking. Policy-only items remain available in `ranked_findings` / `top_findings`.
 When `target.mode=org`, `target.mode=path`, or `target.mode=multi`, `activation.items` projects govern-first candidate paths from the saved privilege map and adds `item_class` values such as `production_target_backed`, `unknown_to_security_write_path`, `approval_gap_path`, and `govern_first_candidate`.
@@ -178,6 +188,7 @@ Invalid `--approved-tools` policy files fail closed with `invalid_input` (exit `
 For `--my-setup`, omitting `--approved-tools` keeps `inventory.local_governance.reference_basis=unavailable` instead of fabricating sanctioned or unsanctioned local claims.
 For `--repo` and `--org` scans, `source_manifest.repos[*].source` is `github_repo_materialized`, and `source_manifest.repos[*].location` points to the deterministic materialized local root used for detector execution.
 Prompt-channel findings use stable reason codes and evidence hashes only (`pattern_family`, `evidence_snippet_hash`, `location_class`, `confidence_class`) and do not emit raw secret values.
+Secret-bearing workflow evidence separates `secret_reference_detected`, `secret_value_detected`, `secret_scope_unknown`, `secret_rotation_evidence_missing`, `secret_owner_missing`, and `secret_used_by_write_capable_workflow`. Workflow references such as `${{ secrets.NAME }}` are classified as references, not leaked values, and raw secret values are not emitted.
 When `--enrich` is enabled, MCP findings include enrich provenance and quality fields: `source`, `as_of`, `package`, `version`, `advisory_count`, `registry_status`, `enrich_quality` (`ok|partial|stale|unavailable`), `advisory_schema`, `registry_schema`, and `enrich_errors`.
 When production target policy loading is non-fatal (`--production-targets` without `--production-targets-strict`), output may include `policy_warnings`.
 

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -47,6 +47,7 @@ Scan mode behavior is explicit:
 - `--mode quick` runs the highest-signal governance detectors for coding assistant configs, MCP, skills, CI automation, secret references, and policy files.
 - `--mode deep` runs the full detector set and marks `scan_quality.mode=deep`; generated/package paths remain available to raw/debug investigation instead of being treated as active governance suppression.
 - Invalid mode values fail closed with `invalid_input` (exit `6`) and the normal JSON error envelope in `--json` mode.
+- `--diff` requires the previous saved snapshot and current scan to use the same recorded scan mode. A mode mismatch fails closed with `invalid_input` (exit `6`) instead of reporting synthetic drift caused by quick/governance/deep scope differences.
 
 ## Flags
 

--- a/docs/decisions/wave1-control-backlog-scan-modes.md
+++ b/docs/decisions/wave1-control-backlog-scan-modes.md
@@ -1,0 +1,33 @@
+# Wave 1 Control Backlog And Scan Modes
+
+Title: Add governance control backlog, scan quality, and scan modes
+
+Context:
+Wrkr already produced raw findings, ranked findings, action paths, inventory, risk, and proof artifacts. Enterprise reviews need a short governance queue that separates Wrkr-native control-path signal from supporting security evidence and avoids generated/package noise becoming the apparent product center.
+
+Decision:
+Add a derived `control_backlog` aggregation surface and a separate `scan_quality` appendix. `control_backlog` is built from raw findings, inventory, and action paths; detectors remain raw evidence producers. `scan_quality` owns generated/package suppression context and parser/debug appendix data. Add `wrkr scan --mode quick|governance|deep`, with `governance` as the default and `quick` narrowing the detector set to high-signal governance surfaces.
+
+Alternatives considered:
+- Mutating raw findings directly was rejected because existing findings are compatibility evidence and feed diff, risk, proof, and downstream consumers.
+- Folding scan quality into the backlog was rejected because generated/package noise should not compete with reviewable control paths.
+- Making deep mode the default was rejected because first-value enterprise scans need a govern-first queue rather than exhaustive debug output.
+
+Tradeoffs:
+- The backlog is additive and can duplicate some concepts from action paths, but it gives operators a stable decision surface with action, confidence, SLA, and closure fields.
+- Generated-path filtering is conservative and can be extended as new package-manager or SDK trees appear.
+- Quick mode provides faster signal but may omit lower-priority detector families by design.
+
+Rollback plan:
+Because the surfaces are additive, rollback can remove `control_backlog`, `scan_quality`, and `--mode` wiring while leaving raw findings, inventory, risk, proof, and report contracts intact. Existing state readers tolerate missing additive fields.
+
+Validation plan:
+- `go test ./core/aggregate/controlbacklog ./core/aggregate/inventory ./core/model -count=1`
+- `go test ./core/aggregate/controlbacklog ./core/risk ./core/report -count=1`
+- `go test ./core/detect/secrets ./core/detect/workflowcap ./core/aggregate/controlbacklog ./core/risk -count=1`
+- `go test ./core/detect/... ./core/source/local ./core/source/github ./core/aggregate/scanquality -count=1`
+- `go test ./internal/scenarios -run 'TestControlBacklogGovernance|TestSecretReferenceSemantics' -count=1 -tags=scenario`
+- `go test ./internal/e2e/cli_contract -count=1`
+- `make test-contracts`
+- `make test-perf`
+- `make prepush-full`

--- a/docs/trust/contracts-and-schemas.md
+++ b/docs/trust/contracts-and-schemas.md
@@ -5,6 +5,22 @@ description: "Reference index for Wrkr command contracts, schema assets, and pro
 
 # Contracts and Schemas
 
+## Scan Governance Additions
+
+`wrkr scan --json` includes additive governance-first artifacts while preserving existing raw finding and inventory surfaces.
+
+- `control_backlog.control_backlog_version = "1"` identifies the backlog schema.
+- `control_backlog.items[*].signal_class` is one of `unique_wrkr_signal` or `supporting_security_signal`.
+- `control_backlog.items[*].recommended_action` is one of `attach_evidence`, `approve`, `remediate`, `downgrade`, `deprecate`, `exclude`, `monitor`, `inventory_review`, `suppress`, or `debug_only`.
+- `control_backlog.items[*].confidence` is one of `high`, `medium`, or `low`.
+- `scan_quality.scan_quality_version = "1"` identifies the scan-quality appendix schema.
+- `scan_quality.mode` is one of `quick`, `governance`, or `deep`.
+- `scan_quality.parse_errors[*].recommended_action` is `suppress` for generated/package-manager noise and `debug_only` for parser diagnostics that should stay outside the active governance backlog.
+
+These fields are additive. Consumers that depend on `findings`, `ranked_findings`, `top_findings`, `inventory`, `profile`, `posture_score`, and `compliance_summary` can continue to read those fields unchanged.
+
+Secret-bearing workflow semantics are also additive. Workflow references such as `${{ secrets.NAME }}` are classified as `secret_reference_detected` and may combine with `secret_used_by_write_capable_workflow`; they must not be treated as `secret_value_detected` unless a detector explicitly proves a value was exposed.
+
 ## Canonical references
 
 - Root exit codes and flags: `docs/commands/root.md`

--- a/internal/scenarios/control_backlog_governance_scenario_test.go
+++ b/internal/scenarios/control_backlog_governance_scenario_test.go
@@ -1,0 +1,152 @@
+package scenarios
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/cli"
+)
+
+func TestControlBacklogGovernance(t *testing.T) {
+	repoRoot := mustFindRepoRootWithoutTag(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "control-backlog-governance", "repos")
+	first := runControlBacklogScenarioCommandJSON(t, []string{"scan", "--path", scanPath, "--state", filepath.Join(t.TempDir(), "state-a.json"), "--json"})
+	second := runControlBacklogScenarioCommandJSON(t, []string{"scan", "--path", scanPath, "--state", filepath.Join(t.TempDir(), "state-b.json"), "--json"})
+
+	backlog := requireScenarioObject(t, first, "control_backlog")
+	if backlog["control_backlog_version"] != "1" {
+		t.Fatalf("unexpected control backlog version: %v", backlog["control_backlog_version"])
+	}
+	items := requireScenarioArrayFromObject(t, backlog, "items")
+	if len(items) == 0 {
+		t.Fatal("expected control backlog items")
+	}
+	if !scenarioPayloadsEqual(backlog["items"], requireScenarioObject(t, second, "control_backlog")["items"]) {
+		t.Fatalf("expected deterministic backlog ordering\nfirst=%v\nsecond=%v", backlog["items"], requireScenarioObject(t, second, "control_backlog")["items"])
+	}
+	seenUnique := false
+	seenSupporting := false
+	for _, raw := range items {
+		item := requireScenarioMap(t, raw)
+		if item["signal_class"] == "unique_wrkr_signal" {
+			seenUnique = true
+		}
+		if item["signal_class"] == "supporting_security_signal" {
+			seenSupporting = true
+		}
+		if links, ok := item["linked_finding_ids"].([]any); !ok || len(links) == 0 {
+			t.Fatalf("expected linked finding ids on item: %v", item)
+		}
+	}
+	if !seenUnique || !seenSupporting {
+		t.Fatalf("expected unique and supporting signal classes in %v", items)
+	}
+	if _, ok := first["findings"].([]any); !ok {
+		t.Fatalf("legacy findings missing: %v", first)
+	}
+	if _, ok := first["top_findings"].([]any); !ok {
+		t.Fatalf("legacy top_findings missing: %v", first)
+	}
+	if _, ok := first["inventory"].(map[string]any); !ok {
+		t.Fatalf("legacy inventory missing: %v", first)
+	}
+}
+
+func TestSecretReferenceSemantics(t *testing.T) {
+	repoRoot := mustFindRepoRootWithoutTag(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "secret-reference-semantics", "repos")
+	payload := runControlBacklogScenarioCommandJSON(t, []string{"scan", "--path", scanPath, "--state", filepath.Join(t.TempDir(), "state.json"), "--json"})
+	backlog := requireScenarioObject(t, payload, "control_backlog")
+	items := requireScenarioArrayFromObject(t, backlog, "items")
+
+	foundSecretReference := false
+	for _, raw := range items {
+		item := requireScenarioMap(t, raw)
+		signals, _ := item["secret_signal_types"].([]any)
+		if len(signals) == 0 {
+			continue
+		}
+		if scenarioArrayContains(signals, "secret_reference_detected") {
+			foundSecretReference = true
+		}
+		if scenarioArrayContains(signals, "secret_value_detected") {
+			t.Fatalf("workflow secret reference was misclassified as secret value: %v", item)
+		}
+		if !scenarioArrayContains(signals, "secret_used_by_write_capable_workflow") {
+			t.Fatalf("expected write-capable secret workflow signal: %v", item)
+		}
+		if action := item["recommended_action"]; action != "attach_evidence" && action != "approve" {
+			t.Fatalf("expected attach_evidence or approve, got %v in %v", action, item)
+		}
+	}
+	if !foundSecretReference {
+		t.Fatalf("expected a secret reference backlog item in %v", items)
+	}
+	if bytes, ok := payload["findings"]; ok && scenarioPayloadContains(bytes, "super-secret-value") {
+		t.Fatal("raw secret value leaked in findings payload")
+	}
+}
+
+func requireScenarioObject(t *testing.T, payload map[string]any, key string) map[string]any {
+	t.Helper()
+	value, ok := payload[key].(map[string]any)
+	if !ok {
+		t.Fatalf("expected %s object, got %T (%v)", key, payload[key], payload[key])
+	}
+	return value
+}
+
+func runControlBacklogScenarioCommandJSON(t *testing.T, args []string) map[string]any {
+	t.Helper()
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := cli.Run(args, &out, &errOut); code != 0 {
+		t.Fatalf("command failed: %v code=%d stderr=%s", args, code, errOut.String())
+	}
+	payload := map[string]any{}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse command json output for %v: %v", args, err)
+	}
+	return payload
+}
+
+func requireScenarioArrayFromObject(t *testing.T, payload map[string]any, key string) []any {
+	t.Helper()
+	value, ok := payload[key].([]any)
+	if !ok {
+		t.Fatalf("expected %s array, got %T (%v)", key, payload[key], payload[key])
+	}
+	return value
+}
+
+func requireScenarioMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+	item, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("expected object, got %T (%v)", value, value)
+	}
+	return item
+}
+
+func scenarioArrayContains(values []any, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func scenarioPayloadContains(value any, needle string) bool {
+	encoded, _ := json.Marshal(value)
+	return strings.Contains(string(encoded), needle)
+}
+
+func scenarioPayloadsEqual(a, b any) bool {
+	left, _ := json.Marshal(a)
+	right, _ := json.Marshal(b)
+	return string(left) == string(right)
+}

--- a/scenarios/wrkr/control-backlog-governance/repos/automation-voting-app/.codex/config.toml
+++ b/scenarios/wrkr/control-backlog-governance/repos/automation-voting-app/.codex/config.toml
@@ -1,0 +1,3 @@
+sandbox_mode = "danger-full-access"
+approval_policy = "never"
+network_access = true

--- a/scenarios/wrkr/control-backlog-governance/repos/automation-voting-app/.cursor/mcp.json
+++ b/scenarios/wrkr/control-backlog-governance/repos/automation-voting-app/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "tickets": {
+      "url": "https://mcp.example.local/tickets",
+      "transport": "http"
+    }
+  }
+}

--- a/scenarios/wrkr/control-backlog-governance/repos/automation-voting-app/.github/workflows/call-docker-build-result.yaml
+++ b/scenarios/wrkr/control-backlog-governance/repos/automation-voting-app/.github/workflows/call-docker-build-result.yaml
@@ -1,0 +1,15 @@
+name: call-docker-build-result
+on: [pull_request]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  publish-result:
+    runs-on: ubuntu-latest
+    steps:
+      - name: agent summary
+        run: codex --full-auto "summarize build result"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: merge
+        run: gh pr merge "$PR_URL" --merge

--- a/scenarios/wrkr/control-backlog-governance/repos/automation-voting-app/package.json
+++ b/scenarios/wrkr/control-backlog-governance/repos/automation-voting-app/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "automation-voting-app",
+  "dependencies": {
+    "@anthropic-ai/sdk": "0.1.0"
+  }
+}

--- a/scenarios/wrkr/secret-reference-semantics/repos/secret-writer/.github/workflows/pr-write-secret.yaml
+++ b/scenarios/wrkr/secret-reference-semantics/repos/secret-writer/.github/workflows/pr-write-secret.yaml
@@ -1,0 +1,12 @@
+name: pr-write-secret
+on: [pull_request]
+permissions:
+  pull-requests: write
+jobs:
+  update-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: agent update
+        run: codex --full-auto "update pull request"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/testinfra/contracts/story1_contracts_test.go
+++ b/testinfra/contracts/story1_contracts_test.go
@@ -70,6 +70,7 @@ func TestScanJSONContractStableKeys(t *testing.T) {
 		"agent_privilege_map",
 		"attack_paths",
 		"compliance_summary",
+		"control_backlog",
 		"findings",
 		"inventory",
 		"posture_score",
@@ -77,6 +78,8 @@ func TestScanJSONContractStableKeys(t *testing.T) {
 		"profile",
 		"ranked_findings",
 		"repo_exposure_summaries",
+		"scan_mode",
+		"scan_quality",
 		"source_manifest",
 		"status",
 		"target",
@@ -85,6 +88,23 @@ func TestScanJSONContractStableKeys(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected top-level keys: got %v want %v", got, want)
+	}
+	if payload["scan_mode"] != "governance" {
+		t.Fatalf("expected default scan_mode=governance, got %v", payload["scan_mode"])
+	}
+	controlBacklog, ok := payload["control_backlog"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected control_backlog object, got %T", payload["control_backlog"])
+	}
+	if controlBacklog["control_backlog_version"] != "1" {
+		t.Fatalf("unexpected control_backlog_version: %v", controlBacklog["control_backlog_version"])
+	}
+	scanQuality, ok := payload["scan_quality"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected scan_quality object, got %T", payload["scan_quality"])
+	}
+	if scanQuality["scan_quality_version"] != "1" {
+		t.Fatalf("unexpected scan_quality_version: %v", scanQuality["scan_quality_version"])
 	}
 
 	inventoryPayload, ok := payload["inventory"].(map[string]any)
@@ -134,7 +154,7 @@ func TestDiffJSONContractStableKeys(t *testing.T) {
 		t.Fatalf("parse diff payload: %v", err)
 	}
 	got := sortedKeys(payload)
-	want := []string{"diff", "diff_empty", "source_manifest", "status", "target"}
+	want := []string{"diff", "diff_empty", "scan_mode", "scan_quality", "source_manifest", "status", "target"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected top-level keys: got %v want %v", got, want)
 	}


### PR DESCRIPTION
## Problem

Wrkr needs Wave 1 of the govern-first control-path plan: a deterministic control backlog contract, action/confidence taxonomy, secret-reference semantics, and explicit scan modes that keep generated/package noise out of the default governance decision surface.

## Changes

- Added the versioned `control_backlog` aggregation surface while preserving legacy scan JSON fields such as `findings`, `top_findings`, and `inventory`.
- Added deterministic recommended actions, confidence/evidence fields, SLA, closure criteria, and secret signal semantics for governance backlog items.
- Added `scan_quality` with generated/package suppression context, parser diagnostics, and scan-quality actions.
- Added `wrkr scan --mode quick|governance|deep`, defaulting to governance mode, with deep mode preserving raw/debug generated-path evidence.
- Added scenario fixtures, contract tests, docs, ADR, and changelog entries for Wave 1.

## Validation

- `make prepush-full`
- CodeQL completed locally and wrote `.tmp/codeql-results.sarif`
