### PR TITLE
Inventory approval evidence and drift workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Added the versioned control backlog contract for governance-first scan output while preserving existing raw finding JSON surfaces.
 - Added deterministic recommended-action, evidence-quality, confidence, and SLA fields to governance backlog items.
 - Added explicit engineering write-path classification and governance control mappings across scan, inventory, risk, and proof outputs.
+- Added inventory governance commands for approvals, evidence attachments, accepted risk, deprecation, exclusion, and time-bound review state.
+- Added proof and evidence lifecycle mapping so governance controls can show verifiable approval, least-privilege, rotation, deployment-gate, and review evidence.
 
 ### Changed
 
@@ -18,6 +20,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Changed scan output to lead with a prioritized control backlog while keeping raw findings available for compatibility.
 - Expanded security visibility into governance-native states for approved, unapproved, accepted-risk, deprecated, revoked, and needs-review control paths.
 - Flagged deprecated tool reappearance as deterministic regress drift alongside revoked tool reappearance.
+- Changed regress and inventory drift to focus on new or changed AI/automation control paths, approval expiry, owner changes, and risk increases from approved baselines.
 
 ### Deprecated
 

--- a/core/cli/evidence.go
+++ b/core/cli/evidence.go
@@ -62,6 +62,7 @@ func runEvidence(args []string, stdout io.Writer, stderr io.Writer) int {
 			"manifest_path":      result.ManifestPath,
 			"chain_path":         result.ChainPath,
 			"framework_coverage": result.FrameworkCoverage,
+			"control_evidence":   result.ControlEvidence,
 			"coverage_note":      result.CoverageNote,
 			"report_artifacts":   result.ReportArtifacts,
 		})

--- a/core/cli/inventory.go
+++ b/core/cli/inventory.go
@@ -18,6 +18,12 @@ import (
 )
 
 func runInventory(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		switch args[0] {
+		case "approve", "attach-evidence", "accept-risk", "deprecate", "exclude":
+			return runInventoryMutation(strings.ReplaceAll(args[0], "-", "_"), args[1:], stdout, stderr)
+		}
+	}
 	jsonRequested := wantsJSONOutput(args)
 	fs := flag.NewFlagSet("inventory", flag.ContinueOnError)
 	if jsonRequested {

--- a/core/cli/inventory_mutations.go
+++ b/core/cli/inventory_mutations.go
@@ -1,0 +1,520 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Clyra-AI/wrkr/core/aggregate/controlbacklog"
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/identity"
+	"github.com/Clyra-AI/wrkr/core/lifecycle"
+	"github.com/Clyra-AI/wrkr/core/manifest"
+	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/proofemit"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+func runInventoryMutation(action string, args []string, stdout io.Writer, stderr io.Writer) int {
+	jsonRequested := wantsJSONOutput(args)
+	preID := ""
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		preID = args[0]
+		args = args[1:]
+	}
+
+	fs := flag.NewFlagSet("inventory "+action, flag.ContinueOnError)
+	if jsonRequested {
+		fs.SetOutput(io.Discard)
+	} else {
+		fs.SetOutput(stderr)
+	}
+	jsonOut := fs.Bool("json", false, "emit machine-readable output")
+	statePathFlag := fs.String("state", "", "state file path override")
+	owner := fs.String("owner", "", "owning team or reviewer")
+	evidenceRef := fs.String("evidence", "", "approval evidence ticket or URL")
+	evidenceURL := fs.String("url", "", "evidence URL")
+	controlID := fs.String("control", "", "governance control id")
+	expires := fs.String("expires", "", "approval or accepted-risk expiry duration, RFC3339 timestamp, or YYYY-MM-DD date")
+	reason := fs.String("reason", "", "deterministic lifecycle reason")
+	reviewCadence := fs.String("review-cadence", "90d", "review cadence for approved inventory entries")
+
+	if code, handled := parseFlags(fs, args, stderr, jsonRequested || *jsonOut); handled {
+		return code
+	}
+	id := strings.TrimSpace(preID)
+	if id == "" {
+		if fs.NArg() != 1 {
+			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", "inventory item id is required", exitInvalidInput)
+		}
+		id = fs.Arg(0)
+	} else if fs.NArg() != 0 {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", "inventory item id is required", exitInvalidInput)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	mutation := lifecycle.InventoryMutation{
+		Action:        action,
+		Owner:         strings.TrimSpace(*owner),
+		ControlID:     strings.TrimSpace(*controlID),
+		Reason:        strings.TrimSpace(*reason),
+		ReviewCadence: strings.TrimSpace(*reviewCadence),
+		Now:           now,
+	}
+	switch action {
+	case "approve":
+		mutation.EvidenceURL = strings.TrimSpace(*evidenceRef)
+		if err := validateEvidenceOrTicket(mutation.EvidenceURL); err != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
+		}
+		expiresAt, err := parseRequiredFutureExpiry(*expires, now)
+		if err != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
+		}
+		mutation.ExpiresAt = expiresAt
+	case "attach_evidence":
+		mutation.EvidenceURL = strings.TrimSpace(*evidenceURL)
+		if err := validateEvidenceURL(mutation.EvidenceURL); err != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
+		}
+	case "accept_risk":
+		expiresAt, err := parseRequiredFutureExpiry(*expires, now)
+		if err != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
+		}
+		mutation.ExpiresAt = expiresAt
+	}
+
+	resolvedStatePath := state.ResolvePath(*statePathFlag)
+	preflight, preflightErr := preflightStateMutationArtifacts(resolvedStatePath)
+	if preflightErr != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "unsafe_operation_blocked", preflightErr.Error(), exitUnsafeBlocked)
+	}
+
+	snapshot, err := state.Load(resolvedStatePath)
+	if err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
+	loadedManifest, err := manifest.Load(preflight.manifestPath)
+	if err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
+	loadedManifest.Identities = model.FilterLegacyArtifactIdentityRecords(loadedManifest.Identities)
+
+	agentID, resolveErr := resolveInventoryMutationAgentID(id, loadedManifest, snapshot)
+	if resolveErr != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", resolveErr.Error(), exitInvalidInput)
+	}
+	mutation.AgentID = agentID
+	nextManifest, transition, transitionErr := lifecycle.ApplyInventoryMutation(loadedManifest, mutation)
+	if transitionErr != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", transitionErr.Error(), exitInvalidInput)
+	}
+	updatedRecord, ok := findManifestIdentity(nextManifest, agentID)
+	if !ok {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", "updated identity record missing after mutation", exitRuntime)
+	}
+	applyInventoryMutationToSnapshot(&snapshot, updatedRecord, transition, id, action)
+
+	lifecycleChain, chainErr := lifecycle.LoadChain(preflight.lifecyclePath)
+	if chainErr != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", chainErr.Error(), exitRuntime)
+	}
+	if _, err := proofemit.LoadChain(preflight.proofChainPath); err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
+	if err := lifecycle.AppendTransitionRecord(lifecycleChain, transition, eventTypeForInventoryAction(action)); err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
+
+	snapshots, snapshotErr := captureManagedArtifacts(
+		preflight.statePath,
+		preflight.manifestPath,
+		preflight.lifecyclePath,
+		preflight.proofChainPath,
+		preflight.proofAttestationPath,
+		preflight.signingKeyPath,
+	)
+	if snapshotErr != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "unsafe_operation_blocked", snapshotErr.Error(), exitUnsafeBlocked)
+	}
+	if err := state.Save(preflight.statePath, snapshot); err != nil {
+		return emitRolledBackRuntimeFailure(stderr, jsonRequested || *jsonOut, err, snapshots)
+	}
+	if err := lifecycle.SaveChain(preflight.lifecyclePath, lifecycleChain); err != nil {
+		return emitRolledBackRuntimeFailure(stderr, jsonRequested || *jsonOut, err, snapshots)
+	}
+	if err := proofemit.EmitIdentityTransition(preflight.statePath, transition, eventTypeForInventoryAction(action)); err != nil {
+		return emitRolledBackRuntimeFailure(stderr, jsonRequested || *jsonOut, err, snapshots)
+	}
+	if err := manifest.Save(preflight.manifestPath, nextManifest); err != nil {
+		return emitRolledBackRuntimeFailure(stderr, jsonRequested || *jsonOut, err, snapshots)
+	}
+
+	payload := map[string]any{
+		"status":                     "ok",
+		"approval_inventory_version": manifest.ApprovalInventoryVersion,
+		"action":                     action,
+		"identity":                   updatedRecord,
+		"transition":                 transition,
+		"state_path":                 preflight.statePath,
+		"manifest_path":              preflight.manifestPath,
+		"proof_chain_path":           preflight.proofChainPath,
+	}
+	if jsonRequested || *jsonOut {
+		_ = json.NewEncoder(stdout).Encode(payload)
+		return exitSuccess
+	}
+	_, _ = fmt.Fprintf(stdout, "wrkr inventory %s %s\n", action, agentID)
+	return exitSuccess
+}
+
+type stateMutationPreflight struct {
+	statePath            string
+	manifestPath         string
+	lifecyclePath        string
+	proofChainPath       string
+	proofAttestationPath string
+	signingKeyPath       string
+}
+
+func preflightStateMutationArtifacts(statePathRaw string) (stateMutationPreflight, error) {
+	statePath, err := normalizeManagedArtifactPath(statePathRaw)
+	if err != nil {
+		return stateMutationPreflight{}, err
+	}
+	manifestPath, err := normalizeManagedArtifactPath(manifest.ResolvePath(statePath))
+	if err != nil {
+		return stateMutationPreflight{}, err
+	}
+	lifecyclePath, err := normalizeManagedArtifactPath(lifecycle.ChainPath(statePath))
+	if err != nil {
+		return stateMutationPreflight{}, err
+	}
+	proofChainPath, err := normalizeManagedArtifactPath(proofemit.ChainPath(statePath))
+	if err != nil {
+		return stateMutationPreflight{}, err
+	}
+	proofAttestationPath, err := normalizeManagedArtifactPath(proofemit.ChainAttestationPath(proofChainPath))
+	if err != nil {
+		return stateMutationPreflight{}, err
+	}
+	signingKeyPath, err := normalizeManagedArtifactPath(proofemit.SigningKeyPath(statePath))
+	if err != nil {
+		return stateMutationPreflight{}, err
+	}
+	entries := []scanArtifactPathEntry{}
+	for _, item := range []struct {
+		label string
+		path  string
+	}{
+		{label: "--state", path: statePath},
+		{label: "manifest", path: manifestPath},
+		{label: "lifecycle chain", path: lifecyclePath},
+		{label: "proof chain", path: proofChainPath},
+		{label: "proof attestation", path: proofAttestationPath},
+		{label: "proof signing key", path: signingKeyPath},
+	} {
+		entry, entryErr := newScanArtifactPathEntry(item.label, item.path)
+		if entryErr != nil {
+			return stateMutationPreflight{}, entryErr
+		}
+		entries = append(entries, entry)
+		if err := rejectUnsafeExistingMutationArtifact(item.path); err != nil {
+			return stateMutationPreflight{}, err
+		}
+	}
+	if err := detectScanArtifactPathCollisions(entries); err != nil {
+		return stateMutationPreflight{}, err
+	}
+	return stateMutationPreflight{
+		statePath:            statePath,
+		manifestPath:         manifestPath,
+		lifecyclePath:        lifecyclePath,
+		proofChainPath:       proofChainPath,
+		proofAttestationPath: proofAttestationPath,
+		signingKeyPath:       signingKeyPath,
+	}, nil
+}
+
+func rejectUnsafeExistingMutationArtifact(path string) error {
+	cleanPath := filepath.Clean(strings.TrimSpace(path))
+	info, err := os.Lstat(cleanPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat managed mutation artifact %s: %w", cleanPath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("managed mutation artifact must be a regular file, not a symlink: %s", cleanPath)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("managed mutation artifact must be a regular file: %s", cleanPath)
+	}
+	return nil
+}
+
+func resolveInventoryMutationAgentID(id string, m manifest.Manifest, snapshot state.Snapshot) (string, error) {
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return "", fmt.Errorf("inventory item id is required")
+	}
+	for _, record := range m.Identities {
+		if strings.TrimSpace(record.AgentID) == trimmed || strings.TrimSpace(record.ToolID) == trimmed {
+			return strings.TrimSpace(record.AgentID), nil
+		}
+	}
+	if snapshot.Inventory != nil {
+		for _, tool := range snapshot.Inventory.Tools {
+			if strings.TrimSpace(tool.AgentID) == trimmed || strings.TrimSpace(tool.ToolID) == trimmed {
+				return strings.TrimSpace(tool.AgentID), nil
+			}
+		}
+	}
+	if snapshot.ControlBacklog != nil {
+		for _, item := range snapshot.ControlBacklog.Items {
+			if strings.TrimSpace(item.ID) != trimmed {
+				continue
+			}
+			if agentID := agentIDForInventoryPath(snapshot, item.Repo, item.Path); agentID != "" {
+				return agentID, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("inventory item %s not found", trimmed)
+}
+
+func findManifestIdentity(m manifest.Manifest, agentID string) (manifest.IdentityRecord, bool) {
+	for _, record := range m.Identities {
+		if strings.TrimSpace(record.AgentID) == strings.TrimSpace(agentID) {
+			return record, true
+		}
+	}
+	return manifest.IdentityRecord{}, false
+}
+
+func applyInventoryMutationToSnapshot(snapshot *state.Snapshot, record manifest.IdentityRecord, transition lifecycle.Transition, requestedID string, action string) {
+	if snapshot == nil {
+		return
+	}
+	snapshot.ApprovalInventoryVersion = state.ApprovalInventoryVersion
+	replaced := false
+	for idx := range snapshot.Identities {
+		if strings.TrimSpace(snapshot.Identities[idx].AgentID) == strings.TrimSpace(record.AgentID) {
+			snapshot.Identities[idx] = record
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		snapshot.Identities = append(snapshot.Identities, record)
+	}
+	snapshot.Transitions = append(snapshot.Transitions, transition)
+
+	if snapshot.Inventory != nil {
+		for idx := range snapshot.Inventory.Tools {
+			tool := &snapshot.Inventory.Tools[idx]
+			if strings.TrimSpace(tool.AgentID) != strings.TrimSpace(record.AgentID) && strings.TrimSpace(tool.ToolID) != strings.TrimSpace(record.ToolID) {
+				continue
+			}
+			tool.ApprovalStatus = strings.TrimSpace(record.ApprovalState)
+			tool.LifecycleState = strings.TrimSpace(record.Status)
+			tool.ApprovalClass = inventoryApprovalClass(record)
+			tool.SecurityVisibilityStatus = inventorySecurityVisibility(record)
+			if strings.TrimSpace(record.Approval.Owner) != "" {
+				for locIdx := range tool.Locations {
+					tool.Locations[locIdx].Owner = strings.TrimSpace(record.Approval.Owner)
+					tool.Locations[locIdx].OwnerSource = "inventory_approval"
+					tool.Locations[locIdx].OwnershipStatus = "explicit"
+				}
+			}
+		}
+		for idx := range snapshot.Inventory.Agents {
+			agent := &snapshot.Inventory.Agents[idx]
+			if strings.TrimSpace(agent.AgentID) == strings.TrimSpace(record.AgentID) || strings.TrimSpace(agent.AgentInstanceID) == strings.TrimSpace(record.ToolID) {
+				agent.SecurityVisibilityStatus = inventorySecurityVisibility(record)
+			}
+		}
+	}
+	if snapshot.ControlBacklog != nil {
+		items := snapshot.ControlBacklog.Items[:0]
+		for _, item := range snapshot.ControlBacklog.Items {
+			if backlogItemMatchesRecord(item.ID, item.Repo, item.Path, requestedID, record) {
+				if action == "exclude" {
+					continue
+				}
+				item.ApprovalStatus = strings.TrimSpace(record.ApprovalState)
+				item.SecurityVisibility = inventorySecurityVisibility(record)
+				item.Owner = strings.TrimSpace(record.Approval.Owner)
+				if item.Owner != "" {
+					item.OwnerSource = "inventory_approval"
+					item.OwnershipStatus = "explicit"
+				}
+				switch action {
+				case "approve", "accept_risk", "attach_evidence":
+					item.RecommendedAction = controlbacklog.ActionMonitor
+					item.EvidenceGaps = nil
+					item.ConfidenceRaise = nil
+				case "deprecate":
+					item.RecommendedAction = controlbacklog.ActionDeprecate
+				}
+			}
+			items = append(items, item)
+		}
+		snapshot.ControlBacklog.Items = items
+		snapshot.ControlBacklog.Summary = summarizeBacklogItems(items)
+	}
+}
+
+func backlogItemMatchesRecord(itemID, repo, path, requestedID string, record manifest.IdentityRecord) bool {
+	if strings.TrimSpace(itemID) != "" && strings.TrimSpace(itemID) == strings.TrimSpace(requestedID) {
+		return true
+	}
+	return strings.TrimSpace(repo) == strings.TrimSpace(record.Repo) && strings.TrimSpace(path) == strings.TrimSpace(record.Location)
+}
+
+func summarizeBacklogItems(items []controlbacklog.Item) controlbacklog.Summary {
+	summary := controlbacklog.Summary{TotalItems: len(items)}
+	for _, item := range items {
+		switch strings.TrimSpace(item.SignalClass) {
+		case controlbacklog.SignalClassUniqueWrkrSignal:
+			summary.UniqueWrkrSignalItems++
+		case controlbacklog.SignalClassSupportingSecurity:
+			summary.SupportingSecurityItems++
+		}
+		switch strings.TrimSpace(item.RecommendedAction) {
+		case controlbacklog.ActionAttachEvidence:
+			summary.AttachEvidenceActionItems++
+		case controlbacklog.ActionApprove:
+			summary.ApproveActionItems++
+		case controlbacklog.ActionRemediate:
+			summary.RemediateActionItems++
+		}
+	}
+	return summary
+}
+
+func inventoryApprovalClass(record manifest.IdentityRecord) string {
+	switch strings.TrimSpace(record.ApprovalState) {
+	case "valid":
+		return "approved"
+	case "accepted_risk", "expired", "invalid", "deprecated", "excluded", "revoked", "missing":
+		return "unapproved"
+	default:
+		if strings.TrimSpace(record.Status) == identity.StateActive || strings.TrimSpace(record.Status) == identity.StateApproved {
+			return "approved"
+		}
+		return "unknown"
+	}
+}
+
+func inventorySecurityVisibility(record manifest.IdentityRecord) string {
+	switch strings.TrimSpace(record.ApprovalState) {
+	case "valid":
+		return agginventory.SecurityVisibilityKnownApproved
+	case "accepted_risk":
+		return agginventory.SecurityVisibilityAcceptedRisk
+	case "expired", "invalid":
+		return agginventory.SecurityVisibilityNeedsReview
+	case "deprecated":
+		return agginventory.SecurityVisibilityDeprecated
+	case "excluded", "revoked":
+		return agginventory.SecurityVisibilityRevoked
+	}
+	switch strings.TrimSpace(record.Status) {
+	case identity.StateDeprecated:
+		return agginventory.SecurityVisibilityDeprecated
+	case identity.StateRevoked:
+		return agginventory.SecurityVisibilityRevoked
+	case identity.StateActive, identity.StateApproved:
+		return agginventory.SecurityVisibilityKnownApproved
+	default:
+		return agginventory.SecurityVisibilityNeedsReview
+	}
+}
+
+func agentIDForInventoryPath(snapshot state.Snapshot, repo string, path string) string {
+	if snapshot.Inventory != nil {
+		for _, tool := range snapshot.Inventory.Tools {
+			for _, loc := range tool.Locations {
+				if strings.TrimSpace(loc.Repo) == strings.TrimSpace(repo) && strings.TrimSpace(loc.Location) == strings.TrimSpace(path) {
+					return strings.TrimSpace(tool.AgentID)
+				}
+			}
+		}
+	}
+	for _, record := range snapshot.Identities {
+		if strings.TrimSpace(record.Repo) == strings.TrimSpace(repo) && strings.TrimSpace(record.Location) == strings.TrimSpace(path) {
+			return strings.TrimSpace(record.AgentID)
+		}
+	}
+	return ""
+}
+
+func eventTypeForInventoryAction(action string) string {
+	switch strings.TrimSpace(action) {
+	case "approve":
+		return "approval_recorded"
+	case "attach_evidence":
+		return "evidence_attached"
+	case "accept_risk":
+		return "risk_accepted"
+	default:
+		return "lifecycle_transition"
+	}
+}
+
+func parseRequiredFutureExpiry(raw string, now time.Time) (time.Time, error) {
+	if strings.TrimSpace(raw) == "" {
+		return time.Time{}, fmt.Errorf("--expires is required")
+	}
+	expiresAt, err := lifecycle.ParseExpiry(raw, now)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if !expiresAt.After(now) {
+		return time.Time{}, fmt.Errorf("expiry must be in the future")
+	}
+	return expiresAt, nil
+}
+
+func validateEvidenceOrTicket(value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fmt.Errorf("--evidence is required")
+	}
+	if strings.Contains(trimmed, "://") {
+		return validateEvidenceURL(trimmed)
+	}
+	if strings.ContainsAny(trimmed, " \t\r\n") {
+		return fmt.Errorf("evidence ticket must not contain whitespace")
+	}
+	return nil
+}
+
+func validateEvidenceURL(value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fmt.Errorf("evidence URL is required")
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return fmt.Errorf("invalid evidence URL: %w", err)
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "http", "https", "file":
+		if parsed.Scheme != "file" && strings.TrimSpace(parsed.Host) == "" {
+			return fmt.Errorf("invalid evidence URL: host is required")
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid evidence URL scheme %q", parsed.Scheme)
+	}
+}

--- a/core/cli/inventory_mutations.go
+++ b/core/cli/inventory_mutations.go
@@ -266,18 +266,43 @@ func resolveInventoryMutationAgentID(id string, m manifest.Manifest, snapshot st
 	if trimmed == "" {
 		return "", fmt.Errorf("inventory item id is required")
 	}
+	exactAgentMatches := map[string]struct{}{}
 	for _, record := range m.Identities {
-		if strings.TrimSpace(record.AgentID) == trimmed || strings.TrimSpace(record.ToolID) == trimmed {
-			return strings.TrimSpace(record.AgentID), nil
+		if strings.TrimSpace(record.AgentID) == trimmed {
+			exactAgentMatches[strings.TrimSpace(record.AgentID)] = struct{}{}
 		}
 	}
 	if snapshot.Inventory != nil {
 		for _, tool := range snapshot.Inventory.Tools {
-			if strings.TrimSpace(tool.AgentID) == trimmed || strings.TrimSpace(tool.ToolID) == trimmed {
-				return strings.TrimSpace(tool.AgentID), nil
+			if strings.TrimSpace(tool.AgentID) == trimmed {
+				exactAgentMatches[strings.TrimSpace(tool.AgentID)] = struct{}{}
 			}
 		}
 	}
+	if agentID, ok := singleAgentMatch(exactAgentMatches); ok {
+		return agentID, nil
+	}
+
+	toolIDMatches := map[string]struct{}{}
+	for _, record := range m.Identities {
+		if strings.TrimSpace(record.ToolID) == trimmed && strings.TrimSpace(record.AgentID) != "" {
+			toolIDMatches[strings.TrimSpace(record.AgentID)] = struct{}{}
+		}
+	}
+	if snapshot.Inventory != nil {
+		for _, tool := range snapshot.Inventory.Tools {
+			if strings.TrimSpace(tool.ToolID) == trimmed && strings.TrimSpace(tool.AgentID) != "" {
+				toolIDMatches[strings.TrimSpace(tool.AgentID)] = struct{}{}
+			}
+		}
+	}
+	if len(toolIDMatches) > 1 {
+		return "", fmt.Errorf("inventory item %s is ambiguous; use an explicit agent_id", trimmed)
+	}
+	if agentID, ok := singleAgentMatch(toolIDMatches); ok {
+		return agentID, nil
+	}
+
 	if snapshot.ControlBacklog != nil {
 		for _, item := range snapshot.ControlBacklog.Items {
 			if strings.TrimSpace(item.ID) != trimmed {
@@ -289,6 +314,16 @@ func resolveInventoryMutationAgentID(id string, m manifest.Manifest, snapshot st
 		}
 	}
 	return "", fmt.Errorf("inventory item %s not found", trimmed)
+}
+
+func singleAgentMatch(matches map[string]struct{}) (string, bool) {
+	if len(matches) != 1 {
+		return "", false
+	}
+	for agentID := range matches {
+		return agentID, true
+	}
+	return "", false
 }
 
 func findManifestIdentity(m manifest.Manifest, agentID string) (manifest.IdentityRecord, bool) {
@@ -321,7 +356,7 @@ func applyInventoryMutationToSnapshot(snapshot *state.Snapshot, record manifest.
 	if snapshot.Inventory != nil {
 		for idx := range snapshot.Inventory.Tools {
 			tool := &snapshot.Inventory.Tools[idx]
-			if strings.TrimSpace(tool.AgentID) != strings.TrimSpace(record.AgentID) && strings.TrimSpace(tool.ToolID) != strings.TrimSpace(record.ToolID) {
+			if strings.TrimSpace(tool.AgentID) != strings.TrimSpace(record.AgentID) {
 				continue
 			}
 			tool.ApprovalStatus = strings.TrimSpace(record.ApprovalState)
@@ -338,7 +373,7 @@ func applyInventoryMutationToSnapshot(snapshot *state.Snapshot, record manifest.
 		}
 		for idx := range snapshot.Inventory.Agents {
 			agent := &snapshot.Inventory.Agents[idx]
-			if strings.TrimSpace(agent.AgentID) == strings.TrimSpace(record.AgentID) || strings.TrimSpace(agent.AgentInstanceID) == strings.TrimSpace(record.ToolID) {
+			if strings.TrimSpace(agent.AgentID) == strings.TrimSpace(record.AgentID) {
 				agent.SecurityVisibilityStatus = inventorySecurityVisibility(record)
 			}
 		}

--- a/core/cli/inventory_mutations_test.go
+++ b/core/cli/inventory_mutations_test.go
@@ -134,6 +134,116 @@ func TestInventoryMutationRejectsUnsafeManagedMarker(t *testing.T) {
 	}
 }
 
+func TestInventoryApproveUpdatesOnlyResolvedAgentID(t *testing.T) {
+	tmp := t.TempDir()
+	statePath, agentID := writeInventoryMutationFixture(t, tmp)
+	loadedState, err := state.Load(statePath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	loadedManifest, err := manifest.Load(manifest.ResolvePath(statePath))
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	sharedToolID := loadedManifest.Identities[0].ToolID
+	other := loadedManifest.Identities[0]
+	other.AgentID = identity.AgentID(sharedToolID, "beta")
+	other.Org = "beta"
+	other.Repo = "beta/repo"
+	other.ApprovalState = "missing"
+	other.Status = identity.StateUnderReview
+	loadedManifest.Identities = append(loadedManifest.Identities, other)
+	if err := manifest.Save(manifest.ResolvePath(statePath), loadedManifest); err != nil {
+		t.Fatalf("save expanded manifest: %v", err)
+	}
+	loadedState.Identities = append(loadedState.Identities, other)
+	loadedState.Inventory.Tools = append(loadedState.Inventory.Tools, agginventory.Tool{
+		ToolID:         sharedToolID,
+		AgentID:        other.AgentID,
+		ToolType:       "codex",
+		Org:            "beta",
+		Repos:          []string{"beta/repo"},
+		Locations:      []agginventory.ToolLocation{{Repo: "beta/repo", Location: "AGENTS.md"}},
+		ApprovalStatus: "missing",
+		ApprovalClass:  "unapproved",
+		LifecycleState: identity.StateUnderReview,
+	})
+	if err := state.Save(statePath, loadedState); err != nil {
+		t.Fatalf("save expanded state: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"inventory", "approve", agentID,
+		"--owner", "platform-security",
+		"--evidence", "SEC-123",
+		"--expires", "90d",
+		"--state", statePath,
+		"--json",
+	}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("inventory approve failed: code=%d stderr=%s", code, errOut.String())
+	}
+	next, err := state.Load(statePath)
+	if err != nil {
+		t.Fatalf("load mutated state: %v", err)
+	}
+	byAgent := map[string]agginventory.Tool{}
+	for _, tool := range next.Inventory.Tools {
+		byAgent[tool.AgentID] = tool
+	}
+	if byAgent[agentID].ApprovalStatus != "valid" {
+		t.Fatalf("expected targeted agent approved, got %+v", byAgent[agentID])
+	}
+	if byAgent[other.AgentID].ApprovalStatus != "missing" {
+		t.Fatalf("expected non-target agent unchanged, got %+v", byAgent[other.AgentID])
+	}
+}
+
+func TestInventoryMutationRejectsAmbiguousToolID(t *testing.T) {
+	tmp := t.TempDir()
+	statePath, _ := writeInventoryMutationFixture(t, tmp)
+	loadedState, err := state.Load(statePath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	loadedManifest, err := manifest.Load(manifest.ResolvePath(statePath))
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	sharedToolID := loadedManifest.Identities[0].ToolID
+	other := loadedManifest.Identities[0]
+	other.AgentID = identity.AgentID(sharedToolID, "beta")
+	other.Org = "beta"
+	other.Repo = "beta/repo"
+	loadedManifest.Identities = append(loadedManifest.Identities, other)
+	if err := manifest.Save(manifest.ResolvePath(statePath), loadedManifest); err != nil {
+		t.Fatalf("save expanded manifest: %v", err)
+	}
+	loadedState.Identities = append(loadedState.Identities, other)
+	if err := state.Save(statePath, loadedState); err != nil {
+		t.Fatalf("save expanded state: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"inventory", "approve", sharedToolID,
+		"--owner", "platform-security",
+		"--evidence", "SEC-123",
+		"--expires", "90d",
+		"--state", statePath,
+		"--json",
+	}, &out, &errOut)
+	if code != exitInvalidInput {
+		t.Fatalf("expected exit 6, got %d stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "ambiguous") {
+		t.Fatalf("expected ambiguous tool_id error, got %q", errOut.String())
+	}
+}
+
 func writeInventoryMutationFixture(t *testing.T, dir string) (string, string) {
 	t.Helper()
 	statePath := filepath.Join(dir, "state.json")

--- a/core/cli/inventory_mutations_test.go
+++ b/core/cli/inventory_mutations_test.go
@@ -1,0 +1,215 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Clyra-AI/wrkr/core/aggregate/controlbacklog"
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/identity"
+	"github.com/Clyra-AI/wrkr/core/manifest"
+	"github.com/Clyra-AI/wrkr/core/proofemit"
+	"github.com/Clyra-AI/wrkr/core/source"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+func TestInventoryApproveWritesApprovalProofRecordAtomically(t *testing.T) {
+	tmp := t.TempDir()
+	statePath, agentID := writeInventoryMutationFixture(t, tmp)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"inventory", "approve", agentID,
+		"--owner", "platform-security",
+		"--evidence", "https://tickets.example/SEC-123",
+		"--expires", time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339),
+		"--state", statePath,
+		"--json",
+	}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("inventory approve failed: code=%d stderr=%s", code, errOut.String())
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("expected clean stderr, got %q", errOut.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse approve payload: %v", err)
+	}
+	if payload["approval_inventory_version"] != manifest.ApprovalInventoryVersion {
+		t.Fatalf("expected approval_inventory_version, got %v", payload)
+	}
+
+	loadedManifest, err := manifest.Load(manifest.ResolvePath(statePath))
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	if loadedManifest.Identities[0].Approval.Owner != "platform-security" {
+		t.Fatalf("expected approval owner, got %+v", loadedManifest.Identities[0].Approval)
+	}
+	if loadedManifest.Identities[0].ApprovalState != "valid" {
+		t.Fatalf("expected valid approval, got %+v", loadedManifest.Identities[0])
+	}
+	loadedState, err := state.Load(statePath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if loadedState.ApprovalInventoryVersion != state.ApprovalInventoryVersion {
+		t.Fatalf("expected state approval inventory version, got %q", loadedState.ApprovalInventoryVersion)
+	}
+	if loadedState.ControlBacklog == nil || len(loadedState.ControlBacklog.Items) != 1 {
+		t.Fatalf("expected retained backlog item after approval, got %+v", loadedState.ControlBacklog)
+	}
+	if loadedState.ControlBacklog.Items[0].RecommendedAction != controlbacklog.ActionMonitor {
+		t.Fatalf("expected approved item to move to monitor, got %+v", loadedState.ControlBacklog.Items[0])
+	}
+
+	chain, err := proofemit.LoadChain(proofemit.ChainPath(statePath))
+	if err != nil {
+		t.Fatalf("load proof chain: %v", err)
+	}
+	found := false
+	for _, record := range chain.Records {
+		eventType, _ := record.Event["event_type"].(string)
+		if record.RecordType == "approval" && eventType == "approval_recorded" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected approval_recorded proof record, got %+v", chain.Records)
+	}
+}
+
+func TestInventoryAcceptRiskRequiresExpiry(t *testing.T) {
+	tmp := t.TempDir()
+	statePath, agentID := writeInventoryMutationFixture(t, tmp)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{"inventory", "accept-risk", agentID, "--state", statePath, "--json"}, &out, &errOut)
+	if code != exitInvalidInput {
+		t.Fatalf("expected exit 6, got %d stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected no stdout on invalid input, got %q", out.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(errOut.Bytes(), &payload); err != nil {
+		t.Fatalf("parse error payload: %v", err)
+	}
+	errObj, _ := payload["error"].(map[string]any)
+	if errObj["code"] != "invalid_input" {
+		t.Fatalf("expected invalid_input, got %v", payload)
+	}
+}
+
+func TestInventoryMutationRejectsUnsafeManagedMarker(t *testing.T) {
+	tmp := t.TempDir()
+	realStatePath, agentID := writeInventoryMutationFixture(t, tmp)
+	stateLink := filepath.Join(tmp, "state-link.json")
+	if err := os.Symlink(filepath.Base(realStatePath), stateLink); err != nil {
+		t.Fatalf("create state symlink: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"inventory", "deprecate", agentID,
+		"--reason", "retired",
+		"--state", stateLink,
+		"--json",
+	}, &out, &errOut)
+	if code != exitUnsafeBlocked {
+		t.Fatalf("expected unsafe exit 8, got %d stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "regular file") {
+		t.Fatalf("expected regular-file safety error, got %q", errOut.String())
+	}
+}
+
+func writeInventoryMutationFixture(t *testing.T, dir string) (string, string) {
+	t.Helper()
+	statePath := filepath.Join(dir, "state.json")
+	toolID := identity.ToolID("codex", "AGENTS.md")
+	agentID := identity.AgentID(toolID, "acme")
+	record := manifest.IdentityRecord{
+		AgentID:       agentID,
+		ToolID:        toolID,
+		ToolType:      "codex",
+		Org:           "acme",
+		Repo:          "acme/repo",
+		Location:      "AGENTS.md",
+		Status:        identity.StateUnderReview,
+		ApprovalState: "missing",
+		FirstSeen:     "2026-04-22T12:00:00Z",
+		LastSeen:      "2026-04-22T12:00:00Z",
+		Present:       true,
+	}
+	if err := manifest.Save(manifest.ResolvePath(statePath), manifest.Manifest{
+		Version:   manifest.Version,
+		UpdatedAt: "2026-04-22T12:00:00Z",
+		Identities: []manifest.IdentityRecord{
+			record,
+		},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	inventory := agginventory.Inventory{
+		InventoryVersion: "1",
+		Org:              "acme",
+		Tools: []agginventory.Tool{
+			{
+				ToolID:         toolID,
+				AgentID:        agentID,
+				ToolType:       "codex",
+				Org:            "acme",
+				Repos:          []string{"acme/repo"},
+				Locations:      []agginventory.ToolLocation{{Repo: "acme/repo", Location: "AGENTS.md"}},
+				ApprovalStatus: "missing",
+				ApprovalClass:  "unapproved",
+				LifecycleState: identity.StateUnderReview,
+			},
+		},
+	}
+	backlog := controlbacklog.Backlog{
+		ControlBacklogVersion: controlbacklog.BacklogVersion,
+		Summary:               controlbacklog.Summary{TotalItems: 1, ApproveActionItems: 1},
+		Items: []controlbacklog.Item{
+			{
+				ID:                 "cb-1",
+				Repo:               "acme/repo",
+				Path:               "AGENTS.md",
+				ControlSurfaceType: controlbacklog.ControlSurfaceCodingAssistant,
+				ControlPathType:    controlbacklog.ControlPathAgentConfig,
+				Capability:         "repo.contents.read",
+				EvidenceSource:     "test",
+				EvidenceBasis:      []string{"fixture"},
+				ApprovalStatus:     "missing",
+				SecurityVisibility: agginventory.SecurityVisibilityNeedsReview,
+				SignalClass:        controlbacklog.SignalClassUniqueWrkrSignal,
+				RecommendedAction:  controlbacklog.ActionApprove,
+				Confidence:         controlbacklog.ConfidenceMedium,
+				SLA:                "14d",
+				ClosureCriteria:    "Record approval evidence and review cadence.",
+			},
+		},
+	}
+	if err := state.Save(statePath, state.Snapshot{
+		Version:        state.SnapshotVersion,
+		Target:         source.Target{Mode: "path", Value: dir},
+		Findings:       []source.Finding{},
+		Inventory:      &inventory,
+		ControlBacklog: &backlog,
+		Identities:     []manifest.IdentityRecord{record},
+	}); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	return statePath, agentID
+}

--- a/core/cli/verify.go
+++ b/core/cli/verify.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Clyra-AI/wrkr/core/evidence"
 	"github.com/Clyra-AI/wrkr/core/proofemit"
 	"github.com/Clyra-AI/wrkr/core/state"
 	verifycore "github.com/Clyra-AI/wrkr/core/verify"
@@ -74,6 +75,13 @@ func runVerify(args []string, stdout io.Writer, stderr io.Writer) int {
 			"verification_mode":   result.VerificationMode,
 			"authenticity_status": result.AuthenticityStatus,
 		},
+	}
+	if snapshot, loadErr := state.Load(keyLookupPath); loadErr == nil {
+		if chain, chainErr := proofemit.LoadChain(chainPath); chainErr == nil {
+			if controlEvidence := evidence.BuildControlEvidence(snapshot, chain); len(controlEvidence) > 0 {
+				payload["control_evidence"] = controlEvidence
+			}
+		}
 	}
 	if *jsonOut {
 		_ = json.NewEncoder(stdout).Encode(payload)

--- a/core/evidence/control_evidence_test.go
+++ b/core/evidence/control_evidence_test.go
@@ -1,0 +1,133 @@
+package evidence
+
+import (
+	"testing"
+	"time"
+
+	proof "github.com/Clyra-AI/proof"
+	"github.com/Clyra-AI/wrkr/core/aggregate/controlbacklog"
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/identity"
+	"github.com/Clyra-AI/wrkr/core/manifest"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+func TestControlEvidenceRecordVerifiesInProofChain(t *testing.T) {
+	toolID := identity.ToolID("codex", "AGENTS.md")
+	agentID := identity.AgentID(toolID, "acme")
+	snapshot := controlEvidenceSnapshot(agentID, toolID, controlbacklog.Item{
+		ID:                "cb-approve",
+		Repo:              "acme/repo",
+		Path:              "AGENTS.md",
+		RecommendedAction: controlbacklog.ActionApprove,
+		ClosureCriteria:   "Record owner-approved, time-bounded approval evidence and rescan.",
+		GovernanceControls: []agginventory.GovernanceControlMapping{
+			{Control: agginventory.GovernanceControlApproval, Status: agginventory.ControlStatusGap},
+		},
+	})
+	chain := proof.NewChain("wrkr-proof")
+	chain.Records = append(chain.Records, proof.Record{
+		RecordID:   "rec-approval",
+		RecordType: "approval",
+		AgentID:    agentID,
+		Timestamp:  time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC),
+		Event: map[string]any{
+			"event_type":     "approval_recorded",
+			"owner":          "platform-security",
+			"review_cadence": "90d",
+			"control_id":     agginventory.GovernanceControlApproval,
+		},
+	})
+
+	status := BuildControlEvidence(snapshot, chain)
+	if len(status) != 1 {
+		t.Fatalf("expected one control evidence status, got %+v", status)
+	}
+	if status[0].Status != "satisfied" {
+		t.Fatalf("expected satisfied proof status, got %+v", status[0])
+	}
+	for _, required := range []string{
+		agginventory.GovernanceControlApproval,
+		agginventory.GovernanceControlOwnerAssigned,
+		agginventory.GovernanceControlReviewCadence,
+	} {
+		if !containsString(status[0].ExistingProof, required) {
+			t.Fatalf("expected %s proof, got %+v", required, status[0])
+		}
+	}
+}
+
+func TestBacklogClosureCriteriaMapsToProofRequirements(t *testing.T) {
+	toolID := identity.ToolID("workflow", ".github/workflows/deploy.yml")
+	agentID := identity.AgentID(toolID, "acme")
+	snapshot := controlEvidenceSnapshot(agentID, toolID, controlbacklog.Item{
+		ID:                "cb-secret-write",
+		Repo:              "acme/repo",
+		Path:              ".github/workflows/deploy.yml",
+		RecommendedAction: controlbacklog.ActionAttachEvidence,
+		ClosureCriteria:   "Attach proof for secret rotation, least privilege, and deployment gate evidence.",
+		WritePathClasses:  []string{agginventory.WritePathRepoWrite, agginventory.WritePathDeployWrite},
+		SecretSignalTypes: []string{"secret_rotation_evidence_missing"},
+		GovernanceControls: []agginventory.GovernanceControlMapping{
+			{Control: agginventory.GovernanceControlRotation, Status: agginventory.ControlStatusGap},
+		},
+	})
+	chain := proof.NewChain("wrkr-proof")
+	chain.Records = append(chain.Records, proof.Record{
+		RecordID:   "rec-evidence",
+		RecordType: "evidence",
+		AgentID:    agentID,
+		Event: map[string]any{
+			"event_type":   "evidence_attached",
+			"evidence_url": "https://tickets.example/SEC-123",
+			"control_id":   agginventory.GovernanceControlRotation,
+		},
+	})
+
+	status := BuildControlEvidence(snapshot, chain)
+	if len(status) != 1 {
+		t.Fatalf("expected one control evidence status, got %+v", status)
+	}
+	for _, required := range []string{
+		agginventory.GovernanceControlLeastPrivilege,
+		agginventory.GovernanceControlDeploymentGate,
+		agginventory.GovernanceControlRotation,
+		agginventory.GovernanceControlProof,
+	} {
+		if !containsString(status[0].MissingProof, required) {
+			t.Fatalf("expected missing %s proof, got %+v", required, status[0])
+		}
+	}
+	if !containsString(status[0].ExistingProof, "evidence_attached") {
+		t.Fatalf("expected attached evidence proof, got %+v", status[0])
+	}
+}
+
+func controlEvidenceSnapshot(agentID string, toolID string, item controlbacklog.Item) state.Snapshot {
+	return state.Snapshot{
+		Inventory: &agginventory.Inventory{
+			Tools: []agginventory.Tool{
+				{
+					AgentID:   agentID,
+					ToolID:    toolID,
+					Org:       "acme",
+					Repos:     []string{"acme/repo"},
+					Locations: []agginventory.ToolLocation{{Repo: item.Repo, Location: item.Path}},
+				},
+			},
+		},
+		ControlBacklog: &controlbacklog.Backlog{Items: []controlbacklog.Item{item}},
+		Identities: []manifest.IdentityRecord{
+			{AgentID: agentID, ToolID: toolID, Org: "acme", Repo: item.Repo, Location: item.Path, Present: true},
+		},
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/core/evidence/evidence.go
+++ b/core/evidence/evidence.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	proof "github.com/Clyra-AI/proof"
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/compliance"
 	"github.com/Clyra-AI/wrkr/core/proofemit"
 	reportcore "github.com/Clyra-AI/wrkr/core/report"
@@ -37,8 +38,19 @@ type BuildResult struct {
 	ManifestPath      string             `json:"manifest_path"`
 	ChainPath         string             `json:"chain_path"`
 	FrameworkCoverage map[string]float64 `json:"framework_coverage"`
+	ControlEvidence   []ControlEvidence  `json:"control_evidence,omitempty"`
 	CoverageNote      CoverageNote       `json:"coverage_note"`
 	ReportArtifacts   []string           `json:"report_artifacts"`
+}
+
+type ControlEvidence struct {
+	ControlID     string   `json:"control_id"`
+	BacklogItemID string   `json:"backlog_item_id"`
+	AgentID       string   `json:"agent_id,omitempty"`
+	Status        string   `json:"status"`
+	ExistingProof []string `json:"existing_proof,omitempty"`
+	MissingProof  []string `json:"missing_proof,omitempty"`
+	RecordIDs     []string `json:"record_ids,omitempty"`
 }
 
 type CoverageNote struct {
@@ -247,6 +259,10 @@ func Build(in BuildInput) (BuildResult, error) {
 	if err := writeJSON(filepath.Join(outputDir, "compliance-summary.json"), complianceSummary); err != nil {
 		return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 	}
+	controlEvidence := BuildControlEvidence(snapshot, chain)
+	if err := writeJSON(filepath.Join(outputDir, "control-evidence.json"), controlEvidence); err != nil {
+		return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
+	}
 	if err := writeJSON(filepath.Join(outputDir, "posture-score.json"), snapshot.PostureScore); err != nil {
 		return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 	}
@@ -394,6 +410,7 @@ func Build(in BuildInput) (BuildResult, error) {
 		ManifestPath:      filepath.Join(targetOutputDir, "manifest.json"),
 		ChainPath:         chainPath,
 		FrameworkCoverage: coverage,
+		ControlEvidence:   controlEvidence,
 		CoverageNote:      defaultCoverageNote(),
 		ReportArtifacts:   reportArtifacts,
 	}, nil
@@ -408,6 +425,221 @@ func defaultCoverageNote() CoverageNote {
 			"Run wrkr report --top 5 --json to prioritize missing controls and approvals.",
 			"Remediate the highest-priority gaps and rerun wrkr scan, wrkr evidence, and wrkr report with the same deterministic inputs.",
 		},
+	}
+}
+
+func BuildControlEvidence(snapshot state.Snapshot, chain *proof.Chain) []ControlEvidence {
+	if chain == nil || snapshot.ControlBacklog == nil || len(snapshot.ControlBacklog.Items) == 0 {
+		return nil
+	}
+	out := make([]ControlEvidence, 0, len(snapshot.ControlBacklog.Items))
+	for _, item := range snapshot.ControlBacklog.Items {
+		controlID := primaryControlID(item.GovernanceControls)
+		agentID := agentIDForBacklogItem(snapshot, item.Repo, item.Path)
+		requirements := proofRequirementsForBacklogItem(item.RecommendedAction, item.ClosureCriteria, item.WritePathClasses, item.SecretSignalTypes)
+		existing, recordIDs := existingProofForRequirements(requirements, controlID, agentID, chain.Records)
+		missing := differenceStrings(requirements, existing)
+		status := "satisfied"
+		if len(missing) > 0 {
+			status = "missing"
+		}
+		out = append(out, ControlEvidence{
+			ControlID:     controlID,
+			BacklogItemID: strings.TrimSpace(item.ID),
+			AgentID:       agentID,
+			Status:        status,
+			ExistingProof: existing,
+			MissingProof:  missing,
+			RecordIDs:     recordIDs,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ControlID != out[j].ControlID {
+			return out[i].ControlID < out[j].ControlID
+		}
+		return out[i].BacklogItemID < out[j].BacklogItemID
+	})
+	return out
+}
+
+func primaryControlID(controls []agginventory.GovernanceControlMapping) string {
+	values := make([]string, 0, len(controls))
+	for _, item := range controls {
+		control := strings.TrimSpace(item.Control)
+		if control != "" {
+			values = append(values, control)
+		}
+	}
+	sort.Strings(values)
+	if len(values) == 0 {
+		return "control_path_governance"
+	}
+	return values[0]
+}
+
+func proofRequirementsForBacklogItem(action, closure string, writeClasses []string, secretSignals []string) []string {
+	requirements := []string{
+		agginventory.GovernanceControlOwnerAssigned,
+		agginventory.GovernanceControlApproval,
+		agginventory.GovernanceControlReviewCadence,
+	}
+	if strings.TrimSpace(action) == "attach_evidence" || strings.Contains(strings.ToLower(closure), "proof") {
+		requirements = append(requirements, "evidence_attached", agginventory.GovernanceControlProof)
+	}
+	for _, class := range writeClasses {
+		switch strings.TrimSpace(class) {
+		case agginventory.WritePathRepoWrite, agginventory.WritePathPullRequestWrite, agginventory.WritePathReleaseWrite, agginventory.WritePathPackagePublish, agginventory.WritePathDeployWrite, agginventory.WritePathInfraWrite:
+			requirements = append(requirements, agginventory.GovernanceControlLeastPrivilege)
+		case agginventory.WritePathProductionAdjacent:
+			requirements = append(requirements, agginventory.GovernanceControlProduction)
+		}
+		if strings.TrimSpace(class) == agginventory.WritePathDeployWrite || strings.TrimSpace(class) == agginventory.WritePathReleaseWrite {
+			requirements = append(requirements, agginventory.GovernanceControlDeploymentGate)
+		}
+	}
+	for _, signal := range secretSignals {
+		if strings.TrimSpace(signal) == "secret_rotation_evidence_missing" {
+			requirements = append(requirements, agginventory.GovernanceControlRotation)
+		}
+	}
+	return uniqueSortedStrings(requirements)
+}
+
+func existingProofForRequirements(requirements []string, controlID string, agentID string, records []proof.Record) ([]string, []string) {
+	existing := map[string]struct{}{}
+	recordIDs := map[string]struct{}{}
+	for _, record := range records {
+		for _, requirement := range requirements {
+			if !recordSatisfiesProofRequirement(record, requirement, controlID, agentID) {
+				continue
+			}
+			existing[requirement] = struct{}{}
+			if strings.TrimSpace(record.RecordID) != "" {
+				recordIDs[strings.TrimSpace(record.RecordID)] = struct{}{}
+			}
+		}
+	}
+	return sortedKeys(existing), sortedKeys(recordIDs)
+}
+
+func recordSatisfiesProofRequirement(record proof.Record, requirement string, controlID string, agentID string) bool {
+	if strings.TrimSpace(agentID) != "" && strings.TrimSpace(record.AgentID) != "" && strings.TrimSpace(record.AgentID) != strings.TrimSpace(agentID) {
+		return false
+	}
+	eventType := eventString(record.Event, "event_type")
+	if eventType == "" && record.Metadata != nil {
+		eventType = metadataString(record.Metadata, "event_type")
+	}
+	if eventType == "" {
+		eventType = strings.TrimSpace(record.RecordType)
+	}
+	recordControlID := eventString(record.Event, "control_id")
+	if recordControlID == "" {
+		if diff, ok := record.Event["diff"].(map[string]any); ok {
+			recordControlID = stringFromAny(diff["control_id"])
+		}
+	}
+	controlMatches := strings.TrimSpace(controlID) == "" || strings.TrimSpace(controlID) == "control_path_governance" || strings.TrimSpace(recordControlID) == "" || strings.TrimSpace(recordControlID) == strings.TrimSpace(controlID)
+	if !controlMatches {
+		return false
+	}
+	switch requirement {
+	case agginventory.GovernanceControlOwnerAssigned:
+		return eventType == "owner_assigned" || eventString(record.Event, "owner") != "" || eventString(record.Event, "approver") != ""
+	case agginventory.GovernanceControlReviewCadence:
+		return eventType == "review_cadence_set" || eventString(record.Event, "review_cadence") != ""
+	case agginventory.GovernanceControlApproval:
+		return eventType == "approval_recorded" || eventType == "approval" || strings.TrimSpace(record.RecordType) == "approval"
+	case "evidence_attached":
+		return eventType == "evidence_attached" || eventString(record.Event, "evidence_url") != ""
+	default:
+		return eventType == requirement
+	}
+}
+
+func agentIDForBacklogItem(snapshot state.Snapshot, repo string, path string) string {
+	if snapshot.Inventory != nil {
+		for _, tool := range snapshot.Inventory.Tools {
+			if strings.TrimSpace(tool.AgentID) == "" {
+				continue
+			}
+			for _, loc := range tool.Locations {
+				if strings.TrimSpace(loc.Repo) == strings.TrimSpace(repo) && strings.TrimSpace(loc.Location) == strings.TrimSpace(path) {
+					return strings.TrimSpace(tool.AgentID)
+				}
+			}
+		}
+	}
+	for _, identity := range snapshot.Identities {
+		if strings.TrimSpace(identity.Repo) == strings.TrimSpace(repo) && strings.TrimSpace(identity.Location) == strings.TrimSpace(path) {
+			return strings.TrimSpace(identity.AgentID)
+		}
+	}
+	return ""
+}
+
+func differenceStrings(all []string, existing []string) []string {
+	have := map[string]struct{}{}
+	for _, value := range existing {
+		have[strings.TrimSpace(value)] = struct{}{}
+	}
+	missing := map[string]struct{}{}
+	for _, value := range all {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := have[trimmed]; !ok {
+			missing[trimmed] = struct{}{}
+		}
+	}
+	return sortedKeys(missing)
+}
+
+func uniqueSortedStrings(values []string) []string {
+	set := map[string]struct{}{}
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			set[trimmed] = struct{}{}
+		}
+	}
+	return sortedKeys(set)
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		if strings.TrimSpace(value) != "" {
+			out = append(out, strings.TrimSpace(value))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func eventString(event map[string]any, key string) string {
+	if event == nil {
+		return ""
+	}
+	return stringFromAny(event[key])
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	if metadata == nil {
+		return ""
+	}
+	return stringFromAny(metadata[key])
+}
+
+func stringFromAny(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case fmt.Stringer:
+		return strings.TrimSpace(typed.String())
+	default:
+		return ""
 	}
 }
 

--- a/core/lifecycle/chain.go
+++ b/core/lifecycle/chain.go
@@ -62,13 +62,7 @@ func AppendTransitionRecord(chain *proof.Chain, transition Transition, eventType
 	if err != nil {
 		ts = time.Now().UTC().Truncate(time.Second)
 	}
-	recordType := strings.TrimSpace(eventType)
-	if recordType == "" {
-		recordType = "decision"
-	}
-	if recordType == "lifecycle_transition" {
-		recordType = "decision"
-	}
+	recordType := transitionRecordType(eventType)
 	record, err := proof.NewRecord(proof.RecordOpts{
 		Timestamp:     ts,
 		Source:        "wrkr",
@@ -91,6 +85,17 @@ func AppendTransitionRecord(chain *proof.Chain, transition Transition, eventType
 		return fmt.Errorf("append transition record: %w", err)
 	}
 	return nil
+}
+
+func transitionRecordType(eventType string) string {
+	switch strings.TrimSpace(eventType) {
+	case "approval", "approval_recorded", "risk_accepted":
+		return "approval"
+	case "owner_assigned", "evidence_attached", "least_privilege_verified", "rotation_evidence_attached", "deployment_gate_present", "production_access_classified", "proof_artifact_generated", "review_cadence_set":
+		return "evidence"
+	default:
+		return "decision"
+	}
 }
 
 func RecordsForAgent(chain *proof.Chain, agentID string) []proof.Record {

--- a/core/lifecycle/lifecycle.go
+++ b/core/lifecycle/lifecycle.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,6 +34,18 @@ type Transition struct {
 	Trigger       string         `json:"trigger" yaml:"trigger"`
 	Diff          map[string]any `json:"diff,omitempty" yaml:"diff,omitempty"`
 	Timestamp     string         `json:"timestamp" yaml:"timestamp"`
+}
+
+type InventoryMutation struct {
+	Action        string
+	AgentID       string
+	Owner         string
+	EvidenceURL   string
+	ControlID     string
+	Reason        string
+	ReviewCadence string
+	ExpiresAt     time.Time
+	Now           time.Time
 }
 
 func Reconcile(previous manifest.Manifest, observed []ObservedTool, now time.Time) (manifest.Manifest, []Transition) {
@@ -118,7 +131,7 @@ func Reconcile(previous manifest.Manifest, observed []ObservedTool, now time.Tim
 		if record.Status == identity.StateApproved && record.ApprovalState == "valid" {
 			record.Status = identity.StateActive
 		}
-		if record.Status == identity.StateActive && record.ApprovalState != "valid" {
+		if record.Status == identity.StateActive && record.ApprovalState != "valid" && record.ApprovalState != "accepted_risk" {
 			record.Status = identity.StateUnderReview
 		}
 		if record.Status == identity.StateDiscovered && record.ApprovalState != "valid" {
@@ -173,6 +186,144 @@ func Reconcile(previous manifest.Manifest, observed []ObservedTool, now time.Tim
 		return transitions[i].Trigger < transitions[j].Trigger
 	})
 	return next, transitions
+}
+
+func ApplyInventoryMutation(m manifest.Manifest, mutation InventoryMutation) (manifest.Manifest, Transition, error) {
+	now := canonicalNow(mutation.Now)
+	agentID := strings.TrimSpace(mutation.AgentID)
+	if agentID == "" {
+		return manifest.Manifest{}, Transition{}, fmt.Errorf("identity id is required")
+	}
+	index := -1
+	for i := range m.Identities {
+		if strings.TrimSpace(m.Identities[i].AgentID) == agentID {
+			index = i
+			break
+		}
+	}
+	if index < 0 {
+		return manifest.Manifest{}, Transition{}, fmt.Errorf("identity %s not found", agentID)
+	}
+
+	record := m.Identities[index]
+	previousState := record.Status
+	diff := map[string]any{}
+	action := strings.TrimSpace(mutation.Action)
+	if action == "" {
+		return manifest.Manifest{}, Transition{}, fmt.Errorf("inventory action is required")
+	}
+	if strings.TrimSpace(record.Approval.Owner) == "" && strings.TrimSpace(record.Approval.Approver) != "" {
+		record.Approval.Owner = strings.TrimSpace(record.Approval.Approver)
+	}
+
+	switch action {
+	case "approve":
+		if strings.TrimSpace(mutation.Owner) == "" {
+			return manifest.Manifest{}, Transition{}, fmt.Errorf("--owner is required")
+		}
+		if strings.TrimSpace(mutation.EvidenceURL) == "" {
+			return manifest.Manifest{}, Transition{}, fmt.Errorf("--evidence is required")
+		}
+		if mutation.ExpiresAt.IsZero() {
+			return manifest.Manifest{}, Transition{}, fmt.Errorf("--expires is required")
+		}
+		record.Status = identity.StateActive
+		record.ApprovalState = "valid"
+		record.Approval.Approver = strings.TrimSpace(mutation.Owner)
+		record.Approval.Owner = strings.TrimSpace(mutation.Owner)
+		record.Approval.Scope = fallback(record.Approval.Scope, "control_path")
+		record.Approval.EvidenceURL = strings.TrimSpace(mutation.EvidenceURL)
+		record.Approval.ControlID = strings.TrimSpace(mutation.ControlID)
+		record.Approval.Approved = now.Format(time.RFC3339)
+		record.Approval.Expires = mutation.ExpiresAt.UTC().Truncate(time.Second).Format(time.RFC3339)
+		record.Approval.ReviewCadence = fallback(strings.TrimSpace(mutation.ReviewCadence), "90d")
+		record.Approval.LastReviewed = now.Format(time.RFC3339)
+		record.Approval.RenewalState = renewalState(mutation.ExpiresAt, now)
+		record.Approval.AcceptedRisk = false
+		record.Approval.DecisionReason = ""
+		record.Approval.ExclusionReason = ""
+		diff["owner"] = strings.TrimSpace(mutation.Owner)
+		diff["evidence_url"] = strings.TrimSpace(mutation.EvidenceURL)
+		diff["expires"] = record.Approval.Expires
+		diff["review_cadence"] = record.Approval.ReviewCadence
+		if strings.TrimSpace(mutation.ControlID) != "" {
+			diff["control_id"] = strings.TrimSpace(mutation.ControlID)
+		}
+	case "attach_evidence":
+		if strings.TrimSpace(mutation.ControlID) == "" {
+			return manifest.Manifest{}, Transition{}, fmt.Errorf("--control is required")
+		}
+		if strings.TrimSpace(mutation.EvidenceURL) == "" {
+			return manifest.Manifest{}, Transition{}, fmt.Errorf("--url is required")
+		}
+		record.Approval.ControlID = strings.TrimSpace(mutation.ControlID)
+		record.Approval.EvidenceURL = strings.TrimSpace(mutation.EvidenceURL)
+		record.Approval.LastReviewed = now.Format(time.RFC3339)
+		if strings.TrimSpace(mutation.Owner) != "" {
+			record.Approval.Owner = strings.TrimSpace(mutation.Owner)
+		}
+		diff["control_id"] = strings.TrimSpace(mutation.ControlID)
+		diff["evidence_url"] = strings.TrimSpace(mutation.EvidenceURL)
+	case "accept_risk":
+		if mutation.ExpiresAt.IsZero() {
+			return manifest.Manifest{}, Transition{}, fmt.Errorf("--expires is required")
+		}
+		record.Status = identity.StateActive
+		record.ApprovalState = "accepted_risk"
+		record.Approval.AcceptedRisk = true
+		record.Approval.Approved = now.Format(time.RFC3339)
+		record.Approval.Expires = mutation.ExpiresAt.UTC().Truncate(time.Second).Format(time.RFC3339)
+		record.Approval.LastReviewed = now.Format(time.RFC3339)
+		record.Approval.RenewalState = renewalState(mutation.ExpiresAt, now)
+		record.Approval.DecisionReason = strings.TrimSpace(mutation.Reason)
+		record.Approval.ExclusionReason = ""
+		diff["expires"] = record.Approval.Expires
+		diff["accepted_risk"] = true
+		if strings.TrimSpace(mutation.Reason) != "" {
+			diff["reason"] = strings.TrimSpace(mutation.Reason)
+		}
+	case "deprecate":
+		if strings.TrimSpace(mutation.Reason) == "" {
+			return manifest.Manifest{}, Transition{}, fmt.Errorf("--reason is required")
+		}
+		record.Status = identity.StateDeprecated
+		record.ApprovalState = "deprecated"
+		record.Approval.AcceptedRisk = false
+		record.Approval.Expires = ""
+		record.Approval.DecisionReason = strings.TrimSpace(mutation.Reason)
+		record.Approval.LastReviewed = now.Format(time.RFC3339)
+		record.Approval.RenewalState = "not_applicable"
+		diff["reason"] = strings.TrimSpace(mutation.Reason)
+	case "exclude":
+		if strings.TrimSpace(mutation.Reason) == "" {
+			return manifest.Manifest{}, Transition{}, fmt.Errorf("--reason is required")
+		}
+		record.Status = identity.StateRevoked
+		record.ApprovalState = "excluded"
+		record.Approval.AcceptedRisk = false
+		record.Approval.Expires = ""
+		record.Approval.ExclusionReason = strings.TrimSpace(mutation.Reason)
+		record.Approval.LastReviewed = now.Format(time.RFC3339)
+		record.Approval.RenewalState = "not_applicable"
+		diff["reason"] = strings.TrimSpace(mutation.Reason)
+	default:
+		return manifest.Manifest{}, Transition{}, fmt.Errorf("unsupported inventory action %q", action)
+	}
+
+	record.LastSeen = now.Format(time.RFC3339)
+	m.Identities[index] = record
+	m.UpdatedAt = now.Format(time.RFC3339)
+	m.ApprovalInventoryVersion = manifest.ApprovalInventoryVersion
+
+	transition := Transition{
+		AgentID:       record.AgentID,
+		PreviousState: previousState,
+		NewState:      record.Status,
+		Trigger:       "inventory_" + action,
+		Timestamp:     now.Format(time.RFC3339),
+		Diff:          diff,
+	}
+	return m, transition, nil
 }
 
 func ApplyManualState(m manifest.Manifest, agentID, state, approver, scope, reason string, expiresAt time.Time, now time.Time) (manifest.Manifest, Transition, error) {
@@ -241,13 +392,22 @@ func ParseExpiry(raw string, now time.Time) (time.Time, error) {
 	if trimmed == "" {
 		return now.Add(defaultApprovalTTL), nil
 	}
+	if parsed, err := time.Parse(time.RFC3339, trimmed); err == nil {
+		return parsed.UTC().Truncate(time.Second), nil
+	}
+	if parsed, err := time.Parse("2006-01-02", trimmed); err == nil {
+		return parsed.UTC(), nil
+	}
 	if strings.HasSuffix(trimmed, "d") {
 		days := strings.TrimSuffix(trimmed, "d")
-		value, err := time.ParseDuration(days + "24h")
+		value, err := strconv.Atoi(days)
 		if err != nil {
 			return time.Time{}, fmt.Errorf("parse expiry %q: %w", raw, err)
 		}
-		return now.Add(value), nil
+		if value <= 0 {
+			return time.Time{}, fmt.Errorf("parse expiry %q: days must be positive", raw)
+		}
+		return now.Add(time.Duration(value) * 24 * time.Hour), nil
 	}
 	dur, err := time.ParseDuration(trimmed)
 	if err != nil {
@@ -257,8 +417,16 @@ func ParseExpiry(raw string, now time.Time) (time.Time, error) {
 }
 
 func applyApprovalState(record *manifest.IdentityRecord, now time.Time) {
+	if strings.TrimSpace(record.Approval.ExclusionReason) != "" {
+		record.ApprovalState = "excluded"
+		record.Status = identity.StateRevoked
+		return
+	}
 	record.ApprovalState = "missing"
 	if strings.TrimSpace(record.Approval.Expires) == "" {
+		if record.Status == identity.StateDeprecated && strings.TrimSpace(record.Approval.DecisionReason) != "" {
+			record.ApprovalState = "deprecated"
+		}
 		return
 	}
 	expiresAt, err := time.Parse(time.RFC3339, record.Approval.Expires)
@@ -271,10 +439,28 @@ func applyApprovalState(record *manifest.IdentityRecord, now time.Time) {
 		record.Status = identity.StateUnderReview
 		return
 	}
+	if record.Approval.AcceptedRisk {
+		record.ApprovalState = "accepted_risk"
+		record.Status = identity.StateActive
+		return
+	}
 	record.ApprovalState = "valid"
 	if record.Status == identity.StateApproved {
 		record.Status = identity.StateActive
 	}
+}
+
+func renewalState(expiresAt time.Time, now time.Time) string {
+	if expiresAt.IsZero() {
+		return "missing"
+	}
+	if !expiresAt.After(canonicalNow(now)) {
+		return "expired"
+	}
+	if expiresAt.Sub(canonicalNow(now)) <= 14*24*time.Hour {
+		return "renewal_due"
+	}
+	return "current"
 }
 
 func detectContractDiff(previous, current manifest.IdentityRecord) (bool, map[string]any) {
@@ -296,6 +482,13 @@ func fallbackTimestamp(value string, now time.Time) string {
 		return value
 	}
 	return now.Format(time.RFC3339)
+}
+
+func fallback(value, fallbackValue string) string {
+	if strings.TrimSpace(value) != "" {
+		return strings.TrimSpace(value)
+	}
+	return fallbackValue
 }
 
 func canonicalNow(now time.Time) time.Time {

--- a/core/lifecycle/lifecycle_test.go
+++ b/core/lifecycle/lifecycle_test.go
@@ -222,6 +222,18 @@ func TestParseExpiryDefault90Days(t *testing.T) {
 	}
 }
 
+func TestParseExpiryDaySuffix(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 2, 20, 12, 0, 0, 0, time.UTC)
+	expires, err := ParseExpiry("90d", now)
+	if err != nil {
+		t.Fatalf("parse expiry: %v", err)
+	}
+	if expires.Sub(now) != 90*24*time.Hour {
+		t.Fatalf("expected 90d expiry, got %s", expires.Sub(now))
+	}
+}
+
 func TestApplyManualStateNonApprovedStatesAlwaysRevokeApprovalStatus(t *testing.T) {
 	t.Parallel()
 

--- a/core/manifest/manifest.go
+++ b/core/manifest/manifest.go
@@ -13,12 +13,22 @@ import (
 )
 
 const Version = "v1"
+const ApprovalInventoryVersion = "1"
 
 type Approval struct {
-	Approver string `yaml:"approver,omitempty" json:"approver,omitempty"`
-	Scope    string `yaml:"scope,omitempty" json:"scope,omitempty"`
-	Approved string `yaml:"approved,omitempty" json:"approved,omitempty"`
-	Expires  string `yaml:"expires,omitempty" json:"expires,omitempty"`
+	Approver        string `yaml:"approver,omitempty" json:"approver,omitempty"`
+	Owner           string `yaml:"owner,omitempty" json:"owner,omitempty"`
+	Scope           string `yaml:"scope,omitempty" json:"scope,omitempty"`
+	EvidenceURL     string `yaml:"evidence_url,omitempty" json:"evidence_url,omitempty"`
+	ControlID       string `yaml:"control_id,omitempty" json:"control_id,omitempty"`
+	Approved        string `yaml:"approved,omitempty" json:"approved,omitempty"`
+	Expires         string `yaml:"expires,omitempty" json:"expires,omitempty"`
+	ReviewCadence   string `yaml:"review_cadence,omitempty" json:"review_cadence,omitempty"`
+	LastReviewed    string `yaml:"last_reviewed,omitempty" json:"last_reviewed,omitempty"`
+	RenewalState    string `yaml:"renewal_state,omitempty" json:"renewal_state,omitempty"`
+	AcceptedRisk    bool   `yaml:"accepted_risk,omitempty" json:"accepted_risk,omitempty"`
+	DecisionReason  string `yaml:"decision_reason,omitempty" json:"decision_reason,omitempty"`
+	ExclusionReason string `yaml:"exclusion_reason,omitempty" json:"exclusion_reason,omitempty"`
 }
 
 type IdentityRecord struct {
@@ -41,9 +51,10 @@ type IdentityRecord struct {
 }
 
 type Manifest struct {
-	Version    string           `yaml:"version" json:"version"`
-	UpdatedAt  string           `yaml:"updated_at" json:"updated_at"`
-	Identities []IdentityRecord `yaml:"identities" json:"identities"`
+	Version                  string           `yaml:"version" json:"version"`
+	ApprovalInventoryVersion string           `yaml:"approval_inventory_version,omitempty" json:"approval_inventory_version,omitempty"`
+	UpdatedAt                string           `yaml:"updated_at" json:"updated_at"`
+	Identities               []IdentityRecord `yaml:"identities" json:"identities"`
 }
 
 func ResolvePath(statePath string) string {
@@ -67,12 +78,16 @@ func Load(path string) (Manifest, error) {
 	if strings.TrimSpace(out.Version) == "" {
 		out.Version = Version
 	}
+	if strings.TrimSpace(out.ApprovalInventoryVersion) == "" {
+		out.ApprovalInventoryVersion = ApprovalInventoryVersion
+	}
 	sortRecords(out.Identities)
 	return out, nil
 }
 
 func Save(path string, m Manifest) error {
 	m.Version = Version
+	m.ApprovalInventoryVersion = ApprovalInventoryVersion
 	if strings.TrimSpace(m.UpdatedAt) == "" {
 		m.UpdatedAt = time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
 	}

--- a/core/proofmap/proofmap.go
+++ b/core/proofmap/proofmap.go
@@ -321,8 +321,11 @@ func MapRisk(report risk.Report, posture score.Result, profile profileeval.Resul
 func MapTransition(transition lifecycle.Transition, eventType string) MappedRecord {
 	recordType := "decision"
 	resolvedEventType := strings.TrimSpace(eventType)
-	if resolvedEventType == "approval" {
+	switch resolvedEventType {
+	case "approval", "approval_recorded", "risk_accepted":
 		recordType = "approval"
+	case "owner_assigned", "evidence_attached", "least_privilege_verified", "rotation_evidence_attached", "deployment_gate_present", "production_access_classified", "proof_artifact_generated", "review_cadence_set":
+		recordType = "evidence"
 	}
 	if resolvedEventType == "" {
 		resolvedEventType = "lifecycle_transition"
@@ -352,6 +355,18 @@ func MapTransition(transition lifecycle.Transition, eventType string) MappedReco
 	if expires != "" {
 		event["expires"] = expires
 	}
+	for _, key := range []string{
+		"owner",
+		"control_id",
+		"evidence_url",
+		"review_cadence",
+		"accepted_risk",
+		"reason",
+	} {
+		if value, ok := diff[key]; ok {
+			event[key] = value
+		}
+	}
 
 	timestamp := time.Now().UTC().Truncate(time.Second)
 	if parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(transition.Timestamp)); err == nil {
@@ -366,6 +381,7 @@ func MapTransition(transition lifecycle.Transition, eventType string) MappedReco
 		ApprovedScope: scope,
 		Metadata: map[string]any{
 			"transition_trigger": transition.Trigger,
+			"event_type":         resolvedEventType,
 		},
 	}
 }

--- a/core/regress/inventory_diff.go
+++ b/core/regress/inventory_diff.go
@@ -7,32 +7,39 @@ import (
 )
 
 type InventoryDiffResult struct {
-	Status       string             `json:"status"`
-	Drift        bool               `json:"drift_detected"`
-	BaselinePath string             `json:"baseline_path,omitempty"`
-	AddedCount   int                `json:"added_count"`
-	RemovedCount int                `json:"removed_count"`
-	ChangedCount int                `json:"changed_count"`
-	Added        []source.Finding   `json:"added"`
-	Removed      []source.Finding   `json:"removed"`
-	Changed      []diff.ChangedItem `json:"changed"`
+	Status                 string             `json:"status"`
+	Drift                  bool               `json:"drift_detected"`
+	BaselinePath           string             `json:"baseline_path,omitempty"`
+	AddedCount             int                `json:"added_count"`
+	RemovedCount           int                `json:"removed_count"`
+	ChangedCount           int                `json:"changed_count"`
+	ControlPathDrift       bool               `json:"control_path_drift_detected,omitempty"`
+	ControlPathReasonCount int                `json:"control_path_reason_count,omitempty"`
+	ControlPathReasons     []Reason           `json:"control_path_reasons,omitempty"`
+	Added                  []source.Finding   `json:"added"`
+	Removed                []source.Finding   `json:"removed"`
+	Changed                []diff.ChangedItem `json:"changed"`
 }
 
 func CompareInventory(baseline, current state.Snapshot) InventoryDiffResult {
 	computed := diff.Compute(baseline.Findings, current.Findings)
-	drift := !diff.Empty(computed)
+	controlPath := Compare(BuildBaselineFromSnapshot(baseline), current)
+	drift := !diff.Empty(computed) || controlPath.Drift
 	status := "ok"
 	if drift {
 		status = "drift"
 	}
 	return InventoryDiffResult{
-		Status:       status,
-		Drift:        drift,
-		AddedCount:   len(computed.Added),
-		RemovedCount: len(computed.Removed),
-		ChangedCount: len(computed.Changed),
-		Added:        computed.Added,
-		Removed:      computed.Removed,
-		Changed:      computed.Changed,
+		Status:                 status,
+		Drift:                  drift,
+		AddedCount:             len(computed.Added),
+		RemovedCount:           len(computed.Removed),
+		ChangedCount:           len(computed.Changed),
+		ControlPathDrift:       controlPath.Drift,
+		ControlPathReasonCount: controlPath.ReasonCount,
+		ControlPathReasons:     controlPath.Reasons,
+		Added:                  computed.Added,
+		Removed:                computed.Removed,
+		Changed:                computed.Changed,
 	}
 }

--- a/core/regress/regress.go
+++ b/core/regress/regress.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/identity"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/state"
@@ -18,18 +19,26 @@ import (
 const BaselineVersion = "v1"
 
 const (
-	ReasonNewUnapprovedTool        = "new_unapproved_tool"
-	ReasonRevokedToolReappeared    = "revoked_tool_reappeared"
-	ReasonDeprecatedToolReappeared = "deprecated_tool_reappeared"
-	ReasonPermissionExpansion      = "unapproved_permission_expansion"
-	ReasonCriticalAttackPath       = "critical_attack_path_drift"
-	defaultApprovalState           = "missing"
-	defaultLifecycleState          = identity.StateUnderReview
-	criticalAttackPathMinScore     = 8.0
-	attackPathScoreDeltaMin        = 1.0
-	attackPathDriftMinAbsolute     = 2
-	attackPathDriftMinRelative     = 0.25
-	attackPathExampleLimit         = 5
+	ReasonNewUnapprovedTool         = "new_unapproved_tool"
+	ReasonRevokedToolReappeared     = "revoked_tool_reappeared"
+	ReasonDeprecatedToolReappeared  = "deprecated_tool_reappeared"
+	ReasonPermissionExpansion       = "unapproved_permission_expansion"
+	ReasonCriticalAttackPath        = "critical_attack_path_drift"
+	ReasonNewUnknownAutomation      = "new_unknown_automation"
+	ReasonNewRepoWritePath          = "new_repo_write_path"
+	ReasonNewSecretBearingWorkflow  = "new_secret_bearing_workflow"
+	ReasonNewMCPToolConfig          = "new_mcp_tool_config"
+	ReasonApprovalExpired           = "approval_expired"
+	ReasonOwnerChanged              = "owner_changed"
+	ReasonApprovedPathRiskIncreased = "approved_path_risk_increased"
+	ReasonDeprecatedPathReappeared  = "deprecated_path_reappeared"
+	defaultApprovalState            = "missing"
+	defaultLifecycleState           = identity.StateUnderReview
+	criticalAttackPathMinScore      = 8.0
+	attackPathScoreDeltaMin         = 1.0
+	attackPathDriftMinAbsolute      = 2
+	attackPathDriftMinRelative      = 0.25
+	attackPathExampleLimit          = 5
 )
 
 type Baseline struct {
@@ -40,15 +49,25 @@ type Baseline struct {
 }
 
 type ToolState struct {
-	AgentID         string   `json:"agent_id"`
-	AgentInstanceID string   `json:"agent_instance_id,omitempty"`
-	ToolID          string   `json:"tool_id"`
-	Org             string   `json:"org"`
-	Status          string   `json:"status"`
-	ApprovalStatus  string   `json:"approval_status"`
-	Present         bool     `json:"present"`
-	Permissions     []string `json:"permissions"`
-	LegacyAgentID   string   `json:"-"`
+	AgentID            string   `json:"agent_id"`
+	AgentInstanceID    string   `json:"agent_instance_id,omitempty"`
+	ToolID             string   `json:"tool_id"`
+	Org                string   `json:"org"`
+	Repo               string   `json:"repo,omitempty"`
+	Location           string   `json:"location,omitempty"`
+	Status             string   `json:"status"`
+	ApprovalStatus     string   `json:"approval_status"`
+	SecurityVisibility string   `json:"security_visibility,omitempty"`
+	Owner              string   `json:"owner,omitempty"`
+	EvidenceExpires    string   `json:"evidence_expires,omitempty"`
+	WritePathClasses   []string `json:"write_path_classes,omitempty"`
+	SecretBearing      bool     `json:"secret_bearing,omitempty"`
+	Confidence         string   `json:"confidence,omitempty"`
+	ControlPathType    string   `json:"control_path_type,omitempty"`
+	RiskScore          float64  `json:"risk_score,omitempty"`
+	Present            bool     `json:"present"`
+	Permissions        []string `json:"permissions"`
+	LegacyAgentID      string   `json:"-"`
 }
 
 type AttackPathState struct {
@@ -59,14 +78,18 @@ type AttackPathState struct {
 }
 
 type Reason struct {
-	Code             string                  `json:"code"`
-	AgentID          string                  `json:"agent_id"`
-	AgentInstanceID  string                  `json:"agent_instance_id,omitempty"`
-	ToolID           string                  `json:"tool_id"`
-	Org              string                  `json:"org"`
-	Message          string                  `json:"message"`
-	AddedPermissions []string                `json:"added_permissions,omitempty"`
-	AttackPathDrift  *AttackPathDriftSummary `json:"attack_path_drift,omitempty"`
+	Code              string                  `json:"code"`
+	AgentID           string                  `json:"agent_id"`
+	AgentInstanceID   string                  `json:"agent_instance_id,omitempty"`
+	ToolID            string                  `json:"tool_id"`
+	Org               string                  `json:"org"`
+	Message           string                  `json:"message"`
+	AddedPermissions  []string                `json:"added_permissions,omitempty"`
+	PreviousOwner     string                  `json:"previous_owner,omitempty"`
+	CurrentOwner      string                  `json:"current_owner,omitempty"`
+	PreviousRiskScore float64                 `json:"previous_risk_score,omitempty"`
+	CurrentRiskScore  float64                 `json:"current_risk_score,omitempty"`
+	AttackPathDrift   *AttackPathDriftSummary `json:"attack_path_drift,omitempty"`
 }
 
 type AttackPathScoreChange struct {
@@ -130,8 +153,13 @@ func SnapshotTools(snapshot state.Snapshot) []ToolState {
 			AgentInstanceID: strings.TrimSpace(item.ToolID),
 			ToolID:          strings.TrimSpace(item.ToolID),
 			Org:             fallback(item.Org, "local"),
+			Repo:            strings.TrimSpace(item.Repo),
+			Location:        strings.TrimSpace(item.Location),
 			Status:          fallback(item.Status, defaultLifecycleState),
 			ApprovalStatus:  fallback(item.ApprovalState, defaultApprovalState),
+			Owner:           strings.TrimSpace(item.Approval.Owner),
+			EvidenceExpires: strings.TrimSpace(item.Approval.Expires),
+			RiskScore:       item.RiskScore,
 			Present:         item.Present,
 			Permissions:     []string{},
 		}
@@ -151,6 +179,8 @@ func SnapshotTools(snapshot state.Snapshot) []ToolState {
 				AgentInstanceID: toolID,
 				ToolID:          toolID,
 				Org:             org,
+				Repo:            strings.TrimSpace(finding.Repo),
+				Location:        strings.TrimSpace(finding.Location),
 				Status:          defaultLifecycleState,
 				ApprovalStatus:  defaultApprovalState,
 				Present:         true,
@@ -168,9 +198,17 @@ func SnapshotTools(snapshot state.Snapshot) []ToolState {
 		if strings.TrimSpace(item.LegacyAgentID) == "" {
 			item.LegacyAgentID = legacyAgentID
 		}
+		if strings.TrimSpace(item.Repo) == "" {
+			item.Repo = strings.TrimSpace(finding.Repo)
+		}
+		if strings.TrimSpace(item.Location) == "" {
+			item.Location = strings.TrimSpace(finding.Location)
+		}
 		item.Present = true
 		item.Permissions = append(item.Permissions, finding.Permissions...)
 	}
+
+	enrichToolStatesFromInventoryAndBacklog(byAgent, snapshot)
 
 	out := make([]ToolState, 0, len(byAgent))
 	for _, item := range byAgent {
@@ -192,6 +230,82 @@ func SnapshotTools(snapshot state.Snapshot) []ToolState {
 	return out
 }
 
+func enrichToolStatesFromInventoryAndBacklog(byAgent map[string]*ToolState, snapshot state.Snapshot) {
+	if snapshot.Inventory != nil {
+		for _, tool := range snapshot.Inventory.Tools {
+			agentID := strings.TrimSpace(tool.AgentID)
+			if agentID == "" {
+				continue
+			}
+			item, exists := byAgent[agentID]
+			if !exists {
+				item = &ToolState{
+					AgentID:         agentID,
+					AgentInstanceID: strings.TrimSpace(tool.ToolID),
+					ToolID:          strings.TrimSpace(tool.ToolID),
+					Org:             fallback(tool.Org, "local"),
+					Status:          fallback(tool.LifecycleState, defaultLifecycleState),
+					ApprovalStatus:  fallback(tool.ApprovalStatus, defaultApprovalState),
+					Present:         true,
+				}
+				byAgent[agentID] = item
+			}
+			item.SecurityVisibility = fallback(item.SecurityVisibility, tool.SecurityVisibilityStatus)
+			item.WritePathClasses = mergeSortedStrings(item.WritePathClasses, tool.WritePathClasses)
+			if tool.RiskScore > item.RiskScore {
+				item.RiskScore = tool.RiskScore
+			}
+			if strings.TrimSpace(item.Repo) == "" && len(tool.Repos) > 0 {
+				item.Repo = strings.TrimSpace(tool.Repos[0])
+			}
+			if strings.TrimSpace(item.Location) == "" && len(tool.Locations) > 0 {
+				item.Location = strings.TrimSpace(tool.Locations[0].Location)
+			}
+			for _, loc := range tool.Locations {
+				if strings.TrimSpace(item.Owner) == "" {
+					item.Owner = strings.TrimSpace(loc.Owner)
+				}
+				if strings.TrimSpace(item.Repo) == strings.TrimSpace(loc.Repo) && strings.TrimSpace(item.Location) == strings.TrimSpace(loc.Location) {
+					item.Owner = fallback(item.Owner, loc.Owner)
+				}
+			}
+		}
+	}
+	if snapshot.ControlBacklog == nil {
+		return
+	}
+	for _, backlogItem := range snapshot.ControlBacklog.Items {
+		agentID := agentIDForBacklogItem(snapshot, backlogItem.Repo, backlogItem.Path)
+		if agentID == "" {
+			continue
+		}
+		item, exists := byAgent[agentID]
+		if !exists {
+			item = &ToolState{
+				AgentID:            agentID,
+				AgentInstanceID:    strings.TrimSpace(backlogItem.ID),
+				ToolID:             strings.TrimSpace(backlogItem.ID),
+				Org:                fallback(orgForBacklogItem(snapshot, backlogItem.Repo, backlogItem.Path), "local"),
+				Repo:               strings.TrimSpace(backlogItem.Repo),
+				Location:           strings.TrimSpace(backlogItem.Path),
+				Status:             defaultLifecycleState,
+				ApprovalStatus:     fallback(backlogItem.ApprovalStatus, defaultApprovalState),
+				SecurityVisibility: strings.TrimSpace(backlogItem.SecurityVisibility),
+				Present:            true,
+			}
+			byAgent[agentID] = item
+		}
+		item.ControlPathType = fallback(item.ControlPathType, backlogItem.ControlPathType)
+		item.Confidence = fallback(item.Confidence, backlogItem.Confidence)
+		item.SecurityVisibility = fallback(item.SecurityVisibility, backlogItem.SecurityVisibility)
+		item.WritePathClasses = mergeSortedStrings(item.WritePathClasses, backlogItem.WritePathClasses)
+		item.SecretBearing = item.SecretBearing || strings.TrimSpace(backlogItem.ControlPathType) == "secret_bearing_workflow" || len(backlogItem.SecretSignalTypes) > 0
+		if strings.TrimSpace(item.Owner) == "" {
+			item.Owner = strings.TrimSpace(backlogItem.Owner)
+		}
+	}
+}
+
 func SaveBaseline(path string, baseline Baseline) error {
 	path = strings.TrimSpace(path)
 	if path == "" {
@@ -209,6 +323,7 @@ func SaveBaseline(path string, baseline Baseline) error {
 	})
 	for i := range baseline.Tools {
 		baseline.Tools[i].Permissions = dedupeSortedPermissions(baseline.Tools[i].Permissions)
+		baseline.Tools[i].WritePathClasses = mergeSortedStrings(baseline.Tools[i].WritePathClasses, nil)
 	}
 	baseline.AttackPaths = sortAttackPaths(baseline.AttackPaths)
 
@@ -280,14 +395,7 @@ func Compare(baseline Baseline, current state.Snapshot) Result {
 		baseTool, exists := matchBaselineTool(baseByAgent, baseByInstance, legacyClaims, currentTool)
 		if !exists {
 			if currentTool.Present && !isApproved(currentTool) {
-				reasons = append(reasons, Reason{
-					Code:            ReasonNewUnapprovedTool,
-					AgentID:         currentTool.AgentID,
-					AgentInstanceID: currentTool.AgentInstanceID,
-					ToolID:          currentTool.ToolID,
-					Org:             currentTool.Org,
-					Message:         "detected tool not present in approved baseline",
-				})
+				reasons = append(reasons, newControlPathReason(currentTool))
 			}
 			continue
 		}
@@ -310,6 +418,51 @@ func Compare(baseline Baseline, current state.Snapshot) Result {
 				ToolID:          currentTool.ToolID,
 				Org:             currentTool.Org,
 				Message:         "deprecated tool reappeared in current scan",
+			})
+			if strings.TrimSpace(baseTool.ControlPathType) != "" || strings.TrimSpace(currentTool.ControlPathType) != "" {
+				reasons = append(reasons, Reason{
+					Code:            ReasonDeprecatedPathReappeared,
+					AgentID:         currentTool.AgentID,
+					AgentInstanceID: currentTool.AgentInstanceID,
+					ToolID:          currentTool.ToolID,
+					Org:             currentTool.Org,
+					Message:         "deprecated control path reappeared in current scan",
+				})
+			}
+		}
+
+		if strings.TrimSpace(currentTool.ApprovalStatus) == "expired" {
+			reasons = append(reasons, Reason{
+				Code:            ReasonApprovalExpired,
+				AgentID:         currentTool.AgentID,
+				AgentInstanceID: currentTool.AgentInstanceID,
+				ToolID:          currentTool.ToolID,
+				Org:             currentTool.Org,
+				Message:         "approval expired and requires review before promotion",
+			})
+		}
+		if strings.TrimSpace(baseTool.Owner) != "" && strings.TrimSpace(currentTool.Owner) != "" && strings.TrimSpace(baseTool.Owner) != strings.TrimSpace(currentTool.Owner) {
+			reasons = append(reasons, Reason{
+				Code:            ReasonOwnerChanged,
+				AgentID:         currentTool.AgentID,
+				AgentInstanceID: currentTool.AgentInstanceID,
+				ToolID:          currentTool.ToolID,
+				Org:             currentTool.Org,
+				Message:         "control-path owner changed since approved baseline",
+				PreviousOwner:   strings.TrimSpace(baseTool.Owner),
+				CurrentOwner:    strings.TrimSpace(currentTool.Owner),
+			})
+		}
+		if isApproved(baseTool) && currentTool.RiskScore > 0 && currentTool.RiskScore-baseTool.RiskScore >= 1 {
+			reasons = append(reasons, Reason{
+				Code:              ReasonApprovedPathRiskIncreased,
+				AgentID:           currentTool.AgentID,
+				AgentInstanceID:   currentTool.AgentInstanceID,
+				ToolID:            currentTool.ToolID,
+				Org:               currentTool.Org,
+				Message:           "approved control-path risk increased since baseline",
+				PreviousRiskScore: round2(baseTool.RiskScore),
+				CurrentRiskScore:  round2(currentTool.RiskScore),
 			})
 		}
 
@@ -399,6 +552,46 @@ func matchBaselineTool(baseByAgent map[string]ToolState, baseByInstance map[stri
 	return baseTool, true
 }
 
+func newControlPathReason(currentTool ToolState) Reason {
+	code := ReasonNewUnapprovedTool
+	message := "detected tool not present in approved baseline"
+	switch {
+	case currentTool.SecretBearing:
+		code = ReasonNewSecretBearingWorkflow
+		message = "new secret-bearing workflow appeared since approved baseline"
+	case hasWritePathClass(currentTool, agginventory.WritePathRepoWrite, agginventory.WritePathPullRequestWrite, agginventory.WritePathReleaseWrite, agginventory.WritePathDeployWrite, agginventory.WritePathInfraWrite, agginventory.WritePathPackagePublish):
+		code = ReasonNewRepoWritePath
+		message = "new repository write-capable control path appeared since approved baseline"
+	case strings.TrimSpace(currentTool.ControlPathType) == "mcp_tool" || strings.Contains(strings.ToLower(currentTool.ToolID), "mcp") || strings.Contains(strings.ToLower(currentTool.AgentID), "mcp"):
+		code = ReasonNewMCPToolConfig
+		message = "new MCP tool configuration appeared since approved baseline"
+	case strings.TrimSpace(currentTool.SecurityVisibility) == agginventory.SecurityVisibilityUnknownToSecurity:
+		code = ReasonNewUnknownAutomation
+		message = "new automation path unknown to security appeared since approved baseline"
+	}
+	return Reason{
+		Code:            code,
+		AgentID:         currentTool.AgentID,
+		AgentInstanceID: currentTool.AgentInstanceID,
+		ToolID:          currentTool.ToolID,
+		Org:             currentTool.Org,
+		Message:         message,
+	}
+}
+
+func hasWritePathClass(tool ToolState, values ...string) bool {
+	set := map[string]struct{}{}
+	for _, value := range values {
+		set[strings.TrimSpace(value)] = struct{}{}
+	}
+	for _, class := range tool.WritePathClasses {
+		if _, ok := set[strings.TrimSpace(class)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 func baselineInstanceKey(org, instanceID string) string {
 	return fallback(org, "local") + "::" + strings.TrimSpace(instanceID)
 }
@@ -466,6 +659,7 @@ func normalizeBaseline(baseline Baseline) Baseline {
 	})
 	for i := range baseline.Tools {
 		baseline.Tools[i].Permissions = dedupeSortedPermissions(baseline.Tools[i].Permissions)
+		baseline.Tools[i].WritePathClasses = mergeSortedStrings(baseline.Tools[i].WritePathClasses, nil)
 	}
 	baseline.AttackPaths = sortAttackPaths(baseline.AttackPaths)
 	return baseline
@@ -520,6 +714,58 @@ func fallback(value, fallbackValue string) string {
 		return fallbackValue
 	}
 	return value
+}
+
+func mergeSortedStrings(a []string, b []string) []string {
+	set := map[string]struct{}{}
+	for _, value := range append(append([]string(nil), a...), b...) {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			set[trimmed] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func agentIDForBacklogItem(snapshot state.Snapshot, repo string, path string) string {
+	if snapshot.Inventory != nil {
+		for _, tool := range snapshot.Inventory.Tools {
+			for _, loc := range tool.Locations {
+				if strings.TrimSpace(loc.Repo) == strings.TrimSpace(repo) && strings.TrimSpace(loc.Location) == strings.TrimSpace(path) {
+					return strings.TrimSpace(tool.AgentID)
+				}
+			}
+		}
+	}
+	for _, record := range snapshot.Identities {
+		if strings.TrimSpace(record.Repo) == strings.TrimSpace(repo) && strings.TrimSpace(record.Location) == strings.TrimSpace(path) {
+			return strings.TrimSpace(record.AgentID)
+		}
+	}
+	return ""
+}
+
+func orgForBacklogItem(snapshot state.Snapshot, repo string, path string) string {
+	if snapshot.Inventory != nil {
+		for _, tool := range snapshot.Inventory.Tools {
+			for _, loc := range tool.Locations {
+				if strings.TrimSpace(loc.Repo) == strings.TrimSpace(repo) && strings.TrimSpace(loc.Location) == strings.TrimSpace(path) {
+					return strings.TrimSpace(tool.Org)
+				}
+			}
+		}
+	}
+	for _, record := range snapshot.Identities {
+		if strings.TrimSpace(record.Repo) == strings.TrimSpace(repo) && strings.TrimSpace(record.Location) == strings.TrimSpace(path) {
+			return strings.TrimSpace(record.Org)
+		}
+	}
+	return "local"
 }
 
 func snapshotFindingIdentity(finding model.Finding, useInstanceIDs bool) (toolID string, agentID string, legacyAgentID string) {

--- a/core/regress/regress_test.go
+++ b/core/regress/regress_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Clyra-AI/wrkr/core/aggregate/controlbacklog"
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/identity"
 	"github.com/Clyra-AI/wrkr/core/manifest"
 	"github.com/Clyra-AI/wrkr/core/model"
@@ -963,6 +965,124 @@ func TestCompareSummarizesCriticalAttackPathDrift(t *testing.T) {
 	if reason.ToolID != "attack_paths" {
 		t.Fatalf("unexpected summarized tool_id %q", reason.ToolID)
 	}
+}
+
+func TestRegressDetectsNewSecretBearingWriteWorkflow(t *testing.T) {
+	t.Parallel()
+
+	toolID := identity.ToolID("workflow", ".github/workflows/deploy.yml")
+	agentID := identity.AgentID(toolID, "acme")
+	current := state.Snapshot{
+		Inventory: &agginventory.Inventory{
+			Tools: []agginventory.Tool{
+				{
+					AgentID:   agentID,
+					ToolID:    toolID,
+					Org:       "acme",
+					Repos:     []string{"acme/repo"},
+					Locations: []agginventory.ToolLocation{{Repo: "acme/repo", Location: ".github/workflows/deploy.yml"}},
+				},
+			},
+		},
+		Identities: []manifest.IdentityRecord{
+			{
+				AgentID:       agentID,
+				ToolID:        toolID,
+				ToolType:      "workflow",
+				Org:           "acme",
+				Repo:          "acme/repo",
+				Location:      ".github/workflows/deploy.yml",
+				Status:        identity.StateUnderReview,
+				ApprovalState: "missing",
+				Present:       true,
+			},
+		},
+		ControlBacklog: &controlbacklog.Backlog{
+			Items: []controlbacklog.Item{
+				{
+					ID:                 "cb-secret-write",
+					Repo:               "acme/repo",
+					Path:               ".github/workflows/deploy.yml",
+					ControlPathType:    controlbacklog.ControlPathSecretWorkflow,
+					ApprovalStatus:     "missing",
+					SecurityVisibility: agginventory.SecurityVisibilityUnknownToSecurity,
+					RecommendedAction:  controlbacklog.ActionAttachEvidence,
+					WritePathClasses:   []string{agginventory.WritePathRepoWrite},
+					SecretSignalTypes:  []string{controlbacklog.SecretRotationEvidenceMissing},
+				},
+			},
+		},
+	}
+
+	result := Compare(Baseline{Version: BaselineVersion, Tools: []ToolState{}}, current)
+	if !result.Drift {
+		t.Fatal("expected drift for new secret-bearing workflow")
+	}
+	if !hasReasonCode(result.Reasons, ReasonNewSecretBearingWorkflow) {
+		t.Fatalf("expected %s reason, got %+v", ReasonNewSecretBearingWorkflow, result.Reasons)
+	}
+}
+
+func TestRegressDetectsApprovalExpiredAndOwnerChanged(t *testing.T) {
+	t.Parallel()
+
+	toolID := identity.ToolID("codex", "AGENTS.md")
+	agentID := identity.AgentID(toolID, "acme")
+	baseline := Baseline{
+		Version: BaselineVersion,
+		Tools: []ToolState{
+			{
+				AgentID:         agentID,
+				AgentInstanceID: toolID,
+				ToolID:          toolID,
+				Org:             "acme",
+				Status:          identity.StateActive,
+				ApprovalStatus:  "valid",
+				Owner:           "platform-security",
+				RiskScore:       2,
+				Present:         true,
+			},
+		},
+	}
+	current := state.Snapshot{
+		Identities: []manifest.IdentityRecord{
+			{
+				AgentID:       agentID,
+				ToolID:        toolID,
+				ToolType:      "codex",
+				Org:           "acme",
+				Repo:          "acme/repo",
+				Location:      "AGENTS.md",
+				Status:        identity.StateUnderReview,
+				ApprovalState: "expired",
+				Approval: manifest.Approval{
+					Owner:   "appsec",
+					Expires: "2026-04-01T00:00:00Z",
+				},
+				RiskScore: 4,
+				Present:   true,
+			},
+		},
+	}
+
+	result := Compare(baseline, current)
+	if !result.Drift {
+		t.Fatal("expected drift for expired approval and owner change")
+	}
+	for _, code := range []string{ReasonApprovalExpired, ReasonOwnerChanged, ReasonApprovedPathRiskIncreased} {
+		if !hasReasonCode(result.Reasons, code) {
+			t.Fatalf("expected %s reason, got %+v", code, result.Reasons)
+		}
+	}
+}
+
+func hasReasonCode(reasons []Reason, code string) bool {
+	for _, reason := range reasons {
+		if reason.Code == code {
+			return true
+		}
+	}
+	return false
 }
 
 func TestCompareSuppressesAttackPathDriftBelowThreshold(t *testing.T) {

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -22,22 +22,24 @@ import (
 )
 
 const SnapshotVersion = "v1"
+const ApprovalInventoryVersion = "1"
 
 // Snapshot stores deterministic scan material for diff mode.
 type Snapshot struct {
-	Version        string                    `json:"version"`
-	Target         source.Target             `json:"target"`
-	Targets        []source.Target           `json:"targets,omitempty"`
-	Findings       []source.Finding          `json:"findings"`
-	Inventory      *agginventory.Inventory   `json:"inventory,omitempty"`
-	ControlBacklog *controlbacklog.Backlog   `json:"control_backlog,omitempty"`
-	ScanQuality    *scanquality.Report       `json:"scan_quality,omitempty"`
-	ScanMode       string                    `json:"scan_mode,omitempty"`
-	RiskReport     *risk.Report              `json:"risk_report,omitempty"`
-	Profile        *profileeval.Result       `json:"profile,omitempty"`
-	PostureScore   *score.Result             `json:"posture_score,omitempty"`
-	Identities     []manifest.IdentityRecord `json:"identities,omitempty"`
-	Transitions    []lifecycle.Transition    `json:"lifecycle_transitions,omitempty"`
+	Version                  string                    `json:"version"`
+	ApprovalInventoryVersion string                    `json:"approval_inventory_version,omitempty"`
+	Target                   source.Target             `json:"target"`
+	Targets                  []source.Target           `json:"targets,omitempty"`
+	Findings                 []source.Finding          `json:"findings"`
+	Inventory                *agginventory.Inventory   `json:"inventory,omitempty"`
+	ControlBacklog           *controlbacklog.Backlog   `json:"control_backlog,omitempty"`
+	ScanQuality              *scanquality.Report       `json:"scan_quality,omitempty"`
+	ScanMode                 string                    `json:"scan_mode,omitempty"`
+	RiskReport               *risk.Report              `json:"risk_report,omitempty"`
+	Profile                  *profileeval.Result       `json:"profile,omitempty"`
+	PostureScore             *score.Result             `json:"posture_score,omitempty"`
+	Identities               []manifest.IdentityRecord `json:"identities,omitempty"`
+	Transitions              []lifecycle.Transition    `json:"lifecycle_transitions,omitempty"`
 }
 
 type ScoreView struct {
@@ -85,6 +87,7 @@ func ResolvePath(explicit string) string {
 
 func Save(path string, snapshot Snapshot) error {
 	snapshot.Version = SnapshotVersion
+	snapshot.ApprovalInventoryVersion = ApprovalInventoryVersion
 	snapshot.Targets = source.SortTargets(snapshot.Targets)
 	source.SortFindings(snapshot.Findings)
 	payload, err := json.MarshalIndent(snapshot, "", "  ")
@@ -110,6 +113,9 @@ func loadSnapshot(path string) (Snapshot, error) {
 	}
 	if snapshot.Version == "" {
 		snapshot.Version = SnapshotVersion
+	}
+	if snapshot.ApprovalInventoryVersion == "" {
+		snapshot.ApprovalInventoryVersion = ApprovalInventoryVersion
 	}
 	return snapshot, nil
 }

--- a/docs-site/public/llm/contracts.md
+++ b/docs-site/public/llm/contracts.md
@@ -7,6 +7,8 @@ Stable contract surfaces include:
 - Deterministic trust docs in `/docs/trust/`
 - Exit-code contract (`0` success, `1` runtime failure, `2` verification failure, `3` policy/schema violation, `4` approval required, `5` regression drift, `6` invalid input, `7` dependency missing, `8` unsafe operation blocked)
 - Additive `verify --json` success detail fields such as `chain.verification_mode` and `chain.authenticity_status`
+- Additive `control_evidence` in `evidence --json` and `verify --chain --json` when the saved state contains an active control backlog
+- Inventory approval lifecycle commands that mutate local state/manifest/proof artifacts atomically
 - `wrkr score` fail-closed behavior when saved scan snapshots are malformed, even if cached `posture_score` is present
 - `wrkr evidence` fail-closed behavior when saved proof-chain prerequisites are malformed or tampered
 - `wrkr scan --resume` fail-closed behavior when checkpoint files or reused materialized repo roots are symlink-swapped
@@ -19,6 +21,7 @@ Key command anchors:
 - `wrkr scan --my-setup --json`
 - `wrkr mcp-list --json`
 - `wrkr inventory --diff --baseline <baseline-path> --json`
+- `wrkr inventory approve <agent-id> --owner <team> --evidence <ticket-or-url> --expires 90d --json`
 - `wrkr score --json`
 - `wrkr evidence --frameworks <ids> --json`
 - `wrkr verify --chain --json`

--- a/docs-site/public/llm/faq.md
+++ b/docs-site/public/llm/faq.md
@@ -31,10 +31,12 @@ No. Wrkr runs standalone; Gait is the optional control-layer counterpart when ru
 ## How do I gate on posture drift in CI?
 
 Use `wrkr regress run`. It accepts a saved regress baseline or a raw saved scan snapshot baseline. Exit code `5` indicates drift. Legacy `v1` baselines created before instance identities are reconciled automatically when the current identity is equivalent.
+New control-path drift categories include expired approvals, owner changes, risk increases, new write paths, new MCP tool configs, and new secret-bearing workflows.
 
 ## How do I produce verifiable compliance evidence?
 
 Use `wrkr evidence --frameworks ... --json` and verify with `wrkr verify --chain --json`. `wrkr evidence` now fails closed when the saved proof chain is malformed or tampered, while `wrkr verify --chain --json` remains the explicit machine gate. Success JSON includes `chain.verification_mode` and `chain.authenticity_status`; invalid verifier-key material is a verification failure.
+When a saved state carries a control backlog, evidence and verify JSON may include additive `control_evidence` entries with existing proof, missing proof, and related proof record ids.
 
 ## Why can framework coverage be low on the first run?
 

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -38,9 +38,11 @@ wrkr scan --my-setup --json
 wrkr mcp-list --state ./.wrkr/last-scan.json --json
 cp ./.wrkr/last-scan.json ./.wrkr/inventory-baseline.json
 wrkr inventory --diff --baseline ./.wrkr/inventory-baseline.json --state ./.wrkr/last-scan.json --json
+wrkr inventory approve <agent-id> --owner platform-security --evidence SEC-123 --expires 90d --state ./.wrkr/last-scan.json --json
 ```
 
 `wrkr evidence` now fails closed when the saved proof chain is malformed or tampered, and `wrkr verify --chain --json` remains the explicit machine gate for integrity.
+Inventory approval/evidence mutations are local, file-based, and append proof events. Evidence and verify JSON may include additive `control_evidence` so operators can see existing and missing proof for active backlog controls.
 The hosted org path is the primary launch workflow when prerequisites are ready. Use the curated scenario when you want the evaluator-safe fallback because it avoids repo-root fixture noise from Wrkr's own scenarios, docs, and test fixtures. That scenario path is the canonical `repo_set` example for `--path`: Wrkr scans the immediate child repos in the bundle instead of treating the bundle root as one repo.
 Use `wrkr scan --path ./your-repo --json` when the selected directory itself is the repo root and carries repo-root signals such as `.git`, `go.mod`, `AGENTS.md`, or `.codex/`. Use a bundle root like `./scenarios/wrkr/scan-mixed-org/repos` when you want immediate child repos scanned as a deterministic repo-set.
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -17,6 +17,8 @@
 - wrkr scan --github-org <org> --github-api <url> --json
 - wrkr scan --path <dir> --sarif --json
 - wrkr inventory --diff --baseline ./.wrkr/inventory-baseline.json --state ./.wrkr/last-scan.json --json
+- wrkr inventory approve <agent-id> --owner <team> --evidence <ticket-or-url> --expires 90d --state ./.wrkr/last-scan.json --json
+- wrkr inventory attach-evidence <agent-id> --control <control-id> --url <url> --state ./.wrkr/last-scan.json --json
 - wrkr report --top <n> --json
 - wrkr score --json
 - wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence --json
@@ -45,6 +47,7 @@
 - Hosted org posture is the primary first-run path when prerequisites are ready; local `--my-setup`, repo-local `--path`, and the curated scenario remain deterministic fallback paths when hosted setup is not ready yet.
 - Resumed hosted org scans revalidate checkpoint files and reused materialized repo roots before detector execution, so symlink-swapped resume state is blocked as unsafe.
 - Low or zero `framework_coverage` reflects the controls currently evidenced in the scanned state, not missing parser support, and `wrkr evidence --json` emits additive `coverage_note` guidance with the same interpretation.
+- Approval inventory mutations are local/file-based and append proof events; `wrkr evidence --json` and `wrkr verify --chain --json` may include additive `control_evidence` showing existing and missing proof for active backlog controls.
 - Evidence bundles include deterministic inventory artifacts: inventory.json, inventory-snapshot.json, inventory.yaml.
 - Wrkr runs standalone; Gait is the optional control-layer counterpart.
 - Wrkr does not replace vulnerability scanners such as Snyk.

--- a/docs/commands/evidence.md
+++ b/docs/commands/evidence.md
@@ -65,10 +65,12 @@ wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json
 Pair this with the saved-state `wrkr report` and explicit proof-chain verification flow documented in [`docs/examples/security-team.md`](../examples/security-team.md).
 `wrkr evidence` now requires the saved proof chain to be intact before it will stage or publish a bundle; it does not replace the explicit operator or CI proof-chain verification gate.
 
-Expected JSON keys: `status`, `output_dir`, `frameworks`, `manifest_path`, `chain_path`, `framework_coverage`, additive `coverage_note`, `report_artifacts`.
+Expected JSON keys: `status`, `output_dir`, `frameworks`, `manifest_path`, `chain_path`, `framework_coverage`, additive `control_evidence`, additive `coverage_note`, `report_artifacts`.
 `coverage_note` is the machine-readable interpretation companion for `framework_coverage`: it states that coverage reflects only controls evidenced in the current scanned state and that low or zero first-run coverage indicates evidence gaps rather than unsupported framework parsing.
+`control_evidence` lists each active control backlog item with existing proof events, missing proof requirements, and related proof record ids when present.
 Evidence bundle includes deterministic inventory exports at `inventory.json`, `inventory-snapshot.json`, and `inventory.yaml`.
 Evidence bundle includes deterministic compliance rollup export at `compliance-summary.json`.
+Evidence bundle includes deterministic control proof status at `control-evidence.json`.
 Evidence bundle includes deterministic attack-path artifact export at `attack-paths.json` when attack-path scoring is present in scan state.
 Evidence bundle report summaries now carry additive security-visibility context from the scan state, including `unknown_to_security` counts and the reference basis used to derive them.
 If the saved scan state does not carry a usable reference basis, Wrkr suppresses `unknown_to_security` wording in downstream summaries rather than inventing that claim.

--- a/docs/commands/inventory.md
+++ b/docs/commands/inventory.md
@@ -5,9 +5,14 @@
 ```bash
 wrkr inventory [--state <path>] [--anonymize] [--json]
 wrkr inventory --diff [--baseline <path>] [--state <path>] [--json]
+wrkr inventory approve <id> --owner <team> --evidence <ticket-or-url> --expires <date-or-duration> [--control <control-id>] [--review-cadence <duration>] [--state <path>] [--json]
+wrkr inventory attach-evidence <id> --control <control-id> --url <url> [--owner <team>] [--state <path>] [--json]
+wrkr inventory accept-risk <id> --expires <date-or-duration> [--reason <reason>] [--state <path>] [--json]
+wrkr inventory deprecate <id> --reason <reason> [--state <path>] [--json]
+wrkr inventory exclude <id> --reason <reason> [--state <path>] [--json]
 ```
 
-`inventory` is the developer-facing compatibility wrapper over Wrkr's existing inventory export and drift primitives.
+`inventory` is the developer-facing compatibility wrapper over Wrkr's existing inventory export and drift primitives, plus lifecycle governance mutations for discovered control paths.
 
 ## Flags
 
@@ -16,6 +21,13 @@ wrkr inventory --diff [--baseline <path>] [--state <path>] [--json]
 - `--anonymize`
 - `--diff`
 - `--baseline`
+- `--owner`
+- `--evidence`
+- `--expires`
+- `--control`
+- `--review-cadence`
+- `--url`
+- `--reason`
 
 ## Developer personal-hygiene example
 
@@ -23,6 +35,7 @@ wrkr inventory --diff [--baseline <path>] [--state <path>] [--json]
 wrkr inventory --json
 wrkr inventory --anonymize --json
 wrkr inventory --diff --baseline ./.wrkr/inventory-baseline.json --state ./.wrkr/last-scan.json --json
+wrkr inventory approve wrkr:codex-abc123:acme --owner platform-security --evidence SEC-123 --expires 90d --state ./.wrkr/last-scan.json --json
 ```
 
 ## Output contract
@@ -48,8 +61,32 @@ Inventory records may include additive governance fields when they were produced
 - `added`
 - `removed`
 - `changed`
+- additive control-path drift fields: `control_path_drift_detected`, `control_path_reason_count`, and `control_path_reasons`
 
 `inventory --diff` exits `5` when deterministic drift is present.
+
+Mutation commands emit a deterministic JSON response with:
+
+- `status`
+- `approval_inventory_version`
+- `action`
+- `identity`
+- `transition`
+- `state_path`
+- `manifest_path`
+- `proof_chain_path`
+
+Mutations update the state snapshot and `wrkr-manifest.yaml` additively, append lifecycle/proof records, and use atomic rollback if a managed artifact write fails. Unsafe managed artifact paths, including symlinks or non-regular files at state/proof/manifest paths, return exit `8` with `unsafe_operation_blocked`.
+
+## Approval inventory semantics
+
+- `approve` records owner, evidence reference, optional control id, expiry, review cadence, last reviewed timestamp, and renewal state. It creates an `approval_recorded` proof event.
+- `attach-evidence` records a control id and evidence URL without network validation. It creates an `evidence_attached` proof event.
+- `accept-risk` requires an expiry and records time-bounded accepted-risk visibility.
+- `deprecate` records a deterministic reason and moves the identity to deprecated visibility.
+- `exclude` records an exclusion reason, moves the identity out of the active governance backlog, and keeps the underlying evidence available in saved artifacts.
+
+Inventory item ids may be an `agent_id`, `tool_id`, or a `control_backlog.items[*].id` that can be resolved to an inventory path.
 
 ## Baseline semantics
 

--- a/docs/commands/regress.md
+++ b/docs/commands/regress.md
@@ -42,10 +42,24 @@ wrkr regress run --baseline ./.wrkr/inventory-baseline.json --state ./.wrkr/last
 
 Expected JSON keys include `status`, `baseline_path`, `tool_count` (init) and drift fields plus optional `summary_md_path` (run).
 Baseline `tools[*]` continue to expose `agent_id` and `tool_id`; additive `agent_instance_id` is now included when instance-scoped identity is available.
+Baseline `tools[*]` may also include additive approved control-path state: `security_visibility`, `owner`, `evidence_expires`, `write_path_classes`, `secret_bearing`, `confidence`, `control_path_type`, `repo`, `location`, and `risk_score`.
 Drift `reasons[*]` continue to expose `agent_id`/`tool_id` and now include additive `agent_instance_id` when the current state carries instance-scoped identity.
 Deprecated or revoked tools that reappear in current scan state produce deterministic `deprecated_tool_reappeared` or `revoked_tool_reappeared` drift reasons.
 When critical attack-path sets diverge above deterministic thresholds, `reasons` includes a single `critical_attack_path_drift` summary entry with machine-readable `attack_path_drift` details (`added`, `removed`, `score_changed`).
 Regress baselines and drift comparison operate on lifecycle-bearing real tool identities only. Finding-only signals such as `secret_presence`, `source_discovery`, `policy_*`, and `parse_error` stay in findings/risk output and do not create `new_unapproved_tool` drift on their own.
+
+Control-path drift categories are additive and stable:
+
+- `new_unknown_automation`
+- `new_repo_write_path`
+- `new_secret_bearing_workflow`
+- `new_mcp_tool_config`
+- `approval_expired`
+- `owner_changed`
+- `approved_path_risk_increased`
+- `deprecated_path_reappeared`
+
+Approval expiry moves the affected current path toward review-oriented output through `approval_expired`; owner changes include `previous_owner` and `current_owner`; approved-path risk increases include `previous_risk_score` and `current_risk_score`.
 
 Compatibility note:
 

--- a/docs/commands/verify.md
+++ b/docs/commands/verify.md
@@ -20,6 +20,7 @@ wrkr verify --chain --state ./.tmp/state.json --json
 ```
 
 Expected JSON keys: `status`, `chain.path`, `chain.intact`, `chain.count`, `chain.head_hash`, `chain.reason`, `chain.verification_mode`, `chain.authenticity_status`.
+When the state snapshot contains a control backlog, success JSON may include additive `control_evidence` entries showing which proof records exist or are still missing for each backlog control.
 
 Lookup precedence:
 

--- a/docs/decisions/wave3-approval-evidence-drift.md
+++ b/docs/decisions/wave3-approval-evidence-drift.md
@@ -1,0 +1,24 @@
+# Wave 3 Approval, Evidence, And Drift
+
+## Status
+
+Accepted.
+
+## Context
+
+Wave 3 turns governance backlog items into lifecycle-managed controls. The implementation must remain deterministic, offline-first, file-based, and compatible with existing state, manifest, proof, evidence, and regress contracts.
+
+## Decision
+
+- Inventory governance mutations are CLI-local state transitions over saved Wrkr artifacts.
+- Mutations update the saved state snapshot and `wrkr-manifest.yaml`, append lifecycle/proof records, and roll back managed artifacts on write failure.
+- Approval inventory fields are additive and versioned with `approval_inventory_version`.
+- Proof and evidence lifecycle status is derived from the existing proof chain and active control backlog items.
+- Regress drift remains a persisted-state comparison. It does not rescan and does not call detectors.
+
+## Consequences
+
+- `wrkr inventory approve|attach-evidence|accept-risk|deprecate|exclude` can be used in CI or operator workflows without network execution.
+- `wrkr evidence --json` and `wrkr verify --chain --json` can show which control proof exists and what is still missing.
+- `wrkr regress run --json` and `wrkr inventory --diff --json` can prioritize approved-baseline drift categories such as expired approvals, owner changes, new write paths, and new secret-bearing workflows.
+- Existing raw findings, inventory export fields, proof chains, and legacy regress reasons remain available for compatibility.

--- a/docs/evidence_templates.md
+++ b/docs/evidence_templates.md
@@ -24,6 +24,7 @@ description: "Template structures for sharing Wrkr posture and evidence outputs 
 - `wrkr evidence` output manifest path.
 - Proof chain verification result.
 - Framework coverage summary.
+- Control evidence status (`control-evidence.json`) showing existing and missing proof for approval, owner, least-privilege, rotation, deployment-gate, production-access, and review-cadence requirements.
 - Contract references (`docs/specs/wrkr-manifest.md`, `docs/contracts/compatibility_matrix.md`).
 
 ## Command Anchors

--- a/docs/specs/wrkr-manifest.md
+++ b/docs/specs/wrkr-manifest.md
@@ -44,6 +44,8 @@ These fields are modeled in `schemas/v1/manifest/manifest.schema.json` as the po
 
 Primary fields include `agent_id`, `tool_id`, `tool_type`, `org`, `repo`, `location`, `status`, `approval_status`, `first_seen`, `last_seen`, `present`, `data_class`, `endpoint_class`, `autonomy_level`, and `risk_score`.
 
+Approval inventory mutations add `approval_inventory_version` and optional approval metadata: `owner`, `evidence_url`, `control_id`, `expires`, `review_cadence`, `last_reviewed`, `renewal_state`, `accepted_risk`, `decision_reason`, and `exclusion_reason`. These fields are additive and missing values are interpreted as `missing` or `needs_review` by governance views.
+
 ## Interoperability guidance
 
 For producers:

--- a/docs/trust/proof-chain-verification.md
+++ b/docs/trust/proof-chain-verification.md
@@ -21,6 +21,7 @@ wrkr verify --chain --state ./.tmp/state.json --json
 - `chain.head_hash`
 - `chain.verification_mode`
 - `chain.authenticity_status`
+- additive `control_evidence` when the saved state contains a control backlog
 
 ## Exit codes
 
@@ -35,6 +36,7 @@ If no verifier key exists, success remains possible only with explicit structura
 When `--path` is passed without `--state`, Wrkr resolves verifier material beside that explicit chain path; ambient `WRKR_STATE_PATH` does not override it.
 When `--state` is also passed, verifier lookup stays anchored to the explicit state directory.
 Verification failures are blocking contract signals.
+Approval inventory mutations add stable proof events such as `approval_recorded`, `evidence_attached`, and `risk_accepted`. `wrkr verify --chain --json` keeps chain integrity as the gate and can also surface backlog-level proof gaps when the state file is available.
 
 ## Q&A
 

--- a/internal/scenarios/drift_first_baseline_scenario_test.go
+++ b/internal/scenarios/drift_first_baseline_scenario_test.go
@@ -1,0 +1,56 @@
+//go:build scenario
+
+package scenarios
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/cli"
+)
+
+func TestDriftFirstBaseline(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "drift-first-baseline", "repos")
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	baselinePath := filepath.Join(tmp, "empty-approved-baseline.json")
+	if err := os.WriteFile(baselinePath, []byte("{\"version\":\"v1\",\"generated_at\":\"2026-04-22T12:00:00Z\",\"tools\":[]}\n"), 0o600); err != nil {
+		t.Fatalf("write baseline: %v", err)
+	}
+
+	_ = runScenarioCommandJSON(t, []string{"scan", "--path", scanPath, "--state", statePath, "--json"})
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := cli.Run([]string{"regress", "run", "--baseline", baselinePath, "--state", statePath, "--json"}, &out, &errOut)
+	if code != 5 {
+		t.Fatalf("expected drift exit 5, got %d stderr=%s", code, errOut.String())
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("expected drift JSON on stdout only, got stderr=%q", errOut.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse regress payload: %v", err)
+	}
+	reasons, ok := payload["reasons"].([]any)
+	if !ok || len(reasons) == 0 {
+		t.Fatalf("expected drift reasons, got %v", payload)
+	}
+	for _, item := range reasons {
+		reason, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if reason["code"] == "new_secret_bearing_workflow" {
+			return
+		}
+	}
+	t.Fatalf("expected new_secret_bearing_workflow reason, got %v", reasons)
+}

--- a/scenarios/wrkr/drift-first-baseline/repos/secret-writer/.github/workflows/deploy.yml
+++ b/scenarios/wrkr/drift-first-baseline/repos/secret-writer/.github/workflows/deploy.yml
@@ -1,0 +1,14 @@
+name: deploy
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: deploy with referenced secret
+        run: echo "${{ secrets.PROD_DEPLOY_TOKEN }}"

--- a/scripts/check_docs_cli_parity.sh
+++ b/scripts/check_docs_cli_parity.sh
@@ -61,22 +61,22 @@ flag_patterns = (
     re.compile(r'fs\.Var\([^,]+,\s*"([a-z0-9-]+)"'),
 )
 
-source_to_doc = {
-    "core/cli/root.go": "docs/commands/root.md",
-    "core/cli/init.go": "docs/commands/init.md",
-    "core/cli/scan.go": "docs/commands/scan.md",
-    "core/cli/mcp_list.go": "docs/commands/mcp-list.md",
-    "core/cli/report.go": "docs/commands/report.md",
-    "core/cli/export.go": "docs/commands/export.md",
-    "core/cli/inventory.go": "docs/commands/inventory.md",
-    "core/cli/identity.go": "docs/commands/identity.md",
-    "core/cli/lifecycle.go": "docs/commands/lifecycle.md",
-    "core/cli/manifest.go": "docs/commands/manifest.md",
-    "core/cli/regress.go": "docs/commands/regress.md",
-    "core/cli/score.go": "docs/commands/score.md",
-    "core/cli/verify.go": "docs/commands/verify.md",
-    "core/cli/evidence.go": "docs/commands/evidence.md",
-    "core/cli/fix.go": "docs/commands/fix.md",
+doc_to_sources = {
+    "docs/commands/root.md": ["core/cli/root.go"],
+    "docs/commands/init.md": ["core/cli/init.go"],
+    "docs/commands/scan.md": ["core/cli/scan.go"],
+    "docs/commands/mcp-list.md": ["core/cli/mcp_list.go"],
+    "docs/commands/report.md": ["core/cli/report.go"],
+    "docs/commands/export.md": ["core/cli/export.go"],
+    "docs/commands/inventory.md": ["core/cli/inventory.go", "core/cli/inventory_mutations.go"],
+    "docs/commands/identity.md": ["core/cli/identity.go"],
+    "docs/commands/lifecycle.md": ["core/cli/lifecycle.go"],
+    "docs/commands/manifest.md": ["core/cli/manifest.go"],
+    "docs/commands/regress.md": ["core/cli/regress.go"],
+    "docs/commands/score.md": ["core/cli/score.go"],
+    "docs/commands/verify.md": ["core/cli/verify.go"],
+    "docs/commands/evidence.md": ["core/cli/evidence.go"],
+    "docs/commands/fix.md": ["core/cli/fix.go"],
 }
 
 def extract_flags(path: pathlib.Path) -> set[str]:
@@ -86,20 +86,22 @@ def extract_flags(path: pathlib.Path) -> set[str]:
         flags.update(pattern.findall(text))
     return flags
 
-for source_path, doc_path in source_to_doc.items():
-    source_flags = extract_flags(repo / source_path)
+for doc_path, source_paths in doc_to_sources.items():
+    source_flags: set[str] = set()
+    for source_path in source_paths:
+        source_flags.update(extract_flags(repo / source_path))
     doc_text = (repo / doc_path).read_text(encoding="utf-8")
     doc_flags = set(re.findall(r"--[a-z0-9-]+", doc_text))
 
     missing_flags = sorted(f"--{flag}" for flag in source_flags if f"--{flag}" not in doc_text)
     if missing_flags:
-        print(f"{doc_path} missing flags from {source_path}: {', '.join(missing_flags)}", file=sys.stderr)
+        print(f"{doc_path} missing flags from {', '.join(source_paths)}: {', '.join(missing_flags)}", file=sys.stderr)
         sys.exit(3)
 
     allowed_doc_flags = set(f"--{flag}" for flag in source_flags)
     stale_flags = sorted(flag for flag in doc_flags if flag not in allowed_doc_flags)
     if stale_flags:
-        print(f"{doc_path} contains undocumented/stale flags not in {source_path}: {', '.join(stale_flags)}", file=sys.stderr)
+        print(f"{doc_path} contains undocumented/stale flags not in {', '.join(source_paths)}: {', '.join(stale_flags)}", file=sys.stderr)
         sys.exit(3)
 
 print("docs CLI parity: pass")


### PR DESCRIPTION
## Problem

Wave 3 of `plan_next.md` turns governance backlog items into lifecycle-managed controls. Wrkr needed local inventory workflows for approval/evidence/risk/deprecation/exclusion, proof-aware control evidence output, and drift-first monitoring from approved baselines while preserving deterministic offline artifacts.

## Changes

- Add `wrkr inventory approve|attach-evidence|accept-risk|deprecate|exclude` with deterministic JSON responses, state/manifest updates, lifecycle transitions, proof events, safe managed artifact preflight, and rollback behavior.
- Add additive `approval_inventory_version` and approval metadata to saved state/manifest artifacts.
- Add control proof status into `wrkr evidence --json`, evidence bundles, and `wrkr verify --chain --json` when a control backlog is present.
- Extend regress baselines and inventory diff with approved control-path state and drift categories for new secret-bearing workflows, write paths, MCP configs, expired approvals, owner changes, risk increases, and deprecated path reappearance.
- Add Wave 3 scenario/docs/ADR/changelog coverage and docs parity updates.

## Validation

- `make prepush-full`
- Baseline before implementation: `make lint-fast`, `make test-fast`
- Targeted Wave 3 lanes: CLI/lifecycle/state/evidence/proof/regress package tests, e2e CLI contract, e2e regress, interop, scenarios, docs parity, hardening, chaos, contracts, and CodeQL via `make prepush-full`
