### PR TITLE
Fix state mutation authority and lifecycle contract drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- (none yet)
+- Fixed manual identity and inventory mutations to update the saved scan snapshot in the same rollback-safe transaction as manifest and proof artifacts.
+- Fixed saved-state posture calculations so score, report, and regress immediately reflect approval mutations without requiring a fresh scan.
+- Fixed lifecycle reconciliation so newly discovered tools persist as `discovered` until explicitly reviewed or approval state requires review.
 
 ### Security
 
 - Refined secret-bearing automation semantics so Wrkr distinguishes secret references, leaked values, ownership/scope gaps, and rotation evidence gaps without exposing secret values.
+- Hardened stateful CLI commands to fail closed on symlinked `--state` paths so scan, manifest, and proof artifacts cannot split across directories.
 
 ## Changelog maintenance process
 

--- a/core/aggregate/inventory/inventory.go
+++ b/core/aggregate/inventory/inventory.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Clyra-AI/wrkr/core/aggregate/exposure"
 	"github.com/Clyra-AI/wrkr/core/identity"
+	"github.com/Clyra-AI/wrkr/core/manifest"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/owners"
 	"github.com/Clyra-AI/wrkr/core/source"
@@ -685,6 +686,96 @@ func ApplySecurityVisibilityToPrivilegeMap(inv *Inventory) {
 	}
 }
 
+// RefreshIdentityGovernance projects persisted lifecycle and approval changes
+// back into the saved inventory snapshot so downstream commands read the same
+// posture the manifest and lifecycle chain now describe.
+func RefreshIdentityGovernance(inv *Inventory, identities []manifest.IdentityRecord) {
+	if inv == nil {
+		return
+	}
+	byAgent := make(map[string]manifest.IdentityRecord, len(identities))
+	for _, record := range identities {
+		agentID := strings.TrimSpace(record.AgentID)
+		if agentID == "" {
+			continue
+		}
+		byAgent[agentID] = record
+	}
+	for idx := range inv.Tools {
+		record, ok := byAgent[strings.TrimSpace(inv.Tools[idx].AgentID)]
+		if !ok {
+			continue
+		}
+		inv.Tools[idx].ApprovalStatus = strings.TrimSpace(record.ApprovalState)
+		inv.Tools[idx].LifecycleState = strings.TrimSpace(record.Status)
+		inv.Tools[idx].ApprovalClass = classifyApproval(inv.Tools[idx].ApprovalStatus, inv.Tools[idx].LifecycleState)
+		inv.Tools[idx].RiskTier = projectRiskTier(inv.Tools[idx].PermissionTier, inv.Tools[idx].RiskScore, inv.Tools[idx].AutonomyLevel, inv.Tools[idx].ApprovalClass)
+		inv.Tools[idx].RegulatoryMapping = regulatoryMappings(inv.Tools[idx])
+		if owner := strings.TrimSpace(record.Approval.Owner); owner != "" {
+			for locIdx := range inv.Tools[idx].Locations {
+				inv.Tools[idx].Locations[locIdx].Owner = owner
+				inv.Tools[idx].Locations[locIdx].OwnerSource = "inventory_approval"
+				inv.Tools[idx].Locations[locIdx].OwnershipStatus = "explicit"
+			}
+		}
+		inv.Tools[idx].SecurityVisibilityStatus = securityVisibilityFromIdentityRecord(record)
+	}
+	for idx := range inv.Agents {
+		record, ok := byAgent[strings.TrimSpace(inv.Agents[idx].AgentID)]
+		if !ok {
+			continue
+		}
+		inv.Agents[idx].SecurityVisibilityStatus = normalizeSecurityVisibilityStatus(securityVisibilityFromIdentityRecord(record))
+	}
+	for idx := range inv.AgentPrivilegeMap {
+		record, ok := byAgent[strings.TrimSpace(inv.AgentPrivilegeMap[idx].AgentID)]
+		if !ok {
+			continue
+		}
+		inv.AgentPrivilegeMap[idx].ApprovalClassification = classifyApproval(strings.TrimSpace(record.ApprovalState), strings.TrimSpace(record.Status))
+		inv.AgentPrivilegeMap[idx].SecurityVisibilityStatus = normalizeSecurityVisibilityStatus(securityVisibilityFromIdentityRecord(record))
+		if inv.AgentPrivilegeMap[idx].ApprovalClassification == "approved" {
+			inv.AgentPrivilegeMap[idx].ApprovalGapReasons = nil
+		}
+		if owner := strings.TrimSpace(record.Approval.Owner); owner != "" {
+			inv.AgentPrivilegeMap[idx].OperationalOwner = owner
+			inv.AgentPrivilegeMap[idx].OwnerSource = "inventory_approval"
+			inv.AgentPrivilegeMap[idx].OwnershipStatus = "explicit"
+		}
+		inv.AgentPrivilegeMap[idx].GovernanceControls = BuildGovernanceControls(GovernanceControlInput{
+			Owner:                    inv.AgentPrivilegeMap[idx].OperationalOwner,
+			OwnershipStatus:          inv.AgentPrivilegeMap[idx].OwnershipStatus,
+			ApprovalClassification:   inv.AgentPrivilegeMap[idx].ApprovalClassification,
+			SecurityVisibilityStatus: inv.AgentPrivilegeMap[idx].SecurityVisibilityStatus,
+			DeploymentGate:           deploymentGateFromEvidence(inv.AgentPrivilegeMap[idx].DeploymentEvidenceKeys),
+			ProofRequirement:         proofRequirementFromEvidence(inv.AgentPrivilegeMap[idx].DeploymentEvidenceKeys),
+			ProductionTargetStatus:   inv.AgentPrivilegeMap[idx].ProductionTargetStatus,
+			WritePathClasses:         inv.AgentPrivilegeMap[idx].WritePathClasses,
+			CredentialAccess:         inv.AgentPrivilegeMap[idx].CredentialAccess,
+			ProductionWrite:          inv.AgentPrivilegeMap[idx].ProductionWrite,
+			EvidenceBasis:            append(append([]string(nil), inv.AgentPrivilegeMap[idx].Permissions...), inv.AgentPrivilegeMap[idx].DeploymentEvidenceKeys...),
+		})
+	}
+	for idx := range inv.Tools {
+		owner, ownerStatus := primaryToolOwner(inv.Tools[idx])
+		inv.Tools[idx].GovernanceControls = BuildGovernanceControls(GovernanceControlInput{
+			Owner:                    owner,
+			OwnershipStatus:          ownerStatus,
+			ApprovalStatus:           inv.Tools[idx].ApprovalStatus,
+			ApprovalClassification:   inv.Tools[idx].ApprovalClass,
+			LifecycleState:           inv.Tools[idx].LifecycleState,
+			SecurityVisibilityStatus: inv.Tools[idx].SecurityVisibilityStatus,
+			WritePathClasses:         inv.Tools[idx].WritePathClasses,
+			CredentialAccess:         hasCredentialAccess(inv.Tools[idx]),
+			EvidenceBasis:            inv.Tools[idx].Permissions,
+		})
+	}
+	inv.ApprovalSummary = buildApprovalSummary(inv.Tools)
+	inv.RegulatorySummary = buildRegulatorySummary(inv.Tools)
+	inv.Summary = buildToolSummary(inv.Tools)
+	inv.SecurityVisibility = buildSecurityVisibilitySummary(inv.SecurityVisibility.ReferenceBasis, inv.SecurityVisibility.ReferencePath, inv.Agents, inv.Tools, inv.AgentPrivilegeMap)
+}
+
 func securityVisibilityForAgent(agent Agent, tools []Tool, ref SecurityVisibilityReference) string {
 	if agentApproved(agent, tools) {
 		return SecurityVisibilityApproved
@@ -697,6 +788,83 @@ func securityVisibilityForAgent(agent Agent, tools []Tool, ref SecurityVisibilit
 		return SecurityVisibilityKnownUnapproved
 	}
 	return SecurityVisibilityUnknownToSecurity
+}
+
+func securityVisibilityFromIdentityRecord(record manifest.IdentityRecord) string {
+	switch strings.TrimSpace(record.ApprovalState) {
+	case "valid":
+		return SecurityVisibilityKnownApproved
+	case "accepted_risk", "risk_accepted":
+		return SecurityVisibilityAcceptedRisk
+	case "expired", "invalid":
+		return SecurityVisibilityNeedsReview
+	case "deprecated":
+		return SecurityVisibilityDeprecated
+	case "excluded", "revoked":
+		return SecurityVisibilityRevoked
+	}
+	switch strings.TrimSpace(record.Status) {
+	case identity.StateDeprecated:
+		return SecurityVisibilityDeprecated
+	case identity.StateRevoked:
+		return SecurityVisibilityRevoked
+	case identity.StateActive, identity.StateApproved:
+		return SecurityVisibilityKnownApproved
+	default:
+		return SecurityVisibilityNeedsReview
+	}
+}
+
+func buildSecurityVisibilitySummary(referenceBasis, referencePath string, agents []Agent, tools []Tool, privilegeMap []AgentPrivilegeMapEntry) SecurityVisibilitySummary {
+	summary := SecurityVisibilitySummary{
+		ReferenceBasis: strings.TrimSpace(referenceBasis),
+		ReferencePath:  strings.TrimSpace(referencePath),
+	}
+	if summary.ReferenceBasis == "" {
+		summary.ReferenceBasis = "initial_scan"
+	}
+	for _, agent := range agents {
+		switch strings.TrimSpace(agent.SecurityVisibilityStatus) {
+		case SecurityVisibilityApproved, SecurityVisibilityKnownApproved:
+			summary.ApprovedAgents++
+		case SecurityVisibilityAcceptedRisk:
+			summary.AcceptedRiskAgents++
+		case SecurityVisibilityDeprecated:
+			summary.DeprecatedAgents++
+		case SecurityVisibilityRevoked:
+			summary.RevokedAgents++
+		case SecurityVisibilityNeedsReview:
+			summary.NeedsReviewAgents++
+		case SecurityVisibilityKnownUnapproved:
+			summary.KnownUnapprovedAgents++
+		default:
+			summary.UnknownToSecurityAgents++
+		}
+	}
+	for _, tool := range tools {
+		switch strings.TrimSpace(tool.SecurityVisibilityStatus) {
+		case SecurityVisibilityApproved, SecurityVisibilityKnownApproved:
+			summary.ApprovedTools++
+		case SecurityVisibilityAcceptedRisk:
+			summary.AcceptedRiskTools++
+		case SecurityVisibilityDeprecated:
+			summary.DeprecatedTools++
+		case SecurityVisibilityRevoked:
+			summary.RevokedTools++
+		case SecurityVisibilityNeedsReview:
+			summary.NeedsReviewTools++
+		case SecurityVisibilityKnownUnapproved:
+			summary.KnownUnapprovedTools++
+		default:
+			summary.UnknownToSecurityTools++
+		}
+	}
+	for _, entry := range privilegeMap {
+		if entry.WriteCapable && strings.TrimSpace(entry.SecurityVisibilityStatus) == SecurityVisibilityUnknownToSecurity {
+			summary.UnknownToSecurityWriteCapableAgents++
+		}
+	}
+	return summary
 }
 
 func securityVisibilityForTool(tool Tool, agentStatuses []string, ref SecurityVisibilityReference) string {
@@ -1088,6 +1256,22 @@ func buildApprovalSummary(tools []Tool) ApprovalSummary {
 		}
 	}
 	return finalizeApprovalSummary(summary)
+}
+
+func buildToolSummary(tools []Tool) Summary {
+	summary := Summary{}
+	for _, tool := range tools {
+		summary.TotalTools++
+		switch {
+		case tool.RiskScore >= 8:
+			summary.HighRisk++
+		case tool.RiskScore >= 5:
+			summary.MediumRisk++
+		default:
+			summary.LowRisk++
+		}
+	}
+	return summary
 }
 
 func buildRegulatorySummary(tools []Tool) RegulatorySummary {

--- a/core/aggregate/inventory/inventory.go
+++ b/core/aggregate/inventory/inventory.go
@@ -701,14 +701,36 @@ func RefreshIdentityGovernance(inv *Inventory, identities []manifest.IdentityRec
 		}
 		byAgent[agentID] = record
 	}
+	type projectedToolState struct {
+		approvalStatus     string
+		approvalClass      string
+		lifecycleState     string
+		securityVisibility string
+	}
+	projectedByAgent := make(map[string]projectedToolState, len(inv.Tools))
 	for idx := range inv.Tools {
 		record, ok := byAgent[strings.TrimSpace(inv.Tools[idx].AgentID)]
 		if !ok {
 			continue
 		}
-		inv.Tools[idx].ApprovalStatus = strings.TrimSpace(record.ApprovalState)
-		inv.Tools[idx].LifecycleState = strings.TrimSpace(record.Status)
-		inv.Tools[idx].ApprovalClass = classifyApproval(inv.Tools[idx].ApprovalStatus, inv.Tools[idx].LifecycleState)
+		approvalStatus := strings.TrimSpace(record.ApprovalState)
+		lifecycleState := strings.TrimSpace(record.Status)
+		preserveApprovedList := strings.TrimSpace(inv.Tools[idx].ApprovalStatus) == "approved_list" &&
+			approvalStatus == "missing" &&
+			(lifecycleState == "" || lifecycleState == identity.StateDiscovered || lifecycleState == identity.StateUnderReview)
+		if preserveApprovedList {
+			approvalStatus = strings.TrimSpace(inv.Tools[idx].ApprovalStatus)
+		}
+		inv.Tools[idx].ApprovalStatus = approvalStatus
+		inv.Tools[idx].LifecycleState = lifecycleState
+		if preserveApprovedList {
+			inv.Tools[idx].ApprovalClass = strings.TrimSpace(inv.Tools[idx].ApprovalClass)
+			if inv.Tools[idx].ApprovalClass == "" {
+				inv.Tools[idx].ApprovalClass = "approved"
+			}
+		} else {
+			inv.Tools[idx].ApprovalClass = classifyApproval(inv.Tools[idx].ApprovalStatus, inv.Tools[idx].LifecycleState)
+		}
 		inv.Tools[idx].RiskTier = projectRiskTier(inv.Tools[idx].PermissionTier, inv.Tools[idx].RiskScore, inv.Tools[idx].AutonomyLevel, inv.Tools[idx].ApprovalClass)
 		inv.Tools[idx].RegulatoryMapping = regulatoryMappings(inv.Tools[idx])
 		if owner := strings.TrimSpace(record.Approval.Owner); owner != "" {
@@ -718,9 +740,24 @@ func RefreshIdentityGovernance(inv *Inventory, identities []manifest.IdentityRec
 				inv.Tools[idx].Locations[locIdx].OwnershipStatus = "explicit"
 			}
 		}
-		inv.Tools[idx].SecurityVisibilityStatus = securityVisibilityFromIdentityRecord(record)
+		if preserveApprovedList {
+			inv.Tools[idx].SecurityVisibilityStatus = SecurityVisibilityKnownApproved
+		} else {
+			inv.Tools[idx].SecurityVisibilityStatus = securityVisibilityFromIdentityRecord(record)
+		}
+		projectedByAgent[strings.TrimSpace(inv.Tools[idx].AgentID)] = projectedToolState{
+			approvalStatus:     strings.TrimSpace(inv.Tools[idx].ApprovalStatus),
+			approvalClass:      strings.TrimSpace(inv.Tools[idx].ApprovalClass),
+			lifecycleState:     strings.TrimSpace(inv.Tools[idx].LifecycleState),
+			securityVisibility: strings.TrimSpace(inv.Tools[idx].SecurityVisibilityStatus),
+		}
 	}
 	for idx := range inv.Agents {
+		toolState, ok := projectedByAgent[strings.TrimSpace(inv.Agents[idx].AgentID)]
+		if ok {
+			inv.Agents[idx].SecurityVisibilityStatus = normalizeSecurityVisibilityStatus(toolState.securityVisibility)
+			continue
+		}
 		record, ok := byAgent[strings.TrimSpace(inv.Agents[idx].AgentID)]
 		if !ok {
 			continue
@@ -728,6 +765,27 @@ func RefreshIdentityGovernance(inv *Inventory, identities []manifest.IdentityRec
 		inv.Agents[idx].SecurityVisibilityStatus = normalizeSecurityVisibilityStatus(securityVisibilityFromIdentityRecord(record))
 	}
 	for idx := range inv.AgentPrivilegeMap {
+		if toolState, ok := projectedByAgent[strings.TrimSpace(inv.AgentPrivilegeMap[idx].AgentID)]; ok {
+			inv.AgentPrivilegeMap[idx].ApprovalClassification = toolState.approvalClass
+			inv.AgentPrivilegeMap[idx].SecurityVisibilityStatus = normalizeSecurityVisibilityStatus(toolState.securityVisibility)
+			if toolState.approvalClass == "approved" {
+				inv.AgentPrivilegeMap[idx].ApprovalGapReasons = nil
+			}
+			inv.AgentPrivilegeMap[idx].GovernanceControls = BuildGovernanceControls(GovernanceControlInput{
+				Owner:                    inv.AgentPrivilegeMap[idx].OperationalOwner,
+				OwnershipStatus:          inv.AgentPrivilegeMap[idx].OwnershipStatus,
+				ApprovalClassification:   inv.AgentPrivilegeMap[idx].ApprovalClassification,
+				SecurityVisibilityStatus: inv.AgentPrivilegeMap[idx].SecurityVisibilityStatus,
+				DeploymentGate:           deploymentGateFromEvidence(inv.AgentPrivilegeMap[idx].DeploymentEvidenceKeys),
+				ProofRequirement:         proofRequirementFromEvidence(inv.AgentPrivilegeMap[idx].DeploymentEvidenceKeys),
+				ProductionTargetStatus:   inv.AgentPrivilegeMap[idx].ProductionTargetStatus,
+				WritePathClasses:         inv.AgentPrivilegeMap[idx].WritePathClasses,
+				CredentialAccess:         inv.AgentPrivilegeMap[idx].CredentialAccess,
+				ProductionWrite:          inv.AgentPrivilegeMap[idx].ProductionWrite,
+				EvidenceBasis:            append(append([]string(nil), inv.AgentPrivilegeMap[idx].Permissions...), inv.AgentPrivilegeMap[idx].DeploymentEvidenceKeys...),
+			})
+			continue
+		}
 		record, ok := byAgent[strings.TrimSpace(inv.AgentPrivilegeMap[idx].AgentID)]
 		if !ok {
 			continue

--- a/core/aggregate/inventory/inventory_test.go
+++ b/core/aggregate/inventory/inventory_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Clyra-AI/wrkr/core/aggregate/exposure"
 	"github.com/Clyra-AI/wrkr/core/identity"
+	"github.com/Clyra-AI/wrkr/core/manifest"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/source"
 )
@@ -471,6 +472,61 @@ func TestApplySecurityVisibilityDoesNotBorrowApprovalAcrossOrgs(t *testing.T) {
 	}
 	if inv.Agents[1].SecurityVisibilityStatus != SecurityVisibilityUnknownToSecurity {
 		t.Fatalf("expected globex agent to stay unknown_to_security, got %+v", inv.Agents[1])
+	}
+}
+
+func TestRefreshIdentityGovernancePreservesApprovedListForUnchangedTool(t *testing.T) {
+	t.Parallel()
+
+	inv := &Inventory{
+		Tools: []Tool{
+			{
+				ToolID:                   "codex-aa",
+				AgentID:                  "wrkr:codex-aa:acme",
+				ToolType:                 "codex",
+				Org:                      "acme",
+				ApprovalStatus:           "approved_list",
+				ApprovalClass:            "approved",
+				SecurityVisibilityStatus: SecurityVisibilityKnownApproved,
+				LifecycleState:           identity.StateDiscovered,
+				PermissionTier:           "read",
+				AutonomyLevel:            "interactive",
+				Locations:                []ToolLocation{{Repo: "acme/repo", Location: "AGENTS.md"}},
+			},
+		},
+		Agents: []Agent{{AgentID: "wrkr:codex-aa:acme", AgentInstanceID: "codex-aa", Framework: "codex", Location: "AGENTS.md", Org: "acme"}},
+		AgentPrivilegeMap: []AgentPrivilegeMapEntry{{
+			AgentID:                  "wrkr:codex-aa:acme",
+			AgentInstanceID:          "codex-aa",
+			ToolID:                   "codex-aa",
+			ToolType:                 "codex",
+			ApprovalClassification:   "approved",
+			SecurityVisibilityStatus: SecurityVisibilityKnownApproved,
+			Repos:                    []string{"acme/repo"},
+		}},
+		SecurityVisibility: SecurityVisibilitySummary{ReferenceBasis: "baseline_snapshot"},
+	}
+
+	RefreshIdentityGovernance(inv, []manifest.IdentityRecord{{
+		AgentID:       "wrkr:codex-aa:acme",
+		ToolID:        "codex-aa",
+		ToolType:      "codex",
+		Org:           "acme",
+		Repo:          "acme/repo",
+		Location:      "AGENTS.md",
+		Status:        identity.StateDiscovered,
+		ApprovalState: "missing",
+		Present:       true,
+	}})
+
+	if inv.Tools[0].ApprovalStatus != "approved_list" || inv.Tools[0].ApprovalClass != "approved" {
+		t.Fatalf("expected approved_list posture to be preserved, got %+v", inv.Tools[0])
+	}
+	if inv.AgentPrivilegeMap[0].ApprovalClassification != "approved" {
+		t.Fatalf("expected privilege map approval classification to stay approved, got %+v", inv.AgentPrivilegeMap[0])
+	}
+	if inv.Tools[0].SecurityVisibilityStatus != SecurityVisibilityKnownApproved {
+		t.Fatalf("expected known_approved visibility to be preserved, got %+v", inv.Tools[0])
 	}
 }
 

--- a/core/cli/identity.go
+++ b/core/cli/identity.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Clyra-AI/wrkr/core/lifecycle"
 	"github.com/Clyra-AI/wrkr/core/manifest"
 	"github.com/Clyra-AI/wrkr/core/model"
-	"github.com/Clyra-AI/wrkr/core/proofemit"
 	"github.com/Clyra-AI/wrkr/core/state"
 )
 
@@ -212,15 +211,12 @@ func runIdentityTransition(args []string, stdout io.Writer, stderr io.Writer, st
 }
 
 func runIdentityManualTransition(stateName, agentID, approver, scope, reason string, expiresAt time.Time, statePathFlag string, jsonOut bool, stdout io.Writer, stderr io.Writer) int {
-	statePath := state.ResolvePath(statePathFlag)
-	manifestPath := manifest.ResolvePath(statePath)
-	loaded, err := manifest.Load(manifestPath)
+	ctx, err := loadStateMutationContext(state.ResolvePath(statePathFlag))
 	if err != nil {
-		return emitError(stderr, jsonOut, "runtime_failure", err.Error(), exitRuntime)
+		return emitStateMutationError(stderr, jsonOut, err)
 	}
-	loaded.Identities = model.FilterLegacyArtifactIdentityRecords(loaded.Identities)
 	now := time.Now().UTC().Truncate(time.Second)
-	nextManifest, transition, transitionErr := lifecycle.ApplyManualState(loaded, agentID, stateName, approver, scope, reason, expiresAt, now)
+	nextManifest, transition, transitionErr := lifecycle.ApplyManualState(ctx.manifest, agentID, stateName, approver, scope, reason, expiresAt, now)
 	if transitionErr != nil {
 		return emitError(stderr, jsonOut, "invalid_input", transitionErr.Error(), exitInvalidInput)
 	}
@@ -229,36 +225,15 @@ func runIdentityManualTransition(stateName, agentID, approver, scope, reason str
 		eventType = "approval"
 	}
 
-	chainPath := lifecycle.ChainPath(statePath)
-	chain, chainErr := lifecycle.LoadChain(chainPath)
-	if chainErr != nil {
-		return emitError(stderr, jsonOut, "runtime_failure", chainErr.Error(), exitRuntime)
+	if err := applyStateMutationToSnapshot(&ctx.snapshot, nextManifest, transition); err != nil {
+		return emitStateMutationError(stderr, jsonOut, err)
 	}
-	if err := lifecycle.AppendTransitionRecord(chain, transition, eventType); err != nil {
+	if err := lifecycle.AppendTransitionRecord(ctx.lifecycleChain, transition, eventType); err != nil {
 		return emitError(stderr, jsonOut, "runtime_failure", err.Error(), exitRuntime)
 	}
-	proofChainPath := proofemit.ChainPath(statePath)
-	if _, err := proofemit.LoadChain(proofChainPath); err != nil {
-		return emitError(stderr, jsonOut, "runtime_failure", err.Error(), exitRuntime)
-	}
-	snapshots, snapshotErr := captureManagedArtifacts(
-		proofChainPath,
-		proofemit.ChainAttestationPath(proofChainPath),
-		chainPath,
-		manifestPath,
-		proofemit.SigningKeyPath(statePath),
-	)
-	if snapshotErr != nil {
-		return emitError(stderr, jsonOut, "runtime_failure", snapshotErr.Error(), exitRuntime)
-	}
-	if err := lifecycle.SaveChain(chainPath, chain); err != nil {
-		return emitRolledBackRuntimeFailure(stderr, jsonOut, err, snapshots)
-	}
-	if err := proofemit.EmitIdentityTransition(statePath, transition, eventType); err != nil {
-		return emitRolledBackRuntimeFailure(stderr, jsonOut, err, snapshots)
-	}
-	if err := manifest.Save(manifestPath, nextManifest); err != nil {
-		return emitRolledBackRuntimeFailure(stderr, jsonOut, err, snapshots)
+	ctx.manifest = nextManifest
+	if err := commitStateMutationContext(ctx, transition, eventType); err != nil {
+		return emitStateMutationError(stderr, jsonOut, err)
 	}
 	payload := map[string]any{"status": "ok", "transition": transition}
 	if jsonOut {

--- a/core/cli/inventory_mutations.go
+++ b/core/cli/inventory_mutations.go
@@ -108,6 +108,7 @@ func runInventoryMutation(action string, args []string, stdout io.Writer, stderr
 	if err := applyStateMutationToSnapshot(&ctx.snapshot, nextManifest, transition); err != nil {
 		return emitStateMutationError(stderr, jsonRequested || *jsonOut, err)
 	}
+	applyInventoryMutationOverrides(&ctx.snapshot, updatedRecord, id, action)
 	if err := lifecycle.AppendTransitionRecord(ctx.lifecycleChain, transition, eventTypeForInventoryAction(action)); err != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
 	}

--- a/core/cli/inventory_mutations.go
+++ b/core/cli/inventory_mutations.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	"github.com/Clyra-AI/wrkr/core/aggregate/controlbacklog"
-	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
-	"github.com/Clyra-AI/wrkr/core/identity"
 	"github.com/Clyra-AI/wrkr/core/lifecycle"
 	"github.com/Clyra-AI/wrkr/core/manifest"
 	"github.com/Clyra-AI/wrkr/core/proofemit"
@@ -282,86 +280,6 @@ func findManifestIdentity(m manifest.Manifest, agentID string) (manifest.Identit
 	return manifest.IdentityRecord{}, false
 }
 
-func applyInventoryMutationToSnapshot(snapshot *state.Snapshot, record manifest.IdentityRecord, transition lifecycle.Transition, requestedID string, action string) {
-	if snapshot == nil {
-		return
-	}
-	snapshot.ApprovalInventoryVersion = state.ApprovalInventoryVersion
-	replaced := false
-	for idx := range snapshot.Identities {
-		if strings.TrimSpace(snapshot.Identities[idx].AgentID) == strings.TrimSpace(record.AgentID) {
-			snapshot.Identities[idx] = record
-			replaced = true
-			break
-		}
-	}
-	if !replaced {
-		snapshot.Identities = append(snapshot.Identities, record)
-	}
-	snapshot.Transitions = append(snapshot.Transitions, transition)
-
-	if snapshot.Inventory != nil {
-		for idx := range snapshot.Inventory.Tools {
-			tool := &snapshot.Inventory.Tools[idx]
-			if strings.TrimSpace(tool.AgentID) != strings.TrimSpace(record.AgentID) {
-				continue
-			}
-			tool.ApprovalStatus = strings.TrimSpace(record.ApprovalState)
-			tool.LifecycleState = strings.TrimSpace(record.Status)
-			tool.ApprovalClass = inventoryApprovalClass(record)
-			tool.SecurityVisibilityStatus = inventorySecurityVisibility(record)
-			if strings.TrimSpace(record.Approval.Owner) != "" {
-				for locIdx := range tool.Locations {
-					tool.Locations[locIdx].Owner = strings.TrimSpace(record.Approval.Owner)
-					tool.Locations[locIdx].OwnerSource = "inventory_approval"
-					tool.Locations[locIdx].OwnershipStatus = "explicit"
-				}
-			}
-		}
-		for idx := range snapshot.Inventory.Agents {
-			agent := &snapshot.Inventory.Agents[idx]
-			if strings.TrimSpace(agent.AgentID) == strings.TrimSpace(record.AgentID) {
-				agent.SecurityVisibilityStatus = inventorySecurityVisibility(record)
-			}
-		}
-	}
-	if snapshot.ControlBacklog != nil {
-		items := snapshot.ControlBacklog.Items[:0]
-		for _, item := range snapshot.ControlBacklog.Items {
-			if backlogItemMatchesRecord(item.ID, item.Repo, item.Path, requestedID, record) {
-				if action == "exclude" {
-					continue
-				}
-				item.ApprovalStatus = strings.TrimSpace(record.ApprovalState)
-				item.SecurityVisibility = inventorySecurityVisibility(record)
-				item.Owner = strings.TrimSpace(record.Approval.Owner)
-				if item.Owner != "" {
-					item.OwnerSource = "inventory_approval"
-					item.OwnershipStatus = "explicit"
-				}
-				switch action {
-				case "approve", "accept_risk", "attach_evidence":
-					item.RecommendedAction = controlbacklog.ActionMonitor
-					item.EvidenceGaps = nil
-					item.ConfidenceRaise = nil
-				case "deprecate":
-					item.RecommendedAction = controlbacklog.ActionDeprecate
-				}
-			}
-			items = append(items, item)
-		}
-		snapshot.ControlBacklog.Items = items
-		snapshot.ControlBacklog.Summary = summarizeBacklogItems(items)
-	}
-}
-
-func backlogItemMatchesRecord(itemID, repo, path, requestedID string, record manifest.IdentityRecord) bool {
-	if strings.TrimSpace(itemID) != "" && strings.TrimSpace(itemID) == strings.TrimSpace(requestedID) {
-		return true
-	}
-	return strings.TrimSpace(repo) == strings.TrimSpace(record.Repo) && strings.TrimSpace(path) == strings.TrimSpace(record.Location)
-}
-
 func summarizeBacklogItems(items []controlbacklog.Item) controlbacklog.Summary {
 	summary := controlbacklog.Summary{TotalItems: len(items)}
 	for _, item := range items {
@@ -381,45 +299,6 @@ func summarizeBacklogItems(items []controlbacklog.Item) controlbacklog.Summary {
 		}
 	}
 	return summary
-}
-
-func inventoryApprovalClass(record manifest.IdentityRecord) string {
-	switch strings.TrimSpace(record.ApprovalState) {
-	case "valid":
-		return "approved"
-	case "accepted_risk", "expired", "invalid", "deprecated", "excluded", "revoked", "missing":
-		return "unapproved"
-	default:
-		if strings.TrimSpace(record.Status) == identity.StateActive || strings.TrimSpace(record.Status) == identity.StateApproved {
-			return "approved"
-		}
-		return "unknown"
-	}
-}
-
-func inventorySecurityVisibility(record manifest.IdentityRecord) string {
-	switch strings.TrimSpace(record.ApprovalState) {
-	case "valid":
-		return agginventory.SecurityVisibilityKnownApproved
-	case "accepted_risk":
-		return agginventory.SecurityVisibilityAcceptedRisk
-	case "expired", "invalid":
-		return agginventory.SecurityVisibilityNeedsReview
-	case "deprecated":
-		return agginventory.SecurityVisibilityDeprecated
-	case "excluded", "revoked":
-		return agginventory.SecurityVisibilityRevoked
-	}
-	switch strings.TrimSpace(record.Status) {
-	case identity.StateDeprecated:
-		return agginventory.SecurityVisibilityDeprecated
-	case identity.StateRevoked:
-		return agginventory.SecurityVisibilityRevoked
-	case identity.StateActive, identity.StateApproved:
-		return agginventory.SecurityVisibilityKnownApproved
-	default:
-		return agginventory.SecurityVisibilityNeedsReview
-	}
 }
 
 func agentIDForInventoryPath(snapshot state.Snapshot, repo string, path string) string {

--- a/core/cli/inventory_mutations.go
+++ b/core/cli/inventory_mutations.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -16,7 +14,6 @@ import (
 	"github.com/Clyra-AI/wrkr/core/identity"
 	"github.com/Clyra-AI/wrkr/core/lifecycle"
 	"github.com/Clyra-AI/wrkr/core/manifest"
-	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/proofemit"
 	"github.com/Clyra-AI/wrkr/core/state"
 )
@@ -92,27 +89,17 @@ func runInventoryMutation(action string, args []string, stdout io.Writer, stderr
 	}
 
 	resolvedStatePath := state.ResolvePath(*statePathFlag)
-	preflight, preflightErr := preflightStateMutationArtifacts(resolvedStatePath)
-	if preflightErr != nil {
-		return emitError(stderr, jsonRequested || *jsonOut, "unsafe_operation_blocked", preflightErr.Error(), exitUnsafeBlocked)
+	ctx, err := loadStateMutationContext(resolvedStatePath)
+	if err != nil {
+		return emitStateMutationError(stderr, jsonRequested || *jsonOut, err)
 	}
 
-	snapshot, err := state.Load(resolvedStatePath)
-	if err != nil {
-		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
-	}
-	loadedManifest, err := manifest.Load(preflight.manifestPath)
-	if err != nil {
-		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
-	}
-	loadedManifest.Identities = model.FilterLegacyArtifactIdentityRecords(loadedManifest.Identities)
-
-	agentID, resolveErr := resolveInventoryMutationAgentID(id, loadedManifest, snapshot)
+	agentID, resolveErr := resolveInventoryMutationAgentID(id, ctx.manifest, ctx.snapshot)
 	if resolveErr != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", resolveErr.Error(), exitInvalidInput)
 	}
 	mutation.AgentID = agentID
-	nextManifest, transition, transitionErr := lifecycle.ApplyInventoryMutation(loadedManifest, mutation)
+	nextManifest, transition, transitionErr := lifecycle.ApplyInventoryMutation(ctx.manifest, mutation)
 	if transitionErr != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", transitionErr.Error(), exitInvalidInput)
 	}
@@ -120,41 +107,15 @@ func runInventoryMutation(action string, args []string, stdout io.Writer, stderr
 	if !ok {
 		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", "updated identity record missing after mutation", exitRuntime)
 	}
-	applyInventoryMutationToSnapshot(&snapshot, updatedRecord, transition, id, action)
-
-	lifecycleChain, chainErr := lifecycle.LoadChain(preflight.lifecyclePath)
-	if chainErr != nil {
-		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", chainErr.Error(), exitRuntime)
+	if err := applyStateMutationToSnapshot(&ctx.snapshot, nextManifest, transition); err != nil {
+		return emitStateMutationError(stderr, jsonRequested || *jsonOut, err)
 	}
-	if _, err := proofemit.LoadChain(preflight.proofChainPath); err != nil {
+	if err := lifecycle.AppendTransitionRecord(ctx.lifecycleChain, transition, eventTypeForInventoryAction(action)); err != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
 	}
-	if err := lifecycle.AppendTransitionRecord(lifecycleChain, transition, eventTypeForInventoryAction(action)); err != nil {
-		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
-	}
-
-	snapshots, snapshotErr := captureManagedArtifacts(
-		preflight.statePath,
-		preflight.manifestPath,
-		preflight.lifecyclePath,
-		preflight.proofChainPath,
-		preflight.proofAttestationPath,
-		preflight.signingKeyPath,
-	)
-	if snapshotErr != nil {
-		return emitError(stderr, jsonRequested || *jsonOut, "unsafe_operation_blocked", snapshotErr.Error(), exitUnsafeBlocked)
-	}
-	if err := state.Save(preflight.statePath, snapshot); err != nil {
-		return emitRolledBackRuntimeFailure(stderr, jsonRequested || *jsonOut, err, snapshots)
-	}
-	if err := lifecycle.SaveChain(preflight.lifecyclePath, lifecycleChain); err != nil {
-		return emitRolledBackRuntimeFailure(stderr, jsonRequested || *jsonOut, err, snapshots)
-	}
-	if err := proofemit.EmitIdentityTransition(preflight.statePath, transition, eventTypeForInventoryAction(action)); err != nil {
-		return emitRolledBackRuntimeFailure(stderr, jsonRequested || *jsonOut, err, snapshots)
-	}
-	if err := manifest.Save(preflight.manifestPath, nextManifest); err != nil {
-		return emitRolledBackRuntimeFailure(stderr, jsonRequested || *jsonOut, err, snapshots)
+	ctx.manifest = nextManifest
+	if err := commitStateMutationContext(ctx, transition, eventTypeForInventoryAction(action)); err != nil {
+		return emitStateMutationError(stderr, jsonRequested || *jsonOut, err)
 	}
 
 	payload := map[string]any{
@@ -163,9 +124,9 @@ func runInventoryMutation(action string, args []string, stdout io.Writer, stderr
 		"action":                     action,
 		"identity":                   updatedRecord,
 		"transition":                 transition,
-		"state_path":                 preflight.statePath,
-		"manifest_path":              preflight.manifestPath,
-		"proof_chain_path":           preflight.proofChainPath,
+		"state_path":                 ctx.preflight.statePath,
+		"manifest_path":              ctx.preflight.manifestPath,
+		"proof_chain_path":           ctx.preflight.proofChainPath,
 	}
 	if jsonRequested || *jsonOut {
 		_ = json.NewEncoder(stdout).Encode(payload)
@@ -185,7 +146,7 @@ type stateMutationPreflight struct {
 }
 
 func preflightStateMutationArtifacts(statePathRaw string) (stateMutationPreflight, error) {
-	statePath, err := normalizeManagedArtifactPath(statePathRaw)
+	statePath, err := preflightTrustedStatePath(statePathRaw)
 	if err != nil {
 		return stateMutationPreflight{}, err
 	}
@@ -244,21 +205,7 @@ func preflightStateMutationArtifacts(statePathRaw string) (stateMutationPrefligh
 }
 
 func rejectUnsafeExistingMutationArtifact(path string) error {
-	cleanPath := filepath.Clean(strings.TrimSpace(path))
-	info, err := os.Lstat(cleanPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("stat managed mutation artifact %s: %w", cleanPath, err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("managed mutation artifact must be a regular file, not a symlink: %s", cleanPath)
-	}
-	if !info.Mode().IsRegular() {
-		return fmt.Errorf("managed mutation artifact must be a regular file: %s", cleanPath)
-	}
-	return nil
+	return rejectUnsafeExistingManagedFile(path, "managed mutation artifact")
 }
 
 func resolveInventoryMutationAgentID(id string, m manifest.Manifest, snapshot state.Snapshot) (string, error) {

--- a/core/cli/managed_artifacts.go
+++ b/core/cli/managed_artifacts.go
@@ -24,6 +24,21 @@ type scanArtifactPathEntry struct {
 	key   string
 }
 
+type unsafeManagedArtifactPathError struct {
+	err error
+}
+
+func (e unsafeManagedArtifactPathError) Error() string {
+	if e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e unsafeManagedArtifactPathError) Unwrap() error {
+	return e.err
+}
+
 func captureManagedArtifacts(paths ...string) ([]managedArtifactSnapshot, error) {
 	snapshots := make([]managedArtifactSnapshot, 0, len(paths))
 	seen := map[string]struct{}{}
@@ -75,6 +90,40 @@ func normalizeManagedArtifactPath(raw string) (string, error) {
 		return "", fmt.Errorf("scan artifact path must not be empty")
 	}
 	return filepath.Clean(trimmed), nil
+}
+
+func preflightTrustedStatePath(raw string) (string, error) {
+	statePath, err := normalizeManagedArtifactPath(raw)
+	if err != nil {
+		return "", err
+	}
+	if err := rejectUnsafeExistingManagedFile(statePath, "--state"); err != nil {
+		return "", unsafeManagedArtifactPathError{err: err}
+	}
+	return statePath, nil
+}
+
+func rejectUnsafeExistingManagedFile(path string, label string) error {
+	cleanPath := filepath.Clean(strings.TrimSpace(path))
+	info, err := os.Lstat(cleanPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat %s: %w", cleanPath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s must be a regular file, not a symlink: %s", strings.TrimSpace(label), cleanPath)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s must be a regular file: %s", strings.TrimSpace(label), cleanPath)
+	}
+	return nil
+}
+
+func isUnsafeManagedArtifactPathError(err error) bool {
+	var target unsafeManagedArtifactPathError
+	return errors.As(err, &target)
 }
 
 func newScanArtifactPathEntry(label, path string) (scanArtifactPathEntry, error) {

--- a/core/cli/managed_artifacts.go
+++ b/core/cli/managed_artifacts.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -248,14 +247,4 @@ func (s managedArtifactSnapshot) restore() error {
 		return fmt.Errorf("restore managed artifact %s: %w", s.path, err)
 	}
 	return nil
-}
-
-func emitRolledBackRuntimeFailure(stderr io.Writer, jsonOut bool, actionErr error, snapshots []managedArtifactSnapshot) int {
-	if actionErr == nil {
-		return exitSuccess
-	}
-	if restoreErr := restoreManagedArtifacts(snapshots); restoreErr != nil {
-		return emitError(stderr, jsonOut, "runtime_failure", fmt.Sprintf("%v (rollback restore failed: %v)", actionErr, restoreErr), exitRuntime)
-	}
-	return emitError(stderr, jsonOut, "runtime_failure", actionErr.Error(), exitRuntime)
 }

--- a/core/cli/root_test.go
+++ b/core/cli/root_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1790,6 +1791,67 @@ func TestIdentityNonApprovedTransitionsUseDeterministicDefaultReasonAndRevokeApp
 	}
 }
 
+func TestIdentityRejectsSymlinkedStatePath(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink fixture is not portable on windows")
+	}
+
+	tmp := t.TempDir()
+	realDir := filepath.Join(tmp, "real")
+	workDir := filepath.Join(tmp, "work")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("mkdir real dir: %v", err)
+	}
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir work dir: %v", err)
+	}
+	realStatePath := filepath.Join(realDir, "state.json")
+	agentID := scanIdentityAgentID(t, realStatePath)
+
+	linkPath := filepath.Join(workDir, "state-link.json")
+	relativeTarget, err := filepath.Rel(filepath.Dir(linkPath), realStatePath)
+	if err != nil {
+		t.Fatalf("relative target: %v", err)
+	}
+	if err := os.Symlink(relativeTarget, linkPath); err != nil {
+		t.Skipf("symlink unsupported in current environment: %v", err)
+	}
+
+	originalState, err := os.ReadFile(realStatePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{"identity", "approve", agentID, "--approver", "@maria", "--scope", "read-only", "--expires", "90d", "--state", linkPath, "--json"}, &out, &errOut)
+	if code != exitUnsafeBlocked {
+		t.Fatalf("expected exit %d, got %d stdout=%q stderr=%q", exitUnsafeBlocked, code, out.String(), errOut.String())
+	}
+	assertErrorEnvelopeCode(t, errOut.Bytes(), "unsafe_operation_blocked", exitUnsafeBlocked)
+
+	currentState, err := os.ReadFile(realStatePath)
+	if err != nil {
+		t.Fatalf("read unchanged state: %v", err)
+	}
+	if !bytes.Equal(currentState, originalState) {
+		t.Fatal("expected real state file to remain unchanged after rejected symlinked mutation")
+	}
+	for _, path := range []string{
+		manifest.ResolvePath(linkPath),
+		lifecycle.ChainPath(linkPath),
+		proofemit.ChainPath(linkPath),
+		proofemit.ChainAttestationPath(proofemit.ChainPath(linkPath)),
+		proofemit.SigningKeyPath(linkPath),
+	} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected no lexical sibling artifact at %s after rejected identity mutation, got err=%v", path, err)
+		}
+	}
+}
+
 func TestIdentityApproveRollbackOnProofChainParseFailure(t *testing.T) {
 	t.Parallel()
 
@@ -1848,6 +1910,7 @@ func TestIdentityReviewRollbackOnProofEmitFailure(t *testing.T) {
 	proofAttestationPath := proofemit.ChainAttestationPath(proofChainPath)
 	signingKeyPath := proofemit.SigningKeyPath(statePath)
 
+	stateBefore := readOptionalTestFile(t, statePath)
 	manifestBefore := readOptionalTestFile(t, manifestPath)
 	lifecycleBefore := readOptionalTestFile(t, lifecyclePath)
 	proofBefore := readOptionalTestFile(t, proofChainPath)
@@ -1881,6 +1944,7 @@ func TestIdentityReviewRollbackOnProofEmitFailure(t *testing.T) {
 		t.Fatalf("expected runtime_failure, got %v", errObj["code"])
 	}
 
+	assertOptionalTestFileEquals(t, statePath, stateBefore)
 	assertOptionalTestFileEquals(t, manifestPath, manifestBefore)
 	assertOptionalTestFileEquals(t, lifecyclePath, lifecycleBefore)
 	assertOptionalTestFileEquals(t, proofChainPath, proofBefore)
@@ -2494,7 +2558,7 @@ func TestReportRejectsInvalidTemplateAndShareProfile(t *testing.T) {
 	}
 }
 
-func TestManifestGenerateCreatesUnderReviewBaseline(t *testing.T) {
+func TestManifestGenerateReflectsSavedStateLifecycle(t *testing.T) {
 	t.Parallel()
 
 	tmp := t.TempDir()
@@ -2547,6 +2611,7 @@ func TestManifestGenerateCreatesUnderReviewBaseline(t *testing.T) {
 	}
 	var generated struct {
 		Identities []struct {
+			AgentID       string `yaml:"agent_id"`
 			Status        string `yaml:"status"`
 			ApprovalState string `yaml:"approval_status"`
 		} `yaml:"identities"`
@@ -2557,13 +2622,27 @@ func TestManifestGenerateCreatesUnderReviewBaseline(t *testing.T) {
 	if len(generated.Identities) == 0 {
 		t.Fatal("expected manifest identities")
 	}
+	foundApproved := false
 	for _, record := range generated.Identities {
-		if record.Status != "under_review" {
-			t.Fatalf("expected under_review status, got %q", record.Status)
+		if record.AgentID == agentID {
+			foundApproved = true
+			if record.Status != "approved" {
+				t.Fatalf("expected approved status for %s, got %q", record.AgentID, record.Status)
+			}
+			if record.ApprovalState != "valid" {
+				t.Fatalf("expected valid approval status for %s, got %q", record.AgentID, record.ApprovalState)
+			}
+			continue
+		}
+		if record.Status != "discovered" {
+			t.Fatalf("expected discovered status for unapproved identity %s, got %q", record.AgentID, record.Status)
 		}
 		if record.ApprovalState != "missing" {
-			t.Fatalf("expected missing approval status, got %q", record.ApprovalState)
+			t.Fatalf("expected missing approval status for %s, got %q", record.AgentID, record.ApprovalState)
 		}
+	}
+	if !foundApproved {
+		t.Fatalf("expected approved identity %s in generated manifest", agentID)
 	}
 }
 

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -159,6 +159,9 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		*sarifPath,
 	)
 	if preflightErr != nil {
+		if isUnsafeManagedArtifactPathError(preflightErr) {
+			return emitError(stderr, jsonRequested || *jsonOut, "unsafe_operation_blocked", preflightErr.Error(), exitUnsafeBlocked)
+		}
 		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", preflightErr.Error(), exitInvalidInput)
 	}
 	jsonSink, jsonSinkErr := newJSONOutputSink(*jsonOut, artifactPreflight.JSONPath, stdout)
@@ -834,7 +837,7 @@ func finalScanArtifactPaths(statePath string, preflight scanArtifactPreflight, j
 
 func preflightScanArtifacts(statePathRaw, jsonPath string, reportEnabled bool, reportPath, reportTemplateRaw, reportShareProfileRaw string, sarifEnabled bool, sarifPath string) (scanArtifactPreflight, error) {
 	preflight := scanArtifactPreflight{}
-	statePath, err := normalizeManagedArtifactPath(statePathRaw)
+	statePath, err := preflightTrustedStatePath(statePathRaw)
 	if err != nil {
 		return scanArtifactPreflight{}, err
 	}

--- a/core/cli/scan_json_path_test.go
+++ b/core/cli/scan_json_path_test.go
@@ -247,6 +247,63 @@ func TestScanJSONPathRejectsAliasViaSymlinkedParentPath(t *testing.T) {
 	}
 }
 
+func TestScanRejectsSymlinkedStatePathBeforeWritingManagedArtifacts(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink fixture is not portable on windows")
+	}
+
+	tmp := t.TempDir()
+	reposPath := filepath.Join(tmp, "repos")
+	repoPath := filepath.Join(reposPath, "alpha", ".codex")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoPath, "config.toml"), []byte("approval_policy = \"never\"\n"), 0o600); err != nil {
+		t.Fatalf("write codex config: %v", err)
+	}
+
+	workDir := filepath.Join(tmp, "work")
+	realDir := filepath.Join(tmp, "real")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir work dir: %v", err)
+	}
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("mkdir real dir: %v", err)
+	}
+	realStatePath := filepath.Join(realDir, "state.json")
+	stateLink := filepath.Join(workDir, "state-link.json")
+	relativeTarget, err := filepath.Rel(filepath.Dir(stateLink), realStatePath)
+	if err != nil {
+		t.Fatalf("relative target: %v", err)
+	}
+	if err := os.Symlink(relativeTarget, stateLink); err != nil {
+		t.Skipf("symlink unsupported in current environment: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{"scan", "--path", reposPath, "--state", stateLink, "--json"}, &out, &errOut)
+	if code != exitUnsafeBlocked {
+		t.Fatalf("expected exit %d, got %d stdout=%q stderr=%q", exitUnsafeBlocked, code, out.String(), errOut.String())
+	}
+	assertErrorEnvelopeCode(t, errOut.Bytes(), "unsafe_operation_blocked", exitUnsafeBlocked)
+
+	for _, path := range []string{
+		realStatePath,
+		manifest.ResolvePath(stateLink),
+		lifecycle.ChainPath(stateLink),
+		proofemit.ChainPath(stateLink),
+		proofemit.ChainAttestationPath(proofemit.ChainPath(stateLink)),
+		proofemit.SigningKeyPath(stateLink),
+	} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected no managed artifact at %s after rejected state symlink, got err=%v", path, err)
+		}
+	}
+}
+
 func TestScanJSONPathRejectsAliasWithReportPath(t *testing.T) {
 	t.Parallel()
 

--- a/core/cli/state_mutation.go
+++ b/core/cli/state_mutation.go
@@ -104,7 +104,7 @@ func refreshDerivedMutationSnapshot(snapshot *state.Snapshot) error {
 		}
 	}
 
-	profileResult := profileeval.Result{}
+	var profileResult profileeval.Result
 	if snapshot.Profile != nil {
 		profileResult = *snapshot.Profile
 	} else {
@@ -183,7 +183,7 @@ func refreshExistingControlBacklog(snapshot *state.Snapshot) {
 		record, ok := recordsByAgent[strings.TrimSpace(agentID)]
 		if ok {
 			updated.ApprovalStatus = backlogApprovalStatus(record)
-			updated.SecurityVisibility = inventorySecurityVisibility(record)
+			updated.SecurityVisibility = agginventory.GovernanceSecurityVisibilityStatus(backlogSecurityVisibility(record), strings.TrimSpace(record.ApprovalState), strings.TrimSpace(record.Status))
 			if owner := strings.TrimSpace(record.Approval.Owner); owner != "" {
 				updated.Owner = owner
 				updated.OwnerSource = "inventory_approval"
@@ -212,5 +212,30 @@ func backlogApprovalStatus(record manifest.IdentityRecord) string {
 		return "unknown"
 	default:
 		return "unapproved"
+	}
+}
+
+func backlogSecurityVisibility(record manifest.IdentityRecord) string {
+	switch strings.TrimSpace(record.ApprovalState) {
+	case "valid":
+		return agginventory.SecurityVisibilityKnownApproved
+	case "accepted_risk", "risk_accepted":
+		return agginventory.SecurityVisibilityAcceptedRisk
+	case "expired", "invalid":
+		return agginventory.SecurityVisibilityNeedsReview
+	case "deprecated":
+		return agginventory.SecurityVisibilityDeprecated
+	case "excluded", "revoked":
+		return agginventory.SecurityVisibilityRevoked
+	}
+	switch strings.TrimSpace(record.Status) {
+	case identity.StateDeprecated:
+		return agginventory.SecurityVisibilityDeprecated
+	case identity.StateRevoked:
+		return agginventory.SecurityVisibilityRevoked
+	case identity.StateActive, identity.StateApproved:
+		return agginventory.SecurityVisibilityKnownApproved
+	default:
+		return agginventory.SecurityVisibilityNeedsReview
 	}
 }

--- a/core/cli/state_mutation.go
+++ b/core/cli/state_mutation.go
@@ -1,0 +1,216 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	proof "github.com/Clyra-AI/proof"
+	"github.com/Clyra-AI/wrkr/core/aggregate/controlbacklog"
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/identity"
+	"github.com/Clyra-AI/wrkr/core/lifecycle"
+	"github.com/Clyra-AI/wrkr/core/manifest"
+	"github.com/Clyra-AI/wrkr/core/model"
+	profilemodel "github.com/Clyra-AI/wrkr/core/policy/profile"
+	profileeval "github.com/Clyra-AI/wrkr/core/policy/profileeval"
+	"github.com/Clyra-AI/wrkr/core/proofemit"
+	"github.com/Clyra-AI/wrkr/core/risk"
+	"github.com/Clyra-AI/wrkr/core/score"
+	scoremodel "github.com/Clyra-AI/wrkr/core/score/model"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+type stateMutationContext struct {
+	preflight      stateMutationPreflight
+	snapshot       state.Snapshot
+	manifest       manifest.Manifest
+	lifecycleChain *proof.Chain
+}
+
+func loadStateMutationContext(statePathRaw string) (stateMutationContext, error) {
+	preflight, err := preflightStateMutationArtifacts(statePathRaw)
+	if err != nil {
+		if isUnsafeManagedArtifactPathError(err) {
+			return stateMutationContext{}, err
+		}
+		return stateMutationContext{}, unsafeManagedArtifactPathError{err: err}
+	}
+	snapshot, err := state.Load(preflight.statePath)
+	if err != nil {
+		return stateMutationContext{}, err
+	}
+	loadedManifest, err := manifest.Load(preflight.manifestPath)
+	if err != nil {
+		return stateMutationContext{}, err
+	}
+	loadedManifest.Identities = model.FilterLegacyArtifactIdentityRecords(loadedManifest.Identities)
+	lifecycleChain, err := lifecycle.LoadChain(preflight.lifecyclePath)
+	if err != nil {
+		return stateMutationContext{}, err
+	}
+	if _, err := proofemit.LoadChain(preflight.proofChainPath); err != nil {
+		return stateMutationContext{}, err
+	}
+	return stateMutationContext{
+		preflight:      preflight,
+		snapshot:       snapshot,
+		manifest:       loadedManifest,
+		lifecycleChain: lifecycleChain,
+	}, nil
+}
+
+func applyStateMutationToSnapshot(snapshot *state.Snapshot, nextManifest manifest.Manifest, transition lifecycle.Transition) error {
+	if snapshot == nil {
+		return nil
+	}
+	snapshot.ApprovalInventoryVersion = state.ApprovalInventoryVersion
+	snapshot.Identities = append([]manifest.IdentityRecord(nil), nextManifest.Identities...)
+	snapshot.Transitions = append(snapshot.Transitions, transition)
+	return refreshDerivedMutationSnapshot(snapshot)
+}
+
+func refreshDerivedMutationSnapshot(snapshot *state.Snapshot) error {
+	if snapshot == nil {
+		return nil
+	}
+	if snapshot.Inventory != nil {
+		agginventory.RefreshIdentityGovernance(snapshot.Inventory, snapshot.Identities)
+	}
+	actionPaths := []risk.ActionPath(nil)
+	if snapshot.RiskReport != nil && snapshot.Inventory != nil {
+		snapshot.RiskReport.ActionPaths, snapshot.RiskReport.ActionPathToControlFirst = risk.BuildActionPaths(snapshot.RiskReport.AttackPaths, snapshot.Inventory)
+		actionPaths = snapshot.RiskReport.ActionPaths
+	}
+	if snapshot.ControlBacklog != nil && len(snapshot.Findings) == 0 && len(actionPaths) == 0 {
+		refreshExistingControlBacklog(snapshot)
+	} else if snapshot.Inventory != nil || snapshot.ControlBacklog != nil {
+		backlog := controlbacklog.Build(controlbacklog.Input{
+			Mode:        snapshot.ScanMode,
+			Findings:    snapshot.Findings,
+			Inventory:   snapshot.Inventory,
+			ActionPaths: actionPaths,
+		})
+		snapshot.ControlBacklog = &backlog
+	}
+
+	weights := scoremodel.DefaultWeights()
+	var previous *score.Result
+	if snapshot.PostureScore != nil {
+		copyResult := *snapshot.PostureScore
+		previous = &copyResult
+		if err := copyResult.Weights.Validate(); err == nil {
+			weights = copyResult.Weights
+		}
+	}
+
+	profileResult := profileeval.Result{}
+	if snapshot.Profile != nil {
+		profileResult = *snapshot.Profile
+	} else {
+		profileDef, err := profilemodel.Builtin("standard")
+		if err != nil {
+			return err
+		}
+		profileResult = profileeval.Evaluate(profileDef, snapshot.Findings, nil)
+	}
+
+	computed := score.Compute(score.Input{
+		Findings:        snapshot.Findings,
+		Identities:      model.FilterLegacyArtifactIdentityRecords(snapshot.Identities),
+		ProfileResult:   profileResult,
+		TransitionCount: driftTransitionCount(snapshot.Transitions),
+		Weights:         weights,
+		Previous:        previous,
+	})
+	snapshot.PostureScore = &computed
+	return nil
+}
+
+func commitStateMutationContext(ctx stateMutationContext, transition lifecycle.Transition, eventType string) error {
+	snapshots, err := captureManagedArtifacts(
+		ctx.preflight.statePath,
+		ctx.preflight.manifestPath,
+		ctx.preflight.lifecyclePath,
+		ctx.preflight.proofChainPath,
+		ctx.preflight.proofAttestationPath,
+		ctx.preflight.signingKeyPath,
+	)
+	if err != nil {
+		return unsafeManagedArtifactPathError{err: err}
+	}
+	if err := state.Save(ctx.preflight.statePath, ctx.snapshot); err != nil {
+		return rollbackStateMutationError(err, snapshots)
+	}
+	if err := lifecycle.SaveChain(ctx.preflight.lifecyclePath, ctx.lifecycleChain); err != nil {
+		return rollbackStateMutationError(err, snapshots)
+	}
+	if err := proofemit.EmitIdentityTransition(ctx.preflight.statePath, transition, eventType); err != nil {
+		return rollbackStateMutationError(err, snapshots)
+	}
+	if err := manifest.Save(ctx.preflight.manifestPath, ctx.manifest); err != nil {
+		return rollbackStateMutationError(err, snapshots)
+	}
+	return nil
+}
+
+func rollbackStateMutationError(actionErr error, snapshots []managedArtifactSnapshot) error {
+	if restoreErr := restoreManagedArtifacts(snapshots); restoreErr != nil {
+		return fmt.Errorf("%v (rollback restore failed: %v)", actionErr, restoreErr)
+	}
+	return actionErr
+}
+
+func emitStateMutationError(stderr io.Writer, jsonOut bool, err error) int {
+	if isUnsafeManagedArtifactPathError(err) {
+		return emitError(stderr, jsonOut, "unsafe_operation_blocked", err.Error(), exitUnsafeBlocked)
+	}
+	return emitError(stderr, jsonOut, "runtime_failure", err.Error(), exitRuntime)
+}
+
+func refreshExistingControlBacklog(snapshot *state.Snapshot) {
+	if snapshot == nil || snapshot.ControlBacklog == nil {
+		return
+	}
+	recordsByAgent := make(map[string]manifest.IdentityRecord, len(snapshot.Identities))
+	for _, record := range snapshot.Identities {
+		recordsByAgent[strings.TrimSpace(record.AgentID)] = record
+	}
+	items := snapshot.ControlBacklog.Items[:0]
+	for _, item := range snapshot.ControlBacklog.Items {
+		updated := item
+		agentID := agentIDForInventoryPath(*snapshot, item.Repo, item.Path)
+		record, ok := recordsByAgent[strings.TrimSpace(agentID)]
+		if ok {
+			updated.ApprovalStatus = backlogApprovalStatus(record)
+			updated.SecurityVisibility = inventorySecurityVisibility(record)
+			if owner := strings.TrimSpace(record.Approval.Owner); owner != "" {
+				updated.Owner = owner
+				updated.OwnerSource = "inventory_approval"
+				updated.OwnershipStatus = "explicit"
+			}
+			switch {
+			case strings.TrimSpace(record.Status) == identity.StateDeprecated:
+				updated.RecommendedAction = controlbacklog.ActionDeprecate
+			case strings.TrimSpace(record.ApprovalState) == "valid" || strings.TrimSpace(record.ApprovalState) == "accepted_risk":
+				updated.RecommendedAction = controlbacklog.ActionMonitor
+				updated.EvidenceGaps = nil
+				updated.ConfidenceRaise = nil
+			}
+		}
+		items = append(items, updated)
+	}
+	snapshot.ControlBacklog.Items = items
+	snapshot.ControlBacklog.Summary = summarizeBacklogItems(items)
+}
+
+func backlogApprovalStatus(record manifest.IdentityRecord) string {
+	switch strings.TrimSpace(record.ApprovalState) {
+	case "valid", "approved", "approved_list", "accepted_risk", "risk_accepted":
+		return "approved"
+	case "", "unknown":
+		return "unknown"
+	default:
+		return "unapproved"
+	}
+}

--- a/core/cli/state_mutation.go
+++ b/core/cli/state_mutation.go
@@ -204,6 +204,24 @@ func refreshExistingControlBacklog(snapshot *state.Snapshot) {
 	snapshot.ControlBacklog.Summary = summarizeBacklogItems(items)
 }
 
+func applyInventoryMutationOverrides(snapshot *state.Snapshot, record manifest.IdentityRecord, requestedID string, action string) {
+	if snapshot == nil || snapshot.ControlBacklog == nil {
+		return
+	}
+	if strings.TrimSpace(action) != "exclude" {
+		return
+	}
+	items := snapshot.ControlBacklog.Items[:0]
+	for _, item := range snapshot.ControlBacklog.Items {
+		if backlogItemMatchesRecord(item.ID, item.Repo, item.Path, requestedID, record) {
+			continue
+		}
+		items = append(items, item)
+	}
+	snapshot.ControlBacklog.Items = items
+	snapshot.ControlBacklog.Summary = summarizeBacklogItems(items)
+}
+
 func backlogApprovalStatus(record manifest.IdentityRecord) string {
 	switch strings.TrimSpace(record.ApprovalState) {
 	case "valid", "approved", "approved_list", "accepted_risk", "risk_accepted":
@@ -213,6 +231,13 @@ func backlogApprovalStatus(record manifest.IdentityRecord) string {
 	default:
 		return "unapproved"
 	}
+}
+
+func backlogItemMatchesRecord(itemID, repo, path, requestedID string, record manifest.IdentityRecord) bool {
+	if strings.TrimSpace(itemID) != "" && strings.TrimSpace(itemID) == strings.TrimSpace(requestedID) {
+		return true
+	}
+	return strings.TrimSpace(repo) == strings.TrimSpace(record.Repo) && strings.TrimSpace(path) == strings.TrimSpace(record.Location)
 }
 
 func backlogSecurityVisibility(record manifest.IdentityRecord) string {

--- a/core/cli/state_mutation_test.go
+++ b/core/cli/state_mutation_test.go
@@ -241,6 +241,43 @@ func TestRegressBaselineInitializedAfterApprovalUsesUpdatedSavedState(t *testing
 	t.Fatalf("expected baseline tool for %s", agentID)
 }
 
+func TestInventoryExcludeRemovesControlBacklogWithoutRescan(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	agentID := scanIdentityAgentID(t, statePath)
+
+	snapshotBefore, err := state.Load(statePath)
+	if err != nil {
+		t.Fatalf("load state before exclude: %v", err)
+	}
+	recordBefore, ok := testIdentityRecord(snapshotBefore.Identities, agentID)
+	if !ok {
+		t.Fatalf("missing identity %s before exclude", agentID)
+	}
+	before := runReportJSON(t, statePath)
+	if _, ok := reportBacklogItem(before, recordBefore.Repo, recordBefore.Location); !ok {
+		t.Fatalf("expected report backlog item for %s %s before exclude", recordBefore.Repo, recordBefore.Location)
+	}
+
+	var excludeOut bytes.Buffer
+	var excludeErr bytes.Buffer
+	if code := Run([]string{
+		"inventory", "exclude", agentID,
+		"--reason", "retired_control_path",
+		"--state", statePath,
+		"--json",
+	}, &excludeOut, &excludeErr); code != 0 {
+		t.Fatalf("inventory exclude failed: %d %s", code, excludeErr.String())
+	}
+
+	after := runReportJSON(t, statePath)
+	if _, ok := reportBacklogItem(after, recordBefore.Repo, recordBefore.Location); ok {
+		t.Fatalf("expected excluded control path to be removed from report backlog without rescanning")
+	}
+}
+
 func runScoreJSON(t *testing.T, statePath string) map[string]any {
 	t.Helper()
 	var out bytes.Buffer

--- a/core/cli/state_mutation_test.go
+++ b/core/cli/state_mutation_test.go
@@ -1,0 +1,304 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/identity"
+	"github.com/Clyra-AI/wrkr/core/lifecycle"
+	"github.com/Clyra-AI/wrkr/core/manifest"
+	"github.com/Clyra-AI/wrkr/core/proofemit"
+	"github.com/Clyra-AI/wrkr/core/regress"
+	"github.com/Clyra-AI/wrkr/core/state"
+	"github.com/Clyra-AI/wrkr/internal/atomicwrite"
+)
+
+func TestIdentityApproveUpdatesSavedStateSnapshot(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	agentID := scanIdentityAgentID(t, statePath)
+
+	var approveOut bytes.Buffer
+	var approveErr bytes.Buffer
+	if code := Run([]string{"identity", "approve", agentID, "--approver", "@maria", "--scope", "read-only", "--expires", "90d", "--state", statePath, "--json"}, &approveOut, &approveErr); code != 0 {
+		t.Fatalf("identity approve failed: %d %s", code, approveErr.String())
+	}
+
+	snapshot, err := state.Load(statePath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	stateRecord, ok := testIdentityRecord(snapshot.Identities, agentID)
+	if !ok {
+		t.Fatalf("expected state identity %s in snapshot", agentID)
+	}
+	if stateRecord.Status != identity.StateApproved {
+		t.Fatalf("expected saved state status approved, got %+v", stateRecord)
+	}
+	if stateRecord.ApprovalState != "valid" {
+		t.Fatalf("expected saved state approval_status=valid, got %+v", stateRecord)
+	}
+	if snapshot.PostureScore == nil || snapshot.PostureScore.Breakdown.ApprovalCoverage <= 0 {
+		t.Fatalf("expected recomputed posture score approval coverage, got %+v", snapshot.PostureScore)
+	}
+
+	loadedManifest, err := manifest.Load(manifest.ResolvePath(statePath))
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	manifestRecord, ok := testIdentityRecord(loadedManifest.Identities, agentID)
+	if !ok {
+		t.Fatalf("expected manifest identity %s", agentID)
+	}
+	if manifestRecord.Status != stateRecord.Status || manifestRecord.ApprovalState != stateRecord.ApprovalState {
+		t.Fatalf("expected manifest/state parity, manifest=%+v state=%+v", manifestRecord, stateRecord)
+	}
+}
+
+func TestInventoryApproveRollsBackSavedStateOnProofEmitFailure(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath, agentID := writeInventoryMutationFixture(t, tmp)
+	manifestPath := manifest.ResolvePath(statePath)
+	lifecyclePath := lifecycle.ChainPath(statePath)
+	proofChainPath := proofemit.ChainPath(statePath)
+	proofAttestationPath := proofemit.ChainAttestationPath(proofChainPath)
+	signingKeyPath := proofemit.SigningKeyPath(statePath)
+
+	stateBefore := readOptionalTestFile(t, statePath)
+	manifestBefore := readOptionalTestFile(t, manifestPath)
+	lifecycleBefore := readOptionalTestFile(t, lifecyclePath)
+	proofBefore := readOptionalTestFile(t, proofChainPath)
+	attestationBefore := readOptionalTestFile(t, proofAttestationPath)
+	signingKeyBefore := readOptionalTestFile(t, signingKeyPath)
+
+	var injected atomic.Bool
+	restore := atomicwrite.SetBeforeRenameHookForTest(func(targetPath string, _ string) error {
+		if filepath.Clean(targetPath) != filepath.Clean(proofChainPath) {
+			return nil
+		}
+		if injected.CompareAndSwap(false, true) {
+			return errors.New("simulated interruption before proof chain rename")
+		}
+		return nil
+	})
+	defer restore()
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"inventory", "approve", agentID,
+		"--owner", "platform-security",
+		"--evidence", "SEC-123",
+		"--expires", "90d",
+		"--state", statePath,
+		"--json",
+	}, &out, &errOut)
+	if code != exitRuntime {
+		t.Fatalf("expected runtime failure, got %d stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+	assertErrorEnvelopeCode(t, errOut.Bytes(), "runtime_failure", exitRuntime)
+
+	assertOptionalTestFileEquals(t, statePath, stateBefore)
+	assertOptionalTestFileEquals(t, manifestPath, manifestBefore)
+	assertOptionalTestFileEquals(t, lifecyclePath, lifecycleBefore)
+	assertOptionalTestFileEquals(t, proofChainPath, proofBefore)
+	assertOptionalTestFileEquals(t, proofAttestationPath, attestationBefore)
+	assertOptionalTestFileEquals(t, signingKeyPath, signingKeyBefore)
+}
+
+func TestScoreReflectsIdentityApproveWithoutRescan(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	agentID := scanIdentityAgentID(t, statePath)
+
+	before := runScoreJSON(t, statePath)
+	beforeBreakdown, ok := before["breakdown"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected score breakdown, got %v", before)
+	}
+	beforeCoverage, ok := beforeBreakdown["approval_coverage"].(float64)
+	if !ok {
+		t.Fatalf("expected approval_coverage float, got %v", beforeBreakdown)
+	}
+
+	var approveOut bytes.Buffer
+	var approveErr bytes.Buffer
+	if code := Run([]string{"identity", "approve", agentID, "--approver", "@maria", "--scope", "read-only", "--expires", "90d", "--state", statePath, "--json"}, &approveOut, &approveErr); code != 0 {
+		t.Fatalf("identity approve failed: %d %s", code, approveErr.String())
+	}
+
+	after := runScoreJSON(t, statePath)
+	afterBreakdown, ok := after["breakdown"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected score breakdown after approval, got %v", after)
+	}
+	afterCoverage, ok := afterBreakdown["approval_coverage"].(float64)
+	if !ok {
+		t.Fatalf("expected approval_coverage float after approval, got %v", afterBreakdown)
+	}
+	if afterCoverage <= beforeCoverage {
+		t.Fatalf("expected approval coverage to increase after approval, before=%.2f after=%.2f", beforeCoverage, afterCoverage)
+	}
+}
+
+func TestReportReflectsInventoryApproveWithoutRescan(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	agentID := scanIdentityAgentID(t, statePath)
+
+	snapshotBefore, err := state.Load(statePath)
+	if err != nil {
+		t.Fatalf("load state before approval: %v", err)
+	}
+	recordBefore, ok := testIdentityRecord(snapshotBefore.Identities, agentID)
+	if !ok {
+		t.Fatalf("missing identity %s before approval", agentID)
+	}
+
+	before := runReportJSON(t, statePath)
+	beforeItem, ok := reportBacklogItem(before, recordBefore.Repo, recordBefore.Location)
+	if !ok {
+		t.Fatalf("expected report backlog item for %s %s before approval", recordBefore.Repo, recordBefore.Location)
+	}
+	if beforeItem["approval_status"] == "valid" {
+		t.Fatalf("expected pre-approval report item to remain unapproved, got %v", beforeItem)
+	}
+
+	var approveOut bytes.Buffer
+	var approveErr bytes.Buffer
+	if code := Run([]string{
+		"inventory", "approve", agentID,
+		"--owner", "platform-security",
+		"--evidence", "SEC-123",
+		"--expires", "90d",
+		"--state", statePath,
+		"--json",
+	}, &approveOut, &approveErr); code != 0 {
+		t.Fatalf("inventory approve failed: %d %s", code, approveErr.String())
+	}
+
+	after := runReportJSON(t, statePath)
+	afterItem, ok := reportBacklogItem(after, recordBefore.Repo, recordBefore.Location)
+	if !ok {
+		t.Fatalf("expected report backlog item for %s %s after approval", recordBefore.Repo, recordBefore.Location)
+	}
+	if afterItem["approval_status"] != "approved" {
+		t.Fatalf("expected report backlog item approval_status=approved after approval, got %v", afterItem)
+	}
+	if afterItem["security_visibility"] != "known_approved" {
+		t.Fatalf("expected report backlog item security_visibility=known_approved after approval, got %v", afterItem)
+	}
+}
+
+func TestRegressBaselineInitializedAfterApprovalUsesUpdatedSavedState(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	baselinePath := filepath.Join(tmp, "baseline.json")
+	agentID := scanIdentityAgentID(t, statePath)
+
+	var approveOut bytes.Buffer
+	var approveErr bytes.Buffer
+	if code := Run([]string{"identity", "approve", agentID, "--approver", "@maria", "--scope", "read-only", "--expires", "90d", "--state", statePath, "--json"}, &approveOut, &approveErr); code != 0 {
+		t.Fatalf("identity approve failed: %d %s", code, approveErr.String())
+	}
+
+	var initOut bytes.Buffer
+	var initErr bytes.Buffer
+	if code := Run([]string{"regress", "init", "--baseline", statePath, "--output", baselinePath, "--json"}, &initOut, &initErr); code != 0 {
+		t.Fatalf("regress init failed: %d %s", code, initErr.String())
+	}
+
+	baseline, err := regress.LoadBaseline(baselinePath)
+	if err != nil {
+		t.Fatalf("load baseline: %v", err)
+	}
+	for _, tool := range baseline.Tools {
+		if tool.AgentID != agentID {
+			continue
+		}
+		if tool.Status != identity.StateApproved {
+			t.Fatalf("expected approved lifecycle state in baseline, got %+v", tool)
+		}
+		if tool.ApprovalStatus != "valid" {
+			t.Fatalf("expected valid approval status in baseline, got %+v", tool)
+		}
+		return
+	}
+	t.Fatalf("expected baseline tool for %s", agentID)
+}
+
+func runScoreJSON(t *testing.T, statePath string) map[string]any {
+	t.Helper()
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := Run([]string{"score", "--state", statePath, "--json"}, &out, &errOut); code != 0 {
+		t.Fatalf("score failed: %d %s", code, errOut.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse score payload: %v", err)
+	}
+	return payload
+}
+
+func runReportJSON(t *testing.T, statePath string) map[string]any {
+	t.Helper()
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := Run([]string{"report", "--state", statePath, "--json"}, &out, &errOut); code != 0 {
+		t.Fatalf("report failed: %d %s", code, errOut.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse report payload: %v", err)
+	}
+	return payload
+}
+
+func reportBacklogItem(payload map[string]any, repo string, path string) (map[string]any, bool) {
+	summary, ok := payload["summary"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	backlog, ok := summary["control_backlog"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	items, ok := backlog["items"].([]any)
+	if !ok {
+		return nil, false
+	}
+	for _, item := range items {
+		typed, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if typed["repo"] == repo && typed["path"] == path {
+			return typed, true
+		}
+	}
+	return nil, false
+}
+
+func testIdentityRecord(records []manifest.IdentityRecord, agentID string) (manifest.IdentityRecord, bool) {
+	for _, record := range records {
+		if record.AgentID == agentID {
+			return record, true
+		}
+	}
+	return manifest.IdentityRecord{}, false
+}

--- a/core/lifecycle/lifecycle.go
+++ b/core/lifecycle/lifecycle.go
@@ -134,9 +134,6 @@ func Reconcile(previous manifest.Manifest, observed []ObservedTool, now time.Tim
 		if record.Status == identity.StateActive && record.ApprovalState != "valid" && record.ApprovalState != "accepted_risk" {
 			record.Status = identity.StateUnderReview
 		}
-		if record.Status == identity.StateDiscovered && record.ApprovalState != "valid" {
-			record.Status = identity.StateUnderReview
-		}
 		if record.Status == "" {
 			record.Status = identity.StateUnderReview
 		}

--- a/core/lifecycle/lifecycle_test.go
+++ b/core/lifecycle/lifecycle_test.go
@@ -38,6 +38,33 @@ func TestReconcileDerivesUnderReviewWhenApprovalExpired(t *testing.T) {
 	}
 }
 
+func TestReconcilePreservesDiscoveredForFirstSeenIdentity(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 2, 20, 12, 0, 0, 0, time.UTC)
+	next, transitions := Reconcile(manifest.Manifest{}, []ObservedTool{{
+		AgentID:  "wrkr:mcp-1:acme",
+		ToolID:   "mcp-1",
+		ToolType: "mcp",
+		Org:      "acme",
+		Repo:     "acme/repo",
+		Location: ".mcp.json",
+	}}, now)
+
+	if len(next.Identities) != 1 {
+		t.Fatalf("expected one identity, got %d", len(next.Identities))
+	}
+	if next.Identities[0].Status != identity.StateDiscovered {
+		t.Fatalf("expected discovered status, got %+v", next.Identities[0])
+	}
+	if next.Identities[0].ApprovalState != "missing" {
+		t.Fatalf("expected missing approval state, got %+v", next.Identities[0])
+	}
+	if len(transitions) == 0 || transitions[0].Trigger != "first_seen" {
+		t.Fatalf("expected first_seen transition, got %+v", transitions)
+	}
+}
+
 func TestReconcileEmitsRemovedAndReappearedTriggers(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 2, 20, 12, 0, 0, 0, time.UTC)
@@ -189,8 +216,8 @@ func TestReconcileLegacyAgentIDMigrationDoesNotFanOutApprovalState(t *testing.T)
 	if migrated.Status != identity.StateActive {
 		t.Fatalf("expected first successor to inherit approved semantics, got %+v", *migrated)
 	}
-	if fresh.Status != identity.StateUnderReview || fresh.ApprovalState != "missing" {
-		t.Fatalf("expected additional successor to require new review, got %+v", *fresh)
+	if fresh.Status != identity.StateDiscovered || fresh.ApprovalState != "missing" {
+		t.Fatalf("expected additional successor to persist discovered, got %+v", *fresh)
 	}
 
 	var migratedTrigger, freshTrigger string

--- a/core/manifestgen/generate.go
+++ b/core/manifestgen/generate.go
@@ -37,12 +37,15 @@ func recordsFromSnapshot(snapshot state.Snapshot, now time.Time) []manifest.Iden
 		out := make([]manifest.IdentityRecord, 0, len(filtered))
 		for _, record := range filtered {
 			item := record
-			item.Status = identity.StateUnderReview
-			item.Approval = manifest.Approval{}
-			item.ApprovalState = "missing"
+			if strings.TrimSpace(item.Status) == "" {
+				item.Status = identity.StateDiscovered
+			}
+			if strings.TrimSpace(item.ApprovalState) == "" {
+				item.ApprovalState = "missing"
+			}
 			item.Present = true
 			item.FirstSeen = fallbackTimestamp(item.FirstSeen, now)
-			item.LastSeen = now.Format(time.RFC3339)
+			item.LastSeen = fallbackTimestamp(item.LastSeen, now)
 			out = append(out, item)
 		}
 		if len(out) > 0 {
@@ -86,9 +89,9 @@ func recordsFromInventory(inv agginventory.Inventory, now time.Time) []manifest.
 				Org:           tool.Org,
 				Repo:          location.Repo,
 				Location:      location.Location,
-				Status:        identity.StateUnderReview,
+				Status:        fallback(tool.LifecycleState, identity.StateDiscovered),
 				Approval:      manifest.Approval{},
-				ApprovalState: "missing",
+				ApprovalState: fallback(tool.ApprovalStatus, "missing"),
 				FirstSeen:     now.Format(time.RFC3339),
 				LastSeen:      now.Format(time.RFC3339),
 				Present:       true,
@@ -108,6 +111,13 @@ func fallbackTimestamp(value string, now time.Time) string {
 		return value
 	}
 	return now.Format(time.RFC3339)
+}
+
+func fallback(value string, fallbackValue string) string {
+	if strings.TrimSpace(value) != "" {
+		return strings.TrimSpace(value)
+	}
+	return fallbackValue
 }
 
 func sortRecords(items []manifest.IdentityRecord) {

--- a/core/manifestgen/generate_test.go
+++ b/core/manifestgen/generate_test.go
@@ -44,16 +44,16 @@ func TestGenerateUnderReviewFromSnapshotIdentities(t *testing.T) {
 		t.Fatalf("expected one identity, got %d", len(generated.Identities))
 	}
 	record := generated.Identities[0]
-	if record.Status != "under_review" {
-		t.Fatalf("expected under_review status, got %q", record.Status)
+	if record.Status != "active" {
+		t.Fatalf("expected active status, got %q", record.Status)
 	}
-	if record.ApprovalState != "missing" {
-		t.Fatalf("expected missing approval state, got %q", record.ApprovalState)
+	if record.ApprovalState != "valid" {
+		t.Fatalf("expected valid approval state, got %q", record.ApprovalState)
 	}
-	if record.Approval.Approver != "" || record.Approval.Scope != "" {
-		t.Fatalf("expected approval to be cleared, got %+v", record.Approval)
+	if record.Approval.Approver != "@maria" || record.Approval.Scope != "read-only" {
+		t.Fatalf("expected approval to be preserved, got %+v", record.Approval)
 	}
-	if record.LastSeen != "2026-02-21T12:00:00Z" {
+	if record.LastSeen != "2026-02-20T00:00:00Z" {
 		t.Fatalf("unexpected last_seen: %q", record.LastSeen)
 	}
 }
@@ -93,8 +93,8 @@ func TestGenerateUnderReviewFallsBackToInventory(t *testing.T) {
 	if record.AgentID != "wrkr:cursor-aa:acme" {
 		t.Fatalf("unexpected agent id %q", record.AgentID)
 	}
-	if record.Status != "under_review" {
-		t.Fatalf("expected under_review status, got %q", record.Status)
+	if record.Status != "discovered" {
+		t.Fatalf("expected discovered status, got %q", record.Status)
 	}
 }
 

--- a/docs-site/public/llm/contracts.md
+++ b/docs-site/public/llm/contracts.md
@@ -9,9 +9,11 @@ Stable contract surfaces include:
 - Additive `verify --json` success detail fields such as `chain.verification_mode` and `chain.authenticity_status`
 - Additive `control_evidence` in `evidence --json` and `verify --chain --json` when the saved state contains an active control backlog
 - Inventory approval lifecycle commands that mutate local state/manifest/proof artifacts atomically
+- Identity and inventory mutations update saved scan state atomically with manifest/lifecycle/proof artifacts, so `score`, `report`, and `regress` reflect approvals without a rescanning step
 - `wrkr score` fail-closed behavior when saved scan snapshots are malformed, even if cached `posture_score` is present
 - `wrkr evidence` fail-closed behavior when saved proof-chain prerequisites are malformed or tampered
 - `wrkr scan --resume` fail-closed behavior when checkpoint files or reused materialized repo roots are symlink-swapped
+- `wrkr scan` and `wrkr identity` fail-closed behavior for symlinked managed `--state` paths
 - `regress` compatibility for legacy `v1` baselines when current instance identities are equivalent
 - `regress run` compatibility for raw saved scan snapshots used as baseline inputs
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -48,6 +48,8 @@
 - Resumed hosted org scans revalidate checkpoint files and reused materialized repo roots before detector execution, so symlink-swapped resume state is blocked as unsafe.
 - Low or zero `framework_coverage` reflects the controls currently evidenced in the scanned state, not missing parser support, and `wrkr evidence --json` emits additive `coverage_note` guidance with the same interpretation.
 - Approval inventory mutations are local/file-based and append proof events; `wrkr evidence --json` and `wrkr verify --chain --json` may include additive `control_evidence` showing existing and missing proof for active backlog controls.
+- `wrkr identity` and `wrkr inventory` mutations update saved state, manifest, lifecycle, and proof artifacts together, so `score`, `report`, and `regress` reflect approvals without a rescanning step.
+- First discovery persists as `discovered`; `under_review` is reserved for explicit review and approval-expiry return-to-review flows.
 - Evidence bundles include deterministic inventory artifacts: inventory.json, inventory-snapshot.json, inventory.yaml.
 - Wrkr runs standalone; Gait is the optional control-layer counterpart.
 - Wrkr does not replace vulnerability scanners such as Snyk.

--- a/docs/commands/identity.md
+++ b/docs/commands/identity.md
@@ -34,6 +34,8 @@
 
 Manual transitions to `under_review`, `deprecated`, or `revoked` always normalize `approval_status` away from `valid` (`approval_status=revoked`).
 Manual transitions are fail closed across manifest posture, lifecycle history, and proof history: if a downstream write or proof-emission step fails, Wrkr returns `runtime_failure` and restores the prior committed state instead of leaving a partial approval or review result behind.
+Symlinked `--state` inputs are rejected as unsafe managed paths before any manifest, lifecycle, proof, or saved-state mutation begins.
+Successful transitions update the saved scan snapshot in the same managed generation, so `wrkr score`, `wrkr report`, and `wrkr regress` reflect approval and review decisions immediately without rescanning.
 
 ## Examples
 

--- a/docs/commands/inventory.md
+++ b/docs/commands/inventory.md
@@ -76,7 +76,7 @@ Mutation commands emit a deterministic JSON response with:
 - `manifest_path`
 - `proof_chain_path`
 
-Mutations update the state snapshot and `wrkr-manifest.yaml` additively, append lifecycle/proof records, and use atomic rollback if a managed artifact write fails. Unsafe managed artifact paths, including symlinks or non-regular files at state/proof/manifest paths, return exit `8` with `unsafe_operation_blocked`.
+Mutations update the state snapshot and `wrkr-manifest.yaml` additively, append lifecycle/proof records, and use atomic rollback if a managed artifact write fails. Successful approval and lifecycle mutations also refresh saved posture surfaces such as backlog and cached posture score so `wrkr score`, `wrkr report`, and `wrkr regress` reflect the decision without requiring a fresh scan. Unsafe managed artifact paths, including symlinks or non-regular files at state/proof/manifest paths, return exit `8` with `unsafe_operation_blocked`.
 
 ## Approval inventory semantics
 

--- a/docs/commands/regress.md
+++ b/docs/commands/regress.md
@@ -43,6 +43,7 @@ wrkr regress run --baseline ./.wrkr/inventory-baseline.json --state ./.wrkr/last
 Expected JSON keys include `status`, `baseline_path`, `tool_count` (init) and drift fields plus optional `summary_md_path` (run).
 Baseline `tools[*]` continue to expose `agent_id` and `tool_id`; additive `agent_instance_id` is now included when instance-scoped identity is available.
 Baseline `tools[*]` may also include additive approved control-path state: `security_visibility`, `owner`, `evidence_expires`, `write_path_classes`, `secret_bearing`, `confidence`, `control_path_type`, `repo`, `location`, and `risk_score`.
+`wrkr regress init` reads the saved scan snapshot directly, so approvals recorded with `wrkr identity` or `wrkr inventory` become visible in newly generated baselines without requiring a follow-up scan.
 Drift `reasons[*]` continue to expose `agent_id`/`tool_id` and now include additive `agent_instance_id` when the current state carries instance-scoped identity.
 Deprecated or revoked tools that reappear in current scan state produce deterministic `deprecated_tool_reappeared` or `revoked_tool_reappeared` drift reasons.
 When critical attack-path sets diverge above deterministic thresholds, `reasons` includes a single `critical_attack_path_drift` summary entry with machine-readable `attack_path_drift` details (`added`, `removed`, `score_changed`).

--- a/docs/commands/report.md
+++ b/docs/commands/report.md
@@ -54,6 +54,7 @@ Customer-ready templates `ciso`, `appsec`, `platform`, `audit`, and `customer-dr
 `summary.security_visibility` exposes additive reference-basis and `unknown_to_security` counts sourced from the saved scan state.
 When the saved scan state does not carry a usable `reference_basis`, report output suppresses `unknown_to_security` claims and surfaces `reference_basis unavailable` wording instead.
 `wrkr report` renders from saved scan state only. It summarizes static posture, risky write paths, and proof artifacts; it does not claim live runtime observation or control-layer enforcement.
+Manual `identity` and `inventory` approvals refresh the saved backlog, action-path posture, and posture score in place, so `wrkr report --state <path> --json` reflects those decisions without a rescanning step.
 
 Public template behavior (`--template public --share-profile public`):
 

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -36,6 +36,7 @@ Acquisition behavior is fail-closed by target:
   - Ownership violations return `unsafe_operation_blocked` (exit `8`).
 - When GitHub acquisition is unavailable, `scan` returns `dependency_missing` with exit code `7` (no synthetic repos are emitted).
 - `--state` defaults to `.wrkr/last-scan.json`, with manifest/proof artifacts written alongside it.
+- Existing `--state` files must be regular files; symlinked `--state` inputs fail closed with `unsafe_operation_blocked` (exit `8`) before any managed artifact mutation.
 - Scan-owned managed artifacts are published transactionally: state snapshot, lifecycle chain, proof chain/attestation, manifest, and any requested `--json-path`, `--report-md-path`, or `--sarif-path` sidecars commit as one generation.
 - Scan status is written as a deterministic sidecar next to `--state` and can be inspected with `wrkr scan status --state <path> --json` without rescanning.
 - Invalid scan-owned artifact paths such as `--report-md-path` and `--sarif-path` are preflight-validated before any managed artifact mutation.

--- a/docs/commands/score.md
+++ b/docs/commands/score.md
@@ -21,4 +21,5 @@ wrkr score --state ./.tmp/state.json --json
 
 Expected JSON keys: `score`, `grade`, `breakdown`, `weighted_breakdown`, `weights`, `trend_delta`.
 When attack-path scoring is present in state, output also includes `attack_paths` and `top_attack_paths`.
+Saved-state approval and lifecycle mutations refresh cached posture score material immediately, so `wrkr score --state <path> --json` reflects `identity` or `inventory` approvals without requiring a new scan.
 Malformed or type-invalid saved scan state fails with `runtime_failure` (exit `1`) instead of returning cached score output, even when the saved snapshot still contains `posture_score`.

--- a/docs/failure_taxonomy_exit_codes.md
+++ b/docs/failure_taxonomy_exit_codes.md
@@ -58,6 +58,10 @@ Use code-based branching with non-zero fail semantics. Keep a simple rule: `0` p
 
 `wrkr identity approve|review|deprecate|revoke --json` fails with exit code `1` and error code `runtime_failure`. Wrkr restores the prior committed manifest, lifecycle, and proof state instead of leaving a partial transition behind.
 
+### What happens when `scan` or `identity` gets a symlinked `--state` path?
+
+`wrkr scan --json` and `wrkr identity ... --json` fail with exit code `8` and error code `unsafe_operation_blocked`. Wrkr rejects symlinked managed state files before any state, manifest, lifecycle, or proof artifact is written.
+
 ### What happens when `scan` gets an invalid report or SARIF output path?
 
 `wrkr scan --json` fails with exit code `6` and error code `invalid_input`. Wrkr now validates scan-owned artifact paths before the managed `.wrkr` state or proof artifacts are written.

--- a/docs/state_lifecycle.md
+++ b/docs/state_lifecycle.md
@@ -36,13 +36,13 @@ Wrkr uses two path classes:
 4. `wrkr evidence` consumes state only after the saved proof chain passes the same local integrity prerequisite used by Wrkr's verification runtime, then emits evidence bundle outputs while preserving chain continuity and only publishing a complete verified bundle to the requested output path.
 5. `wrkr verify --chain` remains the explicit proof-chain integrity gate for operators and CI from the state directory.
 
-Saved scan state also carries additive governance output: `control_backlog`, `scan_quality`, inventory write-path classes, and governance control mappings. Approval evidence that expires is represented as `approval_status=expired` and a lifecycle state requiring review; governance backlog visibility maps that condition to `needs_review` instead of continuing to treat the path as approved.
+Saved scan state also carries additive governance output: `control_backlog`, `scan_quality`, inventory write-path classes, and governance control mappings. Approval evidence that expires is represented as `approval_status=expired` and a lifecycle state requiring review; governance backlog visibility maps that condition to `needs_review` instead of continuing to treat the path as approved. First observation persists as `status=discovered`; Wrkr reserves `under_review` for explicit review and approval-expiry return-to-review semantics rather than auto-normalizing every fresh discovery into review.
 
 ## Manual transition commit rule
 
-- `wrkr identity approve|review|deprecate|revoke` preflights lifecycle and proof reads before mutation begins.
-- The command snapshots the managed artifact set and restores it on downstream lifecycle or proof failure.
-- Manifest posture is committed last so approval or review state does not remain ahead of lifecycle or proof history after a failed command.
+- `wrkr identity approve|review|deprecate|revoke` and `wrkr inventory approve|attach-evidence|accept-risk|deprecate|exclude` preflight lifecycle and proof reads before mutation begins.
+- The commands snapshot the managed artifact set and restore it on downstream saved-state, lifecycle, manifest, or proof failure.
+- Successful mutations update the saved scan snapshot in the same managed generation as manifest, lifecycle chain, and proof artifacts, so downstream posture readers observe the new state immediately.
 
 ## Command links
 

--- a/internal/acceptance/v1_acceptance_test.go
+++ b/internal/acceptance/v1_acceptance_test.go
@@ -421,7 +421,7 @@ func TestV1AcceptanceMatrix(t *testing.T) {
 		}
 	})
 
-	t.Run("AC17_manifest_generate_under_review_and_manual_approval", func(t *testing.T) {
+	t.Run("AC17_manifest_generate_preserves_discovered_and_manual_approval", func(t *testing.T) {
 		statePath := scanScenarioState(t, paths.scanMixedRepos, "standard")
 		manifestPayload := runJSONOK(t, "manifest", "generate", "--state", statePath, "--json")
 		requireKey(t, manifestPayload, "manifest_path")
@@ -436,8 +436,8 @@ func TestV1AcceptanceMatrix(t *testing.T) {
 		}
 		first := loaded.Identities[0]
 		for _, item := range loaded.Identities {
-			if item.Status != "under_review" || item.ApprovalState != "missing" {
-				t.Fatalf("expected under_review + missing approval_state, got %+v", item)
+			if item.Status != "discovered" || item.ApprovalState != "missing" {
+				t.Fatalf("expected discovered + missing approval_state, got %+v", item)
 			}
 		}
 

--- a/internal/e2e/manifest/manifest_e2e_test.go
+++ b/internal/e2e/manifest/manifest_e2e_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Clyra-AI/wrkr/core/manifest"
 )
 
-func TestE2EManifestGenerateUnderReviewAndSchemaArtifacts(t *testing.T) {
+func TestE2EManifestGenerateDiscoveredAndSchemaArtifacts(t *testing.T) {
 	t.Parallel()
 
 	repoRoot := mustFindRepoRoot(t)
@@ -37,8 +37,8 @@ func TestE2EManifestGenerateUnderReviewAndSchemaArtifacts(t *testing.T) {
 		t.Fatal("expected generated identities")
 	}
 	for _, record := range generated.Identities {
-		if record.Status != "under_review" {
-			t.Fatalf("expected under_review state, got %q for %s", record.Status, record.AgentID)
+		if record.Status != "discovered" {
+			t.Fatalf("expected discovered state, got %q for %s", record.Status, record.AgentID)
 		}
 		if record.ApprovalState != "missing" {
 			t.Fatalf("expected missing approval_status, got %q for %s", record.ApprovalState, record.AgentID)

--- a/internal/e2e/regress/regress_e2e_test.go
+++ b/internal/e2e/regress/regress_e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Clyra-AI/wrkr/core/identity"
 	"github.com/Clyra-AI/wrkr/core/manifest"
 	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/regress"
 	"github.com/Clyra-AI/wrkr/core/source"
 	"github.com/Clyra-AI/wrkr/core/state"
 )
@@ -300,6 +301,53 @@ func TestE2ERegressRunAcceptsRawScanSnapshotBaseline(t *testing.T) {
 	}
 }
 
+func TestE2ERegressInitUsesApprovalMutationWithoutRescan(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	repoRoot := mustFindRepoRoot(t)
+	statePath := filepath.Join(tmp, "state.json")
+	baselinePath := filepath.Join(tmp, "baseline.json")
+	reposPath := filepath.Join(repoRoot, "scenarios", "wrkr", "scan-mixed-org", "repos")
+
+	var scanOut bytes.Buffer
+	var scanErr bytes.Buffer
+	if code := cli.Run([]string{"scan", "--path", reposPath, "--state", statePath, "--json"}, &scanOut, &scanErr); code != 0 {
+		t.Fatalf("scan failed: %d (%s)", code, scanErr.String())
+	}
+	agentID := firstInventoryAgentID(t, scanOut.Bytes())
+
+	var approveOut bytes.Buffer
+	var approveErr bytes.Buffer
+	if code := cli.Run([]string{"identity", "approve", agentID, "--approver", "@maria", "--scope", "read-only", "--expires", "90d", "--state", statePath, "--json"}, &approveOut, &approveErr); code != 0 {
+		t.Fatalf("identity approve failed: %d (%s)", code, approveErr.String())
+	}
+
+	var initOut bytes.Buffer
+	var initErr bytes.Buffer
+	if code := cli.Run([]string{"regress", "init", "--baseline", statePath, "--output", baselinePath, "--json"}, &initOut, &initErr); code != 0 {
+		t.Fatalf("regress init failed: %d (%s)", code, initErr.String())
+	}
+
+	baseline, err := regress.LoadBaseline(baselinePath)
+	if err != nil {
+		t.Fatalf("load baseline: %v", err)
+	}
+	for _, tool := range baseline.Tools {
+		if tool.AgentID != agentID {
+			continue
+		}
+		if tool.Status != identity.StateApproved {
+			t.Fatalf("expected approved lifecycle status in baseline, got %+v", tool)
+		}
+		if tool.ApprovalStatus != "valid" {
+			t.Fatalf("expected valid approval status in baseline, got %+v", tool)
+		}
+		return
+	}
+	t.Fatalf("expected baseline tool for %s", agentID)
+}
+
 func mustFindRepoRoot(t *testing.T) string {
 	t.Helper()
 
@@ -321,4 +369,29 @@ func mustFindRepoRoot(t *testing.T) string {
 	}
 	t.Fatalf("could not locate repository root from %s", wd)
 	return ""
+}
+
+func firstInventoryAgentID(t *testing.T, payload []byte) string {
+	t.Helper()
+	var parsed map[string]any
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		t.Fatalf("parse json payload: %v", err)
+	}
+	inventoryPayload, ok := parsed["inventory"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inventory payload, got %v", parsed["inventory"])
+	}
+	tools, ok := inventoryPayload["tools"].([]any)
+	if !ok || len(tools) == 0 {
+		t.Fatalf("expected inventory tools, got %v", inventoryPayload["tools"])
+	}
+	firstTool, ok := tools[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected tool payload: %T", tools[0])
+	}
+	agentID, _ := firstTool["agent_id"].(string)
+	if agentID == "" {
+		t.Fatalf("expected agent_id in tool payload: %v", firstTool)
+	}
+	return agentID
 }

--- a/internal/e2e/score/score_e2e_test.go
+++ b/internal/e2e/score/score_e2e_test.go
@@ -111,3 +111,112 @@ func TestE2EScoreJSONFailsClosedOnMalformedStateWithCachedScore(t *testing.T) {
 		t.Fatalf("unexpected error code: %v", errObject["code"])
 	}
 }
+
+func TestE2EScoreReflectsIdentityApproveWithoutRescan(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	repoRoot := mustFindRepoRoot(t)
+	statePath := filepath.Join(tmp, "state.json")
+	reposPath := filepath.Join(repoRoot, "scenarios", "wrkr", "scan-mixed-org", "repos")
+
+	var scanOut bytes.Buffer
+	var scanErr bytes.Buffer
+	if code := cli.Run([]string{"scan", "--path", reposPath, "--state", statePath, "--json"}, &scanOut, &scanErr); code != 0 {
+		t.Fatalf("scan failed: %d (%s)", code, scanErr.String())
+	}
+	agentID := firstInventoryAgentID(t, scanOut.Bytes())
+
+	var scoreOut bytes.Buffer
+	var scoreErr bytes.Buffer
+	if code := cli.Run([]string{"score", "--state", statePath, "--json"}, &scoreOut, &scoreErr); code != 0 {
+		t.Fatalf("initial score failed: %d (%s)", code, scoreErr.String())
+	}
+	before := parseJSONMap(t, scoreOut.Bytes())
+	beforeBreakdown, ok := before["breakdown"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected initial breakdown, got %v", before)
+	}
+	beforeCoverage, ok := beforeBreakdown["approval_coverage"].(float64)
+	if !ok {
+		t.Fatalf("expected initial approval_coverage, got %v", beforeBreakdown)
+	}
+
+	var approveOut bytes.Buffer
+	var approveErr bytes.Buffer
+	if code := cli.Run([]string{"identity", "approve", agentID, "--approver", "@maria", "--scope", "read-only", "--expires", "90d", "--state", statePath, "--json"}, &approveOut, &approveErr); code != 0 {
+		t.Fatalf("identity approve failed: %d (%s)", code, approveErr.String())
+	}
+
+	scoreOut.Reset()
+	scoreErr.Reset()
+	if code := cli.Run([]string{"score", "--state", statePath, "--json"}, &scoreOut, &scoreErr); code != 0 {
+		t.Fatalf("post-approve score failed: %d (%s)", code, scoreErr.String())
+	}
+	after := parseJSONMap(t, scoreOut.Bytes())
+	afterBreakdown, ok := after["breakdown"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected post-approve breakdown, got %v", after)
+	}
+	afterCoverage, ok := afterBreakdown["approval_coverage"].(float64)
+	if !ok {
+		t.Fatalf("expected post-approve approval_coverage, got %v", afterBreakdown)
+	}
+	if afterCoverage <= beforeCoverage {
+		t.Fatalf("expected approval coverage to increase after approval, before=%.2f after=%.2f", beforeCoverage, afterCoverage)
+	}
+}
+
+func firstInventoryAgentID(t *testing.T, payload []byte) string {
+	t.Helper()
+	parsed := parseJSONMap(t, payload)
+	inventoryPayload, ok := parsed["inventory"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inventory payload, got %v", parsed["inventory"])
+	}
+	tools, ok := inventoryPayload["tools"].([]any)
+	if !ok || len(tools) == 0 {
+		t.Fatalf("expected inventory tools, got %v", inventoryPayload["tools"])
+	}
+	firstTool, ok := tools[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected tool payload: %T", tools[0])
+	}
+	agentID, _ := firstTool["agent_id"].(string)
+	if agentID == "" {
+		t.Fatalf("expected agent_id in tool payload: %v", firstTool)
+	}
+	return agentID
+}
+
+func parseJSONMap(t *testing.T, payload []byte) map[string]any {
+	t.Helper()
+	var parsed map[string]any
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		t.Fatalf("parse json payload: %v", err)
+	}
+	return parsed
+}
+
+func mustFindRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	current := wd
+	for i := 0; i < 8; i++ {
+		if _, err := os.Stat(filepath.Join(current, "go.mod")); err == nil {
+			return current
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+	t.Fatalf("could not locate repository root from %s", wd)
+	return ""
+}

--- a/product/PLAN_NEXT.md
+++ b/product/PLAN_NEXT.md
@@ -1,10 +1,10 @@
-# PLAN NEXT: Govern-First Control-Path Governance
+# PLAN NEXT: State Mutation Safety And Lifecycle Contract Recovery
 
-Date: 2026-04-22
+Date: 2026-04-23
 
 Source of truth:
-- User-provided PM change list after the large-scale organization scan.
-- `AGENTS.md` repository instructions.
+- User-provided code-review findings for approval propagation, managed-artifact state-path safety, and lifecycle-state contract drift.
+- `AGENTS.md`.
 - `product/wrkr.md`.
 - `product/dev_guides.md`.
 - `product/architecture_guides.md`.
@@ -12,1308 +12,580 @@ Source of truth:
 Scope:
 - Wrkr only.
 - Planning only. No implementation is included in this plan.
-- Convert Wrkr from broad scanner posture toward AI and automation control-path governance for engineering environments.
-- Preserve deterministic, offline-first, file-based evidence behavior and existing CLI/exit-code contracts.
+- Fix the release-blocking contract gaps around stateful CLI mutation authority, fail-closed managed artifact ownership, and lifecycle-state semantics.
+- Preserve deterministic, offline-first, file-based evidence behavior and existing exit-code classes.
 
 ## Global Decisions (Locked)
 
-- Product position: Wrkr is "governance and proof for unknown AI and automation control paths across engineering environments."
-- Default customer outcome: answer "What should security review first?" through a short prioritized control backlog.
-- Product umbrella term: `control_surface`.
-- Control surface subtypes: `ai_agent`, `coding_assistant_config`, `mcp_server_tool`, `ci_automation`, `release_automation`, `dependency_agent_surface`, `secret_bearing_workflow`, `non_human_identity`.
-- Primary Wrkr signal is separate from supporting security signal in all new governance outputs.
-- Raw findings remain available as machine-readable evidence but are not the default human/operator decision surface.
-- Default scan mode becomes governance-oriented while keeping existing stable JSON keys additive and backward compatible.
-- Secret semantics classify references, value evidence, scope gaps, owner gaps, rotation evidence gaps, and write-capable usage separately.
-- No scan/risk/proof path may call an LLM or exfiltrate scan data by default.
-- Structured parsing remains mandatory for structured configs; regex-only parsing is allowed only for unstructured text or a narrowly bounded reference detector.
-- Enterprise integrations such as Jira, ServiceNow, GitHub Issues, Slack, or Teams must default to local dry-run/export artifacts unless explicit opt-in network execution is provided.
-- Contract/runtime waves must land before docs/report/ticket polish waves.
+- Treat the approval-propagation and symlinked-state issues as the minimum blocker set for safe release posture.
+- Treat `product/wrkr.md` and `AGENTS.md` as authoritative for lifecycle semantics unless a future explicit versioned migration says otherwise.
+- Fail-closed decision: symlinked `--state` inputs are unsupported across all stateful Wrkr commands and must return exit `8` with `error.code=unsafe_operation_blocked` before any managed artifact mutation.
+- Managed artifacts remain a same-root contract derived from one trusted state location; Wrkr must not split `state.json` and sibling manifest/proof/status artifacts across directories.
+- A successful manual identity or inventory mutation must make the saved snapshot authoritative immediately for `score`, `report`, `regress init`, and `regress run`; no rescanning is required to observe approved posture.
+- Mutation projection must be centralized. Do not keep separate best-effort snapshot patch logic per command family.
+- Any snapshot fields affected by lifecycle or approval mutation must be updated in the same transaction or deterministically recomputed before success is returned.
+- `discovered` remains the persisted first-seen lifecycle state.
+- `under_review` is reserved for explicit review, approval expiry, or other explicit downgrade-to-review cases.
+- `active` remains an auto-derived state for approved-present identities during scan reconciliation.
+- CLI help/docs/failure-taxonomy changes ship in the same stories as runtime changes.
+- No schema-major version bump is planned for this work. Use additive or behavior-fix semantics only.
 
 ## Current Baseline (Observed)
 
-- `core/model/finding.go` is the canonical detector/policy finding contract. It has severity, remediation, permissions, evidence, and parse error metadata, but no native control backlog fields, action taxonomy, evidence quality, signal class, confidence level, control-path type, SLA, or explicit secret-reference subtype.
-- `core/cli/scan.go` emits `findings`, `ranked_findings`, `top_findings`, `action_paths`, `inventory`, `privilege_budget`, profile, posture score, and compliance summary. It does not expose `--mode quick|governance|deep`.
-- `core/aggregate/inventory` already models tools, agents, owner metadata, approval summary, security visibility summary, privilege budget, and agent privilege map. Security visibility currently has `approved`, `known_unapproved`, and `unknown_to_security`.
-- `core/owners` supports CODEOWNERS and deterministic repo fallback ownership. It does not yet support service catalog, Backstage, GitHub teams, repo topics, explicit custom owner mappings, or conflicting owner resolution.
-- `core/detect/workflowcap` already parses GitHub workflow YAML and derives write/deploy/db/IaC capabilities, headless execution, secret access, and gate/proof hints.
-- `core/detect/secrets` redacts values and detects env files plus workflow/Jenkins secret references, but current finding type is still generic `secret_presence`.
-- `core/regress` already supports deterministic baselines, drift exit code `5`, permission expansion, revoked-tool reappearance, and critical attack-path drift. Drift reasons do not yet map to governance-first categories like new secret-bearing workflow or approval expired.
-- `core/report` supports `exec`, `operator`, `audit`, and `public` templates with deterministic Markdown/PDF generation. It does not yet provide native CISO/AppSec/platform/customer-draft bundles led by a control backlog.
-- `core/export` supports inventory and appendix export. It does not yet export tickets.
-- Scenario, e2e, acceptance, contract, hardening, chaos, and perf gates already exist and must be wired into implementation stories.
-- `PLAN_NEXT.md` did not exist before this planning run.
+- `scan` derives sibling manifest/proof/status paths from the lexical `--state` path in `core/cli/scan.go`.
+- `internal/atomicwrite` resolves a final-file symlink target when writing the state file, which allows `state.json` to land in a different directory than sibling managed artifacts when `--state` is a symlink.
+- `inventory` already rejects symlinked managed mutation artifacts in `core/cli/inventory_mutations.go`, but `scan` and `identity` do not apply the same fail-closed gate.
+- `identity approve|review|deprecate|revoke` updates manifest, lifecycle chain, and proof artifacts but never rewrites `state.json`.
+- `inventory approve|attach-evidence|accept-risk|deprecate|exclude` updates `state.json`, but cached derived sections such as `posture_score` remain stale.
+- `score`, `report`, `regress init`, and `regress run` read saved snapshot material rather than rescanning, so stale lifecycle and approval data can persist after successful mutations.
+- `core/lifecycle/lifecycle.go` initializes first-seen identities as `discovered` and then immediately normalizes them to `under_review`, so the documented `discovered` state does not persist in practice.
+- Existing docs already promise same-root managed artifacts, fail-closed mutation rollback, and a persisted lifecycle path that includes `discovered`, so runtime currently drifts from published behavior.
+- `go test ./... -count=1` passes locally, so this work is a contract-correction plan for green-but-wrong behavior rather than a red-suite rescue.
 
 ## Exit Criteria
 
-- `wrkr scan --json` includes a deterministic `control_backlog` led by unique Wrkr signals and keeps existing raw finding surfaces available for compatibility.
-- `wrkr scan` defaults to governance mode, with explicit `--mode quick`, `--mode governance`, and `--mode deep`.
-- Generated, vendored, package-manager, minified, and build-output noise is suppressed or moved to a scan-quality appendix by default.
-- Every control backlog item includes repo, path, control-path type, capability, owner, evidence source, approval status, security visibility, recommended action, confidence, evidence gaps, confidence-raising guidance, SLA, and closure criteria.
-- Every finding/control item has a fixed action taxonomy value or deterministic equivalent accepted by the schema.
-- Secret-bearing workflows distinguish secret references from leaked values and explain owner/scope/rotation/proof evidence gaps.
-- Inventory workflows can approve, attach evidence, accept risk, deprecate, exclude, and expire/renew approvals with deterministic proof records.
-- Drift views answer what new or changed AI/automation control paths appeared since the last approved baseline.
-- Ownership resolution distinguishes explicit, inferred, conflicting, and missing owners with confidence.
-- Large-org scans keep JSON stdout clean, progress on stderr, phase timing visible, partial results explicit, and status inspectable after interruptions.
-- Native reports and ticket exports lead with the control backlog and keep raw findings in appendices.
+- `wrkr scan --state <symlink> --json` fails before any managed artifact mutation with exit `8` and `error.code=unsafe_operation_blocked`.
+- `wrkr identity approve|review|deprecate|revoke --json` updates `state.json`, `wrkr-manifest.yaml`, lifecycle chain, and proof artifacts as one rollback-safe generation.
+- `wrkr inventory approve|attach-evidence|accept-risk|deprecate|exclude --json` keeps the same rollback guarantees and refreshes derived posture sections that approval changes affect.
+- After a successful approval mutation, `wrkr score --json`, `wrkr report --json`, and `wrkr regress init/run --json` reflect the new lifecycle and approval posture without a rescan.
+- First-seen identities persist as `discovered`.
+- Explicit review moves an identity to `under_review`.
+- Expired approval returns an identity to `under_review`.
+- Valid approved-present identities resolve to `active` on the next scan.
+- CLI command docs, lifecycle docs, failure taxonomy docs, product lifecycle wording, and changelog entries match shipped behavior.
+- All targeted fast/core/acceptance/cross-platform/risk lanes for these changes are green.
 
 ## Public API and Contract Map
 
-Stable existing public surfaces:
-- CLI commands in `core/cli/root.go`: `scan`, `inventory`, `regress`, `report`, `export`, `evidence`, `verify`, `identity`, `lifecycle`, `manifest`, `score`, `fix`, `campaign`, `mcp-list`, `action`, `version`.
-- Exit codes in `core/cli/root.go`: `0` success, `1` runtime failure, `2` verification failure, `3` policy/schema violation, `4` approval required, `5` regression drift, `6` invalid input, `7` dependency missing, `8` unsafe operation blocked.
-- Existing `wrkr scan --json` keys must remain present unless explicitly deprecated by a future major version: `findings`, `ranked_findings`, `top_findings`, `inventory`, `profile`, `posture_score`, `compliance_summary`.
-- Existing proof chain, lifecycle manifest, state snapshot, report, appendix, SARIF, and regress baseline artifacts remain portable and verifiable.
+Stable public surfaces to preserve:
+- CLI commands: `scan`, `identity`, `inventory`, `score`, `report`, `regress`, `verify`.
+- Exit-code contract in `core/cli/root.go`.
+- Stable JSON error envelope shape under `--json`.
+- Managed artifact family derived from state: scan snapshot, manifest, lifecycle chain, proof chain, proof attestation, signing key, scan status sidecar, regress baseline.
+- Existing `wrkr scan --json` top-level surfaces remain additive; this plan does not remove fields.
 
-New public surfaces to add:
-- `wrkr scan --mode quick|governance|deep`.
-- `control_backlog` object in scan state and scan JSON, versioned as `control_backlog_version`.
-- `scan_quality` appendix containing suppressed generated/package noise, parser errors, detector errors, and completeness warnings.
-- Finding/control item enums: `signal_class`, `control_surface_type`, `control_path_type`, `recommended_action`, `confidence`, `evidence_basis`, `security_visibility_state`, `write_path_class`, `secret_signal_type`.
-- Inventory lifecycle commands: `wrkr inventory approve`, `wrkr inventory attach-evidence`, `wrkr inventory accept-risk`, `wrkr inventory deprecate`, `wrkr inventory exclude`.
-- Drift categories for control-path changes in `wrkr regress run --json` and `wrkr inventory --diff --json`.
-- Report templates: `ciso`, `appsec`, `platform`, `audit`, `customer-draft`, with compatibility alias for current `exec|operator|audit|public`.
-- Ticket export command surface under `wrkr export tickets`.
+Stable semantics to restore or preserve:
+- Managed artifacts live alongside one trusted state root.
+- Successful manual approval/lifecycle mutation makes the saved snapshot authoritative for downstream posture commands.
+- Lifecycle path remains `discovered -> under_review -> approved -> active -> deprecated -> revoked`, with `active` auto-derived rather than directly operator-set for ongoing scans.
 
-Internal surfaces:
-- New aggregation packages may live under `core/aggregate/controlbacklog`, `core/aggregate/scanquality`, and focused helper packages for classification. Keep orchestration thin in `core/cli`.
-- Detector logic remains under `core/detect/*`; risk logic remains under `core/risk/*`; ownership logic remains under `core/owners`; evidence/proof stays under `core/evidence`, `core/proofemit`, and `core/proofmap`.
+Internal surfaces touched by this plan:
+- `core/cli/scan.go`
+- `core/cli/identity.go`
+- `core/cli/inventory_mutations.go`
+- `core/cli/managed_artifacts.go`
+- `core/cli/score.go`
+- `core/cli/report.go`
+- `core/cli/regress.go`
+- `core/lifecycle/lifecycle.go`
+- `core/state/*`
+- `internal/atomicwrite/*`
+- `docs/**`
+- `product/wrkr.md`
 
 Shim and deprecation path:
-- Keep existing finding JSON fields and report templates. Add new fields additively.
-- Map existing security visibility value `approved` to new display value `known_approved` only in new governance surfaces; do not mutate old inventory fields without a schema/version note.
-- Keep current `top_findings` while adding `control_backlog.items`. Do not remove `top_findings` during this plan.
-- Existing `secret_presence` findings may continue for compatibility, but governance outputs must derive and expose new secret signal semantics.
+- No compatibility shim for symlinked `--state` inputs. They become consistently unsupported across all stateful commands.
+- No removal of existing JSON fields or exit codes.
+- Existing stale-state behavior is treated as a bug, not a supported migration mode.
 
 Schema/versioning policy:
-- Add explicit version fields for new artifacts: `control_backlog_version`, `scan_quality_version`, `approval_inventory_version`, `ticket_export_version`.
-- Enum additions are minor-version compatible when old fields remain. Enum renames or removals require shim logic, docs, and compatibility tests.
-- New artifacts must be byte-stable across repeated runs except explicit timestamp/version fields.
+- Prefer no version bump for existing snapshot or manifest artifacts if field shape stays stable.
+- If recomputation normalizes existing derived fields, the change must remain byte-stable for identical logical input state except explicit timestamps already allowed by contract.
+- Fixture and golden updates that encode corrected lifecycle semantics are permitted as contract-repair changes and must be called out in changelog/docs.
 
 Machine-readable error expectations:
-- Invalid scan mode, report template, ticket format, or inventory action arguments: exit `6`, JSON error code `invalid_input`.
-- Invalid governance policy/config schema: exit `3`, JSON error code `policy_schema_violation`.
-- Approval-required enforcement paths: exit `4`, JSON error code `approval_required`.
-- Drift found by regress/inventory diff: exit `5`, JSON status `drift`.
-- Missing optional network adapter configuration: exit `7`, JSON error code `dependency_missing`.
-- Unsafe output path, symlink marker abuse, or unmanaged destructive write: exit `8`, JSON error code `unsafe_operation_blocked`.
+- Symlinked or otherwise unsafe managed `--state` path: exit `8`, `error.code=unsafe_operation_blocked`.
+- Mutation rollback failure: exit `1`, `error.code=runtime_failure`, with the prior committed generation restored.
+- Approval mutation success: `status=ok`, and downstream state consumers read updated lifecycle and approval posture immediately.
+- Drift remains exit `5`; this plan does not alter the drift exit-code class.
 
 ## Docs and OSS Readiness Baseline
 
-- README first screen must say what Wrkr does, who it is for, how to get first value, and why it is governance/proof for control paths rather than generic AppSec scanning.
-- Docs must introduce the lifecycle path model: discover -> classify -> attach evidence -> approve -> monitor drift -> prove control.
-- Integration-first docs flow must lead with `wrkr scan --mode governance --json`, `wrkr inventory approve`, `wrkr regress init/run --json`, `wrkr report --template ciso`, and `wrkr export tickets --dry-run --json`.
-- Docs source of truth: command docs in `docs/commands/*.md`, product positioning in `docs/positioning.md`, trust/security docs in `docs/trust/*.md`, examples in `docs/examples/*.md`, decisions in `docs/decisions/*.md`.
-- OSS trust baseline must remain aligned: `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `SECURITY.md`, `.github/CODEOWNERS`, `.github/ISSUE_TEMPLATE/*`, `.github/pull_request_template.md`, and release/trust docs.
-- Any CLI/help/JSON/schema/exit-code change must update docs and pass docs parity gates in the same implementation story.
+- README first-screen contract remains mostly valid. Update `README.md` only if examples or lifecycle wording explicitly promise behavior changed by this plan.
+- Integration-first docs flow for this scope is `scan -> identity/inventory mutation -> score/report/regress -> verify`.
+- Lifecycle path model must explicitly describe first discovery.
+- Lifecycle path model must explicitly describe explicit review.
+- Lifecycle path model must explicitly describe valid approval.
+- Lifecycle path model must explicitly describe active present use.
+- Lifecycle path model must explicitly describe expiry back to review.
+- Lifecycle path model must explicitly describe deprecation.
+- Lifecycle path model must explicitly describe revocation.
+- Docs source of truth for this work includes `docs/commands/scan.md`.
+- Docs source of truth for this work includes `docs/commands/identity.md`.
+- Docs source of truth for this work includes `docs/commands/inventory.md`.
+- Docs source of truth for this work includes `docs/commands/score.md`.
+- Docs source of truth for this work includes `docs/commands/report.md`.
+- Docs source of truth for this work includes `docs/commands/regress.md`.
+- Docs source of truth for this work includes `docs/state_lifecycle.md`.
+- Docs source of truth for this work includes `docs/failure_taxonomy_exit_codes.md`.
+- Docs source of truth for this work includes `product/wrkr.md`.
+- Docs source of truth for this work includes `CHANGELOG.md`.
+- OSS trust baseline files to verify when touched include `CHANGELOG.md`.
+- OSS trust baseline files to verify when touched include `README.md`.
+- OSS trust baseline files to verify when touched include `SECURITY.md` only if safety/failure wording needs to change materially.
+- No expected changes to `CONTRIBUTING.md`, issue templates, or code-of-conduct material for this plan.
+- Docs parity and storyline checks are mandatory for any user-visible CLI/help/contract wording change.
 
 ## Recommendation Traceability
 
-| Rec | Normalized recommendation | Epic/story coverage |
-|---|---|---|
-| R1 | Reposition Wrkr around AI and automation control-path governance | W1-S1, W5-S1 |
-| R2 | Make govern-first control backlog the default output | W1-S1, W2-S1 |
-| R3 | Split unique Wrkr signals from supporting security signals | W1-S1, W2-S1, W5-S1 |
-| R4 | Add fixed finding action taxonomy | W1-S2, W3-S1 |
-| R5 | Add evidence quality and confidence | W1-S2, W4-S1 |
-| R6 | Add approval inventory workflow | W3-S1, W3-S2 |
-| R7 | Make drift recurring value | W3-S3 |
-| R8 | Add scan modes quick/governance/deep | W1-S4, W2-S1 |
-| R9 | Suppress generated/package noise by default | W1-S4 |
-| R10 | Improve secret reference semantics | W1-S3, W2-S2 |
-| R11 | Add control mapping | W2-S2, W3-S2 |
-| R12 | Add native customer reports | W5-S1 |
-| R13 | Add ticket export | W5-S2 |
-| R14 | Add enterprise ownership resolution | W4-S1 |
-| R15 | Add security visibility state | W2-S3 |
-| R16 | Add write-path classification | W2-S2 |
-| R17 | Add large-org operator UX | W4-S2 |
-| R18 | Add baseline and approval expiration | W3-S1, W3-S3 |
-| R19 | Tighten agent vs automation model around control surfaces | W1-S1, W2-S2 |
-| R20 | Productize proof | W3-S2, W5-S1 |
+| Rec ID | Recommendation | Why | Strategic direction | Expected moat/benefit | Planned stories |
+|---|---|---|---|---|---|
+| R1 | Make approval mutations authoritative for persisted posture state | Successful approvals currently leave downstream posture consumers stale | Treat saved state as the single operator authority between scans | Removes operator confusion and makes approval workflows trustworthy in CI and audit use | W2-S1, W2-S2 |
+| R2 | Enforce one fail-closed managed artifact root for `--state` | Symlinked state paths can split artifacts and weaken ownership guarantees | Normalize all stateful commands around one safety boundary | Prevents artifact confusion and strengthens fail-closed local ownership controls | W1-S1 |
+| R3 | Restore the persisted `discovered` lifecycle state | Runtime currently contradicts the documented lifecycle contract | Re-align lifecycle behavior, proofs, and docs around explicit review semantics | Clearer governance reasoning and less lifecycle-state ambiguity for drift and approval automation | W3-S1 |
 
 ## Test Matrix Wiring
 
 Fast lane:
 - `make lint-fast`
-- `make test-fast`
-- Targeted `go test` commands named by each story.
-- Docs parity checks for touched command docs: `scripts/check_docs_cli_parity.sh`.
+- `go test ./core/cli ./core/lifecycle ./core/state ./internal/atomicwrite -count=1`
+- `scripts/check_docs_cli_parity.sh` when command docs or failure taxonomy files change
 
 Core CI lane:
 - `make prepush`
-- `go test ./internal/e2e -count=1`
-- `go test ./internal/integration -count=1`
-- `.github/required-checks.json` and branch-protection contract validation remain aligned.
+- `go test ./internal/e2e/cli_contract ./internal/e2e/source ./internal/e2e/regress ./internal/e2e/verify -count=1`
+- `go test ./testinfra/contracts -count=1`
 
 Acceptance lane:
 - `scripts/run_v1_acceptance.sh --mode=local`
 - `go test ./internal/acceptance -count=1`
 - `go test ./internal/scenarios -count=1 -tags=scenario`
-- New scenario fixtures under `scenarios/wrkr/**` for each governance behavior.
+- Extend scenario coverage for approval propagation and lifecycle transitions where needed
 
 Cross-platform lane:
-- Required PR checks remain `fast-lane` and `windows-smoke`.
-- Windows/macOS smoke must cover path filtering, JSON stdout cleanliness, and report/ticket artifact path behavior when touched.
+- Preserve `windows-smoke`
+- Keep macOS/Linux symlink safety coverage for managed artifact roots
+- Add explicit skips only where symlink fixtures are not portable, and assert the skip reason in tests
 
 Risk lane:
-- `make prepush-full` for architecture, risk, adapter, or failure-semantics changes.
-- `make test-contracts` for schema/artifact/CLI JSON changes.
-- `make test-scenarios` for outside-in behavior changes.
-- `make test-hardening` and `make test-chaos` for approval persistence, baseline/drift, long-running scan status, and unsafe output behavior.
-- `make test-perf` for generated-path filtering, scan modes, control backlog construction, large-org progress/status, and report/ticket export scaling.
+- `make prepush-full`
+- `make test-contracts`
+- `make test-hardening`
+- `make test-chaos`
+- `scripts/check_docs_storyline.sh` when lifecycle or operator-flow docs change
 
 Merge/release gating rule:
-- No implementation wave may merge with failing fast/core/contract/scenario gates.
-- Stories touching proof, evidence, regress drift, approval state, or failure handling require risk lane green before merge.
-- Report/ticket/docs waves may not merge before Wave 1 through Wave 3 contracts are green.
+- No story in this plan is mergeable without fast lane and core CI lane green.
+- W1-S1 and W2-S1/W2-S2 additionally require risk lane green because they alter fail-closed persistence and rollback behavior.
+- W3-S1 additionally requires docs parity/storyline and changelog updates because it changes user-visible lifecycle semantics.
 
-## Epic Wave 1: Control-Surface Contract And Signal Quality
+## Wave 1: Fail-Closed Managed Artifact Root
 
 Objective:
-- Establish the contract vocabulary that lets Wrkr speak in control surfaces, signal classes, actions, confidence, secret semantics, scan modes, and noise policy without collapsing detector/risk/inventory boundaries.
+- Eliminate command-dependent `--state` path handling so scan and manual identity workflows enforce the same fail-closed ownership boundary already present in inventory mutation flows.
 
-### Story W1-S1: Add Control Surface And Backlog Contract
+### Story W1-S1: Reject Symlinked `--state` Paths Across Stateful Commands
 
-Priority: P0
+Priority:
+- P0
 
 Tasks:
-- Add a focused control backlog model with deterministic item sorting and a stable version field.
-- Define fields for repo, path, control surface type, control-path type, capability, owner, owner source, ownership status, evidence source, approval status, security visibility, signal class, recommended action, confidence, evidence gaps, SLA, closure criteria, and linked raw finding IDs.
-- Add enum validation helpers for `unique_wrkr_signal` vs `supporting_security_signal`.
-- Keep raw detector findings unchanged and derive backlog items in aggregation.
-- Add fixture/golden output for a mixed org scan with CI workflow, MCP config, coding assistant config, dependency surface, and supporting secret reference.
+- Introduce a shared trusted-state-path preflight for stateful commands that rejects symlinked `--state` files before any managed artifact mutation begins.
+- Make `scan` and `identity` use the same fail-closed managed-artifact policy class as `inventory`.
+- Keep sibling manifest/proof/status path derivation anchored to the trusted non-symlink state root only.
+- Add rollback-safe hardening around preflight plus commit ordering so a rejected path never publishes a split artifact generation.
+- Update command docs and failure taxonomy to document consistent exit `8` behavior for unsafe managed state paths.
 
 Repo paths:
-- `core/model/finding.go`
-- `core/aggregate/controlbacklog/`
-- `core/aggregate/inventory/`
-- `core/risk/`
-- `core/state/`
-- `internal/scenarios/`
-- `scenarios/wrkr/control-backlog-governance/`
+- `core/cli/scan.go`
+- `core/cli/identity.go`
+- `core/cli/inventory_mutations.go`
+- `core/cli/managed_artifacts.go`
+- `internal/atomicwrite/atomicwrite.go`
+- `docs/commands/scan.md`
+- `docs/commands/identity.md`
+- `docs/failure_taxonomy_exit_codes.md`
+- `docs/state_lifecycle.md`
+- `CHANGELOG.md`
 
 Run commands:
-- `go test ./core/aggregate/controlbacklog ./core/aggregate/inventory ./core/model -count=1`
-- `go test ./internal/scenarios -run 'TestControlBacklogGovernance' -count=1 -tags=scenario`
+- `go run ./cmd/wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --state "$TMPDIR/state-link.json" --json`
+- `go run ./cmd/wrkr identity approve <agent_id> --approver @maria --scope read-only --state "$TMPDIR/state-link.json" --json`
+- `go test ./core/cli ./internal/atomicwrite -count=1`
+- `go test ./internal/e2e/source ./internal/e2e/cli_contract -count=1`
+- `go test ./testinfra/contracts -count=1`
 - `make test-contracts`
+- `make test-hardening`
+- `make test-chaos`
 - `make prepush-full`
 
 Test requirements:
-- Schema validation tests for the new backlog artifact.
-- Golden JSON repeat-run byte stability tests.
-- Compatibility tests proving existing `findings`, `top_findings`, and `inventory` JSON remain available.
-- Scenario fixture proving primary Wrkr signals rank before supporting security signals.
+- CLI `--json` stability tests for rejected symlinked `--state` input.
+- Exit-code contract tests proving `unsafe_operation_blocked` maps to exit `8`.
+- Machine-readable error-envelope tests for `scan` and `identity`.
+- Non-destructive fail-closed tests proving no managed artifacts are published after rejection.
+- Marker-trust and regular-file tests where managed artifact families are involved.
+- Cross-platform tests with explicit portability skips for symlink fixtures where needed.
 
 Matrix wiring:
-- Fast lane: targeted package tests.
-- Core CI lane: `make prepush`.
-- Acceptance lane: new scenario fixture.
-- Risk lane: `make test-contracts`, `make prepush-full`.
+- Fast lane: targeted `core/cli` and `internal/atomicwrite` tests.
+- Core CI lane: `make prepush` plus e2e CLI/source contract tests.
+- Acceptance lane: extend scenario/e2e coverage if a new fixture is needed.
+- Cross-platform lane: preserve `windows-smoke`, assert explicit skips for unsupported symlink fixtures.
+- Risk lane: `make prepush-full`, `make test-contracts`, `make test-hardening`, `make test-chaos`.
 
 Acceptance criteria:
-- `wrkr scan --path scenarios/wrkr/control-backlog-governance/repos --json` emits `control_backlog.control_backlog_version`.
-- Backlog item order is deterministic across two runs with distinct state paths.
-- Each backlog item has a valid signal class and links back to raw finding evidence.
-- Existing scan JSON consumers can still read `findings`, `top_findings`, and `inventory`.
-
-Changelog impact: required
-
-Changelog section: Added
-
-Draft changelog entry: Added the versioned control backlog contract for governance-first scan output while preserving existing raw finding JSON surfaces.
-
-Semver marker override: none
-
-Contract/API impact:
-- Adds stable scan JSON fields and artifact schema. Existing fields remain stable.
-
-Versioning/migration impact:
-- Add `control_backlog_version: "1"`. No migration required for old state files; old snapshots produce an empty or derived backlog when read.
-
-Architecture constraints:
-- Keep detector output as raw evidence and backlog aggregation as a separate package.
-- Thin CLI orchestration only; no risk logic embedded in `core/cli`.
-- Explicit side-effect-free API naming for backlog build functions.
-- Deterministic sort order by priority, confidence, repo, path, control type, and linked finding ID.
-
-ADR required: yes
-
-TDD first failing test(s):
-- `TestBuildControlBacklogSplitsSignalClassesAndSortsDeterministically`.
-- `TestScanJSONRetainsLegacyFindingSurfacesWithControlBacklog`.
-
-Cost/perf impact: medium
-
-Chaos/failure hypothesis:
-- If a raw finding has incomplete owner/evidence metadata, backlog construction emits a low-confidence item with explicit gaps instead of dropping it or panicking.
-
-### Story W1-S2: Add Action Taxonomy, Evidence Quality, And Confidence
-
-Priority: P0
-
-Tasks:
-- Define fixed recommended actions: `attach_evidence`, `approve`, `remediate`, `downgrade`, `deprecate`, `exclude`, `monitor`, `inventory_review`, `suppress`, `debug_only`.
-- Add evidence quality fields: confidence, evidence basis, evidence gaps, and what would raise confidence.
-- Map existing finding classes into default actions without changing detector semantics.
-- Add deterministic SLA assignment rules by action, capability, write-path class, security visibility, and confidence.
-- Add contract tests for every taxonomy value and reason-code stability.
-
-Repo paths:
-- `core/model/finding.go`
-- `core/aggregate/controlbacklog/`
-- `core/risk/`
-- `core/report/`
-- `docs/trust/contracts-and-schemas.md`
-
-Run commands:
-- `go test ./core/aggregate/controlbacklog ./core/risk ./core/report -count=1`
-- `go test ./internal/e2e/cli_contract -count=1`
-- `make test-contracts`
-- `make prepush-full`
-
-Test requirements:
-- Enum validation tests.
-- Golden JSON tests for each action.
-- CLI `--json` stability tests for error envelopes and valid/invalid action filters when filters are introduced.
-- Deterministic SLA rule tests.
-
-Matrix wiring:
-- Fast lane: targeted package tests.
-- Core CI lane: e2e CLI contract.
-- Risk lane: `make test-contracts`, `make prepush-full`.
-
-Acceptance criteria:
-- Every backlog item has exactly one allowed recommended action.
-- Secret-bearing workflows with only references default to `attach_evidence` or `approve`, not automatic `remediate`, unless unsafe value evidence exists.
-- Generated parse errors can be marked `suppress` or `debug_only` in scan quality surfaces.
-- Confidence basis and confidence-raising guidance are deterministic and non-empty for medium/low confidence items.
-
-Changelog impact: required
-
-Changelog section: Added
-
-Draft changelog entry: Added deterministic recommended-action, evidence-quality, confidence, and SLA fields to governance backlog items.
-
-Semver marker override: none
-
-Contract/API impact:
-- Adds stable enum values and backlog JSON fields.
-
-Versioning/migration impact:
-- Backlog schema remains version `1` if added before release; otherwise bump minor artifact version and preserve old readers.
-
-Architecture constraints:
-- Taxonomy mapping must live in aggregation/risk packages, not detectors.
-- Reason codes and action values must be stable and documented.
-- Fail closed on unknown configured taxonomy values.
-
-ADR required: yes
-
-TDD first failing test(s):
-- `TestRecommendedActionTaxonomyCoversKnownFindingFamilies`.
-- `TestEvidenceQualityExplainsOwnerFallbackConfidence`.
-
-Cost/perf impact: low
-
-Chaos/failure hypothesis:
-- If evidence basis is missing or contradictory, item confidence falls to low and the evidence gap is surfaced instead of silently treating the item as controlled.
-
-### Story W1-S3: Split Secret Reference Semantics From Secret Value Risk
-
-Priority: P0
-
-Tasks:
-- Introduce secret signal types: `secret_reference_detected`, `secret_value_detected`, `secret_scope_unknown`, `secret_rotation_evidence_missing`, `secret_owner_missing`, `secret_used_by_write_capable_workflow`.
-- Update secret detector and workflow capability aggregation so workflow references remain redacted and classified as references.
-- Add control backlog language that says rotation/owner/scope/proof evidence is missing rather than implying a leaked secret.
-- Add tests proving raw values are never emitted and workflow secret reference names are handled deterministically.
-
-Repo paths:
-- `core/detect/secrets/`
-- `core/detect/workflowcap/`
-- `core/aggregate/controlbacklog/`
-- `core/risk/`
-- `core/report/`
-- `scenarios/wrkr/secret-reference-semantics/`
-
-Run commands:
-- `go test ./core/detect/secrets ./core/detect/workflowcap ./core/aggregate/controlbacklog ./core/risk -count=1`
-- `go test ./internal/scenarios -run 'TestSecretReferenceSemantics' -count=1 -tags=scenario`
-- `make test-contracts`
-- `make prepush-full`
-
-Test requirements:
-- Unit tests for secret signal classification.
-- Redaction tests proving secret values are absent from JSON, Markdown, PDF, CSV, and ticket exports.
-- Scenario tests for rotation evidence attached vs missing.
-- Contract tests for secret signal enum stability.
-
-Matrix wiring:
-- Fast lane: detector and backlog tests.
-- Acceptance lane: new secret-reference scenario.
-- Risk lane: `make test-contracts`, `make prepush-full`.
-
-Acceptance criteria:
-- A GitHub workflow with `secrets.MY_TOKEN` produces `secret_reference_detected`, not `secret_value_detected`.
-- If the same workflow is write-capable, backlog item includes `secret_used_by_write_capable_workflow`.
-- If control evidence is attached, the item can close as controlled without remediation language.
-- No output contains raw secret values.
+- `wrkr scan --state <symlink> --json` exits `8` with `error.code=unsafe_operation_blocked`.
+- `wrkr identity approve --state <symlink> --json` exits `8` with the same error class.
+- No state, manifest, lifecycle, proof, attestation, signing-key, or status artifact is newly written when preflight rejects the path.
+- Existing non-symlink `--state` flows continue to pass CLI contract and e2e suites unchanged.
 
 Changelog impact: required
 
 Changelog section: Security
 
-Draft changelog entry: Refined secret-bearing automation semantics so Wrkr distinguishes secret references, leaked values, ownership/scope gaps, and rotation evidence gaps without exposing secret values.
+Draft changelog entry: Hardened stateful CLI commands to fail closed on symlinked `--state` paths so scan, manifest, and proof artifacts cannot split across directories.
 
 Semver marker override: none
 
 Contract/API impact:
-- Adds secret signal enum values and changes governance wording for secret findings. Legacy raw finding compatibility remains.
+- Consistently rejects symlinked managed state paths across stateful commands while preserving existing error-envelope shape and exit-code taxonomy.
 
 Versioning/migration impact:
-- Existing `secret_presence` findings are still accepted and mapped to the new secret signal types in governance outputs.
+- No schema change. Operators using symlinked `--state` paths must switch to real file paths.
 
 Architecture constraints:
-- Secret detectors may flag presence and references only; no raw value extraction.
-- Workflow-derived secret context must be merged in aggregation, not duplicated across detectors.
-- Default behavior remains offline and deterministic.
+- Keep orchestration thin in `core/cli`; centralize trusted-state-path checks in a focused helper.
+- Preserve explicit side-effect semantics in API names and signatures.
+- Use symmetric API semantics for managed state path validation and commit helpers across `scan`, `identity`, and `inventory`.
+- Preserve cancellation and timeout propagation where scan setup or state loading already accepts caller context.
+- Leave extension points for additional stateful commands to reuse the same trusted-state-path policy without copying logic.
+- Do not rely on hidden path canonicalization that weakens fail-closed ownership reasoning.
+- Preserve deterministic local-only behavior; no network fallback or best-effort continuation.
 
 ADR required: yes
 
 TDD first failing test(s):
-- `TestWorkflowSecretReferenceDoesNotClaimLeakedSecret`.
-- `TestSecretValueNeverAppearsInGovernanceOutputs`.
+- `TestScanRejectsSymlinkedStatePath`
+- `TestIdentityRejectsSymlinkedStatePath`
+- `TestScanRejectsUnsafeStateBeforePublishingManagedArtifacts`
 
 Cost/perf impact: low
 
 Chaos/failure hypothesis:
-- If a workflow file cannot be parsed, Wrkr moves the parse failure to scan quality and does not invent secret risk from unreadable content.
+- If the managed state path is unsafe or becomes ambiguous during mutation setup, Wrkr fails closed and leaves the prior committed artifact generation intact.
 
-### Story W1-S4: Add Scan Modes And Generated-Path Noise Policy
-
-Priority: P0
-
-Tasks:
-- Add `--mode quick|governance|deep` to `wrkr scan`.
-- Make `governance` the default mode.
-- Define mode-specific detector/path scope: quick scans high-signal repo/CI/agent/MCP files, governance scans control backlog evidence surfaces, deep runs exhaustive detector/debug scope.
-- Add default generated/package suppression for `dist/`, `build/`, nested `target/`, `.yarn/sdks/`, `node_modules/`, generated SDK folders, vendored dependency trees, minified JS, and package-manager internals.
-- Move parse errors from suppressed/generated paths into `scan_quality` instead of top-level governance backlog.
-- Preserve deterministic ordering and explicit inclusion behavior for deep mode.
-
-Repo paths:
-- `core/cli/scan.go`
-- `core/detect/`
-- `core/source/local/`
-- `core/source/github/`
-- `core/aggregate/scanquality/`
-- `internal/e2e/source/`
-- `scenarios/wrkr/first-offer-noise-pack/`
-- `docs/commands/scan.md`
-
-Run commands:
-- `go test ./core/detect/... ./core/source/local ./core/source/github ./core/aggregate/scanquality -count=1`
-- `go test ./internal/e2e/source -count=1`
-- `go test ./internal/acceptance -run 'TestV1Acceptance/AC06_scan_diff_no_noise' -count=1`
-- `make test-perf`
-- `make prepush-full`
-
-Test requirements:
-- CLI help/usage tests for `--mode`.
-- Invalid mode exit-code and JSON error envelope tests.
-- Fixture/golden tests for quick/governance/deep output differences.
-- Generated path suppression tests including symlink and nested-root safety.
-- Perf regression tests for large path sets.
-
-Matrix wiring:
-- Fast lane: source/detect/scanquality package tests.
-- Core CI lane: e2e source tests.
-- Acceptance lane: noise scenario and acceptance no-noise check.
-- Cross-platform lane: Windows path separator smoke.
-- Risk lane: `make test-perf`, `make prepush-full`.
-
-Acceptance criteria:
-- `wrkr scan --path <repos> --json` behaves as governance mode.
-- `wrkr scan --mode deep --json` can include debug/raw parse errors that governance mode suppresses from the backlog.
-- Suppressed paths are represented in `scan_quality` with counts and rationale, sorted deterministically.
-- Invalid `--mode` exits `6` with JSON error code `invalid_input`.
-
-Changelog impact: required
-
-Changelog section: Changed
-
-Draft changelog entry: Made governance scan mode the default, added quick/deep scan modes, and moved generated/package noise into a deterministic scan-quality appendix.
-
-Semver marker override: none
-
-Contract/API impact:
-- Adds CLI flag and scan JSON fields. Changes default prioritization and human output, but keeps legacy raw JSON fields.
-
-Versioning/migration impact:
-- No state migration required. New state snapshots include mode and scan-quality metadata.
-
-Architecture constraints:
-- Path filtering must be a reusable deterministic source/detector scope layer.
-- Mode selection must not be hidden global state.
-- Long-running scan loops must propagate context cancellation.
-
-ADR required: yes
-
-TDD first failing test(s):
-- `TestScanModeGovernanceSuppressesGeneratedPathNoise`.
-- `TestScanModeDeepKeepsDebugParseErrorsInScanQuality`.
-- `TestInvalidScanModeJSONErrorEnvelope`.
-
-Cost/perf impact: medium
-
-Chaos/failure hypothesis:
-- If suppression encounters unreadable paths or unsafe symlinks, scan quality records deterministic warnings and high-risk unreadable control paths fail closed when applicable.
-
-## Epic Wave 2: Govern-First Runtime Output
+## Wave 2: Authoritative Mutation Snapshot Projection
 
 Objective:
-- Make the new contracts visible in operator output, write-path classification, control mapping, and security visibility without removing existing scanner evidence.
+- Make saved snapshot state authoritative immediately after manual identity and inventory mutations, including any derived posture surfaces consumed by downstream commands.
 
-### Story W2-S1: Make Control Backlog The Default Scan Decision Surface
+### Story W2-S1: Centralize Identity And Inventory Mutation Projection Into Saved State
 
-Priority: P0
-
-Tasks:
-- Emit `control_backlog` in scan JSON and persist it in scan state.
-- Update human `wrkr scan --explain` to lead with top backlog items and rationale.
-- Keep stdout clean JSON when `--json` is set; send progress and warnings to stderr only.
-- Put raw findings, parse errors, detector errors, and generated-path issues in appendix-style JSON surfaces.
-- Add `--top` or reuse existing report top behavior only if needed for backlog count; otherwise default to top 10 backlog items.
-
-Repo paths:
-- `core/cli/scan.go`
-- `core/state/`
-- `core/report/activation.go`
-- `core/report/render_markdown.go`
-- `docs/commands/scan.md`
-- `internal/e2e/cli_contract/`
-- `internal/acceptance/`
-
-Run commands:
-- `go test ./core/cli ./core/state ./core/report -count=1`
-- `go test ./internal/e2e/cli_contract -count=1`
-- `go test ./internal/acceptance -run 'TestV1Acceptance' -count=1`
-- `scripts/check_docs_cli_parity.sh`
-- `make test-contracts`
-
-Test requirements:
-- CLI `--json` stdout-only stability tests.
-- Help/usage tests for new mode/default wording.
-- Golden scan JSON tests for backlog and raw appendix.
-- Exit-code invariants for unchanged success/failure paths.
-
-Matrix wiring:
-- Fast lane: CLI/report package tests.
-- Core CI lane: e2e CLI contract.
-- Acceptance lane: V1 acceptance with new governance assertions.
-- Risk lane: `make test-contracts`.
-
-Acceptance criteria:
-- `wrkr scan --json` has valid `control_backlog.items` and no non-JSON stdout.
-- `wrkr scan --explain` answers which items security should review first.
-- Raw findings are still emitted in JSON for downstream compatibility.
-- Warnings, progress, and scan-quality notes do not corrupt JSON stdout.
-
-Changelog impact: required
-
-Changelog section: Changed
-
-Draft changelog entry: Changed scan output to lead with a prioritized control backlog while keeping raw findings available for compatibility.
-
-Semver marker override: none
-
-Contract/API impact:
-- Adds new default JSON and human output surfaces. Existing JSON fields remain.
-
-Versioning/migration impact:
-- Existing state files remain readable. New state files include backlog and scan quality.
-
-Architecture constraints:
-- CLI should call aggregation/report builders, not rank backlog inline.
-- Output writers must keep stdout/stderr separation explicit.
-- Context cancellation must flush partial progress safely.
-
-ADR required: yes
-
-TDD first failing test(s):
-- `TestScanJSONStdoutContainsOnlyJSONWithControlBacklog`.
-- `TestScanExplainLeadsWithTopControlBacklogItems`.
-
-Cost/perf impact: medium
-
-Chaos/failure hypothesis:
-- If report/backlog artifact writing fails after state save begins, managed artifact rollback preserves previous state and emits deterministic runtime error.
-
-### Story W2-S2: Add Write-Path Classification And Control Mapping
-
-Priority: P0
+Priority:
+- P0
 
 Tasks:
-- Define write-path classes: `read`, `write`, `pr_write`, `repo_write`, `release_write`, `package_publish`, `deploy_write`, `infra_write`, `secret_bearing_execution`, `production_adjacent_write`.
-- Derive write-path class from workflow permissions, workflow steps, MCP/tool config, non-human identities, and dependency agent surfaces.
-- Map backlog items to controls: owner assigned, approval recorded, least privilege verified, rotation evidence attached, deployment gate present, production access classified, proof artifact generated, review cadence set.
-- Ensure write-path classification is visible in scan JSON, inventory, reports, regress drift, and ticket exports.
+- Create a shared mutation transaction helper that loads state, manifest, lifecycle chain, and proof chain from one trusted state root.
+- Reuse the helper for `identity` and `inventory` command families instead of keeping an identity-only manifest/proof mutation path.
+- Project the updated identity record, lifecycle transition, inventory visibility, control backlog effects, and transition history into the saved snapshot in the same transaction.
+- Preserve rollback guarantees across `state.json`, manifest, lifecycle chain, proof chain, proof attestation, and signing material.
+- Ensure mutation success never leaves manifest/proof ahead of saved state.
 
 Repo paths:
-- `core/detect/workflowcap/`
-- `core/aggregate/inventory/privileges.go`
-- `core/aggregate/controlbacklog/`
-- `core/risk/attackpath/`
-- `core/risk/classify/`
-- `core/compliance/`
-- `core/proofmap/`
-- `internal/scenarios/workflow_capabilities_scenario_test.go`
-- `scenarios/wrkr/write-path-classification/`
-
-Run commands:
-- `go test ./core/detect/workflowcap ./core/aggregate/inventory ./core/aggregate/controlbacklog ./core/risk/... ./core/compliance ./core/proofmap -count=1`
-- `go test ./internal/scenarios -run 'TestWorkflowCapabilities|TestWritePathClassification' -count=1 -tags=scenario`
-- `make test-contracts`
-- `make test-scenarios`
-- `make prepush-full`
-
-Test requirements:
-- Unit tests for each write-path class.
-- Scenario fixtures for PR write plus secret reference, deploy workflow with environment gate, package publish, and infra write.
-- Contract tests proving enum names remain stable.
-- Compliance/proof mapping tests for each governance control.
-
-Matrix wiring:
-- Fast lane: detector/risk/compliance targeted tests.
-- Acceptance lane: workflow capability and new write-path scenario.
-- Risk lane: `make test-contracts`, `make test-scenarios`, `make prepush-full`.
-
-Acceptance criteria:
-- A workflow with `pull-requests: write` and `secrets.*` produces `pr_write` plus `secret_bearing_execution`.
-- A release workflow with publish/deploy steps produces release/deploy/package classes as applicable.
-- Control mappings are deterministic and explain which evidence is present or missing.
-- Existing attack/action path output includes write-path class references without breaking prior fields.
-
-Changelog impact: required
-
-Changelog section: Added
-
-Draft changelog entry: Added explicit engineering write-path classification and governance control mappings across scan, inventory, risk, and proof outputs.
-
-Semver marker override: none
-
-Contract/API impact:
-- Adds enum fields to scan, inventory, backlog, and report JSON.
-
-Versioning/migration impact:
-- Additive schema changes only. Old snapshots derive write-path classes when possible.
-
-Architecture constraints:
-- Detection extracts evidence; classification and control mapping happen in risk/aggregation/compliance layers.
-- No workflow execution or remote lookup is introduced.
-- Structured YAML parser behavior remains `gopkg.in/yaml.v3` compatible.
-
-ADR required: yes
-
-TDD first failing test(s):
-- `TestWritePathClassifiesPRWriteSecretBearingWorkflow`.
-- `TestControlMappingRequiresLeastPrivilegeAndProofEvidence`.
-
-Cost/perf impact: medium
-
-Chaos/failure hypothesis:
-- If workflow permissions are ambiguous or inherited, classify confidence as medium/low and surface evidence gaps rather than assuming least privilege.
-
-### Story W2-S3: Expand Security Visibility States
-
-Priority: P1
-
-Tasks:
-- Add governance-native states: `known_approved`, `known_unapproved`, `unknown_to_security`, `accepted_risk`, `deprecated`, `revoked`, `needs_review`.
-- Preserve old inventory status compatibility with shim mapping.
-- Update rollups for tools, agents, write-capable agents, and backlog items.
-- Add drift behavior for expired approvals and revoked/deprecated reappearance.
-- Update docs and schema contract references.
-
-Repo paths:
-- `core/aggregate/inventory/`
-- `core/lifecycle/`
-- `core/manifest/`
-- `core/regress/`
-- `core/aggregate/controlbacklog/`
+- `core/cli/identity.go`
+- `core/cli/inventory_mutations.go`
+- `core/cli/managed_artifacts.go`
+- `core/state/state.go`
+- `core/lifecycle/lifecycle.go`
+- `docs/commands/identity.md`
+- `docs/commands/inventory.md`
 - `docs/state_lifecycle.md`
-- `docs/commands/inventory.md`
-- `docs/trust/contracts-and-schemas.md`
+- `docs/failure_taxonomy_exit_codes.md`
+- `CHANGELOG.md`
 
 Run commands:
-- `go test ./core/aggregate/inventory ./core/lifecycle ./core/manifest ./core/regress ./core/aggregate/controlbacklog -count=1`
-- `go test ./internal/e2e/regress -count=1`
-- `scripts/check_docs_cli_parity.sh`
-- `make test-contracts`
-- `make prepush-full`
-
-Test requirements:
-- Compatibility tests for old `approved` state.
-- Lifecycle transition tests for accepted risk, deprecated, revoked, and needs review.
-- Drift tests for approval expiry and deprecated reappearance.
-- Schema/golden updates for visibility rollups.
-
-Matrix wiring:
-- Fast lane: inventory/lifecycle/regress package tests.
-- Core CI lane: e2e regress.
-- Risk lane: `make test-contracts`, `make prepush-full`.
-
-Acceptance criteria:
-- New governance backlog uses `known_approved` for approved controls.
-- Existing inventory readers still accept current `approved` status where emitted historically.
-- Expired approvals move affected items to `needs_review`.
-- Revoked or deprecated paths that reappear produce deterministic drift reasons.
-
-Changelog impact: required
-
-Changelog section: Changed
-
-Draft changelog entry: Expanded security visibility into governance-native states for approved, unapproved, accepted-risk, deprecated, revoked, and needs-review control paths.
-
-Semver marker override: none
-
-Contract/API impact:
-- Adds/changes visibility enum in new governance surfaces and shims old values.
-
-Versioning/migration impact:
-- Old manifests and state snapshots are migrated in-memory through compatibility mapping.
-
-Architecture constraints:
-- Lifecycle state transitions remain deterministic and proof-record-backed.
-- Visibility rollups must not borrow approval across orgs or repos.
-- Fail closed on invalid manually supplied visibility state.
-
-ADR required: yes
-
-TDD first failing test(s):
-- `TestSecurityVisibilityMapsApprovedToKnownApprovedInBacklog`.
-- `TestExpiredApprovalMovesBacklogItemToNeedsReview`.
-
-Cost/perf impact: low
-
-Chaos/failure hypothesis:
-- If lifecycle manifest has invalid approval metadata, state becomes `needs_review` or `revoked` according to deterministic rules rather than silently staying approved.
-
-## Epic Wave 3: Approval Inventory, Evidence, And Drift
-
-Objective:
-- Turn discovery into lifecycle governance: attach evidence, approve, accept risk, deprecate, exclude, expire approvals, and monitor drift from approved baselines.
-
-### Story W3-S1: Add Approval Inventory Workflow Commands
-
-Priority: P1
-
-Tasks:
-- Add `wrkr inventory approve <id> --owner <team> --evidence <ticket-or-url> --expires <date> --json`.
-- Add `wrkr inventory attach-evidence <id> --control <control-id> --url <url> --json`.
-- Add `wrkr inventory accept-risk <id> --expires <duration-or-date> --json`.
-- Add `wrkr inventory deprecate <id> --reason <reason> --json`.
-- Add `wrkr inventory exclude <id> --reason <reason> --json`.
-- Store approval owner, evidence URL, control ID, approval expiry, review cadence, last reviewed date, exclusion reason, and renewal state in deterministic state/manifest artifacts.
-- Require regular-file markers and safe managed output paths for state mutations.
-
-Repo paths:
-- `core/cli/inventory.go`
-- `core/lifecycle/`
-- `core/manifest/`
-- `core/state/`
-- `core/evidence/`
-- `core/proofemit/`
-- `internal/atomicwrite/`
-- `internal/e2e/cli_contract/`
-- `docs/commands/inventory.md`
-
-Run commands:
-- `go test ./core/cli ./core/lifecycle ./core/manifest ./core/state ./core/evidence ./core/proofemit ./internal/atomicwrite -count=1`
-- `go test ./internal/e2e/cli_contract -count=1`
+- `go run ./cmd/wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --state "$TMPDIR/state.json" --json --quiet`
+- `go run ./cmd/wrkr identity approve <agent_id> --approver @maria --scope read-only --expires 90d --state "$TMPDIR/state.json" --json`
+- `go run ./cmd/wrkr inventory approve <agent_id> --owner team --evidence SEC-1 --expires 90d --state "$TMPDIR/state.json" --json`
+- `go test ./core/cli ./core/state ./core/lifecycle -count=1`
+- `go test ./internal/e2e/cli_contract ./internal/e2e/verify -count=1`
+- `go test ./testinfra/contracts -count=1`
 - `make test-contracts`
 - `make test-hardening`
 - `make test-chaos`
 - `make prepush-full`
 
 Test requirements:
-- CLI help/usage tests.
-- `--json` stability tests.
-- Exit-code tests for missing id, invalid expiry, invalid evidence URL/path, unknown action, and unsafe output path.
-- Crash-safe atomic write and rollback tests.
-- Marker trust tests: marker must be regular file; reject symlink/directory.
-- Approval expiry and renewal lifecycle tests.
+- CLI `--json` success-path contract tests proving saved state changes on manual identity mutation.
+- Rollback tests that inject failure after partial transaction progress and verify prior committed state is restored.
+- Atomic-write and lifecycle contention tests for multi-artifact mutation sequencing.
+- Deterministic repeat-run tests for identical mutation inputs.
+- Failure taxonomy tests preserving runtime-failure behavior on downstream commit failure.
 
 Matrix wiring:
-- Fast lane: targeted CLI/lifecycle/state tests.
-- Core CI lane: e2e CLI contract.
-- Risk lane: `make test-contracts`, `make test-hardening`, `make test-chaos`, `make prepush-full`.
+- Fast lane: targeted `core/cli`, `core/state`, and `core/lifecycle` tests.
+- Core CI lane: `make prepush` plus e2e CLI/verify coverage.
+- Acceptance lane: extend acceptance coverage for post-approval saved-state authority.
+- Cross-platform lane: preserve path-safe behavior on Windows/macOS/Linux.
+- Risk lane: `make prepush-full`, `make test-contracts`, `make test-hardening`, `make test-chaos`.
 
 Acceptance criteria:
-- Each inventory mutation emits a deterministic JSON response and proof/lifecycle transition record.
-- Invalid or unsafe state mutation exits with the correct machine-readable error envelope.
-- Approval expiry is enforced in subsequent scan/regress output.
-- Excluded items remain in evidence appendices but leave the active governance backlog with explicit rationale.
+- After `wrkr identity approve|review|deprecate|revoke --state <path> --json`, the corresponding record in `state.json` matches the committed manifest lifecycle and approval state.
+- After equivalent `wrkr inventory` mutations, the same record family remains synchronized across state, manifest, lifecycle, and proof artifacts.
+- Injected failure after any transaction step restores the prior committed generation rather than leaving mixed artifact state.
+- Successful mutations never require a follow-up scan merely to make the saved snapshot internally consistent.
 
 Changelog impact: required
 
-Changelog section: Added
+Changelog section: Fixed
 
-Draft changelog entry: Added inventory governance commands for approvals, evidence attachments, accepted risk, deprecation, exclusion, and time-bound review state.
+Draft changelog entry: Fixed manual identity and inventory mutations to update the saved scan snapshot in the same rollback-safe transaction as manifest and proof artifacts.
 
 Semver marker override: none
 
 Contract/API impact:
-- Adds inventory subcommands and state/proof artifact fields.
+- Strengthens the existing saved-state authority contract for downstream commands without changing command names, exit codes, or JSON envelope shape.
 
 Versioning/migration impact:
-- Add `approval_inventory_version`. Old manifests read with missing approvals as `missing` or `needs_review`.
+- No schema change. Historic stale-state behavior is corrected in place.
 
 Architecture constraints:
-- Use plan/apply style APIs for mutating lifecycle state.
-- Mutations must be atomic and rollback-safe.
-- Proof emission remains file-based and verifiable.
-- No network validation of evidence URLs by default.
+- Use thin CLI orchestration with a focused mutation-transaction helper.
+- Keep lifecycle logic in `core/lifecycle`, state persistence in `core/state`, and proof emission in `core/proofemit`.
+- Make mutation helper semantics explicit in names and signatures (`load`, `project`, `commit`, `rollback`).
+- Use symmetric mutation APIs so manual identity and inventory mutations share the same projection and rollback contract.
+- Preserve existing context propagation and timeout boundaries where commands already support them.
+- Leave extension points for future stateful mutation commands without re-implementing artifact sequencing.
+- Preserve deterministic ordering and rollback guarantees across all managed artifact writes.
 
 ADR required: yes
 
 TDD first failing test(s):
-- `TestInventoryApproveWritesApprovalProofRecordAtomically`.
-- `TestInventoryAcceptRiskRequiresExpiry`.
-- `TestInventoryMutationRejectsUnsafeManagedMarker`.
-
-Cost/perf impact: medium
-
-Chaos/failure hypothesis:
-- If the process crashes during approval write, previous state remains readable and no partial proof chain is treated as valid.
-
-### Story W3-S2: Productize Proof And Evidence Lifecycle
-
-Priority: P1
-
-Tasks:
-- Define evidence/control proof records for owner assigned, approval recorded, least privilege verified, rotation evidence attached, deployment gate present, production access classified, proof artifact generated, and review cadence set.
-- Map backlog closure criteria to proof requirements.
-- Ensure `wrkr evidence --json`, `wrkr verify --chain --json`, and reports can show whether proof exists for each control.
-- Keep `Clyra-AI/proof` primitives authoritative for proof record creation and verification.
-- Add compatibility assertions for proof chain integrity and mixed scan/evidence records.
-
-Repo paths:
-- `core/evidence/`
-- `core/proofemit/`
-- `core/proofmap/`
-- `core/compliance/`
-- `core/verify/`
-- `core/cli/evidence.go`
-- `core/cli/verify.go`
-- `scenarios/cross-product/proof-record-interop/`
-- `docs/trust/proof-chain-verification.md`
-- `docs/evidence_templates.md`
-
-Run commands:
-- `go test ./core/evidence ./core/proofemit ./core/proofmap ./core/compliance ./core/verify ./core/cli -count=1`
-- `go test ./internal/integration/interop -count=1`
-- `go test ./internal/scenarios -run 'TestPolicyComplianceMapping|TestWave3Compliance' -count=1 -tags=scenario`
-- `make test-contracts`
-- `make test-scenarios`
-- `make prepush-full`
-
-Test requirements:
-- Proof record schema validation tests.
-- Chain integrity tests with mixed scan/evidence records.
-- Golden tests for evidence bundle closure criteria.
-- CLI JSON tests for evidence and verify output.
-
-Matrix wiring:
-- Fast lane: proof/evidence/compliance package tests.
-- Core CI lane: interop integration.
-- Acceptance lane: compliance/proof scenarios.
-- Risk lane: `make test-contracts`, `make test-scenarios`, `make prepush-full`.
-
-Acceptance criteria:
-- Every control backlog item can explain which proof artifacts exist and which are missing.
-- Attached evidence creates verifiable proof records with stable record types.
-- `wrkr verify --chain --json` validates the resulting proof chain.
-- Compliance mapping can consume the same evidence without product-specific hacks.
-
-Changelog impact: required
-
-Changelog section: Added
-
-Draft changelog entry: Added proof and evidence lifecycle mapping so governance controls can show verifiable approval, least-privilege, rotation, deployment-gate, and review evidence.
-
-Semver marker override: none
-
-Contract/API impact:
-- Adds proof/evidence record fields and evidence JSON surfaces.
-
-Versioning/migration impact:
-- Existing proof chains remain valid; new records append with stable types.
-
-Architecture constraints:
-- Do not duplicate proof primitive semantics outside `Clyra-AI/proof`.
-- Compliance mapping consumes evidence abstractions, not raw detector internals.
-- Verification failure remains exit `2`.
-
-ADR required: yes
-
-TDD first failing test(s):
-- `TestControlEvidenceRecordVerifiesInProofChain`.
-- `TestBacklogClosureCriteriaMapsToProofRequirements`.
+- `TestIdentityApproveUpdatesSavedStateSnapshot`
+- `TestIdentityManualTransitionRollsBackSavedStateOnDownstreamFailure`
+- `TestInventoryAndIdentityMutationsShareOneArtifactGenerationContract`
 
 Cost/perf impact: low
 
 Chaos/failure hypothesis:
-- If proof append fails after state mutation planning, mutation apply is blocked or rolled back and verification remains fail-closed.
+- If a mutation succeeds logically but a later artifact commit fails, Wrkr restores the prior saved generation and does not expose a partially approved posture to downstream commands.
 
-### Story W3-S3: Add Drift-First Approved Baseline Monitoring
+Dependencies:
+- W1-S1
 
-Priority: P1
+### Story W2-S2: Recompute Derived Posture Surfaces After Approval Mutations
 
-Tasks:
-- Extend regress baselines with approved control-path state, security visibility, owner, evidence expiry, write-path class, secret-bearing status, and confidence.
-- Add drift categories: `new_unknown_automation`, `new_repo_write_path`, `new_secret_bearing_workflow`, `new_mcp_tool_config`, `approval_expired`, `owner_changed`, `approved_path_risk_increased`, `deprecated_path_reappeared`.
-- Update `wrkr regress init --baseline <state> --json`, `wrkr regress run --baseline <baseline> --state <state> --json`, and `wrkr inventory --diff --json` outputs.
-- Keep drift exit code `5`.
-- Add summary markdown/report integration for drift categories.
-
-Repo paths:
-- `core/regress/`
-- `core/diff/`
-- `core/cli/regress.go`
-- `core/cli/inventory.go`
-- `core/report/`
-- `core/aggregate/controlbacklog/`
-- `internal/e2e/regress/`
-- `scenarios/wrkr/drift-first-baseline/`
-- `docs/commands/regress.md`
-
-Run commands:
-- `go test ./core/regress ./core/diff ./core/cli ./core/report ./core/aggregate/controlbacklog -count=1`
-- `go test ./internal/e2e/regress -count=1`
-- `go test ./internal/scenarios -run 'TestDriftFirstBaseline' -count=1 -tags=scenario`
-- `make test-contracts`
-- `make test-scenarios`
-- `make prepush-full`
-
-Test requirements:
-- Baseline schema compatibility tests.
-- Drift reason-code stability tests.
-- Exit-code `5` contract tests.
-- Golden JSON for every new drift category.
-- Scenario tests for approved path becoming higher risk and deprecated path reappearing.
-
-Matrix wiring:
-- Fast lane: regress/diff/report package tests.
-- Core CI lane: e2e regress.
-- Acceptance lane: new drift scenario.
-- Risk lane: `make test-contracts`, `make test-scenarios`, `make prepush-full`.
-
-Acceptance criteria:
-- Regress output leads with new/changed unknown control paths since approved baseline.
-- Approval expiry creates `approval_expired` drift and moves visibility to `needs_review`.
-- Owner changes are reported with old/new owner and source.
-- Drift output remains sorted and byte-stable.
-
-Changelog impact: required
-
-Changelog section: Changed
-
-Draft changelog entry: Changed regress and inventory drift to focus on new or changed AI/automation control paths, approval expiry, owner changes, and risk increases from approved baselines.
-
-Semver marker override: none
-
-Contract/API impact:
-- Extends regress baseline schema and drift JSON reasons while preserving exit code `5`.
-
-Versioning/migration impact:
-- Add baseline compatibility reader for prior `BaselineVersion`. Bump baseline version only with migration tests.
-
-Architecture constraints:
-- Regress compares persisted state and backlog summaries; it must not rescan or call detectors.
-- Drift reason codes are stable public contract.
-- Ambiguous baseline reads fail closed with machine-readable errors.
-
-ADR required: yes
-
-TDD first failing test(s):
-- `TestRegressDetectsNewSecretBearingWriteWorkflow`.
-- `TestRegressDetectsApprovalExpiredAndOwnerChanged`.
-
-Cost/perf impact: medium
-
-Chaos/failure hypothesis:
-- If baseline is partially written or schema-invalid, regress exits fail-closed with deterministic error and does not produce misleading no-drift output.
-
-## Epic Wave 4: Ownership And Large-Org Operator UX
-
-Objective:
-- Make governance scalable for hundreds of repos by resolving owners better and making long-running scans observable without violating offline-first defaults.
-
-### Story W4-S1: Add Enterprise Ownership Resolution
-
-Priority: P1
+Priority:
+- P1
 
 Tasks:
-- Extend `core/owners` to support CODEOWNERS, custom owner mapping files, service catalog exports, Backstage catalog files, GitHub teams/repo topics when available from source metadata, and fallback owner rules.
-- Add owner source states: `explicit_owner`, `inferred_owner`, `conflicting_owner`, `missing_owner`.
-- Add ownership confidence and evidence basis.
-- Keep all network ownership lookups tied to already configured source acquisition; no standalone network calls by default.
-- Surface owner quality in backlog, inventory, reports, and ticket exports.
+- Identify which snapshot sections are approval- or lifecycle-derived and must be recomputed or invalidated after mutation success.
+- Recompute `posture_score` and any directly approval-derived inventory/backlog summary surfaces as part of the mutation transaction.
+- Add downstream CLI contract tests for `score`, `report`, `regress init`, and `regress run` immediately after approval mutation without rescanning.
+- Keep recomputation deterministic and local; do not invoke detectors or network lookups.
+- Update docs to state explicitly that saved snapshot posture remains authoritative between scans.
 
 Repo paths:
-- `core/owners/`
-- `core/source/github/`
-- `core/source/org/`
-- `core/aggregate/inventory/`
-- `core/aggregate/controlbacklog/`
-- `docs/examples/`
-- `scenarios/wrkr/ownership-quality/`
-- `internal/scenarios/ownership_quality_scenario_test.go`
-
-Run commands:
-- `go test ./core/owners ./core/source/github ./core/source/org ./core/aggregate/inventory ./core/aggregate/controlbacklog -count=1`
-- `go test ./internal/scenarios -run 'TestOwnershipQuality' -count=1 -tags=scenario`
-- `make test-contracts`
-- `make prepush-full`
-
-Test requirements:
-- Parser tests for CODEOWNERS, custom mappings, Backstage/service catalog fixtures.
-- Conflict resolution tests with deterministic tie-breaking.
-- Source adapter parity tests for available GitHub ownership metadata.
-- Scenario tests for explicit, inferred, conflicting, and missing owners.
-
-Matrix wiring:
-- Fast lane: owners/source/inventory tests.
-- Acceptance lane: ownership quality scenario.
-- Risk lane: `make test-contracts`, `make prepush-full`.
-
-Acceptance criteria:
-- Backlog items distinguish explicit, inferred, conflicting, and missing owners.
-- Ownership confidence drives backlog evidence gaps and SLA.
-- Local/offline scans work without GitHub owner metadata.
-- Conflicting owner data is surfaced as a governance gap, not silently resolved.
-
-Changelog impact: required
-
-Changelog section: Added
-
-Draft changelog entry: Added enterprise ownership resolution with explicit, inferred, conflicting, and missing owner states plus ownership confidence in governance outputs.
-
-Semver marker override: none
-
-Contract/API impact:
-- Adds ownership fields and optional owner mapping config surfaces.
-
-Versioning/migration impact:
-- Existing owner fields remain; new owner quality metadata is additive.
-
-Architecture constraints:
-- Vendor/source schemas must be isolated behind owner/source adapter boundaries.
-- Fallback owner rules must be deterministic and documented.
-- Optional network-derived metadata must not alter offline default behavior.
-
-ADR required: yes
-
-TDD first failing test(s):
-- `TestResolveOwnershipFromCustomMappingBeforeFallback`.
-- `TestConflictingOwnersLowerConfidenceAndCreateEvidenceGap`.
-
-Cost/perf impact: medium
-
-Chaos/failure hypothesis:
-- If external ownership metadata is unavailable or stale, Wrkr falls back deterministically and marks confidence/evidence gaps rather than failing the entire scan.
-
-### Story W4-S2: Improve Large-Org Operator UX And Scan Status
-
-Priority: P1
-
-Tasks:
-- Add phase timing and current phase/repo count to scan progress on stderr.
-- Persist last successful phase and partial result marker for interrupted org scans.
-- Add `wrkr scan status --state <path> --json` or equivalent subcommand with deterministic status output.
-- Document `nohup`/background pattern if `--background` is not implemented; avoid hidden daemons.
-- Ensure `--quiet`, `--json`, and `--explain` interactions remain contract-tested.
-- Add failure footer with last successful phase and artifact paths.
-
-Repo paths:
-- `core/cli/scan.go`
-- `core/cli/scan_progress_test.go`
-- `core/state/`
-- `core/source/org/`
-- `internal/e2e/source/`
-- `docs/commands/scan.md`
-- `docs/examples/operator-playbooks.md`
-
-Run commands:
-- `go test ./core/cli ./core/state ./core/source/org -count=1`
-- `go test ./internal/e2e/source -count=1`
-- `make test-hardening`
-- `make test-chaos`
-- `make test-perf`
-- `make prepush-full`
-
-Test requirements:
-- CLI stdout/stderr separation tests.
-- Lifecycle/status tests for completed, running, interrupted, partial, and failed scans.
-- Crash-safe/atomic status update tests.
-- Contention/concurrency tests for status reads during scan writes.
-- Perf tests on large synthetic org manifests.
-
-Matrix wiring:
-- Fast lane: CLI/state/source tests.
-- Core CI lane: e2e source tests.
-- Cross-platform lane: Windows status-path smoke.
-- Risk lane: `make test-hardening`, `make test-chaos`, `make test-perf`, `make prepush-full`.
-
-Acceptance criteria:
-- JSON stdout remains clean for `wrkr scan --json`.
-- Progress, phase timing, warnings, and failure footer go to stderr.
-- Interrupted scans preserve a deterministic partial state marker and last successful phase.
-- `wrkr scan status --json` can describe the last scan without rescanning.
-
-Changelog impact: required
-
-Changelog section: Added
-
-Draft changelog entry: Added large-org scan progress, phase timing, partial-result status, and scan status inspection without changing JSON stdout contracts.
-
-Semver marker override: none
-
-Contract/API impact:
-- Adds scan status command/subcommand and status JSON fields.
-
-Versioning/migration impact:
-- Existing state files report status as unknown or completed based on available snapshot fields.
-
-Architecture constraints:
-- No hidden background daemon by default.
-- Status writes must be atomic and readable under contention.
-- Cancellation/timeouts must propagate through source acquisition and detector execution.
-
-ADR required: yes
-
-TDD first failing test(s):
-- `TestScanJSONProgressOnlyOnStderr`.
-- `TestScanStatusReportsInterruptedPartialPhase`.
-
-Cost/perf impact: medium
-
-Chaos/failure hypothesis:
-- If an org scan is interrupted while writing state, the next status read returns partial/interrupted metadata and does not corrupt the prior completed snapshot.
-
-## Epic Wave 5: Reports And Work Export
-
-Objective:
-- Turn governance outputs into customer-ready artifacts and work items after the core contract/runtime behavior is stable.
-
-### Story W5-S1: Add Native Customer Report Templates Led By Control Backlog
-
-Priority: P2
-
-Tasks:
-- Add report templates: `ciso`, `appsec`, `platform`, `audit`, `customer-draft`.
-- Generate PDF, Markdown, JSON evidence bundle, and CSV backlog from a single report command.
-- Lead every report with the control backlog and move raw findings to an appendix.
-- Add redaction/public share-profile handling for customer-draft reports.
-- Update report docs, examples, and acceptance fixtures.
-
-Repo paths:
+- `core/cli/inventory_mutations.go`
+- `core/cli/score.go`
 - `core/cli/report.go`
-- `core/report/`
-- `core/report/templates/`
-- `core/export/appendix/`
-- `core/export/inventory/`
-- `internal/acceptance/report_pdf_acceptance_test.go`
-- `internal/scenarios/epic9_scenario_test.go`
+- `core/cli/regress.go`
+- `core/score/*`
+- `core/aggregate/inventory/*`
+- `internal/e2e/score/*`
+- `docs/commands/score.md`
 - `docs/commands/report.md`
-- `docs/examples/security-team.md`
+- `docs/commands/regress.md`
+- `docs/state_lifecycle.md`
+- `product/wrkr.md`
+- `CHANGELOG.md`
 
 Run commands:
-- `go test ./core/report ./core/export/appendix ./core/export/inventory ./core/cli -count=1`
-- `go test ./internal/acceptance -run 'TestReportPDFAcceptance|TestV1Acceptance/AC21' -count=1`
-- `go test ./internal/scenarios -run 'TestEpic9' -count=1 -tags=scenario`
-- `scripts/check_docs_cli_parity.sh`
-- `make test-perf`
+- `go run ./cmd/wrkr score --state "$TMPDIR/state.json" --json`
+- `go run ./cmd/wrkr report --state "$TMPDIR/state.json" --json`
+- `go run ./cmd/wrkr regress init --baseline "$TMPDIR/state.json" --output "$TMPDIR/baseline.json" --json`
+- `go run ./cmd/wrkr regress run --baseline "$TMPDIR/baseline.json" --state "$TMPDIR/state.json" --json`
+- `go test ./core/cli ./core/score ./core/aggregate/inventory -count=1`
+- `go test ./internal/e2e/cli_contract ./internal/e2e/regress ./internal/e2e/score -count=1`
+- `go test ./testinfra/contracts -count=1`
+- `make test-contracts`
+- `make test-hardening`
+- `make test-chaos`
 - `make prepush-full`
 
 Test requirements:
-- Template parsing tests.
-- Deterministic PDF/Markdown repeat-run tests.
-- CSV backlog golden tests.
-- Redaction tests for public/customer-draft share profile.
-- Docs consistency checks.
+- CLI `--json` stability tests for `score`, `report`, and `regress` after saved-state mutation.
+- Contract tests proving approval mutation changes downstream posture outputs without rescanning.
+- Determinism tests proving repeated post-mutation reads are byte-stable except for existing timestamp fields.
+- Compatibility tests preserving existing output keys and exit-code classes.
 
 Matrix wiring:
-- Fast lane: report/export/CLI package tests.
-- Acceptance lane: PDF and report scenarios.
-- Cross-platform lane: artifact path smoke.
-- Risk lane: `make test-perf`, `make prepush-full`.
+- Fast lane: targeted `core/cli`, `core/score`, and inventory aggregation tests.
+- Core CI lane: `make prepush` plus e2e CLI/regress coverage.
+- Acceptance lane: extend acceptance flow to cover `scan -> approve -> score/report/regress`.
+- Cross-platform lane: keep snapshot-read behavior path-stable across OSes.
+- Risk lane: `make prepush-full`, `make test-contracts`, `make test-hardening`, `make test-chaos`.
 
 Acceptance criteria:
-- `wrkr report --template ciso --pdf --md --json` returns artifact paths and deterministic summary payload.
-- Report starts with control backlog, not raw findings.
-- CSV backlog includes owner, evidence, recommended action, SLA, and closure criteria.
-- Public/customer-draft reports do not leak secret values or sensitive local paths.
+- `wrkr score --state <path> --json` changes approval-derived posture values immediately after a successful approval mutation.
+- `wrkr report --state <path> --json` and `wrkr regress init/run --json` observe the updated lifecycle and approval state without a rescan.
+- Downstream commands do not rerun detectors or depend on live network sources to achieve updated posture.
+- Existing machine-readable output keys remain present and stable.
 
 Changelog impact: required
 
-Changelog section: Added
+Changelog section: Fixed
 
-Draft changelog entry: Added customer-ready CISO, AppSec, platform, audit, and customer-draft report templates led by the governance control backlog.
+Draft changelog entry: Fixed saved-state posture calculations so score, report, and regress immediately reflect approval mutations without requiring a fresh scan.
 
 Semver marker override: none
 
 Contract/API impact:
-- Adds report template enum values and artifact bundle JSON fields.
+- Corrects downstream CLI semantics for existing saved-state commands without changing their public flags or output-key inventory.
 
 Versioning/migration impact:
-- Existing report templates continue to work as compatibility aliases.
+- No schema change. Existing snapshots gain correct derived posture behavior after mutation.
 
 Architecture constraints:
-- Report rendering consumes state/backlog summaries and does not call detectors.
-- Artifact writes use managed path safety and deterministic rendering.
-- Raw findings must stay appendix-only for these templates.
+- Keep recomputation logic in focused state-refresh helpers rather than embedding it in CLI printing code.
+- Do not call detectors, source acquisition, or remote services during mutation refresh.
+- Use explicit recompute-or-invalidate semantics in helper APIs so callers do not infer partial refresh behavior.
+- Preserve extension points for additional derived snapshot views without duplicating recomputation wiring.
+- Preserve deterministic inputs and outputs for the same saved-state content.
 
 ADR required: no
 
 TDD first failing test(s):
-- `TestReportTemplateCISOLeadsWithControlBacklog`.
-- `TestCustomerDraftReportRedactsSensitiveEvidence`.
-
-Cost/perf impact: medium
-
-Chaos/failure hypothesis:
-- If one artifact in a report bundle fails to write, the command returns a deterministic error and does not claim the bundle is complete.
-
-### Story W5-S2: Add Ticket Export With Offline Dry-Run First
-
-Priority: P2
-
-Tasks:
-- Add `wrkr export tickets --top <n> --format jira|github|servicenow --dry-run --json`.
-- Export ticket payloads with owner, repo, path, control-path type, capability, evidence, recommended action, SLA, closure criteria, confidence, and proof requirements.
-- Add explicit opt-in adapter execution later or behind separate flags; default is local JSON/CSV/Markdown payload generation.
-- Add deterministic grouping/deduping by owner/repo/control path.
-- Add simulated adapter fixtures only if network execution is included in implementation scope.
-
-Repo paths:
-- `core/cli/export.go`
-- `core/export/tickets/`
-- `core/aggregate/controlbacklog/`
-- `internal/e2e/cli_contract/`
-- `docs/commands/export.md`
-- `docs/examples/operator-playbooks.md`
-- `scenarios/wrkr/ticket-export/`
-
-Run commands:
-- `go test ./core/export/tickets ./core/aggregate/controlbacklog ./core/cli -count=1`
-- `go test ./internal/e2e/cli_contract -count=1`
-- `go test ./internal/scenarios -run 'TestTicketExport' -count=1 -tags=scenario`
-- `make test-contracts`
-- `make prepush-full`
-
-Test requirements:
-- CLI help/usage tests.
-- JSON schema/golden tests for Jira/GitHub/ServiceNow payload formats.
-- Deterministic grouping/deduping tests.
-- Invalid format and missing backlog error-envelope tests.
-- Dry-run no-network tests.
-
-Matrix wiring:
-- Fast lane: export/CLI package tests.
-- Core CI lane: e2e CLI contract.
-- Acceptance lane: ticket export scenario.
-- Risk lane: `make test-contracts`, `make prepush-full`.
-
-Acceptance criteria:
-- `wrkr export tickets --top 10 --format jira --dry-run --json` emits deterministic local ticket payloads and makes no network calls.
-- Each ticket includes owner, evidence, recommended action, SLA, and closure criteria.
-- Unsupported formats exit `6` with `invalid_input`.
-- Ticket exports can be generated from saved state without rescanning.
-
-Changelog impact: required
-
-Changelog section: Added
-
-Draft changelog entry: Added offline-first ticket export payloads for Jira, GitHub Issues, and ServiceNow from top governance backlog items.
-
-Semver marker override: none
-
-Contract/API impact:
-- Adds export subcommand/format and ticket export JSON schema.
-
-Versioning/migration impact:
-- Add `ticket_export_version: "1"` to exported payloads.
-
-Architecture constraints:
-- Exporters consume control backlog state and never run detectors.
-- Network adapters must be explicit opt-in and fail closed on missing credentials.
-- Default dry-run path is deterministic and offline.
-
-ADR required: yes
-
-TDD first failing test(s):
-- `TestExportTicketsDryRunDoesNotUseNetwork`.
-- `TestTicketPayloadIncludesClosureCriteriaAndSLA`.
+- `TestScoreReflectsIdentityApproveWithoutRescan`
+- `TestReportReflectsInventoryApproveWithoutRescan`
+- `TestRegressBaselineInitializedAfterApprovalUsesUpdatedSavedState`
 
 Cost/perf impact: low
 
 Chaos/failure hypothesis:
-- If adapter configuration is missing or unavailable, dry-run remains usable and opt-in send mode fails closed with a machine-readable dependency error.
+- If derived posture recomputation fails after an approval mutation starts, Wrkr rolls back the mutation instead of returning success with stale derived state.
+
+Dependencies:
+- W2-S1
+
+## Wave 3: Lifecycle Contract Realignment
+
+Objective:
+- Restore the documented persisted `discovered` lifecycle semantics and align lifecycle docs, fixtures, and downstream expectations around explicit review transitions.
+
+### Story W3-S1: Persist `discovered` On First Observation And Reserve `under_review` For Explicit Review States
+
+Priority:
+- P2
+
+Tasks:
+- Update `core/lifecycle` reconciliation rules so first-seen identities persist as `discovered`.
+- Keep `under_review` for explicit review, approval expiry, and other explicit review-required transitions rather than auto-normalizing all first-seen records.
+- Preserve `active` auto-derivation from valid approval plus present detection.
+- Update manifest/state/regress fixtures and acceptance tests that currently encode `under_review` for first-seen tools.
+- Update command docs, lifecycle docs, and product lifecycle wording to describe the corrected transition rules precisely.
+
+Repo paths:
+- `core/lifecycle/lifecycle.go`
+- `core/lifecycle/lifecycle_test.go`
+- `core/cli/scan_lifecycle_manifest_test.go`
+- `core/cli/root_test.go`
+- `core/regress/*`
+- `internal/acceptance/*`
+- `internal/e2e/manifest/*`
+- `docs/commands/identity.md`
+- `docs/state_lifecycle.md`
+- `product/wrkr.md`
+- `CHANGELOG.md`
+
+Run commands:
+- `go run ./cmd/wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --state "$TMPDIR/state.json" --json --quiet`
+- `go run ./cmd/wrkr identity review <agent_id> --state "$TMPDIR/state.json" --json`
+- `go test ./core/lifecycle ./core/cli ./core/regress -count=1`
+- `go test ./internal/acceptance ./internal/e2e/manifest ./internal/e2e/regress -count=1`
+- `scripts/check_docs_cli_parity.sh`
+- `scripts/check_docs_storyline.sh`
+- `make prepush-full`
+
+Test requirements:
+- Lifecycle unit tests for first-seen `discovered`, explicit `under_review`, expiry-to-review, and approved-present `active`.
+- Regress compatibility tests proving removed/reappeared identities still behave deterministically.
+- Fixture and golden updates where first-seen lifecycle state changes from `under_review` to `discovered`.
+- Docs parity and storyline checks for lifecycle wording changes.
+
+Matrix wiring:
+- Fast lane: targeted lifecycle and CLI tests.
+- Core CI lane: `make prepush` plus regress/e2e manifest coverage.
+- Acceptance lane: acceptance and scenario flows covering the full lifecycle path.
+- Cross-platform lane: preserve deterministic manifest/state serialization across OSes.
+- Risk lane: `make prepush-full`, `scripts/check_docs_storyline.sh`.
+
+Acceptance criteria:
+- A fresh scan persists first-seen identities with `status=discovered`.
+- `wrkr identity review` moves a discovered identity to `under_review`.
+- Approval expiry returns an identity to `under_review`.
+- Valid approved-present identities become `active` on subsequent scan reconciliation.
+- Docs and product lifecycle wording describe the same transition conditions that runtime implements.
+
+Changelog impact: required
+
+Changelog section: Fixed
+
+Draft changelog entry: Fixed lifecycle reconciliation so newly discovered tools persist as `discovered` until explicitly reviewed or approval state requires review.
+
+Semver marker override: none
+
+Contract/API impact:
+- Corrects persisted lifecycle-state semantics in manifest/state outputs while keeping the existing state enum set.
+
+Versioning/migration impact:
+- No schema change. Fixtures, golden files, and operator expectations that encoded first-seen `under_review` must be updated to `discovered`.
+
+Architecture constraints:
+- Keep lifecycle-state authority centralized in `core/lifecycle`.
+- Do not move lifecycle derivation into CLI, reporting, or regress code.
+- Preserve deterministic transition ordering and `present=false` handling for removed identities.
+
+ADR required: yes
+
+TDD first failing test(s):
+- `TestReconcilePreservesDiscoveredForFirstSeenIdentity`
+- `TestReviewAndExpiryProduceUnderReviewWithoutClobberingDiscoveredFirstSeen`
+- `TestApprovedPresentIdentityStillTransitionsToActive`
+
+Cost/perf impact: low
+
+Chaos/failure hypothesis:
+- If a saved state contains expired approvals, reappeared identities, or removed identities, reconciliation still produces deterministic `discovered`, `under_review`, `active`, and `present=false` outcomes without oscillation or lifecycle clobbering.
+
+Dependencies:
+- W2-S1
+- W2-S2
 
 ## Minimum-Now Sequence
 
 Wave 1:
-- Implement W1-S1, W1-S2, W1-S3, and W1-S4.
-- This wave creates the public vocabulary and suppresses large-scale-organization scan noise before changing downstream reports or workflows.
-- Required gates: targeted tests, `make test-contracts`, scenario fixtures, `make prepush-full`, and `make test-perf` for scan modes/noise.
+- W1-S1
 
 Wave 2:
-- Implement W2-S1, W2-S2, and W2-S3.
-- This wave makes governance backlog visible by default and adds write-path/control/visibility semantics.
-- Required gates: CLI contract, acceptance, scenarios, contract tests, and risk lane.
+- W2-S1
+- W2-S2
 
 Wave 3:
-- Implement W3-S1, W3-S2, and W3-S3.
-- This wave turns backlog items into lifecycle-managed controls with proof and drift.
-- Required gates: hardening, chaos, contract, scenario, interop, and prepush-full.
+- W3-S1
 
-Wave 4:
-- Implement W4-S1 and W4-S2.
-- This wave improves enterprise accuracy and scan operability for large orgs.
-- Required gates: source/owner scenarios, hardening, chaos, perf, and cross-platform smoke.
-
-Wave 5:
-- Implement W5-S1 and W5-S2.
-- This wave packages governance output into customer reports and work exports after the underlying contracts are stable.
-- Required gates: report acceptance, ticket export scenarios, docs parity, perf, and contract tests.
+Dependency-driven execution notes:
+- Do not start W2-S1 until W1-S1 has locked the trusted managed-state-path boundary.
+- Do not start W2-S2 until W2-S1 has made saved-state mutation authoritative.
+- Do not land W3-S1 before W2-S1 and W2-S2, because lifecycle semantics need the repaired saved-state authority path and downstream posture assertions.
+- If scope must be split for reviewability, the minimum blocker release sequence is W1-S1, W2-S1, and W2-S2. W3-S1 closes the remaining documented lifecycle contract drift immediately after the blocker set.
 
 ## Explicit Non-Goals
 
-- No dashboard-first scope in this backlog.
-- No Axym or Gait product feature implementation in this repository.
-- No LLM calls in scan, risk, proof, reporting, or ticket export paths.
-- No default network ticket creation or notification sending.
-- No secret value extraction or secret value output.
-- No replacement of SAST, SCA, or secret scanning as Wrkr's product lane.
-- No removal of existing raw finding JSON fields during this plan.
-- No broad refactor that collapses source, detection, aggregation, identity, risk, proof, and compliance boundaries.
-- No generated binary, transient scan report, or customer data commit.
+- No new detector coverage, risk-model redesign, or report-template expansion.
+- No new export or integration surfaces.
+- No exit-code taxonomy redesign beyond consistent reuse of existing exit `8` and runtime-failure behavior.
+- No schema-major version bump.
+- No cross-repo toolchain, CI, or vulnerability-remediation wave beyond the tests already required for this plan.
+- No docs-site redesign or onboarding-taxonomy rewrite outside the touched lifecycle and command-contract surfaces.
 
 ## Definition of Done
 
-- Every recommendation R1-R20 maps to at least one merged story.
-- Every new CLI surface has help text, command docs, JSON tests, and exit-code tests.
-- Every schema/artifact change has versioning, compatibility, and golden tests.
-- Every governance output is deterministic across repeated runs except explicit timestamp/version fields.
-- Every risk-bearing story has failure-mode tests and runs `make prepush-full`.
-- Approval and evidence mutations are atomic, rollback-safe, and proof-verifiable.
-- Raw findings remain accessible while default operator/customer views lead with the control backlog.
-- Secret-bearing automation language distinguishes references from leaked values and never emits secret values.
-- Generated/package noise is suppressed by default or moved to scan quality.
-- Reports and ticket exports are offline-first and backlog-led.
-- Docs, README positioning, trust docs, and command references match implemented behavior.
-- `CHANGELOG.md` `## [Unreleased]` can be updated from the story-level changelog fields without re-deciding semver intent.
+- Every story is implemented with TDD evidence: failing tests first, exact commands run, and green results recorded in the PR.
+- All touched command contracts keep `--json` parseability and stable exit-code classes.
+- Saved-state mutation flows are rollback-safe and deterministic under normal and injected-failure paths.
+- Docs, failure taxonomy, lifecycle wording, and `CHANGELOG.md` are updated in the same implementation PRs as runtime changes.
+- Fast lane, core CI lane, and the required risk lane commands for each story are green before merge.
+- Acceptance/e2e coverage exists for approval propagation and lifecycle semantics.
+- No implementation branch begins with unrelated dirty files beyond the generated plan file from this planning step.

--- a/product/wrkr.md
+++ b/product/wrkr.md
@@ -111,7 +111,7 @@ tools:
     teams: [platform, payments]
     identity:
       agent_id: "wrkr:claude-code-monorepo:acme-corp"
-      status: approved              # discovered | under_review | approved | deprecated | revoked
+      status: approved              # discovered | under_review | approved | active | deprecated | revoked
       first_seen: "2026-06-12T14:20:00Z"
       approved_by: "@maria"
       approved_date: "2026-07-01T10:00:00Z"
@@ -452,6 +452,7 @@ Every discovered AI tool receives a persistent identity that tracks its lifecycl
 - **Identity chain:** Each agent's lifecycle is a proof record chain — append-only, tamper-evident. The chain proves the full history: when it was found, who approved it, when approval was renewed, when it was deprecated. An auditor can verify any agent's lifecycle with `proof verify --chain`.
 - **Cross-product interop:** Wrkr's agent IDs are the same identifiers that appear in Gait's `IntentContext.Identity` field and Axym's `agent_id` field. When Gait gates an action from `claude-code-monorepo`, the enforcement record links to the same identity Wrkr discovered and tracks. No mapping tables, no translation — one ID across the governance stack.
 - **Approval renewal:** Approvals have configurable expiry (default: 90 days). Wrkr scans flag tools with expired approvals as `under_review`. This ensures continuous governance — an approval from six months ago does not mean the tool is still governed today.
+- **Saved-state authority between scans:** `wrkr identity` and `wrkr inventory` mutations update the saved scan snapshot, manifest, lifecycle chain, and proof chain together. `wrkr score`, `wrkr report`, and `wrkr regress` therefore observe approval and review decisions immediately without requiring a follow-up scan.
 - **CLI commands:**
   - `wrkr identity list` — list all tracked agent identities with current status
   - `wrkr identity show <id>` — show identity details and lifecycle chain
@@ -612,7 +613,7 @@ After remediating findings and establishing a clean posture, `wrkr regress init`
 
 ### AC11: The "Identity Lifecycle"
 
-A tool discovered by `wrkr scan` receives a deterministic agent ID (`wrkr:<tool_id>:<org>`) that is stable across scans. Running `wrkr identity approve <id> --approver @maria --scope "read-only" --expires 90d` transitions the tool to `approved`, emits a signed `approval` proof record, and appends it to the identity chain. After 90 days, the next `wrkr scan` flags the tool as `under_review` (expired approval). Running `wrkr identity revoke <id>` transitions the tool to `revoked`, emits a proof record, and causes `wrkr regress run` to fail if the tool reappears. `wrkr identity show <id>` displays the full lifecycle chain, verifiable with `proof verify --chain`.
+A tool discovered by `wrkr scan` receives a deterministic agent ID (`wrkr:<tool_id>:<org>`) that is stable across scans. First observation persists as `discovered` until a human explicitly moves it to `under_review` or grants approval. Running `wrkr identity approve <id> --approver @maria --scope "read-only" --expires 90d` transitions the tool to `approved`, emits a signed `approval` proof record, appends it to the identity chain, and updates the saved scan snapshot so `score`, `report`, and `regress` reflect the decision immediately. After 90 days, the next `wrkr scan` flags the tool as `under_review` (expired approval). Running `wrkr identity revoke <id>` transitions the tool to `revoked`, emits a proof record, and causes `wrkr regress run` to fail if the tool reappears. `wrkr identity show <id>` displays the full lifecycle chain, verifiable with `proof verify --chain`.
 
 ### AC12: The "Autonomous Agent Alert"
 
@@ -636,7 +637,7 @@ A test fixture PR modifies `.claude/settings.json` to add a new MCP server and c
 
 ### AC17: The "Manifest Generation"
 
-Running `wrkr manifest generate` against a repo with Claude Code, Cursor, and 2 MCP servers produces a `wrkr-manifest.yaml` that lists all discovered tools under `review_pending` with status `under_review` and their current configuration (versions, hooks, MCP servers, access scopes), sets `blocked_tools` to empty, and populates the `policy` section with sensible defaults (`require_pinned_versions: true`, `require_mcp_approval: true`). Tools in `under_review` status still carry trust deficit in risk scoring. A human must explicitly move tools to `approved_tools` (via `wrkr identity approve` or manual edit) and commit the manifest for trust deficit to reach zero. This prevents "paper compliance" where auto-generated manifests bypass the review lifecycle. Removing a tool from the manifest and re-scanning flags it as unapproved with elevated risk.
+Running `wrkr manifest generate` against a repo with Claude Code, Cursor, and 2 MCP servers produces a `wrkr-manifest.yaml` that preserves the lifecycle and approval posture already present in the saved scan state: fresh unreviewed tools remain `discovered`, explicitly reviewed tools remain `under_review`, and manually approved tools stay `approved` until a later scan derives `active`. The generated manifest carries the current configuration (versions, hooks, MCP servers, access scopes), sets `blocked_tools` to empty, and populates the `policy` section with sensible defaults (`require_pinned_versions: true`, `require_mcp_approval: true`). Tools that remain unapproved continue to carry trust deficit in risk scoring. This prevents "paper compliance" where auto-generated manifests silently rewrite the review lifecycle. Removing a tool from the manifest and re-scanning flags it as unapproved with elevated risk.
 
 ### AC18: The "Policy Check"
 


### PR DESCRIPTION
## Problem
- manual identity and inventory mutations were not authoritative for the saved snapshot consumed by `score`, `report`, and `regress`
- symlinked managed `--state` paths were blocked by `inventory` but not consistently by `scan` and `identity`
- first-seen lifecycle state drifted from the documented `discovered` contract

## Changes
- hardened managed artifact preflight so `scan`, `identity`, and `inventory` all fail closed on symlinked `--state` paths
- centralized state mutation loading, snapshot projection, rollback-safe commit sequencing, and derived posture refresh for manual mutations
- restored persisted `discovered` semantics for first observation and updated manifest generation to preserve saved lifecycle/approval posture
- synced CLI docs, lifecycle docs, docs-site contract summaries, product contract text, changelog, acceptance coverage, and e2e coverage

## Validation
- `make prepush-full`
- `make test-contracts`
- `make test-hardening`
- `make test-chaos`
- `make test-docs-consistency`
- `make test-docs-storyline`
