### PR TITLE
feat: add hosted source privacy contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Added
 
-- (none yet)
+- [semver:minor] Added explicit `source_privacy` metadata to scan state, scan JSON, scan status, reports, evidence bundle metadata, and SARIF output so operators can prove hosted source retention and cleanup behavior.
 
 ### Changed
 
-- (none yet)
+- Hosted source manifests now serialize logical repository references while detector execution uses private scan roots and source-code materialization is opt-in.
 
 ### Deprecated
 
@@ -28,7 +28,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Security
 
-- (none yet)
+- Hosted repository and organization scans now default to ephemeral source materialization with explicit retention modes and cleanup status.
+- Scan artifacts, proof mapping, reports, evidence, and SARIF now redact hosted materialized paths from shareable outputs.
+- Added privacy regression coverage and operator documentation proving hosted scans do not retain or serialize source code by default.
 
 ## Changelog maintenance process
 

--- a/core/aggregate/inventory/inventory.go
+++ b/core/aggregate/inventory/inventory.go
@@ -1541,6 +1541,9 @@ func deriveOrg(manifest source.Manifest) string {
 func repoRoot(manifest source.Manifest, repo string) string {
 	for _, item := range manifest.Repos {
 		if item.Repo == repo {
+			if strings.TrimSpace(item.ScanRoot) != "" {
+				return item.ScanRoot
+			}
 			return item.Location
 		}
 	}

--- a/core/cli/evidence.go
+++ b/core/cli/evidence.go
@@ -67,6 +67,7 @@ func runEvidence(args []string, stdout io.Writer, stderr io.Writer) int {
 			"control_evidence":   result.ControlEvidence,
 			"coverage_note":      result.CoverageNote,
 			"report_artifacts":   result.ReportArtifacts,
+			"source_privacy":     result.SourcePrivacy,
 			"next_steps":         evidenceNextSteps(resolvedStatePath, result.OutputDir, result.ManifestPath, result.ReportArtifacts),
 		})
 		return exitSuccess

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -37,6 +37,7 @@ import (
 	sourcegithub "github.com/Clyra-AI/wrkr/core/source/github"
 	"github.com/Clyra-AI/wrkr/core/source/localsetup"
 	sourceorg "github.com/Clyra-AI/wrkr/core/source/org"
+	"github.com/Clyra-AI/wrkr/core/sourceprivacy"
 	"github.com/Clyra-AI/wrkr/core/state"
 )
 
@@ -71,6 +72,8 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	fs.Var(&explicitTargets, "target", "repeatable scan target <mode>:<value>")
 	timeout := fs.Duration("timeout", 0, "optional scan timeout (0 disables)")
 	scanModeRaw := fs.String("mode", "governance", "scan mode [quick|governance|deep]")
+	sourceRetentionRaw := fs.String("source-retention", sourceprivacy.RetentionEphemeral, "hosted source retention [ephemeral|retain_for_resume|retain]")
+	allowSourceMaterialization := fs.Bool("allow-source-materialization", false, "allow hosted scans to fetch generic source-code files")
 	diffMode := fs.Bool("diff", false, "show only changes since previous scan")
 	enrich := fs.Bool("enrich", false, "enable non-deterministic enrichment lookups (network required)")
 	baselinePath := fs.String("baseline", "", "optional fallback baseline when local state is absent")
@@ -104,6 +107,11 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	if scanModeErr != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", scanModeErr.Error(), exitInvalidInput)
 	}
+	sourceRetentionMode, sourceRetentionErr := sourceprivacy.ParseRetentionMode(*sourceRetentionRaw)
+	if sourceRetentionErr != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", sourceRetentionErr.Error(), exitInvalidInput)
+	}
+	allowHostedSourceMaterialization := *allowSourceMaterialization || scanMode == "deep"
 	productionTargetsFile := strings.TrimSpace(*productionTargetsPath)
 	if *productionTargetsStrict && productionTargetsFile == "" {
 		return emitError(
@@ -182,6 +190,20 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", jsonSinkErr.Error(), exitInvalidInput)
 	}
 	statePath := artifactPreflight.StatePath
+	materializedRoot := ""
+	if targetsNeedMaterializedRoot(targets) {
+		var rootErr error
+		if *resume {
+			materializedRoot, rootErr = prepareMaterializedRootForResume(statePath)
+		} else {
+			materializedRoot, rootErr = prepareMaterializedRoot(statePath)
+		}
+		if rootErr != nil {
+			return emitScanRuntimeError(stderr, jsonRequested || *jsonOut, rootErr)
+		}
+	}
+	sourcePrivacy := sourceprivacy.InitialContract(sourceRetentionMode, materializedRoot != "", allowHostedSourceMaterialization)
+	sourceCleanupFinalized := false
 
 	ctx := parentCtx
 	cancel := func() {}
@@ -204,9 +226,44 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		configTargetsToSourceTargets(targets),
 		scanStartedAt,
 		artifactPaths,
+		sourcePrivacy,
 	)
 	if err := statusTracker.Start(); err != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
+	finalizeSourceCleanup := func(success bool) error {
+		if sourceCleanupFinalized {
+			return nil
+		}
+		sourceCleanupFinalized = true
+		if strings.TrimSpace(materializedRoot) == "" {
+			sourcePrivacy = sourceprivacy.Normalize(sourcePrivacy)
+			statusTracker.SetSourcePrivacy(sourcePrivacy)
+			return nil
+		}
+		if sourceprivacy.ShouldRetainMaterializedSource(sourceRetentionMode, success) {
+			sourcePrivacy = sourceprivacy.MarkRetained(sourcePrivacy)
+			statusTracker.SetSourcePrivacy(sourcePrivacy)
+			return nil
+		}
+		if err := cleanupManagedMaterializedRoot(statePath, materializedRoot); err != nil {
+			sourcePrivacy = sourceprivacy.MarkFailed(sourcePrivacy, err.Error())
+			statusTracker.SetSourcePrivacy(sourcePrivacy)
+			return err
+		}
+		sourcePrivacy = sourceprivacy.MarkRemoved(sourcePrivacy)
+		statusTracker.SetSourcePrivacy(sourcePrivacy)
+		return nil
+	}
+	cleanupFailure := func(err error) error {
+		cleanupErr := finalizeSourceCleanup(false)
+		if cleanupErr == nil {
+			return err
+		}
+		if err == nil {
+			return cleanupErr
+		}
+		return fmt.Errorf("%v (source cleanup failed: %w)", err, cleanupErr)
 	}
 	checkScanContext := func() error {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -216,6 +273,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	}
 	emitScanFailure := func(err error) int {
 		progress.Flush()
+		err = cleanupFailure(err)
 		statusTracker.Fail(err, artifactPaths)
 		if !jsonRequested && !*jsonOut && !*quiet {
 			_, _ = fmt.Fprintf(stderr, "scan failure footer: %s\n", statusTracker.Footer())
@@ -224,6 +282,10 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	}
 	emitScanError := func(code, message string, exitCode int) int {
 		progress.Flush()
+		if cleanupErr := finalizeSourceCleanup(false); cleanupErr != nil {
+			statusTracker.Fail(cleanupErr, artifactPaths)
+			return emitScanRuntimeError(stderr, jsonRequested || *jsonOut, cleanupErr)
+		}
 		statusTracker.Fail(errors.New(message), artifactPaths)
 		if !jsonRequested && !*jsonOut && !*quiet {
 			_, _ = fmt.Fprintf(stderr, "scan failure footer: %s\n", statusTracker.Footer())
@@ -235,9 +297,11 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		return emitScanFailure(err)
 	}
 	manifestOut, findings, err := acquireSources(ctx, targets, *githubBaseURL, *githubToken, acquireOptions{
-		StatePath: statePath,
-		Progress:  progress,
-		Resume:    *resume,
+		StatePath:                  statePath,
+		Progress:                   progress,
+		Resume:                     *resume,
+		MaterializedRoot:           materializedRoot,
+		AllowSourceMaterialization: allowHostedSourceMaterialization,
 	})
 	if err != nil {
 		return emitScanFailure(err)
@@ -475,6 +539,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		PostureScore:   &postureScore,
 		Identities:     nextManifest.Identities,
 		Transitions:    transitions,
+		SourcePrivacy:  &sourcePrivacy,
 	}
 	chainPath := artifactPreflight.LifecyclePath
 	proofChainPath := artifactPreflight.ProofChainPath
@@ -504,6 +569,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		if err == nil {
 			return exitSuccess
 		}
+		err = cleanupFailure(err)
 		statusTracker.Fail(err, artifactPaths)
 		if !jsonRequested && !*jsonOut && !*quiet {
 			_, _ = fmt.Fprintf(stderr, "scan failure footer: %s\n", statusTracker.Footer())
@@ -515,6 +581,13 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	}
 	emitRolledBackScanError := func(code, message string, exitCode int) int {
 		progress.Flush()
+		if cleanupErr := finalizeSourceCleanup(false); cleanupErr != nil {
+			statusTracker.Fail(cleanupErr, artifactPaths)
+			if restoreErr := restoreManagedArtifacts(managedSnapshots); restoreErr != nil {
+				return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", fmt.Sprintf("%v (rollback restore failed: %v)", cleanupErr, restoreErr), exitRuntime)
+			}
+			return emitScanRuntimeError(stderr, jsonRequested || *jsonOut, cleanupErr)
+		}
 		statusTracker.Fail(errors.New(message), artifactPaths)
 		if !jsonRequested && !*jsonOut && !*quiet {
 			_, _ = fmt.Fprintf(stderr, "scan failure footer: %s\n", statusTracker.Footer())
@@ -566,11 +639,19 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	if err := checkScanContext(); err != nil {
 		return emitRolledBackScanFailure(err)
 	}
+	if err := finalizeSourceCleanup(true); err != nil {
+		return emitRolledBackScanFailure(err)
+	}
+	snapshot.SourcePrivacy = &sourcePrivacy
+	if err := state.Save(statePath, snapshot); err != nil {
+		return emitRolledBackScanFailure(err)
+	}
 
 	payload := map[string]any{
 		"status":          "ok",
 		"target":          manifestOut.Target,
 		"source_manifest": manifestOut,
+		"source_privacy":  sourcePrivacy,
 		"scan_mode":       scanMode,
 		"scan_quality":    scanQuality,
 	}
@@ -659,7 +740,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		if err := checkScanContext(); err != nil {
 			return emitRolledBackScanFailure(err)
 		}
-		report := exportsarif.Build(findings, wrkrVersion())
+		report := exportsarif.BuildWithSourcePrivacy(findings, wrkrVersion(), &sourcePrivacy)
 		if writeErr := exportsarif.Write(artifactPreflight.SARIFPath, report); writeErr != nil {
 			return emitRolledBackScanFailure(writeErr)
 		}

--- a/core/cli/scan_helpers.go
+++ b/core/cli/scan_helpers.go
@@ -39,9 +39,11 @@ type materializedRootSafetyError struct {
 }
 
 type acquireOptions struct {
-	StatePath string
-	Progress  *scanProgressReporter
-	Resume    bool
+	StatePath                  string
+	Progress                   *scanProgressReporter
+	Resume                     bool
+	MaterializedRoot           string
+	AllowSourceMaterialization bool
 }
 
 type repeatedStringFlag []string
@@ -199,25 +201,17 @@ func acquireSources(ctx context.Context, targets []config.Target, githubBaseURL,
 	}
 
 	connector := github.NewConnector(githubBaseURL, githubToken, nil)
+	connector.SetAllowSourceMaterialization(opts.AllowSourceMaterialization)
 	manifestOut := source.Manifest{
-		Target:  manifestTargetFromTargets(targets),
-		Targets: manifestTargets(targets),
+		Target:           manifestTargetFromTargets(targets),
+		Targets:          manifestTargets(targets),
+		MaterializedRoot: strings.TrimSpace(opts.MaterializedRoot),
 	}
-	materializeRoot := ""
+	materializeRoot := strings.TrimSpace(opts.MaterializedRoot)
 	if targetsNeedMaterializedRoot(targets) {
-		var (
-			root string
-			err  error
-		)
-		if opts.Resume {
-			root, err = prepareMaterializedRootForResume(opts.StatePath)
-		} else {
-			root, err = prepareMaterializedRoot(opts.StatePath)
+		if materializeRoot == "" {
+			return source.Manifest{}, nil, fmt.Errorf("materialized source root is required for hosted source acquisition")
 		}
-		if err != nil {
-			return source.Manifest{}, nil, err
-		}
-		materializeRoot = root
 	}
 	if opts.Resume {
 		if !allTargetsAreOrg(targets) {
@@ -546,6 +540,48 @@ func prepareMaterializedRootForResume(statePath string) (string, error) {
 	return root, nil
 }
 
+func cleanupManagedMaterializedRoot(statePath string, root string) error {
+	cleanRoot := filepath.Clean(strings.TrimSpace(root))
+	if cleanRoot == "" || cleanRoot == "." {
+		return nil
+	}
+	info, err := os.Lstat(cleanRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("lstat materialized source root: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return newMaterializedRootSafetyError("materialized source root must not be a symlink: %s", cleanRoot)
+	}
+	if !info.IsDir() {
+		return newMaterializedRootSafetyError("materialized source root is not a directory: %s", cleanRoot)
+	}
+	markerPath := filepath.Join(cleanRoot, materializedRootMarkerFile)
+	markerInfo, err := os.Lstat(markerPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return newMaterializedRootSafetyError("materialized source root is not managed by wrkr scan: %s", cleanRoot)
+		}
+		return fmt.Errorf("stat materialized source root marker: %w", err)
+	}
+	if !markerInfo.Mode().IsRegular() {
+		return newMaterializedRootSafetyError("materialized source root marker is not a regular file: %s", markerPath)
+	}
+	markerPayload, err := os.ReadFile(markerPath) // #nosec G304 -- marker path is deterministic under the selected local materialized source root.
+	if err != nil {
+		return fmt.Errorf("read materialized source root marker: %w", err)
+	}
+	if err := managedmarker.ValidatePayload(statePath, cleanRoot, materializedRootMarkerKind, markerPayload); err != nil {
+		return newMaterializedRootSafetyError("materialized source root marker content is invalid: %s", markerPath)
+	}
+	if err := os.RemoveAll(cleanRoot); err != nil {
+		return fmt.Errorf("remove materialized source root: %w", err)
+	}
+	return nil
+}
+
 func prepareManagedMaterializedRoot(root string, statePath string, reset bool) error {
 	info, err := os.Lstat(root)
 	if err != nil {
@@ -641,15 +677,18 @@ func evaluatePolicies(scopes []detect.Scope, findings []source.Finding, customPo
 func detectorScopes(manifestOut source.Manifest) []detect.Scope {
 	scopes := make([]detect.Scope, 0, len(manifestOut.Repos))
 	for _, repo := range manifestOut.Repos {
-		location := strings.TrimSpace(repo.Location)
-		if location == "" {
+		root := strings.TrimSpace(repo.ScanRoot)
+		if root == "" {
+			root = strings.TrimSpace(repo.Location)
+		}
+		if root == "" {
 			continue
 		}
 		orgName := deriveOrg(repo)
 		scopes = append(scopes, detect.Scope{
 			Org:        orgName,
 			Repo:       repo.Repo,
-			Root:       location,
+			Root:       root,
 			TargetMode: scopeTargetMode(manifestOut.Target, repo),
 		})
 	}

--- a/core/cli/scan_materialized_root_test.go
+++ b/core/cli/scan_materialized_root_test.go
@@ -3,10 +3,15 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/Clyra-AI/wrkr/core/sourceprivacy"
 	"github.com/Clyra-AI/wrkr/internal/managedmarker"
 )
 
@@ -131,6 +136,53 @@ func TestPrepareMaterializedRootRejectsLegacyMarkerContent(t *testing.T) {
 	}
 }
 
+func TestCleanupManagedMaterializedRootRemovesManagedRoot(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, ".wrkr", "last-scan.json")
+	root, err := prepareMaterializedRoot(statePath)
+	if err != nil {
+		t.Fatalf("prepare materialized root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "source.txt"), []byte("private-source-sentinel"), 0o600); err != nil {
+		t.Fatalf("write source sentinel: %v", err)
+	}
+
+	if err := cleanupManagedMaterializedRoot(statePath, root); err != nil {
+		t.Fatalf("cleanup managed materialized root: %v", err)
+	}
+	if _, statErr := os.Stat(root); !os.IsNotExist(statErr) {
+		t.Fatalf("expected managed materialized root to be removed, stat err=%v", statErr)
+	}
+}
+
+func TestCleanupManagedMaterializedRootRejectsUnmanagedRoot(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, ".wrkr", "last-scan.json")
+	root := filepath.Join(filepath.Dir(statePath), "materialized-sources")
+	if err := os.MkdirAll(root, 0o750); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	sentinel := filepath.Join(root, "keep.txt")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	err := cleanupManagedMaterializedRoot(statePath, root)
+	if err == nil {
+		t.Fatal("expected unmanaged root cleanup to be rejected")
+	}
+	if !isMaterializedRootSafetyError(err) {
+		t.Fatalf("expected materialized root safety error, got: %v", err)
+	}
+	if _, statErr := os.Stat(sentinel); statErr != nil {
+		t.Fatalf("expected unmanaged sentinel to remain, got: %v", statErr)
+	}
+}
+
 func TestScanRepoDoesNotDeleteUnmanagedMaterializedSources(t *testing.T) {
 	t.Parallel()
 
@@ -176,5 +228,104 @@ func TestScanRepoDoesNotDeleteUnmanagedMaterializedSources(t *testing.T) {
 	}
 	if errObj["exit_code"] != float64(exitUnsafeBlocked) {
 		t.Fatalf("unexpected error exit code: %v", errObj["exit_code"])
+	}
+}
+
+func TestScanInvalidSourceRetentionReturnsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{"scan", "--path", t.TempDir(), "--source-retention", "forever", "--json"}, &out, &errOut)
+	if code != exitInvalidInput {
+		t.Fatalf("expected exit %d, got %d (%s)", exitInvalidInput, code, errOut.String())
+	}
+	assertErrorEnvelopeCode(t, errOut.Bytes(), "invalid_input", exitInvalidInput)
+	if out.Len() != 0 {
+		t.Fatalf("expected no stdout on invalid input, got %q", out.String())
+	}
+}
+
+func TestScanHostedDefaultRemovesMaterializedRootAndSerializesLogicalLocation(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/acme/backend":
+			_, _ = fmt.Fprint(w, `{"full_name":"acme/backend","default_branch":"main"}`)
+		case "/repos/acme/backend/git/trees/main":
+			_, _ = fmt.Fprint(w, `{"tree":[{"path":"AGENTS.md","type":"blob","sha":"sha-agents"},{"path":"src/private.py","type":"blob","sha":"sha-source"}]}`)
+		case "/repos/acme/backend/git/blobs/sha-agents":
+			_, _ = fmt.Fprint(w, `{"content":"hosted instructions\n","encoding":"utf-8"}`)
+		case "/repos/acme/backend/git/blobs/sha-source":
+			t.Fatalf("default hosted scan should not fetch generic source blob %s", r.URL.Path)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, ".wrkr", "last-scan.json")
+	materializedRoot := filepath.Join(filepath.Dir(statePath), "materialized-sources")
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"scan",
+		"--repo", "acme/backend",
+		"--github-api", server.URL,
+		"--state", statePath,
+		"--json",
+	}, &out, &errOut)
+	if code != exitSuccess {
+		t.Fatalf("hosted scan failed: %d (%s)", code, errOut.String())
+	}
+	if strings.Contains(out.String(), "materialized-sources") || strings.Contains(errOut.String(), "materialized-sources") {
+		t.Fatalf("expected hosted scan output to avoid materialized root paths\nstdout=%s\nstderr=%s", out.String(), errOut.String())
+	}
+	if _, statErr := os.Stat(materializedRoot); !os.IsNotExist(statErr) {
+		t.Fatalf("expected default hosted scan to remove materialized root, stat err=%v", statErr)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse scan payload: %v", err)
+	}
+	sourceManifest, ok := payload["source_manifest"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected source manifest object, got %T", payload["source_manifest"])
+	}
+	repos, ok := sourceManifest["repos"].([]any)
+	if !ok || len(repos) != 1 {
+		t.Fatalf("expected one source repo, got %v", sourceManifest["repos"])
+	}
+	repo, ok := repos[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected repo object, got %T", repos[0])
+	}
+	if repo["location"] != "github://acme/backend" {
+		t.Fatalf("expected logical hosted location, got %v", repo["location"])
+	}
+	if _, ok := repo["scan_root"]; ok {
+		t.Fatalf("scan_root must not be serialized in source manifest: %v", repo)
+	}
+	privacy, ok := payload["source_privacy"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected source_privacy object, got %T", payload["source_privacy"])
+	}
+	if privacy["retention_mode"] != sourceprivacy.RetentionEphemeral {
+		t.Fatalf("unexpected retention mode: %v", privacy["retention_mode"])
+	}
+	if privacy["cleanup_status"] != sourceprivacy.CleanupRemoved {
+		t.Fatalf("unexpected cleanup status: %v", privacy["cleanup_status"])
+	}
+	if privacy["materialized_source_retained"] != false {
+		t.Fatalf("expected materialized_source_retained=false, got %v", privacy["materialized_source_retained"])
+	}
+	if privacy["raw_source_in_artifacts"] != false {
+		t.Fatalf("expected raw_source_in_artifacts=false, got %v", privacy["raw_source_in_artifacts"])
+	}
+	if privacy["serialized_locations"] != sourceprivacy.SerializedLocationsLogical {
+		t.Fatalf("unexpected serialized locations: %v", privacy["serialized_locations"])
 	}
 }

--- a/core/cli/scan_resume_test.go
+++ b/core/cli/scan_resume_test.go
@@ -89,7 +89,7 @@ func TestScanResumeMismatchReturnsInvalidInput(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state.json")
 	var firstOut bytes.Buffer
 	var firstErr bytes.Buffer
-	if code := Run([]string{"scan", "--org", "acme", "--github-api", server.URL, "--state", statePath, "--json"}, &firstOut, &firstErr); code != exitSuccess {
+	if code := Run([]string{"scan", "--org", "acme", "--github-api", server.URL, "--state", statePath, "--source-retention", "retain", "--json"}, &firstOut, &firstErr); code != exitSuccess {
 		t.Fatalf("initial scan failed: %d (%s)", code, firstErr.String())
 	}
 
@@ -123,7 +123,7 @@ func TestScanResumeSuccessEmitsResumeProgress(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state.json")
 	var firstOut bytes.Buffer
 	var firstErr bytes.Buffer
-	if code := Run([]string{"scan", "--org", "acme", "--github-api", server.URL, "--state", statePath, "--json"}, &firstOut, &firstErr); code != exitSuccess {
+	if code := Run([]string{"scan", "--org", "acme", "--github-api", server.URL, "--state", statePath, "--source-retention", "retain", "--json"}, &firstOut, &firstErr); code != exitSuccess {
 		t.Fatalf("initial scan failed: %d (%s)", code, firstErr.String())
 	}
 

--- a/core/cli/scan_status.go
+++ b/core/cli/scan_status.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Clyra-AI/wrkr/core/source"
+	"github.com/Clyra-AI/wrkr/core/sourceprivacy"
 	"github.com/Clyra-AI/wrkr/core/state"
 )
 
@@ -57,11 +58,22 @@ func runScanStatus(args []string, stdout io.Writer, stderr io.Writer) int {
 		status.LastSuccessfulPhase,
 		status.StatePath,
 	)
+	if status.SourcePrivacy != nil {
+		privacy := sourceprivacy.Normalize(*status.SourcePrivacy)
+		_, _ = fmt.Fprintf(stdout, "source privacy: retention=%s retained=%t cleanup=%s locations=%s raw_source_in_artifacts=%t\n",
+			privacy.RetentionMode,
+			privacy.MaterializedSourceRetained,
+			privacy.CleanupStatus,
+			privacy.SerializedLocations,
+			privacy.RawSourceInArtifacts,
+		)
+	}
 	return exitSuccess
 }
 
-func newScanStatusTracker(statePath string, target source.Target, targets []source.Target, startedAt time.Time, artifactPaths map[string]string) *scanStatusTracker {
+func newScanStatusTracker(statePath string, target source.Target, targets []source.Target, startedAt time.Time, artifactPaths map[string]string, sourcePrivacy sourceprivacy.Contract) *scanStatusTracker {
 	now := startedAt.UTC().Truncate(time.Second)
+	normalizedPrivacy := sourceprivacy.Normalize(sourcePrivacy)
 	status := state.ScanStatus{
 		Status:        state.ScanStatusRunning,
 		StatePath:     filepath.Clean(state.ResolvePath(statePath)),
@@ -70,6 +82,7 @@ func newScanStatusTracker(statePath string, target source.Target, targets []sour
 		StartedAt:     now.Format(time.RFC3339),
 		UpdatedAt:     now.Format(time.RFC3339),
 		ArtifactPaths: cleanArtifactPaths(artifactPaths),
+		SourcePrivacy: &normalizedPrivacy,
 	}
 	return &scanStatusTracker{statePath: statePath, status: status, phaseStarted: map[string]time.Time{}}
 }
@@ -116,6 +129,14 @@ func (t *scanStatusTracker) Repos(total, completed, failed int) error {
 	t.status.ReposFailed = failed
 	t.status.UpdatedAt = time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
 	return state.SaveScanStatus(t.statePath, t.status)
+}
+
+func (t *scanStatusTracker) SetSourcePrivacy(sourcePrivacy sourceprivacy.Contract) {
+	if t == nil {
+		return
+	}
+	normalized := sourceprivacy.Normalize(sourcePrivacy)
+	t.status.SourcePrivacy = &normalized
 }
 
 func (t *scanStatusTracker) Complete(artifactPaths map[string]string) error {

--- a/core/evidence/evidence.go
+++ b/core/evidence/evidence.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Clyra-AI/wrkr/core/compliance"
 	"github.com/Clyra-AI/wrkr/core/proofemit"
 	reportcore "github.com/Clyra-AI/wrkr/core/report"
+	"github.com/Clyra-AI/wrkr/core/sourceprivacy"
 	"github.com/Clyra-AI/wrkr/core/state"
 	verifycore "github.com/Clyra-AI/wrkr/core/verify"
 	"github.com/Clyra-AI/wrkr/internal/managedmarker"
@@ -33,14 +34,15 @@ type BuildInput struct {
 }
 
 type BuildResult struct {
-	OutputDir         string             `json:"output_dir"`
-	Frameworks        []string           `json:"frameworks"`
-	ManifestPath      string             `json:"manifest_path"`
-	ChainPath         string             `json:"chain_path"`
-	FrameworkCoverage map[string]float64 `json:"framework_coverage"`
-	ControlEvidence   []ControlEvidence  `json:"control_evidence,omitempty"`
-	CoverageNote      CoverageNote       `json:"coverage_note"`
-	ReportArtifacts   []string           `json:"report_artifacts"`
+	OutputDir         string                  `json:"output_dir"`
+	Frameworks        []string                `json:"frameworks"`
+	ManifestPath      string                  `json:"manifest_path"`
+	ChainPath         string                  `json:"chain_path"`
+	FrameworkCoverage map[string]float64      `json:"framework_coverage"`
+	ControlEvidence   []ControlEvidence       `json:"control_evidence,omitempty"`
+	CoverageNote      CoverageNote            `json:"coverage_note"`
+	ReportArtifacts   []string                `json:"report_artifacts"`
+	SourcePrivacy     *sourceprivacy.Contract `json:"source_privacy,omitempty"`
 }
 
 type ControlEvidence struct {
@@ -267,9 +269,10 @@ func Build(in BuildInput) (BuildResult, error) {
 		return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 	}
 	if err := writeJSON(filepath.Join(outputDir, "scan-metadata.json"), map[string]any{
-		"generated_at": generatedAt.Format(time.RFC3339),
-		"frameworks":   frameworks,
-		"state_path":   resolvedStatePath,
+		"generated_at":   generatedAt.Format(time.RFC3339),
+		"frameworks":     frameworks,
+		"state_path":     resolvedStatePath,
+		"source_privacy": snapshot.SourcePrivacy,
 	}); err != nil {
 		return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 	}
@@ -413,6 +416,7 @@ func Build(in BuildInput) (BuildResult, error) {
 		ControlEvidence:   controlEvidence,
 		CoverageNote:      defaultCoverageNote(),
 		ReportArtifacts:   reportArtifacts,
+		SourcePrivacy:     snapshot.SourcePrivacy,
 	}, nil
 }
 

--- a/core/export/sarif/sarif.go
+++ b/core/export/sarif/sarif.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/sourceprivacy"
 )
 
 const (
@@ -22,8 +23,9 @@ type Report struct {
 }
 
 type Run struct {
-	Tool    Tool     `json:"tool"`
-	Results []Result `json:"results,omitempty"`
+	Tool       Tool           `json:"tool"`
+	Results    []Result       `json:"results,omitempty"`
+	Properties map[string]any `json:"properties,omitempty"`
 }
 
 type Tool struct {
@@ -67,6 +69,12 @@ type ArtifactLocation struct {
 
 // Build maps Wrkr findings to a deterministic SARIF report.
 func Build(findings []model.Finding, wrkrVersion string) Report {
+	return BuildWithSourcePrivacy(findings, wrkrVersion, nil)
+}
+
+// BuildWithSourcePrivacy maps Wrkr findings to a deterministic SARIF report and,
+// when available, includes the scan source-privacy contract as run metadata.
+func BuildWithSourcePrivacy(findings []model.Finding, wrkrVersion string, privacy *sourceprivacy.Contract) Report {
 	sorted := append([]model.Finding(nil), findings...)
 	model.SortFindings(sorted)
 
@@ -109,22 +117,28 @@ func Build(findings []model.Finding, wrkrVersion string) Report {
 		rules = append(rules, rulesByID[id])
 	}
 
+	run := Run{
+		Tool: Tool{
+			Driver: Driver{
+				Name:           "wrkr",
+				Version:        strings.TrimSpace(wrkrVersion),
+				InformationURI: "https://github.com/Clyra-AI/wrkr",
+				Rules:          rules,
+			},
+		},
+		Results: results,
+	}
+	if privacy != nil {
+		normalized := sourceprivacy.Normalize(*privacy)
+		run.Properties = map[string]any{
+			"source_privacy": normalized,
+		}
+	}
+
 	return Report{
 		Schema:  schemaURL,
 		Version: version,
-		Runs: []Run{
-			{
-				Tool: Tool{
-					Driver: Driver{
-						Name:           "wrkr",
-						Version:        strings.TrimSpace(wrkrVersion),
-						InformationURI: "https://github.com/Clyra-AI/wrkr",
-						Rules:          rules,
-					},
-				},
-				Results: results,
-			},
-		},
+		Runs:    []Run{run},
 	}
 }
 
@@ -157,7 +171,7 @@ func findingMessage(finding model.Finding) string {
 }
 
 func fallbackLocation(location string) string {
-	value := strings.TrimSpace(location)
+	value := sourceprivacy.NewSanitizer().String(location)
 	if value == "" {
 		return "unknown"
 	}

--- a/core/export/sarif/sarif_test.go
+++ b/core/export/sarif/sarif_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/sourceprivacy"
 )
 
 func TestSARIFEmitterBuildDeterministic(t *testing.T) {
@@ -48,6 +49,39 @@ func TestSARIFEmitterBuildDeterministic(t *testing.T) {
 	}
 	if len(first.Runs) != 1 || len(first.Runs[0].Results) != 2 {
 		t.Fatalf("unexpected SARIF run/result counts: %+v", first)
+	}
+}
+
+func TestSARIFEmitterIncludesSourcePrivacyAndRedactsMaterializedLocation(t *testing.T) {
+	t.Parallel()
+
+	privacy := sourceprivacy.InitialContract(sourceprivacy.RetentionEphemeral, true, false)
+	privacy = sourceprivacy.MarkRemoved(privacy)
+	report := BuildWithSourcePrivacy([]model.Finding{
+		{
+			FindingType: "tool_config",
+			Severity:    model.SeverityLow,
+			ToolType:    "codex",
+			Location:    "/tmp/work/.wrkr/materialized-sources/acme/backend/.codex/config.toml",
+			Repo:        "backend",
+			Org:         "acme",
+			Detector:    "codex",
+		},
+	}, "v1.2.3", &privacy)
+
+	if len(report.Runs) != 1 {
+		t.Fatalf("expected one SARIF run, got %+v", report.Runs)
+	}
+	sourcePrivacy, ok := report.Runs[0].Properties["source_privacy"].(sourceprivacy.Contract)
+	if !ok {
+		t.Fatalf("expected source_privacy run property, got %+v", report.Runs[0].Properties)
+	}
+	if sourcePrivacy.CleanupStatus != sourceprivacy.CleanupRemoved {
+		t.Fatalf("unexpected cleanup status: %s", sourcePrivacy.CleanupStatus)
+	}
+	gotLocation := report.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI
+	if sourceprivacy.ContainsMaterializedSourcePath(gotLocation) {
+		t.Fatalf("expected materialized source path to be redacted, got %s", gotLocation)
 	}
 }
 

--- a/core/proofmap/proofmap.go
+++ b/core/proofmap/proofmap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Clyra-AI/wrkr/core/risk"
 	riskattack "github.com/Clyra-AI/wrkr/core/risk/attackpath"
 	"github.com/Clyra-AI/wrkr/core/score"
+	"github.com/Clyra-AI/wrkr/core/sourceprivacy"
 )
 
 type MappedRecord struct {
@@ -137,14 +138,14 @@ func MapFindings(findings []model.Finding, profile *profileeval.Result, visibili
 			}
 		}
 
-		records = append(records, MappedRecord{
+		records = append(records, sanitizeMappedRecord(MappedRecord{
 			RecordType:   "scan_finding",
 			AgentID:      agentID,
 			Timestamp:    canonicalTime(now),
 			Event:        event,
 			Metadata:     metadata,
 			Relationship: buildFindingRelationship(representative, key, ruleIDs, agentID),
-		})
+		}))
 	}
 	return records
 }
@@ -204,14 +205,14 @@ func MapRisk(report risk.Report, posture score.Result, profile profileeval.Resul
 				metadata["agent_framework"] = framework
 			}
 		}
-		records = append(records, MappedRecord{
+		records = append(records, sanitizeMappedRecord(MappedRecord{
 			RecordType:   "risk_assessment",
 			AgentID:      agentID,
 			Timestamp:    canonicalTime(now),
 			Event:        event,
 			Relationship: buildFindingRiskRelationship(item, agentID),
 			Metadata:     metadata,
-		})
+		}))
 	}
 	for idx, path := range report.AttackPaths {
 		event := map[string]any{
@@ -229,7 +230,7 @@ func MapRisk(report risk.Report, posture score.Result, profile profileeval.Resul
 			"edge_rationale":  append([]string(nil), path.EdgeRationale...),
 			"explain":         append([]string(nil), path.Explain...),
 		}
-		records = append(records, MappedRecord{
+		records = append(records, sanitizeMappedRecord(MappedRecord{
 			RecordType:   "risk_assessment",
 			Timestamp:    canonicalTime(now),
 			Event:        event,
@@ -240,7 +241,7 @@ func MapRisk(report risk.Report, posture score.Result, profile profileeval.Resul
 				"attack_path_id":     path.PathID,
 				"attack_path_source": append([]string(nil), path.SourceFindings...),
 			},
-		})
+		}))
 	}
 	for idx, path := range report.ActionPaths {
 		event := map[string]any{
@@ -260,7 +261,7 @@ func MapRisk(report risk.Report, posture score.Result, profile profileeval.Resul
 			"production_write":           path.ProductionWrite,
 			"matched_production_targets": append([]string(nil), path.MatchedProductionTargets...),
 		}
-		records = append(records, MappedRecord{
+		records = append(records, sanitizeMappedRecord(MappedRecord{
 			RecordType: "risk_assessment",
 			AgentID:    path.AgentID,
 			Timestamp:  canonicalTime(now),
@@ -270,7 +271,7 @@ func MapRisk(report risk.Report, posture score.Result, profile profileeval.Resul
 				"canonical_finding": "action_path_governance",
 				"action_path_id":    path.PathID,
 			},
-		})
+		}))
 	}
 
 	postureEvent := map[string]any{
@@ -304,7 +305,7 @@ func MapRisk(report risk.Report, posture score.Result, profile profileeval.Resul
 			"unknown_to_security_write_capable_agents": visibility.Summary.UnknownToSecurityWriteCapableAgents,
 		}
 	}
-	records = append(records, MappedRecord{
+	records = append(records, sanitizeMappedRecord(MappedRecord{
 		RecordType:   "risk_assessment",
 		Timestamp:    canonicalTime(now),
 		Event:        postureEvent,
@@ -313,7 +314,7 @@ func MapRisk(report risk.Report, posture score.Result, profile profileeval.Resul
 			"canonical_finding": "posture_score",
 			"profile_name":      profile.ProfileName,
 		},
-	})
+	}))
 
 	return records
 }
@@ -372,7 +373,7 @@ func MapTransition(transition lifecycle.Transition, eventType string) MappedReco
 	if parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(transition.Timestamp)); err == nil {
 		timestamp = parsed.UTC().Truncate(time.Second)
 	}
-	return MappedRecord{
+	return sanitizeMappedRecord(MappedRecord{
 		RecordType:    recordType,
 		AgentID:       strings.TrimSpace(transition.AgentID),
 		Timestamp:     timestamp,
@@ -383,7 +384,7 @@ func MapTransition(transition lifecycle.Transition, eventType string) MappedReco
 			"transition_trigger": transition.Trigger,
 			"event_type":         resolvedEventType,
 		},
-	}
+	})
 }
 
 func CanonicalFindingKey(finding model.Finding) string {
@@ -397,7 +398,7 @@ func CanonicalFindingKey(finding model.Finding) string {
 		strings.TrimSpace(finding.FindingType),
 		strings.TrimSpace(finding.RuleID),
 		strings.TrimSpace(finding.ToolType),
-		strings.TrimSpace(finding.Location),
+		artifactString(finding.Location),
 		strings.TrimSpace(finding.Repo),
 		canonicalOrg(finding.Org),
 	}
@@ -426,6 +427,94 @@ func selectRepresentative(findings []model.Finding) model.Finding {
 	return findings[0]
 }
 
+func sanitizeMappedRecord(record MappedRecord) MappedRecord {
+	record.AgentID = artifactString(record.AgentID)
+	record.Event = artifactMap(record.Event)
+	record.Metadata = artifactMap(record.Metadata)
+	record.ApprovedScope = artifactString(record.ApprovedScope)
+	record.Relationship = sanitizeRelationship(record.Relationship)
+	return record
+}
+
+func artifactMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return in
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = artifactAny(value)
+	}
+	return out
+}
+
+func artifactAny(value any) any {
+	switch typed := value.(type) {
+	case string:
+		return artifactString(typed)
+	case []string:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, artifactString(item))
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, artifactAny(item))
+		}
+		return out
+	case map[string]any:
+		return artifactMap(typed)
+	case []map[string]any:
+		out := make([]map[string]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, artifactMap(item))
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func artifactString(value string) string {
+	return sourceprivacy.NewSanitizer().String(value)
+}
+
+func sanitizeRelationship(rel *proof.Relationship) *proof.Relationship {
+	if rel == nil {
+		return nil
+	}
+	out := *rel
+	if rel.ParentRef != nil {
+		parent := sanitizeRelationshipRef(*rel.ParentRef)
+		out.ParentRef = &parent
+	}
+	out.EntityRefs = make([]proof.RelationshipRef, 0, len(rel.EntityRefs))
+	for _, ref := range rel.EntityRefs {
+		out.EntityRefs = append(out.EntityRefs, sanitizeRelationshipRef(ref))
+	}
+	out.Edges = make([]proof.RelationshipEdge, 0, len(rel.Edges))
+	for _, edge := range rel.Edges {
+		out.Edges = append(out.Edges, proof.RelationshipEdge{
+			Kind:  edge.Kind,
+			From:  sanitizeRelationshipRef(edge.From),
+			To:    sanitizeRelationshipRef(edge.To),
+			Extra: edge.Extra,
+		})
+	}
+	out.RelatedRecordIDs = append([]string(nil), rel.RelatedRecordIDs...)
+	out.RelatedEntityIDs = make([]string, 0, len(rel.RelatedEntityIDs))
+	for _, id := range rel.RelatedEntityIDs {
+		out.RelatedEntityIDs = append(out.RelatedEntityIDs, artifactString(id))
+	}
+	return &out
+}
+
+func sanitizeRelationshipRef(ref proof.RelationshipRef) proof.RelationshipRef {
+	ref.ID = artifactString(ref.ID)
+	return ref
+}
+
 func evidenceMap(evidence []model.Evidence) map[string]any {
 	if len(evidence) == 0 {
 		return map[string]any{}
@@ -445,7 +534,7 @@ func evidenceMap(evidence []model.Evidence) map[string]any {
 			out[key] = parsed
 			continue
 		}
-		out[key] = value
+		out[key] = artifactString(value)
 	}
 	if len(out) == 0 {
 		return map[string]any{}

--- a/core/proofmap/proofmap_test.go
+++ b/core/proofmap/proofmap_test.go
@@ -1,6 +1,8 @@
 package proofmap
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -65,6 +67,43 @@ func TestMapFindingsDeduplicatesWRKR014Conflict(t *testing.T) {
 	}
 	if record.Relationship.PolicyRef == nil || len(record.Relationship.PolicyRef.MatchedRuleIDs) != 1 || record.Relationship.PolicyRef.MatchedRuleIDs[0] != "WRKR-014" {
 		t.Fatalf("expected relationship policy_ref matched_rule_ids, got %#v", record.Relationship.PolicyRef)
+	}
+}
+
+func TestMapFindingsRedactsMaterializedSourcePaths(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	materializedPath := "/tmp/work/.wrkr/materialized-sources/acme/backend/.codex/config.toml"
+	findings := []model.Finding{
+		{
+			FindingType: "tool_config",
+			Severity:    model.SeverityLow,
+			ToolType:    "codex",
+			Location:    materializedPath,
+			Repo:        "backend",
+			Org:         "acme",
+			ParseError: &model.ParseError{
+				Kind:     "invalid_config",
+				Path:     materializedPath,
+				Message:  "parse failed at " + materializedPath,
+				Detector: "codex",
+			},
+			Evidence: []model.Evidence{{Key: "path", Value: materializedPath}},
+		},
+	}
+
+	records := MapFindings(findings, nil, SecurityVisibilityContext{}, now)
+	if len(records) != 1 {
+		t.Fatalf("expected one proof map record, got %d", len(records))
+	}
+	if strings.Contains(fmt.Sprintf("%#v", records[0].Event), "materialized-sources") {
+		t.Fatalf("expected event to redact materialized path, got %#v", records[0].Event)
+	}
+	if strings.Contains(fmt.Sprintf("%#v", records[0].Metadata), "materialized-sources") {
+		t.Fatalf("expected metadata to redact materialized path, got %#v", records[0].Metadata)
+	}
+	if records[0].Relationship != nil && strings.Contains(fmt.Sprintf("%#v", records[0].Relationship.EntityRefs), "materialized-sources") {
+		t.Fatalf("expected relationship refs to redact materialized path, got %#v", records[0].Relationship.EntityRefs)
 	}
 }
 

--- a/core/report/build.go
+++ b/core/report/build.go
@@ -22,6 +22,7 @@ import (
 	templatespkg "github.com/Clyra-AI/wrkr/core/report/templates"
 	"github.com/Clyra-AI/wrkr/core/risk"
 	"github.com/Clyra-AI/wrkr/core/source"
+	"github.com/Clyra-AI/wrkr/core/sourceprivacy"
 	"github.com/Clyra-AI/wrkr/core/state"
 	verifycore "github.com/Clyra-AI/wrkr/core/verify"
 )
@@ -87,6 +88,7 @@ func BuildSummary(in BuildInput) (Summary, error) {
 	exposureGroups := risk.BuildExposureGroups(riskReport.ActionPaths)
 	assessmentSummary := buildAssessmentSummary(riskReport.ActionPaths, riskReport.ActionPathToControlFirst, in.Snapshot.Inventory, proofRef)
 	controlBacklog := in.Snapshot.ControlBacklog
+	sourcePrivacy := normalizedSourcePrivacy(in.Snapshot.SourcePrivacy)
 
 	if shareProfile == ShareProfilePublic {
 		proofRef = sanitizeProofReferencePublic(proofRef)
@@ -104,7 +106,7 @@ func BuildSummary(in BuildInput) (Summary, error) {
 	securityVisibility := securityVisibilityFromInventory(in.Snapshot.Inventory)
 	nextActions := buildNextActions(riskItems, lifecycleSummary, regressSummary)
 	pack := templatespkg.Resolve(string(template))
-	sections := buildSections(pack, template == TemplatePublic, headline, methodology, riskItems, attackPathFacts, complianceSummary, privilegeBudget, securityVisibility, deltas, lifecycleSummary, regressSummary, proofRef, nextActions)
+	sections := buildSections(pack, template == TemplatePublic, headline, methodology, riskItems, attackPathFacts, complianceSummary, privilegeBudget, securityVisibility, deltas, lifecycleSummary, regressSummary, proofRef, nextActions, sourcePrivacy)
 
 	sectionOrder := []string{
 		SectionHeadline,
@@ -151,9 +153,18 @@ func BuildSummary(in BuildInput) (Summary, error) {
 		ActionPaths:              riskReport.ActionPaths,
 		ActionPathToControlFirst: riskReport.ActionPathToControlFirst,
 		ExposureGroups:           exposureGroups,
+		SourcePrivacy:            sourcePrivacy,
 	}
 
 	return summary, nil
+}
+
+func normalizedSourcePrivacy(in *sourceprivacy.Contract) *sourceprivacy.Contract {
+	if in == nil {
+		return nil
+	}
+	normalized := sourceprivacy.Normalize(*in)
+	return &normalized
 }
 
 type complianceSummaryError struct {
@@ -677,6 +688,7 @@ func buildSections(
 	regressSummary *RegressSummary,
 	proof ProofReference,
 	nextActions []ChecklistItem,
+	sourcePrivacy *sourceprivacy.Contract,
 ) []Section {
 	riskFacts := make([]string, 0, len(risks))
 	for _, item := range risks {
@@ -741,6 +753,15 @@ func buildSections(
 		headlineFacts = append(headlineFacts, fmt.Sprintf("production_write=%d (status=%s)", *privilegeBudget.ProductionWrite.Count, privilegeBudget.ProductionWrite.Status))
 	} else {
 		headlineFacts = append(headlineFacts, fmt.Sprintf("production targets %s; default claim scope is write_capable=%d", privilegeBudget.ProductionWrite.Status, privilegeBudget.WriteCapableTools))
+	}
+	if sourcePrivacy != nil {
+		headlineFacts = append(headlineFacts, fmt.Sprintf("source_privacy retention=%s retained=%t raw_source_in_artifacts=%t serialized_locations=%s cleanup_status=%s",
+			sourcePrivacy.RetentionMode,
+			sourcePrivacy.MaterializedSourceRetained,
+			sourcePrivacy.RawSourceInArtifacts,
+			sourcePrivacy.SerializedLocations,
+			sourcePrivacy.CleanupStatus,
+		))
 	}
 
 	methodologyFacts := []string{

--- a/core/report/types.go
+++ b/core/report/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Clyra-AI/wrkr/core/manifest"
 	"github.com/Clyra-AI/wrkr/core/regress"
 	"github.com/Clyra-AI/wrkr/core/risk"
+	"github.com/Clyra-AI/wrkr/core/sourceprivacy"
 	"github.com/Clyra-AI/wrkr/core/state"
 )
 
@@ -82,6 +83,7 @@ type Summary struct {
 	ActionPaths              []risk.ActionPath                      `json:"action_paths,omitempty"`
 	ActionPathToControlFirst *risk.ActionPathToControlFirst         `json:"action_path_to_control_first,omitempty"`
 	ExposureGroups           []risk.ExposureGroup                   `json:"exposure_groups,omitempty"`
+	SourcePrivacy            *sourceprivacy.Contract                `json:"source_privacy,omitempty"`
 }
 
 type AttackPathSummary struct {

--- a/core/source/github/connector.go
+++ b/core/source/github/connector.go
@@ -37,6 +37,9 @@ type Connector struct {
 	MaxBackoff       time.Duration
 	FailureThreshold int
 	Cooldown         time.Duration
+	// AllowSourceMaterialization permits broad source-code extension fetching for
+	// explicit deep/debug scans. Default hosted scans keep this false.
+	AllowSourceMaterialization bool
 
 	mu                  sync.Mutex
 	consecutiveFailures int
@@ -89,6 +92,13 @@ func (c *Connector) SetCooldownHandler(fn func(CooldownEvent)) {
 		return
 	}
 	c.onCooldown = fn
+}
+
+func (c *Connector) SetAllowSourceMaterialization(allow bool) {
+	if c == nil {
+		return
+	}
+	c.AllowSourceMaterialization = allow
 }
 
 // DegradedError indicates connector circuit-breaker degradation.
@@ -306,7 +316,7 @@ func (c *Connector) MaterializeRepo(ctx context.Context, repo string, materializ
 		if pathErr != nil {
 			return source.RepoManifest{}, pathErr
 		}
-		if !shouldMaterializeBlob(item.Path) {
+		if !shouldMaterializeBlobWithSource(item.Path, c.AllowSourceMaterialization) {
 			continue
 		}
 		blob, blobErr := c.repoBlob(ctx, fullName, item.SHA)
@@ -327,7 +337,8 @@ func (c *Connector) MaterializeRepo(ctx context.Context, repo string, materializ
 
 	return source.RepoManifest{
 		Repo:              fullName,
-		Location:          filepath.ToSlash(repoRoot),
+		Location:          "github://" + fullName,
+		ScanRoot:          filepath.ToSlash(repoRoot),
 		Source:            "github_repo_materialized",
 		OwnershipMetadata: repoOwnershipMetadata(meta),
 	}, nil
@@ -450,6 +461,10 @@ func repoOwnershipMetadata(meta repoMeta) *source.RepoOwnershipMetadata {
 }
 
 func shouldMaterializeBlob(rel string) bool {
+	return shouldMaterializeBlobWithSource(rel, false)
+}
+
+func shouldMaterializeBlobWithSource(rel string, allowSourceMaterialization bool) bool {
 	normalized := strings.Trim(strings.ToLower(filepath.ToSlash(strings.TrimSpace(rel))), "/")
 	if normalized == "" {
 		return false
@@ -482,7 +497,7 @@ func shouldMaterializeBlob(rel string) bool {
 	if strings.HasPrefix(base, "docker-compose") || strings.HasPrefix(base, "compose.") {
 		return true
 	}
-	if !isSparseSourceExtension(path.Ext(normalized)) {
+	if !allowSourceMaterialization || !isSparseSourceExtension(path.Ext(normalized)) {
 		return false
 	}
 	return true

--- a/core/source/github/connector.go
+++ b/core/source/github/connector.go
@@ -460,10 +460,6 @@ func repoOwnershipMetadata(meta repoMeta) *source.RepoOwnershipMetadata {
 	return &source.RepoOwnershipMetadata{Topics: topics, Teams: teams}
 }
 
-func shouldMaterializeBlob(rel string) bool {
-	return shouldMaterializeBlobWithSource(rel, false)
-}
-
 func shouldMaterializeBlobWithSource(rel string, allowSourceMaterialization bool) bool {
 	normalized := strings.Trim(strings.ToLower(filepath.ToSlash(strings.TrimSpace(rel))), "/")
 	if normalized == "" {

--- a/core/source/github/connector_test.go
+++ b/core/source/github/connector_test.go
@@ -299,11 +299,9 @@ func TestMaterializeRepoWritesRepositoryTree(t *testing.T) {
 			payload := base64.StdEncoding.EncodeToString([]byte("system_prompt: keep policy instructions intact\n"))
 			_, _ = fmt.Fprintf(w, `{"content":"%s","encoding":"base64"}`, payload)
 		case "/repos/acme/backend/git/blobs/sha-source-py":
-			payload := base64.StdEncoding.EncodeToString([]byte("from crewai import Agent\n"))
-			_, _ = fmt.Fprintf(w, `{"content":"%s","encoding":"base64"}`, payload)
+			t.Fatalf("default sparse materializer should not fetch generic source blob %s", r.URL.Path)
 		case "/repos/acme/backend/git/blobs/sha-source-generic":
-			payload := base64.StdEncoding.EncodeToString([]byte("from langchain.agents import AgentExecutor\n"))
-			_, _ = fmt.Fprintf(w, `{"content":"%s","encoding":"base64"}`, payload)
+			t.Fatalf("default sparse materializer should not fetch generic source blob %s", r.URL.Path)
 		case "/repos/acme/backend/git/blobs/sha-build-source":
 			t.Fatalf("sparse materializer should not fetch generated source blob %s", r.URL.Path)
 		case "/repos/acme/backend/git/blobs/sha-vendor-source":
@@ -330,6 +328,13 @@ func TestMaterializeRepoWritesRepositoryTree(t *testing.T) {
 	}
 	if manifest.Repo != "acme/backend" {
 		t.Fatalf("unexpected repo: %s", manifest.Repo)
+	}
+	if manifest.Location != "github://acme/backend" {
+		t.Fatalf("expected logical hosted location, got %s", manifest.Location)
+	}
+	expectedScanRoot := filepath.ToSlash(filepath.Join(tmp, "acme", "backend"))
+	if manifest.ScanRoot != expectedScanRoot {
+		t.Fatalf("expected scan root %s, got %s", expectedScanRoot, manifest.ScanRoot)
 	}
 
 	agentsPath := filepath.Join(tmp, "acme", "backend", "AGENTS.md")
@@ -377,11 +382,11 @@ func TestMaterializeRepoWritesRepositoryTree(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(tmp, "acme", "backend", "instructions", "policy.yaml")); err != nil {
 		t.Fatalf("expected materialized instruction YAML: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(tmp, "acme", "backend", "src", "main.py")); err != nil {
-		t.Fatalf("expected materialized generic source file: %v", err)
+	if _, err := os.Stat(filepath.Join(tmp, "acme", "backend", "src", "main.py")); !os.IsNotExist(err) {
+		t.Fatalf("expected default scan to skip generic source file, stat err=%v", err)
 	}
-	if _, err := os.Stat(filepath.Join(tmp, "acme", "backend", "crews", "ops.py")); err != nil {
-		t.Fatalf("expected materialized generic source file in framework-neutral path: %v", err)
+	if _, err := os.Stat(filepath.Join(tmp, "acme", "backend", "crews", "ops.py")); !os.IsNotExist(err) {
+		t.Fatalf("expected default scan to skip generic source file in framework-neutral path, stat err=%v", err)
 	}
 	if _, err := os.Stat(filepath.Join(tmp, "acme", "backend", "build", "main.py")); !os.IsNotExist(err) {
 		t.Fatalf("expected generated source path to remain skipped, stat err=%v", err)
@@ -397,6 +402,44 @@ func TestMaterializeRepoWritesRepositoryTree(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(tmp, "acme", "backend", "docs", "changelog.txt")); !os.IsNotExist(err) {
 		t.Fatalf("expected unrelated docs blob to be skipped, stat err=%v", err)
+	}
+}
+
+func TestMaterializeRepoAllowsGenericSourceWhenExplicitlyEnabled(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/acme/backend":
+			_, _ = fmt.Fprint(w, `{"full_name":"acme/backend","default_branch":"main"}`)
+		case "/repos/acme/backend/git/trees/main":
+			_, _ = fmt.Fprint(w, `{"tree":[{"path":"src/main.py","type":"blob","sha":"sha-source-py"},{"path":"build/generated.py","type":"blob","sha":"sha-build-source"}]}`)
+		case "/repos/acme/backend/git/blobs/sha-source-py":
+			payload := base64.StdEncoding.EncodeToString([]byte("from crewai import Agent\n"))
+			_, _ = fmt.Fprintf(w, `{"content":"%s","encoding":"base64"}`, payload)
+		case "/repos/acme/backend/git/blobs/sha-build-source":
+			t.Fatalf("explicit source materialization should still skip generated source blob %s", r.URL.Path)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	connector := NewConnector(server.URL, "", server.Client())
+	connector.SetAllowSourceMaterialization(true)
+	manifest, err := connector.MaterializeRepo(context.Background(), "acme/backend", tmp)
+	if err != nil {
+		t.Fatalf("materialize repo: %v", err)
+	}
+	if manifest.Location != "github://acme/backend" {
+		t.Fatalf("expected logical hosted location, got %s", manifest.Location)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "acme", "backend", "src", "main.py")); err != nil {
+		t.Fatalf("expected explicit generic source materialization: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "acme", "backend", "build", "generated.py")); !os.IsNotExist(err) {
+		t.Fatalf("expected generated source path to remain skipped, stat err=%v", err)
 	}
 }
 

--- a/core/source/org/materialized.go
+++ b/core/source/org/materialized.go
@@ -242,7 +242,8 @@ func manifestFromCheckpoint(repo string, materializedRoot string) (source.RepoMa
 	}
 	return source.RepoManifest{
 		Repo:     strings.TrimSpace(repo),
-		Location: filepath.ToSlash(location),
+		Location: "github://" + strings.TrimSpace(repo),
+		ScanRoot: filepath.ToSlash(location),
 		Source:   "github_repo_materialized",
 	}, nil
 }

--- a/core/source/types.go
+++ b/core/source/types.go
@@ -18,6 +18,7 @@ const TargetModeMulti = "multi"
 type RepoManifest struct {
 	Repo              string                 `json:"repo"`
 	Location          string                 `json:"location"`
+	ScanRoot          string                 `json:"-" yaml:"-"`
 	Source            string                 `json:"source"`
 	OwnershipMetadata *RepoOwnershipMetadata `json:"ownership_metadata,omitempty"`
 }
@@ -35,10 +36,11 @@ type RepoFailure struct {
 
 // Manifest is the deterministic source acquisition output.
 type Manifest struct {
-	Target   Target         `json:"target"`
-	Targets  []Target       `json:"targets,omitempty"`
-	Repos    []RepoManifest `json:"repos"`
-	Failures []RepoFailure  `json:"failures,omitempty"`
+	Target           Target         `json:"target"`
+	Targets          []Target       `json:"targets,omitempty"`
+	Repos            []RepoManifest `json:"repos"`
+	Failures         []RepoFailure  `json:"failures,omitempty"`
+	MaterializedRoot string         `json:"-" yaml:"-"`
 }
 
 // Finding is the canonical scan record used by diff/state.

--- a/core/sourceprivacy/privacy.go
+++ b/core/sourceprivacy/privacy.go
@@ -1,0 +1,207 @@
+package sourceprivacy
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	RetentionEphemeral       = "ephemeral"
+	RetentionRetainForResume = "retain_for_resume"
+	RetentionRetain          = "retain"
+
+	SerializedLocationsLogical    = "logical"
+	SerializedLocationsFilesystem = "filesystem"
+
+	CleanupNotApplicable = "not_applicable"
+	CleanupPending       = "pending"
+	CleanupRemoved       = "removed"
+	CleanupRetained      = "retained"
+	CleanupFailed        = "failed"
+)
+
+// Contract is the machine-readable privacy contract emitted with scan-derived artifacts.
+type Contract struct {
+	RetentionMode              string   `json:"retention_mode" yaml:"retention_mode"`
+	MaterializedSourceRetained bool     `json:"materialized_source_retained" yaml:"materialized_source_retained"`
+	RawSourceInArtifacts       bool     `json:"raw_source_in_artifacts" yaml:"raw_source_in_artifacts"`
+	SerializedLocations        string   `json:"serialized_locations" yaml:"serialized_locations"`
+	CleanupStatus              string   `json:"cleanup_status" yaml:"cleanup_status"`
+	Warnings                   []string `json:"warnings,omitempty" yaml:"warnings,omitempty"`
+}
+
+func ParseRetentionMode(raw string) (string, error) {
+	switch strings.TrimSpace(raw) {
+	case "", RetentionEphemeral:
+		return RetentionEphemeral, nil
+	case RetentionRetainForResume:
+		return RetentionRetainForResume, nil
+	case RetentionRetain:
+		return RetentionRetain, nil
+	default:
+		return "", fmt.Errorf("--source-retention must be one of ephemeral, retain_for_resume, or retain")
+	}
+}
+
+func InitialContract(mode string, hosted bool, allowSourceMaterialization bool) Contract {
+	if strings.TrimSpace(mode) == "" {
+		mode = RetentionEphemeral
+	}
+	contract := Contract{
+		RetentionMode:              mode,
+		MaterializedSourceRetained: false,
+		RawSourceInArtifacts:       false,
+		SerializedLocations:        SerializedLocationsFilesystem,
+		CleanupStatus:              CleanupNotApplicable,
+	}
+	if hosted {
+		contract.SerializedLocations = SerializedLocationsLogical
+		contract.CleanupStatus = CleanupPending
+	}
+	if mode == RetentionRetain || mode == RetentionRetainForResume {
+		contract.Warnings = append(contract.Warnings, "hosted source materialization retention was explicitly requested")
+	}
+	if allowSourceMaterialization {
+		contract.Warnings = append(contract.Warnings, "generic hosted source-code materialization was explicitly enabled")
+	}
+	return Normalize(contract)
+}
+
+func Normalize(in Contract) Contract {
+	mode, err := ParseRetentionMode(in.RetentionMode)
+	if err != nil {
+		mode = RetentionEphemeral
+	}
+	in.RetentionMode = mode
+	if strings.TrimSpace(in.SerializedLocations) == "" {
+		in.SerializedLocations = SerializedLocationsFilesystem
+	}
+	if strings.TrimSpace(in.CleanupStatus) == "" {
+		in.CleanupStatus = CleanupNotApplicable
+	}
+	in.RawSourceInArtifacts = false
+	in.Warnings = uniqueSortedStrings(in.Warnings)
+	return in
+}
+
+func MarkRemoved(in Contract) Contract {
+	in.MaterializedSourceRetained = false
+	in.CleanupStatus = CleanupRemoved
+	return Normalize(in)
+}
+
+func MarkRetained(in Contract) Contract {
+	in.MaterializedSourceRetained = true
+	in.CleanupStatus = CleanupRetained
+	return Normalize(in)
+}
+
+func MarkFailed(in Contract, reason string) Contract {
+	in.MaterializedSourceRetained = true
+	in.CleanupStatus = CleanupFailed
+	if trimmed := strings.TrimSpace(reason); trimmed != "" {
+		in.Warnings = append(in.Warnings, "source cleanup failed: "+trimmed)
+	}
+	return Normalize(in)
+}
+
+func ShouldRetainMaterializedSource(mode string, success bool) bool {
+	switch strings.TrimSpace(mode) {
+	case RetentionRetain:
+		return true
+	case RetentionRetainForResume:
+		return !success
+	default:
+		return false
+	}
+}
+
+type Sanitizer struct {
+	roots []string
+}
+
+func NewSanitizer(roots ...string) Sanitizer {
+	normalized := make([]string, 0, len(roots)*2)
+	for _, root := range roots {
+		trimmed := strings.TrimSpace(root)
+		if trimmed == "" {
+			continue
+		}
+		clean := filepath.Clean(trimmed)
+		normalized = append(normalized, clean, filepath.ToSlash(clean))
+		if abs, err := filepath.Abs(clean); err == nil {
+			normalized = append(normalized, abs, filepath.ToSlash(abs))
+		}
+	}
+	return Sanitizer{roots: uniqueSortedStrings(normalized)}
+}
+
+func (s Sanitizer) String(value string) string {
+	out := strings.TrimSpace(value)
+	if out == "" {
+		return out
+	}
+	for _, root := range s.roots {
+		if root == "" {
+			continue
+		}
+		out = strings.ReplaceAll(out, root, "$WRKR_SCAN_ROOT")
+	}
+	out = redactMaterializedSegment(out)
+	return out
+}
+
+func (s Sanitizer) Strings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, s.String(value))
+	}
+	return out
+}
+
+func ContainsMaterializedSourcePath(value string) bool {
+	normalized := filepath.ToSlash(strings.TrimSpace(value))
+	return strings.Contains(normalized, ".wrkr/materialized-sources") ||
+		strings.Contains(normalized, "/materialized-sources/")
+}
+
+func redactMaterializedSegment(value string) string {
+	normalized := filepath.ToSlash(value)
+	for _, marker := range []string{".wrkr/materialized-sources/", "materialized-sources/"} {
+		idx := strings.Index(normalized, marker)
+		if idx < 0 {
+			continue
+		}
+		tail := strings.TrimPrefix(normalized[idx+len(marker):], "/")
+		if tail == "" {
+			return "redacted://materialized-source"
+		}
+		return "redacted://materialized-source/" + tail
+	}
+	return value
+}
+
+func uniqueSortedStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	for i := 0; i < len(out); i++ {
+		for j := i + 1; j < len(out); j++ {
+			if out[j] < out[i] {
+				out[i], out[j] = out[j], out[i]
+			}
+		}
+	}
+	return out
+}

--- a/core/sourceprivacy/privacy.go
+++ b/core/sourceprivacy/privacy.go
@@ -162,24 +162,21 @@ func (s Sanitizer) Strings(values []string) []string {
 
 func ContainsMaterializedSourcePath(value string) bool {
 	normalized := filepath.ToSlash(strings.TrimSpace(value))
-	return strings.Contains(normalized, ".wrkr/materialized-sources") ||
-		strings.Contains(normalized, "/materialized-sources/")
+	return strings.Contains(normalized, ".wrkr/materialized-sources")
 }
 
 func redactMaterializedSegment(value string) string {
 	normalized := filepath.ToSlash(value)
-	for _, marker := range []string{".wrkr/materialized-sources/", "materialized-sources/"} {
-		idx := strings.Index(normalized, marker)
-		if idx < 0 {
-			continue
-		}
-		tail := strings.TrimPrefix(normalized[idx+len(marker):], "/")
-		if tail == "" {
-			return "redacted://materialized-source"
-		}
-		return "redacted://materialized-source/" + tail
+	const marker = ".wrkr/materialized-sources/"
+	idx := strings.Index(normalized, marker)
+	if idx < 0 {
+		return value
 	}
-	return value
+	tail := strings.TrimPrefix(normalized[idx+len(marker):], "/")
+	if tail == "" {
+		return "redacted://materialized-source"
+	}
+	return "redacted://materialized-source/" + tail
 }
 
 func uniqueSortedStrings(values []string) []string {

--- a/core/sourceprivacy/privacy_test.go
+++ b/core/sourceprivacy/privacy_test.go
@@ -39,3 +39,29 @@ func TestSanitizerRedactsMaterializedSourceRoots(t *testing.T) {
 		t.Fatalf("expected sanitizer to modify materialized path %s", value)
 	}
 }
+
+func TestSanitizerRedactsLegacyManagedMaterializedPath(t *testing.T) {
+	t.Parallel()
+
+	value := "/tmp/work/.wrkr/materialized-sources/acme/backend/.codex/config.toml"
+	got := NewSanitizer().String(value)
+	if got == value {
+		t.Fatalf("expected legacy managed materialized path to be redacted")
+	}
+	if ContainsMaterializedSourcePath(got) {
+		t.Fatalf("expected redacted output to omit managed materialized path markers, got %s", got)
+	}
+}
+
+func TestSanitizerDoesNotRedactUnmanagedMaterializedSourcesSegment(t *testing.T) {
+	t.Parallel()
+
+	value := "/repo/docs/materialized-sources/reference.md"
+	got := NewSanitizer().String(value)
+	if got != value {
+		t.Fatalf("expected unmanaged materialized-sources segment to remain unchanged, got %s", got)
+	}
+	if ContainsMaterializedSourcePath(value) {
+		t.Fatalf("expected unmanaged path not to match managed materialized root detection")
+	}
+}

--- a/core/sourceprivacy/privacy_test.go
+++ b/core/sourceprivacy/privacy_test.go
@@ -1,0 +1,41 @@
+package sourceprivacy
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestInitialContractHostedDefaultsToEphemeralLogicalAndPendingCleanup(t *testing.T) {
+	t.Parallel()
+
+	contract := InitialContract("", true, false)
+	if contract.RetentionMode != RetentionEphemeral {
+		t.Fatalf("expected default ephemeral retention, got %s", contract.RetentionMode)
+	}
+	if contract.MaterializedSourceRetained {
+		t.Fatal("expected hosted default to start as not retained")
+	}
+	if contract.RawSourceInArtifacts {
+		t.Fatal("expected raw source artifact contract to remain false")
+	}
+	if contract.SerializedLocations != SerializedLocationsLogical {
+		t.Fatalf("expected logical serialized locations, got %s", contract.SerializedLocations)
+	}
+	if contract.CleanupStatus != CleanupPending {
+		t.Fatalf("expected pending cleanup, got %s", contract.CleanupStatus)
+	}
+}
+
+func TestSanitizerRedactsMaterializedSourceRoots(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), ".wrkr", "materialized-sources", "acme", "backend")
+	value := filepath.Join(root, ".codex", "config.toml")
+	got := NewSanitizer(root).String(value)
+	if ContainsMaterializedSourcePath(got) {
+		t.Fatalf("expected materialized path to be redacted, got %s", got)
+	}
+	if got == value {
+		t.Fatalf("expected sanitizer to modify materialized path %s", value)
+	}
+}

--- a/core/state/scan_status.go
+++ b/core/state/scan_status.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Clyra-AI/wrkr/core/sourceprivacy"
 	"github.com/Clyra-AI/wrkr/internal/atomicwrite"
 )
 
@@ -22,24 +23,25 @@ const (
 )
 
 type ScanStatus struct {
-	ScanStatusVersion   string            `json:"scan_status_version"`
-	Status              string            `json:"status"`
-	StatePath           string            `json:"state_path"`
-	Target              any               `json:"target,omitempty"`
-	Targets             any               `json:"targets,omitempty"`
-	CurrentPhase        string            `json:"current_phase,omitempty"`
-	LastSuccessfulPhase string            `json:"last_successful_phase,omitempty"`
-	RepoTotal           int               `json:"repo_total,omitempty"`
-	ReposCompleted      int               `json:"repos_completed,omitempty"`
-	ReposFailed         int               `json:"repos_failed,omitempty"`
-	PartialResult       bool              `json:"partial_result,omitempty"`
-	PartialResultMarker string            `json:"partial_result_marker,omitempty"`
-	StartedAt           string            `json:"started_at,omitempty"`
-	UpdatedAt           string            `json:"updated_at,omitempty"`
-	CompletedAt         string            `json:"completed_at,omitempty"`
-	Error               string            `json:"error,omitempty"`
-	ArtifactPaths       map[string]string `json:"artifact_paths,omitempty"`
-	PhaseTimings        []PhaseTiming     `json:"phase_timings,omitempty"`
+	ScanStatusVersion   string                  `json:"scan_status_version"`
+	Status              string                  `json:"status"`
+	StatePath           string                  `json:"state_path"`
+	Target              any                     `json:"target,omitempty"`
+	Targets             any                     `json:"targets,omitempty"`
+	CurrentPhase        string                  `json:"current_phase,omitempty"`
+	LastSuccessfulPhase string                  `json:"last_successful_phase,omitempty"`
+	RepoTotal           int                     `json:"repo_total,omitempty"`
+	ReposCompleted      int                     `json:"repos_completed,omitempty"`
+	ReposFailed         int                     `json:"repos_failed,omitempty"`
+	PartialResult       bool                    `json:"partial_result,omitempty"`
+	PartialResultMarker string                  `json:"partial_result_marker,omitempty"`
+	StartedAt           string                  `json:"started_at,omitempty"`
+	UpdatedAt           string                  `json:"updated_at,omitempty"`
+	CompletedAt         string                  `json:"completed_at,omitempty"`
+	Error               string                  `json:"error,omitempty"`
+	ArtifactPaths       map[string]string       `json:"artifact_paths,omitempty"`
+	PhaseTimings        []PhaseTiming           `json:"phase_timings,omitempty"`
+	SourcePrivacy       *sourceprivacy.Contract `json:"source_privacy,omitempty"`
 }
 
 type PhaseTiming struct {
@@ -99,6 +101,7 @@ func LoadScanStatus(statePath string) (ScanStatus, error) {
 			CurrentPhase:        "artifact_commit",
 			LastSuccessfulPhase: "artifact_commit",
 			ArtifactPaths:       map[string]string{"state": filepath.Clean(resolved)},
+			SourcePrivacy:       snapshot.SourcePrivacy,
 		}, nil
 	}
 	return ScanStatus{
@@ -123,6 +126,10 @@ func normalizeScanStatus(statePath string, status ScanStatus) ScanStatus {
 			normalized[key] = filepath.Clean(value)
 		}
 		status.ArtifactPaths = normalized
+	}
+	if status.SourcePrivacy != nil {
+		normalizedPrivacy := sourceprivacy.Normalize(*status.SourcePrivacy)
+		status.SourcePrivacy = &normalizedPrivacy
 	}
 	return status
 }

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -17,6 +17,7 @@ import (
 	riskattack "github.com/Clyra-AI/wrkr/core/risk/attackpath"
 	"github.com/Clyra-AI/wrkr/core/score"
 	"github.com/Clyra-AI/wrkr/core/source"
+	"github.com/Clyra-AI/wrkr/core/sourceprivacy"
 	"github.com/Clyra-AI/wrkr/internal/atomicwrite"
 	"os"
 )
@@ -40,6 +41,7 @@ type Snapshot struct {
 	PostureScore             *score.Result             `json:"posture_score,omitempty"`
 	Identities               []manifest.IdentityRecord `json:"identities,omitempty"`
 	Transitions              []lifecycle.Transition    `json:"lifecycle_transitions,omitempty"`
+	SourcePrivacy            *sourceprivacy.Contract   `json:"source_privacy,omitempty"`
 }
 
 type ScoreView struct {

--- a/docs/commands/evidence.md
+++ b/docs/commands/evidence.md
@@ -65,7 +65,7 @@ wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json
 Pair this with the saved-state `wrkr report` and explicit proof-chain verification flow documented in [`docs/examples/security-team.md`](../examples/security-team.md).
 `wrkr evidence` now requires the saved proof chain to be intact before it will stage or publish a bundle; it does not replace the explicit operator or CI proof-chain verification gate.
 
-Expected JSON keys: `status`, `output_dir`, `frameworks`, `manifest_path`, `chain_path`, `framework_coverage`, additive `control_evidence`, additive `coverage_note`, `report_artifacts`, additive `next_steps`.
+Expected JSON keys: `status`, `output_dir`, `frameworks`, `manifest_path`, `chain_path`, `framework_coverage`, additive `control_evidence`, additive `coverage_note`, `report_artifacts`, additive `source_privacy`, additive `next_steps`.
 `coverage_note` is the machine-readable interpretation companion for `framework_coverage`: it states that coverage reflects only controls evidenced in the current scanned state and that low or zero first-run coverage indicates evidence gaps rather than unsupported framework parsing.
 `control_evidence` lists each active control backlog item with existing proof events, missing proof requirements, and related proof record ids when present.
 `next_steps[]` is additive machine-readable handoff guidance for the bundle that was just produced. It points to the explicit proof-verification step, the audit-facing `wrkr report --json` flow, and the generated evidence/report artifact fields.
@@ -73,6 +73,8 @@ Evidence bundle includes deterministic inventory exports at `inventory.json`, `i
 Evidence bundle includes deterministic compliance rollup export at `compliance-summary.json`.
 Evidence bundle includes deterministic control proof status at `control-evidence.json`.
 Evidence bundle includes deterministic attack-path artifact export at `attack-paths.json` when attack-path scoring is present in scan state.
+Evidence bundle metadata includes `source_privacy` in `scan-metadata.json` so auditors can see whether hosted source was retained, whether raw source is included in artifacts, whether serialized locations are logical, and how cleanup finished.
+Shareable evidence artifacts do not include raw source contents by default.
 Evidence bundle report summaries now carry additive security-visibility context from the scan state, including `unknown_to_security` counts and the reference basis used to derive them.
 If the saved scan state does not carry a usable reference basis, Wrkr suppresses `unknown_to_security` wording in downstream summaries rather than inventing that claim.
 When the scanned target is `my_setup`, the bundle also includes `personal-inventory-snapshot.json`.

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -3,7 +3,7 @@
 ## Synopsis
 
 ```bash
-wrkr scan [--repo <owner/repo> | --org <org> | --github-org <org> | --path <dir> | --my-setup | --target <mode>:<value> ...] [--mode quick|governance|deep] [--timeout <duration>] [--diff] [--enrich] [--baseline <path>] [--config <path>] [--state <path>] [--policy <path>] [--approved-tools <path>] [--production-targets <path>] [--production-targets-strict] [--profile baseline|standard|strict|assessment] [--github-api <url>] [--github-token <token>] [--report-md] [--report-md-path <path>] [--report-template exec|operator|audit|public] [--report-share-profile internal|public] [--report-top <n>] [--sarif] [--sarif-path <path>] [--json] [--json-path <path>] [--resume] [--quiet] [--explain]
+wrkr scan [--repo <owner/repo> | --org <org> | --github-org <org> | --path <dir> | --my-setup | --target <mode>:<value> ...] [--mode quick|governance|deep] [--source-retention ephemeral|retain_for_resume|retain] [--allow-source-materialization] [--timeout <duration>] [--diff] [--enrich] [--baseline <path>] [--config <path>] [--state <path>] [--policy <path>] [--approved-tools <path>] [--production-targets <path>] [--production-targets-strict] [--profile baseline|standard|strict|assessment] [--github-api <url>] [--github-token <token>] [--report-md] [--report-md-path <path>] [--report-template exec|operator|audit|public] [--report-share-profile internal|public] [--report-top <n>] [--sarif] [--sarif-path <path>] [--json] [--json-path <path>] [--resume] [--quiet] [--explain]
 wrkr scan status --state <path> [--json]
 ```
 
@@ -36,12 +36,15 @@ Acquisition behavior is fail-closed by target:
 - `--my-setup` runs fully local/offline against the local machine setup rooted at the current user home directory.
   It inspects supported user-home tool configs, selected environment key names, and common workspace roots for local agent project markers without emitting raw secret values.
 - `--repo` and `--org` require real GitHub acquisition via `--github-api`, config `github_api_base`, or `WRKR_GITHUB_API_BASE`.
-- Hosted GitHub materialization is sparse by default: Wrkr fetches detector-relevant files such as agent instructions, MCP/Codex/Cursor/Claude configs, skills, workflows, policy files, dependency manifests, and AI/MCP/source markers instead of every repository blob.
+- Hosted GitHub materialization is sparse by default: Wrkr fetches detector-relevant files such as agent instructions, MCP/Codex/Cursor/Claude configs, skills, workflows, policy files, dependency manifests, and AI/MCP declaration surfaces instead of every repository blob.
+- Hosted scans do not fetch broad source-code extensions by default. Use `--mode deep` or `--allow-source-materialization` only when you explicitly want generic source files such as `.go`, `.py`, `.js`, or `.ts` to be materialized for deeper static detector coverage.
 - Hosted GitHub API base resolution order is: `--github-api`, config `github_api_base`, then `WRKR_GITHUB_API_BASE`.
 - Hosted GitHub token resolution order is: `--github-token`, config `auth.scan.token`, `WRKR_GITHUB_TOKEN`, then `GITHUB_TOKEN`.
 - `--github-org` is an additive alias for `--org`.
 - Explicit multi-target scans set `target.mode=multi` and add deterministic `targets[]` arrays to the top-level scan payload, saved state snapshot, and `source_manifest`.
-- `--repo` and `--org` materialize repository contents into a deterministic local workspace under the scan state directory before detectors run.
+- `--repo` and `--org` materialize the required hosted files into a deterministic local workspace under the scan state directory before detectors run.
+- Hosted materialized source retention defaults to `--source-retention ephemeral`: Wrkr removes the managed materialized root after scan artifacts are committed, and it also cleans up failed runs unless retention is explicitly requested. Use `retain_for_resume` to preserve materialized files after a failed/interrupted run for resume, or `retain` to keep them after success. Both modes leave private repository contents on disk and should be used deliberately.
+- Hosted scan artifacts emit `source_privacy` with `retention_mode`, `materialized_source_retained`, `raw_source_in_artifacts=false`, `serialized_locations`, `cleanup_status`, and optional warnings.
 - Materialized workspace root (`materialized-sources/`) is ownership-gated:
   - Wrkr-managed roots include marker `.wrkr-materialized-sources-managed` with state-bound provenance, not just a static marker body.
   - Non-empty roots without a valid marker are blocked (no recursive cleanup).
@@ -81,6 +84,8 @@ Scan mode behavior is explicit:
 - `--my-setup`
 - `--target`
 - `--mode`
+- `--source-retention`
+- `--allow-source-materialization`
 - `--timeout`
 - `--diff`
 - `--enrich`
@@ -108,7 +113,7 @@ Scan mode behavior is explicit:
 wrkr scan status --state ./.wrkr/last-scan.json --json
 ```
 
-The status payload includes `status`, `current_phase`, `last_successful_phase`, repo counts, `partial_result`, `partial_result_marker`, phase timings, and artifact paths.
+The status payload includes `status`, `current_phase`, `last_successful_phase`, repo counts, `partial_result`, `partial_result_marker`, phase timings, artifact paths, and `source_privacy` when scan state includes source-retention metadata.
 Existing state files without a status sidecar are interpreted as `completed` when the state snapshot can be loaded, otherwise `unknown`.
 
 ## Developer personal-hygiene example
@@ -157,6 +162,7 @@ wrkr scan --github-org acme --github-api https://api.github.com --state ./.wrkr/
 When `--json` is set for hosted org and local path scans, Wrkr keeps stdout reserved for the final JSON payload and emits additive progress, retry, cooldown, resume, per-repo materialization completion/discovery, scan phase, and completion lines to stderr only. Scan phase progress includes deterministic phase labels, elapsed `duration_ms`, and repo counters. For hosted scans, `repo_materialize` means a repo job was dispatched to a worker and `repo_materialize_done` means that repo reached a success or failure result. For path scans, `repo_discovered` means a local repo root was selected for detector execution. `--quiet` suppresses those progress lines. `--json-path` writes the same final JSON payload to disk, and `--json --json-path` emits byte-identical payload bytes to both stdout and the selected file. Any requested `--json-path`, `--report-md-path`, or `--sarif-path` must be unique from one another and from scan-managed `--state` sibling artifacts.
 `--resume` is supported only when every requested target is an org target. Wrkr stores internal checkpoint metadata under the scan-state directory in `org-checkpoints/` and reuses already-materialized repositories only when the checkpoint target set, per-org repo sets, and materialized-root path still match the current org-target scan.
 Resume also revalidates that checkpoint files and reused repo roots are still trusted local artifacts under the managed materialized root; symlink-swapped entries fail closed as `unsafe_operation_blocked`.
+Default successful hosted scans remove that managed root, so resume from retained materialized source requires an explicit retention mode such as `--source-retention retain` for completed runs or `retain_for_resume` for failed/interrupted runs.
 Mixed target sets such as org-plus-path scans fail closed with `invalid_input` when `--resume` is requested.
 If a run is interrupted after some repositories are checkpointed, rerun the same target with `--resume` and keep the same `--state` path. Use `wrkr scan status --state <path> --json` to inspect the last successful phase and partial marker before rerunning. If `partial_result`, `source_errors`, or `source_degraded` is present, treat the scan as incomplete and rerun after the blocking condition is resolved.
 
@@ -180,7 +186,7 @@ wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --profile assessment --re
 ```
 
 This is the canonical `repo_set` example for `--path`: the selected directory is a bundle of immediate child repos, so Wrkr preserves per-child repo manifests and deterministic ordering instead of collapsing the bundle into one repo.
-Expected JSON keys include `status`, `target`, `scan_mode`, `scan_quality`, `findings`, additive `control_backlog`, `ranked_findings`, `top_findings`, `attack_paths`, `top_attack_paths`, additive `action_paths`, additive `action_path_to_control_first`, `inventory`, `privilege_budget`, `agent_privilege_map`, `repo_exposure_summaries`, `profile`, `posture_score`, `compliance_summary`, additive `activation`, and optional `report` when summary output is requested.
+Expected JSON keys include `status`, `target`, `source_privacy`, `scan_mode`, `scan_quality`, `findings`, additive `control_backlog`, `ranked_findings`, `top_findings`, `attack_paths`, `top_attack_paths`, additive `action_paths`, additive `action_path_to_control_first`, `inventory`, `privilege_budget`, `agent_privilege_map`, `repo_exposure_summaries`, `profile`, `posture_score`, `compliance_summary`, additive `activation`, and optional `report` when summary output is requested.
 Explicit multi-target runs also emit additive `targets[]` arrays at the top level and inside `source_manifest`, and saved state snapshots preserve the same additive `targets[]` contract.
 `control_backlog.control_backlog_version` is the stable backlog schema version. `control_backlog.items[*]` includes repo, path, control surface/path type, capability, additive `write_path_classes`, additive `governance_controls`, owner/source/status, evidence source/basis, approval status, governance security visibility, signal class (`unique_wrkr_signal|supporting_security_signal`), recommended action (`attach_evidence|approve|remediate|downgrade|deprecate|exclude|monitor|inventory_review|suppress|debug_only`), confidence (`high|medium|low`), evidence gaps, confidence-raising guidance, SLA, closure criteria, optional secret signal types, and linked raw finding IDs. Raw `findings` remain the compatibility evidence surface.
 Governance backlog visibility uses `known_approved`, `known_unapproved`, `unknown_to_security`, `accepted_risk`, `deprecated`, `revoked`, and `needs_review`. Legacy inventory compatibility fields may still emit or accept `approved` for existing consumers, while new backlog items map that state to `known_approved`.
@@ -224,7 +230,7 @@ When a downstream workflow does not have a usable `reference_basis`, Wrkr suppre
 `--approved-tools <path>` accepts a schema-validated YAML policy (`schemas/v1/policy/approved-tools.schema.json`) for explicit approved-list matching (`tool_ids`, `agent_ids`, `tool_types`, `orgs`, `repos` via exact/prefix sets).
 Invalid `--approved-tools` policy files fail closed with `invalid_input` (exit `6`).
 For `--my-setup`, omitting `--approved-tools` keeps `inventory.local_governance.reference_basis=unavailable` instead of fabricating sanctioned or unsanctioned local claims.
-For `--repo` and `--org` scans, `source_manifest.repos[*].source` is `github_repo_materialized`, and `source_manifest.repos[*].location` points to the deterministic materialized local root used for detector execution.
+For `--repo` and `--org` scans, `source_manifest.repos[*].source` is `github_repo_materialized`, and `source_manifest.repos[*].location` is a logical hosted reference such as `github://acme/backend`. The detector filesystem root is internal-only and is not serialized in customer-facing artifacts.
 Prompt-channel findings use stable reason codes and evidence hashes only (`pattern_family`, `evidence_snippet_hash`, `location_class`, `confidence_class`) and do not emit raw secret values.
 Secret-bearing workflow evidence separates `secret_reference_detected`, `secret_value_detected`, `secret_scope_unknown`, `secret_rotation_evidence_missing`, `secret_owner_missing`, and `secret_used_by_write_capable_workflow`. Workflow references such as `${{ secrets.NAME }}` are classified as references, not leaked values, and raw secret values are not emitted.
 When `--enrich` is enabled, MCP findings include enrich provenance and quality fields: `source`, `as_of`, `package`, `version`, `advisory_count`, `registry_status`, `enrich_quality` (`ok|partial|stale|unavailable`), `advisory_schema`, `registry_schema`, and `enrich_errors`.
@@ -249,7 +255,8 @@ SARIF contract:
 
 - `--sarif` emits a SARIF `2.1.0` report from scan findings.
 - `--sarif-path` selects output path (default `wrkr.sarif`).
-- Native `scan --json` payloads and proof outputs remain unchanged; SARIF is additive.
+- SARIF runs include `properties.source_privacy` when source-retention metadata is available.
+- The core `scan --json` contract remains backward-compatible; SARIF is additive.
 
 Approved-tools policy example: [`docs/examples/approved-tools.v1.yaml`](../examples/approved-tools.v1.yaml).
 

--- a/docs/decisions/wave1-source-privacy-governance.md
+++ b/docs/decisions/wave1-source-privacy-governance.md
@@ -1,0 +1,33 @@
+# ADR: Wave 1 Source Privacy Governance
+
+Date: 2026-04-24
+Status: accepted
+
+## Context
+
+Hosted `--repo` and `--org` scans need temporary filesystem access to selected GitHub blobs so existing deterministic detectors can run without network-specific code paths. The prior hosted materialization model kept those files under the scan-state directory after a scan and serialized that local path in some public artifacts.
+
+That created avoidable customer privacy risk: private source could remain on disk, be confused with evidence, or leak through shareable outputs as `.wrkr/materialized-sources` paths.
+
+## Decision
+
+1. Default hosted source retention to `ephemeral`.
+2. Add explicit retention modes: `retain_for_resume` and `retain`.
+3. Keep hosted detector execution rooted at an internal-only `RepoManifest.ScanRoot`.
+4. Serialize hosted repository identity through logical `RepoManifest.Location` values such as `github://org/repo`.
+5. Fetch only detector-owned governance/config/policy/declaration paths by default; generic source-code extensions require `--mode deep` or `--allow-source-materialization`.
+6. Emit a `source_privacy` contract in scan state, scan JSON, status, reports, evidence metadata, and SARIF where applicable.
+7. Sanitize shareable artifact paths so materialized source roots are redacted if a detector or future output path accidentally carries one forward.
+
+## Rationale
+
+- Source materialization is an implementation detail of hosted acquisition, not a customer evidence artifact.
+- Logical hosted locations preserve stable source identity without exposing local filesystem paths.
+- Default sparse fetching reduces private source copied to disk while keeping high-signal governance coverage.
+- Explicit source privacy metadata gives operators and auditors a machine-readable answer about retention, raw-source inclusion, serialized location mode, and cleanup status.
+
+## Consequences
+
+- Consumers that relied on hosted `source_manifest.repos[].location` as a local path must switch to logical source references or explicitly use internal/debug retention workflows.
+- Successful hosted scans remove managed materialized source by default, so completed-run resume requires explicit `--source-retention retain`.
+- Deep or generic source materialization is still available, but it is visible as an explicit operator opt-in and documented as privacy-sensitive.

--- a/docs/failure_taxonomy_exit_codes.md
+++ b/docs/failure_taxonomy_exit_codes.md
@@ -70,6 +70,10 @@ Use code-based branching with non-zero fail semantics. Keep a simple rule: `0` p
 
 `wrkr scan --json` fails with exit code `6` and error code `invalid_input`. Wrkr now validates scan-owned artifact paths before the managed `.wrkr` state or proof artifacts are written.
 
+### What happens when hosted source cleanup cannot be done safely?
+
+Hosted scan cleanup is guarded by the managed materialized-source marker. If cleanup would touch a non-managed, symlinked, or invalid materialized root, `wrkr scan --json` fails closed with exit code `8` and error code `unsafe_operation_blocked` before deleting anything. If cleanup fails after a managed root is accepted, scan status and JSON error output carry the cleanup failure and `source_privacy.cleanup_status=failed` where status state can be written.
+
 ### How does `wrkr score` behave when the saved state is malformed but still contains `posture_score`?
 
 `wrkr score --json` fails with exit code `1` and error code `runtime_failure`. Wrkr validates the saved scan snapshot before reusing cached posture score data, so malformed state does not return stale success output.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,6 +19,10 @@ Yes. Wrkr scan/risk/proof paths are deterministic by default for fixed inputs.
 
 No. Core operation is local and file-based by default.
 
+### Does Wrkr upload or retain private source code?
+
+Wrkr does not upload source code by default. Hosted `--repo` and `--org` scans fetch required detector files from GitHub into a local managed workspace, emit logical repository locations in shareable artifacts, and remove the materialized source root after scan artifacts commit. Retention is explicit through `--source-retention retain_for_resume` or `--source-retention retain`; generic source-file fetching requires `--mode deep` or `--allow-source-materialization`.
+
 ### Does Wrkr require setup for repo or org scans?
 
 `--path` is the zero-integration first-value path. Hosted `--repo` and `--org` scans require explicit GitHub API configuration via `--github-api`, config `github_api_base`, or `WRKR_GITHUB_API_BASE`, and they usually also need a GitHub token for private repos or to avoid public API rate limits. Token resolution order is `--github-token`, config `auth.scan.token`, `WRKR_GITHUB_TOKEN`, then `GITHUB_TOKEN`.

--- a/docs/trust/security-and-privacy.md
+++ b/docs/trust/security-and-privacy.md
@@ -16,6 +16,11 @@ description: "Wrkr fail-closed safety, local-data handling defaults, and privacy
 - Scan data remains local by default.
 - Secret values are not extracted; only risk context is emitted.
 - Local path scans stay bounded to the selected repo root. Root-escaping symlinked config, env, workflow, and MCP files are rejected with explicit deterministic diagnostics instead of being read.
+- Hosted `--repo` and `--org` scans fetch only required detector files from GitHub into a local managed workspace under the selected scan state directory. Wrkr does not upload hosted source code.
+- Hosted materialized source is ephemeral by default. After scan artifacts commit, Wrkr removes the managed materialized source root and records the result in `source_privacy.cleanup_status`.
+- Shareable scan, report, SARIF, and evidence outputs serialize hosted repositories as logical locations such as `github://org/repo`; the private detector filesystem root is not serialized.
+- Default shareable artifacts set `source_privacy.raw_source_in_artifacts=false`.
+- `--source-retention retain_for_resume`, `--source-retention retain`, `--mode deep`, and `--allow-source-materialization` are explicit operator opt-ins that can leave more private repository content on disk or fetch generic source files for deeper static coverage.
 
 ## Command anchors
 
@@ -34,6 +39,10 @@ No. Wrkr flags secret-risk context but does not extract and emit raw secret mate
 ### Can Wrkr run fully local for private repositories?
 
 Yes. Default scan and evidence workflows operate locally with file-based artifacts and no required data exfiltration path.
+
+### Does Wrkr retain private source code from hosted scans?
+
+Not by default. Hosted scans use a local managed materialized workspace while detectors run, then clean it up after artifacts commit. Retention requires explicit `--source-retention retain_for_resume` or `--source-retention retain`.
 
 ### How does Wrkr handle symlinked files that point outside the selected repo root?
 

--- a/internal/e2e/source/source_e2e_test.go
+++ b/internal/e2e/source/source_e2e_test.go
@@ -187,7 +187,7 @@ func TestE2EScanOrgResumeRejectsSymlinkSwappedRepoRoot(t *testing.T) {
 
 	var firstOut bytes.Buffer
 	var firstErr bytes.Buffer
-	if code := cli.Run([]string{"scan", "--org", "acme", "--github-api", server.URL, "--state", statePath, "--json"}, &firstOut, &firstErr); code != 0 {
+	if code := cli.Run([]string{"scan", "--org", "acme", "--github-api", server.URL, "--state", statePath, "--source-retention", "retain", "--json"}, &firstOut, &firstErr); code != 0 {
 		t.Fatalf("initial org scan failed: %d (%s)", code, firstErr.String())
 	}
 

--- a/internal/scenarios/org_resume_scenario_test.go
+++ b/internal/scenarios/org_resume_scenario_test.go
@@ -60,6 +60,7 @@ func TestOrgResumeMatchesCleanRun(t *testing.T) {
 			"--org", "acme",
 			"--github-api", server.URL,
 			"--state", resumeState,
+			"--source-retention", "retain_for_resume",
 			"--json",
 		}, &interruptedOut, &interruptedErr)
 	}()

--- a/product/wrkr.md
+++ b/product/wrkr.md
@@ -503,6 +503,7 @@ Every discovered AI tool receives a persistent identity that tracks its lifecycl
 ### NFR1: Data Sovereignty
 
 - **Zero data exfiltration.** Wrkr never sends scan data outside the user's environment. No telemetry on scan contents. No cloud backend required.
+- **Ephemeral hosted source handling by default.** Hosted GitHub scans materialize only required detector files into a local managed workspace, serialize logical repository references in shareable artifacts, set `source_privacy.raw_source_in_artifacts=false`, and remove materialized source after artifact commit unless retention is explicitly requested.
 - Optional anonymous usage telemetry (command counts only, opt-in) for open-source metrics.
 
 ### NFR2: Performance

--- a/schemas/v1/evidence/evidence-bundle.schema.json
+++ b/schemas/v1/evidence/evidence-bundle.schema.json
@@ -16,6 +16,41 @@
     "framework_coverage": {
       "type": "object",
       "additionalProperties": {"type": "number"}
+    },
+    "source_privacy": {
+      "$ref": "#/definitions/sourcePrivacy"
+    }
+  },
+  "definitions": {
+    "sourcePrivacy": {
+      "type": "object",
+      "required": [
+        "retention_mode",
+        "materialized_source_retained",
+        "raw_source_in_artifacts",
+        "serialized_locations",
+        "cleanup_status"
+      ],
+      "properties": {
+        "retention_mode": {
+          "type": "string",
+          "enum": ["ephemeral", "retain_for_resume", "retain"]
+        },
+        "materialized_source_retained": {"type": "boolean"},
+        "raw_source_in_artifacts": {"type": "boolean"},
+        "serialized_locations": {
+          "type": "string",
+          "enum": ["logical", "filesystem"]
+        },
+        "cleanup_status": {
+          "type": "string",
+          "enum": ["not_applicable", "pending", "removed", "retained", "failed"]
+        },
+        "warnings": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
     }
   },
   "additionalProperties": true

--- a/schemas/v1/report/report-summary.schema.json
+++ b/schemas/v1/report/report-summary.schema.json
@@ -77,6 +77,9 @@
       "items": {
         "$ref": "#/$defs/checklistItem"
       }
+    },
+    "source_privacy": {
+      "$ref": "#/$defs/sourcePrivacy"
     }
   },
   "$defs": {
@@ -287,6 +290,36 @@
       "properties": {
         "id": {"type": "string"},
         "text": {"type": "string"}
+      }
+    },
+    "sourcePrivacy": {
+      "type": "object",
+      "required": [
+        "retention_mode",
+        "materialized_source_retained",
+        "raw_source_in_artifacts",
+        "serialized_locations",
+        "cleanup_status"
+      ],
+      "properties": {
+        "retention_mode": {
+          "type": "string",
+          "enum": ["ephemeral", "retain_for_resume", "retain"]
+        },
+        "materialized_source_retained": {"type": "boolean"},
+        "raw_source_in_artifacts": {"type": "boolean"},
+        "serialized_locations": {
+          "type": "string",
+          "enum": ["logical", "filesystem"]
+        },
+        "cleanup_status": {
+          "type": "string",
+          "enum": ["not_applicable", "pending", "removed", "retained", "failed"]
+        },
+        "warnings": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
       }
     }
   }

--- a/testinfra/contracts/story1_contracts_test.go
+++ b/testinfra/contracts/story1_contracts_test.go
@@ -81,6 +81,7 @@ func TestScanJSONContractStableKeys(t *testing.T) {
 		"scan_mode",
 		"scan_quality",
 		"source_manifest",
+		"source_privacy",
 		"status",
 		"target",
 		"top_attack_paths",
@@ -105,6 +106,13 @@ func TestScanJSONContractStableKeys(t *testing.T) {
 	}
 	if scanQuality["scan_quality_version"] != "1" {
 		t.Fatalf("unexpected scan_quality_version: %v", scanQuality["scan_quality_version"])
+	}
+	sourcePrivacy, ok := payload["source_privacy"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected source_privacy object, got %T", payload["source_privacy"])
+	}
+	if sourcePrivacy["raw_source_in_artifacts"] != false {
+		t.Fatalf("expected raw_source_in_artifacts=false, got %v", sourcePrivacy["raw_source_in_artifacts"])
 	}
 
 	inventoryPayload, ok := payload["inventory"].(map[string]any)
@@ -154,7 +162,7 @@ func TestDiffJSONContractStableKeys(t *testing.T) {
 		t.Fatalf("parse diff payload: %v", err)
 	}
 	got := sortedKeys(payload)
-	want := []string{"diff", "diff_empty", "scan_mode", "scan_quality", "source_manifest", "status", "target"}
+	want := []string{"diff", "diff_empty", "scan_mode", "scan_quality", "source_manifest", "source_privacy", "status", "target"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected top-level keys: got %v want %v", got, want)
 	}


### PR DESCRIPTION
## Problem
Hosted `--repo` and `--org` scans needed temporary local materialization, but parts of the scan/report/evidence surface could still expose filesystem-root details or leave privacy posture ambiguous in shareable artifacts.

## Changes
- default hosted source retention to `ephemeral` with explicit `retain_for_resume` and `retain` modes
- keep hosted detector execution on private scan roots while serializing logical repo locations in shareable outputs
- add a reusable `source_privacy` contract and thread it through scan state, scan JSON, status, reports, evidence, proof mapping, and SARIF
- redact materialized hosted roots from shareable artifacts and document the Wave 1 privacy decision
- add regression coverage for retention, cleanup, contract stability, resume flows, and hosted source outputs

## Validation
- `make prepush-full`

## Risks
- consumers that treated hosted `source_manifest.repos[].location` as a local filesystem path now need to rely on logical hosted references instead
- completed hosted scans now require explicit retention flags if operators want materialized sources preserved for post-run debugging or resume workflows
