### PR TITLE
test: stabilize local Homebrew UAT tap

### DIFF
--- a/scripts/test_uat_local.sh
+++ b/scripts/test_uat_local.sh
@@ -257,7 +257,7 @@ else
   brew_local_formula_path="$brew_local_tap_dir/Formula/${brew_local_formula_name}.rb"
 
   brew untap "$brew_local_tap_name" >/dev/null 2>&1 || true
-  brew tap-new "$brew_local_tap_name"
+  brew tap-new --no-git "$brew_local_tap_name"
 
   mkdir -p "$(dirname "$brew_local_formula_path")"
   cat >"$brew_local_formula_path" <<RB


### PR DESCRIPTION
Problem
- Release preflight failed in `make test-release-smoke` when `brew tap-new wrkr/uat-local` tried to create an initial git commit without a configured local/global git identity.

Changes
- Use `brew tap-new --no-git` for the transient local UAT tap, since the release smoke only needs a local Formula directory and does not need tap git history.

Validation
- `make test-release-smoke`
- `make prepush-full`
