### PR TITLE
test: serialize atomic write hook rollback tests

### DIFF
--- a/core/cli/root_test.go
+++ b/core/cli/root_test.go
@@ -1989,8 +1989,6 @@ func TestIdentityApproveRollbackOnProofChainParseFailure(t *testing.T) {
 }
 
 func TestIdentityReviewRollbackOnProofEmitFailure(t *testing.T) {
-	t.Parallel()
-
 	tmp := t.TempDir()
 	statePath := filepath.Join(tmp, "state.json")
 	agentID := scanIdentityAgentID(t, statePath)

--- a/core/cli/state_mutation_test.go
+++ b/core/cli/state_mutation_test.go
@@ -62,8 +62,6 @@ func TestIdentityApproveUpdatesSavedStateSnapshot(t *testing.T) {
 }
 
 func TestInventoryApproveRollsBackSavedStateOnProofEmitFailure(t *testing.T) {
-	t.Parallel()
-
 	tmp := t.TempDir()
 	statePath, agentID := writeInventoryMutationFixture(t, tmp)
 	manifestPath := manifest.ResolvePath(statePath)


### PR DESCRIPTION
Problem
The v1.2.0 local release preflight exposed a flaky core/cli rollback test. A process-wide atomic-write hook could be overwritten by another parallel rollback test before the expected proof-chain write failure fired.

Root cause
Two tests that install atomicwrite.SetBeforeRenameHookForTest also called t.Parallel(), even though the hook is process-wide and shared across tests in the package.

Fix
Keep those two rollback tests serial within core/cli by removing t.Parallel() from each test.

Validation
- go test ./core/cli -count=1 -run 'Test(IdentityReviewRollbackOnProofEmitFailure|InventoryApproveRollsBackSavedStateOnProofEmitFailure)' -v
- go test ./core/cli -count=10 -run 'Test(IdentityReviewRollbackOnProofEmitFailure|InventoryApproveRollsBackSavedStateOnProofEmitFailure)'
- go test ./core/cli -count=1
