### PR TITLE
[codex] add factory skill discovery wrappers

### DIFF
--- a/.agents/skills/adhoc-plan/SKILL.md
+++ b/.agents/skills/adhoc-plan/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: adhoc-plan
+description: Convert user-provided recommendations into a timestamped, execution-ready backlog plan using the active repo profile. Use when a repo needs a one-off plan that should not overwrite PLAN_NEXT.
+disable-model-invocation: true
+---
+
+# Adhoc Plan
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/adhoc-plan/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/adhoc-plan/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/adhoc-plan/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/adhoc-plan/agents/openai.yaml
+++ b/.agents/skills/adhoc-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Adhoc Plan"
+  short_description: "Turn recommendations into execution-ready plans"
+  default_prompt: "Use $adhoc-plan to convert provided recommendations into a timestamped, profile-driven execution plan."

--- a/.agents/skills/app-audit/SKILL.md
+++ b/.agents/skills/app-audit/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: app-audit
+description: Run a profile-driven evidence-based OSS/product readiness audit across product model, onboarding, architecture, DX, security, release readiness, and market wedge.
+disable-model-invocation: true
+---
+
+# App Audit
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/app-audit/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/app-audit/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/app-audit/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/app-audit/agents/openai.yaml
+++ b/.agents/skills/app-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "App Audit"
+  short_description: "Audit product and OSS readiness"
+  default_prompt: "Use $app-audit to run a profile-driven readiness audit with evidence, severity-ranked findings, and fix waves."

--- a/.agents/skills/backlog-plan/SKILL.md
+++ b/.agents/skills/backlog-plan/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: backlog-plan
+description: Convert repo-owned strategic ideas into a timestamped, execution-ready backlog plan using the active repo profile.
+disable-model-invocation: true
+---
+
+# Backlog Plan
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/backlog-plan/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/backlog-plan/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/backlog-plan/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/backlog-plan/agents/openai.yaml
+++ b/.agents/skills/backlog-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Backlog Plan"
+  short_description: "Turn repo ideas into test-wired plans"
+  default_prompt: "Use $backlog-plan to convert repo-owned ideas into a timestamped execution plan with profile-specific validation wiring."

--- a/.agents/skills/branches-clean/SKILL.md
+++ b/.agents/skills/branches-clean/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: branches-clean
+description: Delete non-default local and configured-remote branches one-by-one using the active repo profile, safety checks, and a final prune/report.
+disable-model-invocation: true
+---
+
+# Branches Clean
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/branches-clean/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/branches-clean/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/branches-clean/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/branches-clean/agents/openai.yaml
+++ b/.agents/skills/branches-clean/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Branches Clean"
+  short_description: "Safely clean local and remote branches"
+  default_prompt: "Use $branches-clean to delete non-protected branches one by one using the active repo profile."

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: code-review
+description: Perform a profile-driven full-repository or scoped code review with severity-ranked findings focused on contracts, boundaries, fail-closed safety, determinism, portability, release integrity, and docs correctness.
+disable-model-invocation: true
+---
+
+# Code Review
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/code-review/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/code-review/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/code-review/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/code-review/agents/openai.yaml
+++ b/.agents/skills/code-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Code Review"
+  short_description: "Review code with severity-ranked risks"
+  default_prompt: "Use $code-review to perform a profile-driven code review focused on contracts, safety, determinism, portability, and docs correctness."

--- a/.agents/skills/commit-push/SKILL.md
+++ b/.agents/skills/commit-push/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: commit-push
+description: Commit scoped changes, push a branch, open or update a PR, and keep driving profile-defined CI, passive review, merge, and post-merge loops until success or a hard blocker remains.
+disable-model-invocation: true
+---
+
+# Commit Push
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/commit-push/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/commit-push/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/commit-push/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/commit-push/agents/openai.yaml
+++ b/.agents/skills/commit-push/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Commit Push"
+  short_description: "Commit, PR, CI, review, and land"
+  default_prompt: "Use $commit-push to commit scoped changes, open or update a PR, and drive profile-defined checks and review loops."

--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: cut-release
+description: Resolve changelog-derived semver, finalize the release changelog through Factory scripts, tag from the default branch, monitor release/UAT, and run bounded hotfix loops when failures are actionable.
+disable-model-invocation: true
+---
+
+# Cut Release
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/cut-release/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/cut-release/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/cut-release/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/cut-release/agents/openai.yaml
+++ b/.agents/skills/cut-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Cut Release"
+  short_description: "Resolve, tag, monitor, and hotfix releases"
+  default_prompt: "Use $cut-release to resolve a release version, finalize changelog, tag from the default branch, monitor release/UAT, and run bounded hotfix loops."

--- a/.agents/skills/eval-suite-runner/SKILL.md
+++ b/.agents/skills/eval-suite-runner/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: eval-suite-runner
+description: Run continuous evaluation suites for workflow, skill, routing, or contract changes. Use for typical, edge, adversarial, and replay coverage before promoting workflow-affecting changes.
+disable-model-invocation: true
+---
+
+# Eval Suite Runner
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/eval-suite-runner/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/eval-suite-runner/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/eval-suite-runner/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/eval-suite-runner/agents/openai.yaml
+++ b/.agents/skills/eval-suite-runner/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Eval Suite Runner"
+  short_description: "Run required evaluation suites"
+  default_prompt: "Use $eval-suite-runner to execute profile or workflow-required evaluation suites and report evidence."

--- a/.agents/skills/evidence-attestor/SKILL.md
+++ b/.agents/skills/evidence-attestor/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: evidence-attestor
+description: Attach and verify provenance for shipped proof packets or externally consumed artifacts. Use when policy, workflow, or shipping requires tamper-evident evidence.
+disable-model-invocation: true
+---
+
+# Evidence Attestor
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/evidence-attestor/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/evidence-attestor/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/evidence-attestor/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/evidence-attestor/agents/openai.yaml
+++ b/.agents/skills/evidence-attestor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Evidence Attestor"
+  short_description: "Produce provenance and evidence attestations"
+  default_prompt: "Use $evidence-attestor to collect validation evidence and produce required provenance or attestation artifacts."

--- a/.agents/skills/execution-compiler/SKILL.md
+++ b/.agents/skills/execution-compiler/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: execution-compiler
+description: Turn a plan story, issue, or repair request into bounded task packets. Use when a downstream builder needs explicit scope, path limits, commands, and acceptance checks.
+disable-model-invocation: true
+---
+
+# Execution Compiler
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/execution-compiler/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/execution-compiler/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/execution-compiler/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/execution-compiler/agents/openai.yaml
+++ b/.agents/skills/execution-compiler/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Execution Compiler"
+  short_description: "Compile plans into executable task packets"
+  default_prompt: "Use $execution-compiler to convert approved plans or requirements into executable task packets."

--- a/.agents/skills/feature-discovery/SKILL.md
+++ b/.agents/skills/feature-discovery/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: feature-discovery
+description: Perform profile-driven, evidence-backed AI/agent market scanning and write timestamped strategic product recommendations without implementation planning.
+disable-model-invocation: true
+---
+
+# Feature Discovery
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/feature-discovery/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/feature-discovery/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/feature-discovery/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/feature-discovery/agents/openai.yaml
+++ b/.agents/skills/feature-discovery/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Feature Discovery"
+  short_description: "Discover evidence-backed product opportunities"
+  default_prompt: "Use $feature-discovery to scan the configured market window and write profile-driven strategic recommendations."

--- a/.agents/skills/fix-ci/SKILL.md
+++ b/.agents/skills/fix-ci/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: fix-ci
+description: Diagnose and repair failing CI for an in-scope repository change. Use when the triggering signal is a failing workflow, failing required check, or post-merge regression that can be fixed in-repo.
+disable-model-invocation: true
+---
+
+# Fix CI
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/fix-ci/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/fix-ci/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/fix-ci/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/fix-ci/agents/openai.yaml
+++ b/.agents/skills/fix-ci/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Fix CI"
+  short_description: "Diagnose and fix failing CI"
+  default_prompt: "Use $fix-ci to inspect failing checks, classify blockers, implement repo-owned fixes, and rerun validation."

--- a/.agents/skills/holdout-evaluator/SKILL.md
+++ b/.agents/skills/holdout-evaluator/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: holdout-evaluator
+description: Run hidden evaluation that the builder cannot see. Use when the change affects critical behavior, policy, external workflow behavior, or any surface that can be overfit by visible tests.
+disable-model-invocation: true
+---
+
+# Holdout Evaluator
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/holdout-evaluator/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/holdout-evaluator/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/holdout-evaluator/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/holdout-evaluator/agents/openai.yaml
+++ b/.agents/skills/holdout-evaluator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Holdout Evaluator"
+  short_description: "Run holdout and hidden evaluation checks"
+  default_prompt: "Use $holdout-evaluator to run required holdout evaluations and report pass/fail evidence."

--- a/.agents/skills/ideas-to-plan/SKILL.md
+++ b/.agents/skills/ideas-to-plan/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: ideas-to-plan
+description: Convert roadmap ideas into an execution-ready backlog plan. Use when an existing repository has strategic ideas and needs them turned into sequenced implementation work.
+disable-model-invocation: true
+---
+
+# Ideas To Plan
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/ideas-to-plan/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/ideas-to-plan/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/ideas-to-plan/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/ideas-to-plan/agents/openai.yaml
+++ b/.agents/skills/ideas-to-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ideas To Plan"
+  short_description: "Convert ideas into implementation plans"
+  default_prompt: "Use $ideas-to-plan to turn repo ideas into an execution-ready plan following the active profile."

--- a/.agents/skills/library-admin/SKILL.md
+++ b/.agents/skills/library-admin/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: library-admin
+description: Maintain the org-level library manifest and cookbook. Use when catalog entries, pinning, trust classes, compatibility scope, install profiles, adapter mappings, or writeback policy need to change.
+disable-model-invocation: true
+---
+
+# Library Admin
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/library-admin/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/library-admin/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/library-admin/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/library-admin/agents/openai.yaml
+++ b/.agents/skills/library-admin/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Library Admin"
+  short_description: "Maintain reusable factory assets"
+  default_prompt: "Use $library-admin to update reusable factory library assets, manifests, and cookbook guidance."

--- a/.agents/skills/library-sync/SKILL.md
+++ b/.agents/skills/library-sync/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: library-sync
+description: Distribute approved cataloged assets to allowed environments and record the result. Use when the org library needs to sync pinned skills, templates, standards, or schemas across devices and sandboxes.
+disable-model-invocation: true
+---
+
+# Library Sync
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/library-sync/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/library-sync/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/library-sync/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/library-sync/agents/openai.yaml
+++ b/.agents/skills/library-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Library Sync"
+  short_description: "Sync shared assets across repositories"
+  default_prompt: "Use $library-sync to package, distribute, or reconcile shared factory assets across repositories."

--- a/.agents/skills/meta-skill-author/SKILL.md
+++ b/.agents/skills/meta-skill-author/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: meta-skill-author
+description: Create or update factory-style skills, templates, or worker instructions from the repo standards. Use when the team needs a new reusable worker definition and wants it to follow the factory contract format.
+disable-model-invocation: true
+---
+
+# Meta Skill Author
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/meta-skill-author/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/meta-skill-author/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/meta-skill-author/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/meta-skill-author/agents/openai.yaml
+++ b/.agents/skills/meta-skill-author/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Meta Skill Author"
+  short_description: "Author and refine reusable skills"
+  default_prompt: "Use $meta-skill-author to create or improve reusable Factory skills with portable profile-driven instructions."

--- a/.agents/skills/plan-implement/SKILL.md
+++ b/.agents/skills/plan-implement/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: plan-implement
+description: Implement any valid Factory execution plan story-by-story using the active repo profile, planned changelog/versioning fields, and required validation lanes.
+disable-model-invocation: true
+---
+
+# Plan Implement
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/plan-implement/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/plan-implement/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/plan-implement/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/plan-implement/agents/openai.yaml
+++ b/.agents/skills/plan-implement/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Plan Implement"
+  short_description: "Execute plan stories with required gates"
+  default_prompt: "Use $plan-implement to implement a provided plan path story-by-story with profile validation and evidence."

--- a/.agents/skills/post-merge-monitor/SKILL.md
+++ b/.agents/skills/post-merge-monitor/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: post-merge-monitor
+description: Monitor post-merge health and trigger recovery when needed. Use after merge to observe mainline CI, detect regressions, and open hotfix or audit flows if required.
+disable-model-invocation: true
+---
+
+# Post Merge Monitor
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/post-merge-monitor/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/post-merge-monitor/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/post-merge-monitor/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/post-merge-monitor/agents/openai.yaml
+++ b/.agents/skills/post-merge-monitor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Post Merge Monitor"
+  short_description: "Monitor default-branch health after merge"
+  default_prompt: "Use $post-merge-monitor to watch post-merge checks and advise or run bounded recovery when failures are actionable."

--- a/.agents/skills/prd-to-plan/SKILL.md
+++ b/.agents/skills/prd-to-plan/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: prd-to-plan
+description: Convert a profile-defined PRD or product contract into a zero-ambiguity execution plan with repo paths, story-level validation, API/contract mapping, docs/OSS readiness, and CI matrix wiring.
+disable-model-invocation: true
+---
+
+# PRD To Plan
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/prd-to-plan/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/prd-to-plan/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/prd-to-plan/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/prd-to-plan/agents/openai.yaml
+++ b/.agents/skills/prd-to-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PRD To Plan"
+  short_description: "Turn product requirements into execution plans"
+  default_prompt: "Use $prd-to-plan to convert the active profile's PRD or product contract into a zero-ambiguity execution plan."

--- a/.agents/skills/recommendations-to-plan/SKILL.md
+++ b/.agents/skills/recommendations-to-plan/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: recommendations-to-plan
+description: Convert recommended work into an execution-ready plan. Use when recommendations come from audits, reviews, research, or leadership direction and need to be turned into implementable stories.
+disable-model-invocation: true
+---
+
+# Recommendations To Plan
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/recommendations-to-plan/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/recommendations-to-plan/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/recommendations-to-plan/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/recommendations-to-plan/agents/openai.yaml
+++ b/.agents/skills/recommendations-to-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Recommendations To Plan"
+  short_description: "Plan from recommendations"
+  default_prompt: "Use $recommendations-to-plan to convert recommendation sets into execution-ready implementation plans."

--- a/.agents/skills/recovery-advisor/SKILL.md
+++ b/.agents/skills/recovery-advisor/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: recovery-advisor
+description: Choose the next typed recovery action when a bounded task or validation loop exhausts its local iteration budget. Use to decide whether to retry differently, split work, accept scoped delivery debt, or escalate to replanning.
+disable-model-invocation: true
+---
+
+# Recovery Advisor
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/recovery-advisor/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/recovery-advisor/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/recovery-advisor/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/recovery-advisor/agents/openai.yaml
+++ b/.agents/skills/recovery-advisor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Recovery Advisor"
+  short_description: "Advise after blocked or exhausted loops"
+  default_prompt: "Use $recovery-advisor to analyze blocked work, no-progress loops, or delivery debt and recommend safe recovery."

--- a/.agents/skills/recurring-gc/SKILL.md
+++ b/.agents/skills/recurring-gc/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: recurring-gc
+description: Run scheduled cleanup and drift-control work across repo contracts, workspaces, branches, examples, schemas, and expired exceptions. Use for recurring maintenance and hygiene automation.
+disable-model-invocation: true
+---
+
+# Recurring GC
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/recurring-gc/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/recurring-gc/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/recurring-gc/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/recurring-gc/agents/openai.yaml
+++ b/.agents/skills/recurring-gc/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Recurring GC"
+  short_description: "Run recurring cleanup and drift control"
+  default_prompt: "Use $recurring-gc to perform scheduled cleanup, drift checks, and maintenance reporting."

--- a/.agents/skills/repair-feedback/SKILL.md
+++ b/.agents/skills/repair-feedback/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: repair-feedback
+description: Collect PR review feedback or user-provided comment refs, implement bounded fixes, validate them, and hand off to commit-push when branch shipping is requested.
+disable-model-invocation: true
+---
+
+# Repair Feedback
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/repair-feedback/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/repair-feedback/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/repair-feedback/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/repair-feedback/agents/openai.yaml
+++ b/.agents/skills/repair-feedback/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Repair Feedback"
+  short_description: "Implement PR feedback with dispositions"
+  default_prompt: "Use $repair-feedback to collect PR comments or feedback, implement bounded fixes, validate, and hand off to commit-push when shipping is requested."

--- a/.agents/skills/repo-audit/SKILL.md
+++ b/.agents/skills/repo-audit/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: repo-audit
+description: Audit a repository against the factory operating model. Use when a team needs a gap assessment for repo contracts, standards compliance, workflow readiness, safety posture, or evidence completeness.
+disable-model-invocation: true
+---
+
+# Repo Audit
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/repo-audit/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/repo-audit/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/repo-audit/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/repo-audit/agents/openai.yaml
+++ b/.agents/skills/repo-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Repo Audit"
+  short_description: "Audit repo operating readiness"
+  default_prompt: "Use $repo-audit to assess a repository against Factory operating, safety, workflow, and evidence standards."

--- a/.agents/skills/repo-bootstrap/SKILL.md
+++ b/.agents/skills/repo-bootstrap/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: repo-bootstrap
+description: Bootstrap a new repository from a PRD plus org-wide standards and templates. Use when a project is new, the main structured input is a PRD, and the goal is to generate the repo operating pack and first execution plan.
+disable-model-invocation: true
+---
+
+# Repo Bootstrap
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/repo-bootstrap/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/repo-bootstrap/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/repo-bootstrap/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/repo-bootstrap/agents/openai.yaml
+++ b/.agents/skills/repo-bootstrap/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Repo Bootstrap"
+  short_description: "Bootstrap a new repository operating pack"
+  default_prompt: "Use $repo-bootstrap to create the initial Factory operating pack for a new repository."

--- a/.agents/skills/repo-retrofit/SKILL.md
+++ b/.agents/skills/repo-retrofit/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: repo-retrofit
+description: Retrofit an existing repository into the factory model. Use when a repository exists but lacks the repo operating pack, workflow contract, or consistent autonomous execution rules.
+disable-model-invocation: true
+---
+
+# Repo Retrofit
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/repo-retrofit/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/repo-retrofit/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/repo-retrofit/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/repo-retrofit/agents/openai.yaml
+++ b/.agents/skills/repo-retrofit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Repo Retrofit"
+  short_description: "Retrofit an existing repo for Factory"
+  default_prompt: "Use $repo-retrofit to add or repair Factory operating contracts in an existing repository."

--- a/.agents/skills/scout-context/SKILL.md
+++ b/.agents/skills/scout-context/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: scout-context
+description: Gather the smallest useful context set for a work item. Use when a worker needs relevant files, constraints, risks, and related changes without loading the entire repository.
+disable-model-invocation: true
+---
+
+# Scout Context
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/scout-context/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/scout-context/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/scout-context/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/scout-context/agents/openai.yaml
+++ b/.agents/skills/scout-context/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Scout Context"
+  short_description: "Gather bounded implementation context"
+  default_prompt: "Use $scout-context to collect focused repo context and summarize what implementation needs next."

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: ship-pr
+description: Turn a validated change into a pull request and drive it through CI and merge policy. Use when a branch is ready to ship and the workflow allows PR creation or merge progression.
+disable-model-invocation: true
+---
+
+# Ship PR
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/ship-pr/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/ship-pr/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/ship-pr/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/ship-pr/agents/openai.yaml
+++ b/.agents/skills/ship-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ship PR"
+  short_description: "Prepare and ship a reviewed PR"
+  default_prompt: "Use $ship-pr to prepare PR evidence, validation, and handoff for branch shipping."

--- a/.agents/skills/task-executor/SKILL.md
+++ b/.agents/skills/task-executor/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: task-executor
+description: Implement one bounded task packet inside an isolated workspace. Use when the system has explicit task scope, allowed paths, commands, and acceptance checks for a builder worker.
+disable-model-invocation: true
+---
+
+# Task Executor
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/task-executor/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/task-executor/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/task-executor/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/task-executor/agents/openai.yaml
+++ b/.agents/skills/task-executor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Task Executor"
+  short_description: "Execute bounded task packets"
+  default_prompt: "Use $task-executor to implement a bounded task packet with scoped edits and validation."

--- a/.agents/skills/trace-grader/SKILL.md
+++ b/.agents/skills/trace-grader/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: trace-grader
+description: Grade full worker traces against the factory rubric. Use when workflow behavior, routing, approval posture, or escalation logic changes and a trace-level promotion signal is required.
+disable-model-invocation: true
+---
+
+# Trace Grader
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/trace-grader/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/trace-grader/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/trace-grader/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/trace-grader/agents/openai.yaml
+++ b/.agents/skills/trace-grader/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Trace Grader"
+  short_description: "Grade workflow traces"
+  default_prompt: "Use $trace-grader to evaluate workflow traces against Factory grading criteria and report findings."

--- a/.agents/skills/validation-gate/SKILL.md
+++ b/.agents/skills/validation-gate/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: validation-gate
+description: Run visible deterministic checks and decide promotion readiness. Use after execution to validate the patch against required commands, test lanes, and contract checks.
+disable-model-invocation: true
+---
+
+# Validation Gate
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/validation-gate/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/validation-gate/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/validation-gate/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/validation-gate/agents/openai.yaml
+++ b/.agents/skills/validation-gate/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Validation Gate"
+  short_description: "Run and summarize required validation"
+  default_prompt: "Use $validation-gate to run required profile validation and report evidence before shipping."

--- a/.agents/skills/workflow-admin/SKILL.md
+++ b/.agents/skills/workflow-admin/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: workflow-admin
+description: Maintain and debug the autonomous runtime contract and orchestration settings. Use when a repository needs a new or updated WORKFLOW.md, approval changes, trust-mode changes, model-routing changes, grading changes, workspace hook changes, or operational troubleshooting.
+disable-model-invocation: true
+---
+
+# Workflow Admin
+
+This is a local discovery wrapper for the shared Factory skill at `factory/skills/workflow-admin/SKILL.md`.
+
+Before using this skill:
+
+1. Verify `factory/skills/workflow-admin/SKILL.md` exists.
+2. If it is missing, stop and ask the user to run:
+
+```bash
+git submodule update --init factory
+```
+
+Then read `factory/skills/workflow-admin/SKILL.md` and follow that Factory skill exactly, using the active `wrkr` repo profile unless the user provides another explicit profile.
+
+Do not treat this wrapper as the source of truth. The Factory skill is authoritative.

--- a/.agents/skills/workflow-admin/agents/openai.yaml
+++ b/.agents/skills/workflow-admin/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Workflow Admin"
+  short_description: "Maintain workflow contracts and runtime policy"
+  default_prompt: "Use $workflow-admin to update or troubleshoot WORKFLOW.md, routing, approvals, trust modes, or workflow policy."


### PR DESCRIPTION
## Summary

- Add local `.agents/skills` discovery wrappers for every shared Factory skill.
- Each wrapper delegates to `factory/skills/<skill>/SKILL.md` as the authoritative source.
- This makes `$adhoc-plan`, `$commit-push`, `$cut-release`, `$plan-implement`, and the rest visible to Codex from the repo.

## Validation
- make lint-fast
- make test-contracts
