### PR TITLE
fix: tighten audit readiness and scan status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed
 
+- Clarified focused local validation guidance for narrow documentation and scan-status/progress changes while preserving required CI and release gates.
 - [semver:minor] Improved scan completion and failure footers so progress-enabled runs explain the last phase, partial-result state, detector/repo counts, artifact paths, and resume hint without polluting stdout contracts.
 - Aligned govern-first ranking, risk tiers, and recommended actions so source-level MCP and agent paths with stronger governable signals outrank dependency-only inventory.
 - Changed report and BOM proof refs to distinguish global proof-chain metadata from path-specific proof coverage and remediation.
@@ -38,6 +39,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
+- [semver:patch] Fixed pinned install and release-smoke examples so documented first-value commands install a compatible Wrkr release.
+- [semver:patch] Fixed scan status so completed scans with source failures remain marked as partial instead of appearing complete to automation.
+- [semver:patch] Fixed hosted scan progress counters so failed repo materialization is counted once and pending progress remains accurate.
 - Fixed repo-level attack-path score spillover so high attack-path scores attach only to matching govern-first paths instead of every candidate path in the same repo.
 - Fixed tolerant detector parsing for additive third-party `package.json` metadata and reduced modern JS/WebMCP parse noise by recovering positive fallback signals while keeping diagnostics out of ranked risk surfaces.
 - Fixed remaining open detector manifests and MCP-adjacent configs to tolerate additive metadata instead of treating unknown fields as parse failures.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,15 @@ make prepush
 
 This path is sufficient for most CLI/runtime changes and does not require Node.
 
+## Focused Local Validation (Additive)
+
+Use these only for narrow, local iteration before you run the full gate set required by the touched surface:
+
+- `make test-focused-docs` for install, README, docs-site quickstart, and release-parity doc changes.
+- `make test-focused-scan` for scan-status, partial-result, and hosted progress-counter changes.
+
+These commands do not replace `make test-fast`, `make prepush`, contract lanes, scenario lanes, risk lanes, or release/UAT lanes when those are required by the story or touched surface.
+
 ## CI Lane Map
 
 | Lane | Purpose | Local command anchor |
@@ -73,6 +82,7 @@ This path is sufficient for most CLI/runtime changes and does not require Node.
 
 1. Keep scope tight and mapped to one story/contract change when possible.
 2. Run required local commands for your touched surfaces (at minimum fast + core lane anchors).
+   `make test-focused-docs` or `make test-focused-scan` are acceptable as the first local pass for narrow changes, but they are additive helpers only and do not satisfy merge or release gates by themselves.
 3. If workflow refs change, rerun the affected workflow class on your branch and inspect it for the absence of the prior deprecation warning:
    - `gh workflow run pr.yml --ref <branch>`
    - `gh workflow run nightly.yml --ref <branch>`

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DOCS_SITE_NPM_CACHE ?= $(CURDIR)/.tmp/npm-cache
 
 .PHONY: fmt lint lint-fast test test-fast test-integration test-e2e test-contracts test-scenarios \
 	test-hardening test-chaos test-perf test-agent-benchmarks test-risk-lane build hooks prepush prepush-full codeql lint-ci \
-	test-docs-consistency test-docs-storyline test-adapter-parity test-v1-acceptance test-uat-local test-release-smoke \
+	test-docs-consistency test-docs-storyline test-focused-docs test-focused-scan test-adapter-parity test-v1-acceptance test-uat-local test-release-smoke \
 	docs-site-install docs-site-lint docs-site-build docs-site-check docs-site-audit-prod
 
 fmt:
@@ -64,6 +64,15 @@ test-docs-consistency:
 
 test-docs-storyline:
 	@scripts/run_docs_smoke.sh --subset
+
+test-focused-docs:
+	@$(GO) test ./testinfra/hygiene -run 'TestInstallDocsSmokeGoOnlyPath|TestInstallDocsPinnedVersionSupportsCurrentReadmeCommands|TestMinimalDependenciesReleaseSmokeVersionIsCurrent' -count=1
+	@$(MAKE) test-docs-consistency
+
+test-focused-scan:
+	@$(GO) test ./core/cli -run 'TestScan.*Partial|TestScanStatus|TestScan.*Progress' -count=1
+	@$(GO) test ./core/state -run TestScanStatus -count=1
+	@$(GO) test ./core/source/org -run 'Test.*Progress|Test.*Resume|Test.*Failure' -count=1
 
 docs-site-install:
 	@mkdir -p "$(DOCS_SITE_NPM_CACHE)"

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ test-focused-docs:
 	@$(MAKE) test-docs-consistency
 
 test-focused-scan:
-	@$(GO) test ./core/cli -run 'TestScan.*Partial|TestScanStatus|TestScan.*Progress' -count=1
+	@$(GO) test ./core/cli -run 'TestScan.*Partial|TestScanStatus|TestScan.*Progress|TestHostedProgress.*' -count=1
 	@$(GO) test ./core/state -run TestScanStatus -count=1
 	@$(GO) test ./core/source/org -run 'Test.*Progress|Test.*Resume|Test.*Failure' -count=1
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ brew install Clyra-AI/tap/wrkr
 ### Go install (Pinned/reproducible)
 
 ```bash
-WRKR_VERSION="v1.0.0"
+WRKR_VERSION="v1.3.0"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -791,7 +791,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		if err := statusTracker.Phase("artifact_commit_complete"); err != nil {
 			return emitRolledBackScanFailure(err)
 		}
-		if err := statusTracker.Complete(artifactPaths); err != nil {
+		if err := statusTracker.Complete(artifactPaths, len(manifestOut.Failures) > 0); err != nil {
 			return emitRolledBackScanFailure(err)
 		}
 		statusCompleted = true

--- a/core/cli/scan_partial_errors_test.go
+++ b/core/cli/scan_partial_errors_test.go
@@ -81,23 +81,7 @@ func TestScanContinuesOnDetectorError(t *testing.T) {
 func TestScanOrgMaterializationFailureReturnsPartialResult(t *testing.T) {
 	t.Parallel()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/orgs/acme/repos":
-			_, _ = fmt.Fprint(w, `[{"full_name":"acme/a"},{"full_name":"acme/b"}]`)
-		case "/repos/acme/a":
-			_, _ = fmt.Fprint(w, `{"full_name":"acme/a","default_branch":"main"}`)
-		case "/repos/acme/b":
-			_, _ = fmt.Fprint(w, `{"full_name":"acme/b","default_branch":"main"}`)
-		case "/repos/acme/a/git/trees/main":
-			_, _ = fmt.Fprint(w, `{"tree":[]}`)
-		case "/repos/acme/b/git/trees/main":
-			w.WriteHeader(http.StatusBadGateway)
-			_, _ = fmt.Fprint(w, `{"message":"upstream unavailable"}`)
-		default:
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
-	}))
+	server := newMaterializationFailureServer(t)
 	defer server.Close()
 
 	tmp := t.TempDir()
@@ -129,6 +113,89 @@ func TestScanOrgMaterializationFailureReturnsPartialResult(t *testing.T) {
 	}
 	if degraded, ok := payload["source_degraded"].(bool); !ok || degraded {
 		t.Fatalf("expected source_degraded=false for non-degraded failure, got %v", payload["source_degraded"])
+	}
+}
+
+func TestScanStatusCompletedPartialResultMatchesScanJSON(t *testing.T) {
+	t.Parallel()
+
+	server := newMaterializationFailureServer(t)
+	defer server.Close()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+
+	code := Run([]string{
+		"scan",
+		"--org", "acme",
+		"--github-api", server.URL,
+		"--state", statePath,
+		"--json",
+	}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("scan failed unexpectedly: exit=%d stderr=%s", code, errOut.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse scan output: %v", err)
+	}
+	if payload["partial_result"] != true {
+		t.Fatalf("expected final scan json to remain partial, got %v", payload["partial_result"])
+	}
+
+	var statusOut bytes.Buffer
+	var statusErr bytes.Buffer
+	if statusCode := Run([]string{"scan", "status", "--state", statePath, "--json"}, &statusOut, &statusErr); statusCode != exitSuccess {
+		t.Fatalf("scan status failed: %d stderr=%s", statusCode, statusErr.String())
+	}
+	var status map[string]any
+	if err := json.Unmarshal(statusOut.Bytes(), &status); err != nil {
+		t.Fatalf("parse scan status: %v", err)
+	}
+	if status["status"] != "completed" {
+		t.Fatalf("expected completed status, got %v", status["status"])
+	}
+	if status["partial_result"] != true || status["partial_result_marker"] != "partial_result" {
+		t.Fatalf("expected completed partial status marker, got %v", status)
+	}
+}
+
+func TestScanStatusCompletedCleanScanStaysNonPartial(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	reposPath := filepath.Join(tmp, "repos")
+	if err := os.MkdirAll(filepath.Join(reposPath, "alpha", ".codex"), 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(reposPath, "alpha", ".codex", "config.toml"), []byte("approval_policy = \"never\"\n"), 0o600); err != nil {
+		t.Fatalf("write repo fixture: %v", err)
+	}
+
+	statePath := filepath.Join(tmp, "state.json")
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := Run([]string{"scan", "--path", reposPath, "--state", statePath, "--json"}, &out, &errOut); code != exitSuccess {
+		t.Fatalf("scan failed unexpectedly: exit=%d stderr=%s", code, errOut.String())
+	}
+
+	var statusOut bytes.Buffer
+	var statusErr bytes.Buffer
+	if statusCode := Run([]string{"scan", "status", "--state", statePath, "--json"}, &statusOut, &statusErr); statusCode != exitSuccess {
+		t.Fatalf("scan status failed: %d stderr=%s", statusCode, statusErr.String())
+	}
+	var status map[string]any
+	if err := json.Unmarshal(statusOut.Bytes(), &status); err != nil {
+		t.Fatalf("parse scan status: %v", err)
+	}
+	if status["status"] != "completed" {
+		t.Fatalf("expected completed status, got %v", status["status"])
+	}
+	if _, present := status["partial_result"]; present {
+		t.Fatalf("expected clean completed scan to omit partial_result, got %v", status["partial_result"])
 	}
 }
 
@@ -191,6 +258,28 @@ func TestScanPathWorkflowPermissionDeniedSurfaced(t *testing.T) {
 	if !found {
 		t.Fatalf("expected permission_denied detector error for beta, got %v", detectorErrors)
 	}
+}
+
+func newMaterializationFailureServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme/repos":
+			_, _ = fmt.Fprint(w, `[{"full_name":"acme/a"},{"full_name":"acme/b"}]`)
+		case "/repos/acme/a":
+			_, _ = fmt.Fprint(w, `{"full_name":"acme/a","default_branch":"main"}`)
+		case "/repos/acme/b":
+			_, _ = fmt.Fprint(w, `{"full_name":"acme/b","default_branch":"main"}`)
+		case "/repos/acme/a/git/trees/main":
+			_, _ = fmt.Fprint(w, `{"tree":[]}`)
+		case "/repos/acme/b/git/trees/main":
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = fmt.Fprint(w, `{"message":"upstream unavailable"}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
 }
 
 func TestScanExplainCallsOutPermissionIncompletePosture(t *testing.T) {

--- a/core/cli/scan_progress.go
+++ b/core/cli/scan_progress.go
@@ -61,6 +61,7 @@ type scanProgressFooter struct {
 	PartialResult       bool
 	RepoTotal           int
 	ReposCompleted      int
+	ReposSucceeded      int
 	ReposFailed         int
 	DetectorProgress    *state.ScanDetectorProgress
 	ArtifactPaths       []string
@@ -78,6 +79,7 @@ type scanProgressUpdate struct {
 	RepoIndex      int
 	RepoTotal      int
 	Completed      int
+	Succeeded      int
 	Failed         int
 	Pending        int
 	Attempt        int
@@ -248,6 +250,7 @@ func (r *scanProgressReporter) PathRepo(root string, index, total int, repo stri
 	}, func(now time.Time) scanProgressSnapshot {
 		r.state.repoProgress = state.ScanRepoProgress{
 			Total:     total,
+			Succeeded: index,
 			Completed: index,
 			Failed:    0,
 			Pending:   maxProgressCount(total-index, 0),
@@ -269,13 +272,14 @@ func (r *scanProgressReporter) RepoMaterialize(org string, index, total int, rep
 	}, func(now time.Time) scanProgressSnapshot {
 		if total > 0 {
 			r.state.repoProgress.Total = total
-			r.state.repoProgress.Pending = maxProgressCount(total-r.state.repoProgress.Completed-r.state.repoProgress.Failed, 0)
+			r.state.repoProgress.Pending = maxProgressCount(total-r.state.repoProgress.Completed, 0)
 		}
 		return r.snapshotLocked(now)
 	})
 }
 
-func (r *scanProgressReporter) RepoMaterializeDone(org string, completed, total int, repo, status string) {
+func (r *scanProgressReporter) RepoMaterializeDone(org string, succeeded, failed, total int, repo, status string) {
+	completed := succeeded + failed
 	r.emit(scanProgressUpdate{
 		Kind:        "repo_materialize_done",
 		TargetMode:  "org",
@@ -283,18 +287,17 @@ func (r *scanProgressReporter) RepoMaterializeDone(org string, completed, total 
 		Repo:        strings.TrimSpace(repo),
 		RepoTotal:   total,
 		Completed:   completed,
+		Succeeded:   succeeded,
+		Failed:      failed,
 		Status:      strings.TrimSpace(status),
 		Message:     repoMaterializeDoneMessage(repo, status, completed, total),
 	}, func(now time.Time) scanProgressSnapshot {
-		failed := r.state.repoProgress.Failed
-		if strings.TrimSpace(status) == "failed" && completed > r.state.repoProgress.Completed {
-			failed++
-		}
 		r.state.repoProgress = state.ScanRepoProgress{
 			Total:     total,
+			Succeeded: succeeded,
 			Completed: completed,
 			Failed:    failed,
-			Pending:   maxProgressCount(total-completed-failed, 0),
+			Pending:   maxProgressCount(total-completed, 0),
 		}
 		r.recomputePercentLocked()
 		return r.snapshotLocked(now)
@@ -381,11 +384,13 @@ func (r *scanProgressReporter) Resume(org string, total, completed, pending int)
 		TargetValue: strings.TrimSpace(org),
 		RepoTotal:   total,
 		Completed:   completed,
+		Succeeded:   completed,
 		Pending:     pending,
 		Message:     fmt.Sprintf("resumed org scan with %d completed and %d pending repo(s)", completed, pending),
 	}, func(now time.Time) scanProgressSnapshot {
 		r.state.repoProgress = state.ScanRepoProgress{
 			Total:     total,
+			Succeeded: completed,
 			Completed: completed,
 			Failed:    r.state.repoProgress.Failed,
 			Pending:   pending,
@@ -395,21 +400,24 @@ func (r *scanProgressReporter) Resume(org string, total, completed, pending int)
 	})
 }
 
-func (r *scanProgressReporter) Complete(org string, total, completed, failed int) {
+func (r *scanProgressReporter) Complete(org string, total, succeeded, failed int) {
+	completed := succeeded + failed
 	r.emit(scanProgressUpdate{
 		Kind:        "complete",
 		TargetMode:  "org",
 		TargetValue: strings.TrimSpace(org),
 		RepoTotal:   total,
 		Completed:   completed,
+		Succeeded:   succeeded,
 		Failed:      failed,
 		Message:     fmt.Sprintf("completed source acquisition for %d repo(s)", total),
 	}, func(now time.Time) scanProgressSnapshot {
 		r.state.repoProgress = state.ScanRepoProgress{
 			Total:     total,
+			Succeeded: succeeded,
 			Completed: completed,
 			Failed:    failed,
-			Pending:   maxProgressCount(total-completed-failed, 0),
+			Pending:   maxProgressCount(total-completed, 0),
 		}
 		r.recomputePercentLocked()
 		return r.snapshotLocked(now)
@@ -713,6 +721,7 @@ func formatScanProgressFooter(footer scanProgressFooter) string {
 		fmt.Sprintf("partial_result=%t", footer.PartialResult),
 		fmt.Sprintf("repos=%d/%d", footer.ReposCompleted, footer.RepoTotal),
 		fmt.Sprintf("failed=%d", footer.ReposFailed),
+		fmt.Sprintf("succeeded=%d", footer.ReposSucceeded),
 		fmt.Sprintf("elapsed=%ds", footer.ElapsedSeconds),
 	}
 	if strings.TrimSpace(footer.ProgressMessage) != "" {

--- a/core/cli/scan_progress_render.go
+++ b/core/cli/scan_progress_render.go
@@ -246,6 +246,8 @@ func formatScanProgressEventLine(snapshot scanProgressSnapshot, update scanProgr
 			fmt.Sprintf("repo_total=%d", update.RepoTotal),
 			"repo="+update.Repo,
 			"status="+fallbackForExplain(update.Status, "ok"),
+			fmt.Sprintf("succeeded=%d", update.Succeeded),
+			fmt.Sprintf("failed=%d", update.Failed),
 		), " ")
 	case "scan_phase":
 		return strings.Join(append(base,
@@ -278,6 +280,7 @@ func formatScanProgressEventLine(snapshot scanProgressSnapshot, update scanProgr
 			fmt.Sprintf("repo_total=%d", update.RepoTotal),
 			fmt.Sprintf("completed=%d", update.Completed),
 			fmt.Sprintf("pending=%d", update.Pending),
+			fmt.Sprintf("succeeded=%d", update.Succeeded),
 		), " ")
 	case "complete":
 		return strings.Join(append(base,
@@ -285,6 +288,7 @@ func formatScanProgressEventLine(snapshot scanProgressSnapshot, update scanProgr
 			fmt.Sprintf("repo_total=%d", update.RepoTotal),
 			fmt.Sprintf("completed=%d", update.Completed),
 			fmt.Sprintf("failed=%d", update.Failed),
+			fmt.Sprintf("succeeded=%d", update.Succeeded),
 		), " ")
 	case "detector_start":
 		return strings.Join(append(base,
@@ -334,6 +338,7 @@ func formatScanProgressEventLine(snapshot scanProgressSnapshot, update scanProgr
 			fmt.Sprintf("repo_total=%d", update.Footer.RepoTotal),
 			fmt.Sprintf("completed=%d", update.Footer.ReposCompleted),
 			fmt.Sprintf("failed=%d", update.Footer.ReposFailed),
+			fmt.Sprintf("succeeded=%d", update.Footer.ReposSucceeded),
 			fmt.Sprintf("progress_percent=%d", update.Footer.ProgressPercent),
 			fmt.Sprintf("elapsed_seconds=%d", update.Footer.ElapsedSeconds),
 		)

--- a/core/cli/scan_progress_test.go
+++ b/core/cli/scan_progress_test.go
@@ -90,6 +90,106 @@ func TestScanJSONOrgProgressEmitsToStderrOnly(t *testing.T) {
 	}
 }
 
+func TestHostedProgressPendingAfterFailedMaterialization(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme/repos":
+			_, _ = fmt.Fprint(w, `[{"full_name":"acme/a"},{"full_name":"acme/b"}]`)
+		case "/repos/acme/a":
+			_, _ = fmt.Fprint(w, `{"full_name":"acme/a","default_branch":"main"}`)
+		case "/repos/acme/b":
+			_, _ = fmt.Fprint(w, `{"full_name":"acme/b","default_branch":"main"}`)
+		case "/repos/acme/a/git/trees/main":
+			_, _ = fmt.Fprint(w, `{"tree":[]}`)
+		case "/repos/acme/b/git/trees/main":
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = fmt.Fprint(w, `{"message":"upstream unavailable"}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"scan",
+		"--org", "acme",
+		"--github-api", server.URL,
+		"--state", statePath,
+		"--json",
+	}, &out, &errOut)
+	if code != exitSuccess {
+		t.Fatalf("scan failed: code=%d stderr=%s", code, errOut.String())
+	}
+
+	var statusOut bytes.Buffer
+	var statusErr bytes.Buffer
+	if statusCode := Run([]string{"scan", "status", "--state", statePath, "--json"}, &statusOut, &statusErr); statusCode != exitSuccess {
+		t.Fatalf("scan status failed: %d stderr=%s", statusCode, statusErr.String())
+	}
+	var status map[string]any
+	if err := json.Unmarshal(statusOut.Bytes(), &status); err != nil {
+		t.Fatalf("parse status: %v", err)
+	}
+	repoProgress, ok := status["repo_progress"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected repo_progress in status, got %v", status)
+	}
+	if repoProgress["total"] != float64(2) || repoProgress["completed"] != float64(2) || repoProgress["succeeded"] != float64(1) || repoProgress["failed"] != float64(1) {
+		t.Fatalf("expected canonical repo progress counts after one failed materialization, got %v", repoProgress)
+	}
+	if pending, present := repoProgress["pending"]; present && pending != float64(0) {
+		t.Fatalf("expected canonical repo progress counts after one failed materialization, got %v", repoProgress)
+	}
+}
+
+func TestScanProgressFooterCountsFailedReposOnce(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme/repos":
+			_, _ = fmt.Fprint(w, `[{"full_name":"acme/a"},{"full_name":"acme/b"}]`)
+		case "/repos/acme/a":
+			_, _ = fmt.Fprint(w, `{"full_name":"acme/a","default_branch":"main"}`)
+		case "/repos/acme/b":
+			_, _ = fmt.Fprint(w, `{"full_name":"acme/b","default_branch":"main"}`)
+		case "/repos/acme/a/git/trees/main":
+			_, _ = fmt.Fprint(w, `{"tree":[]}`)
+		case "/repos/acme/b/git/trees/main":
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = fmt.Fprint(w, `{"message":"upstream unavailable"}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"scan",
+		"--org", "acme",
+		"--github-api", server.URL,
+		"--state", statePath,
+		"--json",
+	}, &out, &errOut)
+	if code != exitSuccess {
+		t.Fatalf("scan failed: code=%d stderr=%s", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "progress target=org org=acme event=complete repo_total=2 completed=2 failed=1 succeeded=1") {
+		t.Fatalf("expected complete progress line to count failed repos once, got %q", errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "progress target=org org=acme event=footer status=completed current_phase=artifact_commit last_successful_phase=artifact_commit partial_result=true repo_total=2 completed=2 failed=1 succeeded=1") {
+		t.Fatalf("expected footer progress line to preserve canonical counts and partial marker, got %q", errOut.String())
+	}
+}
+
 func TestScanJSONProgressOnlyOnStderr(t *testing.T) {
 	t.Parallel()
 

--- a/core/cli/scan_status.go
+++ b/core/cli/scan_status.go
@@ -148,20 +148,23 @@ func (t *scanStatusTracker) Phase(rawPhase string) error {
 	return state.SaveScanStatus(t.statePath, t.status)
 }
 
-func (t *scanStatusTracker) Repos(total, completed, failed int) error {
+func (t *scanStatusTracker) Repos(total, succeeded, failed int) error {
 	if t == nil {
 		return nil
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	completed := maxProgressCount(succeeded+failed, 0)
 	t.status.RepoTotal = total
 	t.status.ReposCompleted = completed
+	t.status.ReposSucceeded = succeeded
 	t.status.ReposFailed = failed
 	t.status.RepoProgress = &state.ScanRepoProgress{
 		Total:     total,
+		Succeeded: succeeded,
 		Completed: completed,
 		Failed:    failed,
-		Pending:   maxProgressCount(total-completed-failed, 0),
+		Pending:   maxProgressCount(total-completed, 0),
 	}
 	t.status.UpdatedAt = time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
 	return state.SaveScanStatus(t.statePath, t.status)
@@ -177,7 +180,7 @@ func (t *scanStatusTracker) SetSourcePrivacy(sourcePrivacy sourceprivacy.Contrac
 	t.status.SourcePrivacy = &normalized
 }
 
-func (t *scanStatusTracker) Complete(artifactPaths map[string]string) error {
+func (t *scanStatusTracker) Complete(artifactPaths map[string]string, partialResult bool) error {
 	if t == nil {
 		return nil
 	}
@@ -187,8 +190,12 @@ func (t *scanStatusTracker) Complete(artifactPaths map[string]string) error {
 	t.status.Status = state.ScanStatusCompleted
 	t.status.CurrentPhase = "artifact_commit"
 	t.status.LastSuccessfulPhase = "artifact_commit"
-	t.status.PartialResult = false
-	t.status.PartialResultMarker = ""
+	t.status.PartialResult = partialResult || t.status.PartialResult
+	if t.status.PartialResult {
+		t.status.PartialResultMarker = "partial_result"
+	} else {
+		t.status.PartialResultMarker = ""
+	}
 	t.status.CompletedAt = now.Format(time.RFC3339)
 	t.status.UpdatedAt = t.status.CompletedAt
 	t.status.ArtifactPaths = cleanArtifactPaths(artifactPaths)
@@ -267,6 +274,7 @@ func (t *scanStatusTracker) FooterData() scanProgressFooter {
 		PartialResult:       t.status.PartialResult,
 		RepoTotal:           t.status.RepoTotal,
 		ReposCompleted:      t.status.ReposCompleted,
+		ReposSucceeded:      t.status.ReposSucceeded,
 		ReposFailed:         t.status.ReposFailed,
 		DetectorProgress:    t.status.DetectorProgress,
 		ArtifactPaths:       append([]string(nil), paths...),
@@ -301,6 +309,7 @@ func (t *scanStatusTracker) applyProgressLocked(snapshot scanProgressSnapshot) {
 		t.status.RepoProgress = &repoProgress
 		t.status.RepoTotal = repoProgress.Total
 		t.status.ReposCompleted = repoProgress.Completed
+		t.status.ReposSucceeded = repoProgress.Succeeded
 		t.status.ReposFailed = repoProgress.Failed
 	}
 	if snapshot.DetectorProgress.Total > 0 || snapshot.DetectorProgress.Completed > 0 || snapshot.DetectorProgress.Failed > 0 || snapshot.DetectorProgress.ActiveDetector != "" {

--- a/core/source/org/acquire_resume_test.go
+++ b/core/source/org/acquire_resume_test.go
@@ -89,16 +89,18 @@ func (p *recordingProgress) RepoMaterialize(org string, index, total int, repo s
 	p.add("repo_materialize org=" + org + " repo=" + repo + " index=" + strconv.Itoa(index) + " total=" + strconv.Itoa(total))
 }
 
-func (p *recordingProgress) RepoMaterializeDone(org string, completed, total int, repo, status string) {
-	p.add("repo_materialize_done org=" + org + " repo=" + repo + " status=" + status + " completed=" + strconv.Itoa(completed) + " total=" + strconv.Itoa(total))
+func (p *recordingProgress) RepoMaterializeDone(org string, succeeded, failed, total int, repo, status string) {
+	completed := succeeded + failed
+	p.add("repo_materialize_done org=" + org + " repo=" + repo + " status=" + status + " completed=" + strconv.Itoa(completed) + " succeeded=" + strconv.Itoa(succeeded) + " failed=" + strconv.Itoa(failed) + " total=" + strconv.Itoa(total))
 }
 
 func (p *recordingProgress) Resume(org string, total, completed, pending int) {
 	p.add("resume org=" + org + " total=" + strconv.Itoa(total) + " completed=" + strconv.Itoa(completed) + " pending=" + strconv.Itoa(pending))
 }
 
-func (p *recordingProgress) Complete(org string, total, completed, failed int) {
-	p.add("complete org=" + org + " total=" + strconv.Itoa(total) + " completed=" + strconv.Itoa(completed) + " failed=" + strconv.Itoa(failed))
+func (p *recordingProgress) Complete(org string, total, succeeded, failed int) {
+	completed := succeeded + failed
+	p.add("complete org=" + org + " total=" + strconv.Itoa(total) + " completed=" + strconv.Itoa(completed) + " succeeded=" + strconv.Itoa(succeeded) + " failed=" + strconv.Itoa(failed))
 }
 
 func (p *recordingProgress) add(event string) {
@@ -291,9 +293,9 @@ func TestAcquireMaterializedProgressReportsCompletedRepos(t *testing.T) {
 	events := progress.joined()
 	for _, want := range []string{
 		"repo_materialize org=acme repo=acme/a index=1 total=2",
-		"repo_materialize_done org=acme repo=acme/a status=ok completed=1 total=2",
-		"repo_materialize_done org=acme repo=acme/b status=failed completed=2 total=2",
-		"complete org=acme total=2 completed=1 failed=1",
+		"repo_materialize_done org=acme repo=acme/a status=ok completed=1 succeeded=1 failed=0 total=2",
+		"repo_materialize_done org=acme repo=acme/b status=failed completed=2 succeeded=1 failed=1 total=2",
+		"complete org=acme total=2 completed=2 succeeded=1 failed=1",
 	} {
 		if !strings.Contains(events, want) {
 			t.Fatalf("expected progress to contain %q, got:\n%s", want, events)
@@ -450,8 +452,8 @@ func TestAcquireMaterializedResumeProgressContinuesCompletedCount(t *testing.T) 
 	events := progress.joined()
 	for _, want := range []string{
 		"resume org=acme total=2 completed=1 pending=1",
-		"repo_materialize_done org=acme repo=acme/b status=ok completed=2 total=2",
-		"complete org=acme total=2 completed=2 failed=0",
+		"repo_materialize_done org=acme repo=acme/b status=ok completed=2 succeeded=2 failed=0 total=2",
+		"complete org=acme total=2 completed=2 succeeded=2 failed=0",
 	} {
 		if !strings.Contains(events, want) {
 			t.Fatalf("expected progress to contain %q, got:\n%s", want, events)

--- a/core/source/org/materialized.go
+++ b/core/source/org/materialized.go
@@ -20,9 +20,9 @@ type RepoMaterializer interface {
 type ProgressReporter interface {
 	RepoDiscovery(org string, total int)
 	RepoMaterialize(org string, index, total int, repo string)
-	RepoMaterializeDone(org string, completed, total int, repo, status string)
+	RepoMaterializeDone(org string, succeeded, failed, total int, repo, status string)
 	Resume(org string, total, completed, pending int)
-	Complete(org string, total, completed, failed int)
+	Complete(org string, total, succeeded, failed int)
 }
 
 type AcquireMaterializedOptions struct {
@@ -181,23 +181,24 @@ func AcquireMaterialized(
 	}()
 
 	var fatalErr error
-	completedResults := len(repos)
+	succeededResults := len(repos)
+	failedResults := len(failures)
 	for result := range results {
 		if result.fatalErr != nil && fatalErr == nil {
 			fatalErr = result.fatalErr
 		}
 		if result.failure.Repo != "" {
 			failures = append(failures, result.failure)
-			completedResults++
+			failedResults++
 			if opts.Progress != nil {
-				opts.Progress.RepoMaterializeDone(org, completedResults, totalRepos, result.failure.Repo, "failed")
+				opts.Progress.RepoMaterializeDone(org, succeededResults, failedResults, totalRepos, result.failure.Repo, "failed")
 			}
 		}
 		if strings.TrimSpace(result.manifest.Repo) != "" {
 			repos = append(repos, result.manifest)
-			completedResults++
+			succeededResults++
 			if opts.Progress != nil {
-				opts.Progress.RepoMaterializeDone(org, completedResults, totalRepos, result.manifest.Repo, "ok")
+				opts.Progress.RepoMaterializeDone(org, succeededResults, failedResults, totalRepos, result.manifest.Repo, "ok")
 			}
 		}
 	}

--- a/core/state/scan_status.go
+++ b/core/state/scan_status.go
@@ -32,6 +32,7 @@ type ScanStatus struct {
 	LastSuccessfulPhase string                  `json:"last_successful_phase,omitempty"`
 	RepoTotal           int                     `json:"repo_total,omitempty"`
 	ReposCompleted      int                     `json:"repos_completed,omitempty"`
+	ReposSucceeded      int                     `json:"repos_succeeded,omitempty"`
 	ReposFailed         int                     `json:"repos_failed,omitempty"`
 	ProgressPercent     int                     `json:"progress_percent,omitempty"`
 	ProgressMessage     string                  `json:"progress_message,omitempty"`
@@ -65,6 +66,7 @@ type ScanPhaseProgress struct {
 
 type ScanRepoProgress struct {
 	Total     int `json:"total,omitempty"`
+	Succeeded int `json:"succeeded,omitempty"`
 	Completed int `json:"completed,omitempty"`
 	Failed    int `json:"failed,omitempty"`
 	Pending   int `json:"pending,omitempty"`

--- a/core/state/scan_status_test.go
+++ b/core/state/scan_status_test.go
@@ -17,6 +17,7 @@ func TestScanStatusSaveLoadAtomicSidecar(t *testing.T) {
 		LastSuccessfulPhase: "repo_discovery",
 		RepoTotal:           3,
 		ReposCompleted:      1,
+		ReposSucceeded:      1,
 		PartialResult:       true,
 		PartialResultMarker: "partial_result",
 		ArtifactPaths:       map[string]string{"state": statePath},
@@ -65,7 +66,7 @@ func TestScanStatusSaveLoadProgressFields(t *testing.T) {
 		LastProgressAt:  "2026-05-07T14:40:30Z",
 		ElapsedSeconds:  12,
 		PhaseProgress:   &ScanPhaseProgress{Phase: "detectors", Percent: 36},
-		RepoProgress:    &ScanRepoProgress{Total: 2, Completed: 1, Pending: 1},
+		RepoProgress:    &ScanRepoProgress{Total: 2, Succeeded: 1, Completed: 1, Pending: 1},
 		DetectorProgress: &ScanDetectorProgress{
 			Total:          8,
 			Completed:      3,
@@ -94,7 +95,7 @@ func TestScanStatusSaveLoadProgressFields(t *testing.T) {
 	}
 }
 
-func TestScanStatusLoadsLegacySidecarWithoutProgress(t *testing.T) {
+func TestScanStatusLoadsLegacySidecarWithoutPartialProgress(t *testing.T) {
 	t.Parallel()
 
 	statePath := filepath.Join(t.TempDir(), "last-scan.json")
@@ -117,6 +118,9 @@ func TestScanStatusLoadsLegacySidecarWithoutProgress(t *testing.T) {
 	}
 	if got.Status != ScanStatusRunning || got.CurrentPhase != "source_acquire" {
 		t.Fatalf("unexpected legacy status: %+v", got)
+	}
+	if got.PartialResult || got.PartialResultMarker != "" {
+		t.Fatalf("expected legacy sidecar to remain non-partial, got %+v", got)
 	}
 	if got.ProgressPercent != 0 || got.PhaseProgress != nil || got.RepoProgress != nil || got.DetectorProgress != nil {
 		t.Fatalf("expected legacy sidecar to load without additive progress fields, got %+v", got)

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -4,7 +4,7 @@ Install with Homebrew or the pinned Go path first, then verify the installed CLI
 
 ```bash
 brew install Clyra-AI/tap/wrkr
-WRKR_VERSION="v1.0.0"
+WRKR_VERSION="v1.3.0"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 wrkr version --json
 

--- a/docs/commands/action.md
+++ b/docs/commands/action.md
@@ -21,7 +21,7 @@ Any packaged GitHub Action surface must wrap these CLI contracts rather than dup
 Wrkr now ships a repo-root `action.yml` composite action that wraps the same CLI contracts through `scripts/action_entrypoint.sh`.
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.0.0
+- uses: Clyra-AI/wrkr@v1.3.0
   with:
     mode: scheduled
     remediation_mode: summary_only
@@ -65,7 +65,7 @@ wrkr action pr-comment --changed-paths ".codex/config.toml" --risk-delta 2.8 --c
 ```
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.0.0
+- uses: Clyra-AI/wrkr@v1.3.0
   with:
     mode: scheduled
     target_mode: repo

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -117,7 +117,9 @@ wrkr scan status --state ./.wrkr/last-scan.json --json
 ```
 
 The status payload includes `status`, `current_phase`, `last_successful_phase`, repo counts, `partial_result`, `partial_result_marker`, phase timings, artifact paths, and `source_privacy` when scan state includes source-retention metadata.
-During active or recently interrupted scans, additive progress fields may also include `progress_percent`, `progress_message`, `last_progress_at`, `elapsed_seconds`, `phase_progress`, `repo_progress`, and `detector_progress`.
+Completed scans that hit non-fatal source acquisition failures keep `partial_result=true` in status JSON until the same target is rerun cleanly.
+During active, interrupted, or completed-partial scans, additive progress fields may also include `progress_percent`, `progress_message`, `last_progress_at`, `elapsed_seconds`, `phase_progress`, `repo_progress`, and `detector_progress`.
+When present, `repo_progress.completed` counts repos that reached a terminal source-acquisition result, `repo_progress.succeeded` isolates successful materializations, and `repo_progress.pending` stays `total - completed` so failed repos are counted once.
 Existing state files without a status sidecar are interpreted as `completed` when the state snapshot can be loaded, otherwise `unknown`.
 
 ## Developer personal-hygiene example
@@ -185,7 +187,7 @@ For CI or log-stable automation, prefer `--progress none` when you want no progr
 Resume also revalidates that checkpoint files and reused repo roots are still trusted local artifacts under the managed materialized root; symlink-swapped entries fail closed as `unsafe_operation_blocked`.
 Default successful hosted scans remove that managed root, so resume from retained materialized source requires an explicit retention mode such as `--source-retention retain` for completed runs or `retain_for_resume` for failed/interrupted runs.
 Mixed target sets such as org-plus-path scans fail closed with `invalid_input` when `--resume` is requested.
-If a run is interrupted after some repositories are checkpointed, rerun the same target with `--resume` and keep the same `--state` path. Use `wrkr scan status --state <path> --json` to inspect the last successful phase and partial marker before rerunning. If `partial_result`, `source_errors`, or `source_degraded` is present, treat the scan as incomplete and rerun after the blocking condition is resolved.
+If a run is interrupted after some repositories are checkpointed, rerun the same target with `--resume` and keep the same `--state` path. Use `wrkr scan status --state <path> --json` to inspect the last successful phase, partial marker, and repo counters before rerunning. If `partial_result`, `source_errors`, or `source_degraded` is present, treat the scan as incomplete and rerun after the blocking condition is resolved.
 
 For long org scans, run the foreground command under your process supervisor or shell backgrounding rather than relying on a hidden daemon:
 

--- a/docs/contracts/readme_contract.md
+++ b/docs/contracts/readme_contract.md
@@ -63,6 +63,7 @@ Section requirements:
   - Include `wrkr version` verification on the first screen.
   - README may keep a convenience `@latest` Go install path only if it is explicitly secondary to the pinned path.
   - Pinned/reproducible install guidance must remain canonical in `docs/install/minimal-dependencies.md`.
+  - The pinned install tag must track the current supported Wrkr release mirrored by install-path UAT snippets.
 - Start Here
   - Make the current launch persona explicit at the top of the section.
   - For the current Wrkr launch, foreground the security/platform-led org posture workflow.

--- a/docs/examples/operator-playbooks.md
+++ b/docs/examples/operator-playbooks.md
@@ -29,7 +29,9 @@ wrkr scan status --state ./.wrkr/last-scan.json --json
 
 Wrkr does not start a hidden scan daemon. The status sidecar records `running`, `completed`, `interrupted`, or `failed` state, current phase, last successful phase, repo counts, partial marker, phase timings, and artifact paths.
 Use `--progress events` when you want deterministic stderr liveness in background logs, `--progress none` when you want stderr progress suppressed without muting errors, and `--quiet` when you want all non-error progress output suppressed.
-During active or interrupted scans, `wrkr scan status --state ... --json` may also include additive `progress_percent`, `progress_message`, `last_progress_at`, `elapsed_seconds`, `phase_progress`, `repo_progress`, and `detector_progress` fields.
+Completed scans with non-fatal source acquisition failures remain explicitly partial in `wrkr scan status --state ... --json` until the same target is rerun cleanly.
+During active, interrupted, or completed-partial scans, `wrkr scan status --state ... --json` may also include additive `progress_percent`, `progress_message`, `last_progress_at`, `elapsed_seconds`, `phase_progress`, `repo_progress`, and `detector_progress` fields.
+When present, `repo_progress.completed` counts terminal source-acquisition results, `repo_progress.succeeded` isolates successful materializations, and `repo_progress.pending` stays `total - completed` so failed repos are counted once.
 
 ### Ticket export dry run
 

--- a/docs/examples/security-team.md
+++ b/docs/examples/security-team.md
@@ -35,10 +35,11 @@ Interpretation notes:
 
 - `--progress auto` keeps `--json` stdout clean and preserves structured stderr progress by default; use `--progress events` to keep explicit event lines, `--progress none` for CI-stable stderr, or `--quiet` to suppress progress output entirely
 - retry, cooldown, resume, per-repo materialization completion, local repo discovery, detector lifecycle, heartbeat, scan phase, and final footer progress lines are additive stderr-only operator UX in `--json` mode
-- `partial_result`, `source_errors`, or `source_degraded` means the org posture is incomplete and should be rerun before downstream campaign-style aggregation
+- `partial_result`, `source_errors`, or `source_degraded` means the org posture is incomplete and should be rerun before downstream campaign-style aggregation, even when `wrkr scan status --json` reports `status=completed`
 - `org-checkpoints/` is resumability metadata beside the scan state, not a proof artifact
 - `--resume` revalidates checkpoint files and reused materialized repo roots before detector execution, so symlink-swapped resume state is blocked as unsafe
-- `wrkr scan status --state ./.wrkr/last-scan.json --json` now surfaces additive `progress_percent`, `progress_message`, `last_progress_at`, `phase_progress`, `repo_progress`, and `detector_progress` fields during active or interrupted runs
+- `wrkr scan status --state ./.wrkr/last-scan.json --json` now surfaces additive `progress_percent`, `progress_message`, `last_progress_at`, `phase_progress`, `repo_progress`, and `detector_progress` fields during active, interrupted, or completed-partial runs
+- `repo_progress.completed` counts terminal source-acquisition results, `repo_progress.succeeded` isolates successful materializations, and `repo_progress.pending` stays `total - completed` so failed repos are counted once
 
 Optional deeper triage after the saved state exists:
 

--- a/docs/install/minimal-dependencies.md
+++ b/docs/install/minimal-dependencies.md
@@ -7,7 +7,7 @@ The main README landing page surfaces Homebrew, the pinned Go install path below
 ## Go-only pinned install
 
 ```bash
-WRKR_VERSION="v1.0.0"
+WRKR_VERSION="v1.3.0"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 
@@ -56,6 +56,6 @@ Install commands above are validated by release UAT together with the public `wr
 
 ```bash
 scripts/test_uat_local.sh --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.0.0 --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.0.0 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.3.0 --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.3.0 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
 ```

--- a/docs/map.md
+++ b/docs/map.md
@@ -24,6 +24,15 @@ If the Wrkr README uses the landing-page Variant B contract, install and OSS tru
 Public contract wording changes should update `CHANGELOG.md` under `Unreleased` in the same change, even when runtime JSON, exit-code, and schema contracts stay unchanged.
 Maintainers should finalize `Unreleased` with `python3 scripts/finalize_release_changelog.py --json` before cutting a release tag, land that prepared changelog update through a release-prep PR, and tag the merged `main` commit so the tag points at the finalized versioned section.
 
+## Focused local commands
+
+Use these as narrow local iteration helpers before the full required lanes:
+
+- `make test-focused-docs` for install-contract, README, docs-site quickstart, and release-parity doc changes.
+- `make test-focused-scan` for scan-status, completed-partial-result, and hosted progress-counter changes.
+
+These helpers are additive only. They do not replace `make test-fast`, `make prepush`, `make test-contracts`, scenario lanes, risk lanes, or release/UAT lanes when those are required by the touched surface.
+
 ## Required validation bundle
 
 Run this bundle before merge when docs are touched:

--- a/docs/trust/release-integrity.md
+++ b/docs/trust/release-integrity.md
@@ -24,7 +24,7 @@ description: "Release hardening checks, reproducibility expectations, and integr
 make lint-fast
 python3 scripts/resolve_release_version.py --json
 python3 scripts/finalize_release_changelog.py --json
-python3 scripts/validate_release_changelog.py --release-version v1.0.0 --json
+python3 scripts/validate_release_changelog.py --release-version vX.Y.Z --json
 go test ./... -count=1
 make test-contracts
 scripts/validate_contracts.sh
@@ -69,7 +69,7 @@ scripts/test_uat_local.sh
 scripts/test_uat_local.sh --skip-global-gates
 
 # Validate exact public install commands (brew + pinned go install) for a published tag
-scripts/test_uat_local.sh --release-version v1.0.0 --brew-formula Clyra-AI/tap/wrkr
+scripts/test_uat_local.sh --release-version v1.3.0 --brew-formula Clyra-AI/tap/wrkr
 ```
 
 ## Changelog finalization
@@ -79,7 +79,7 @@ Before tagging a release, resolve the next version from `## [Unreleased]`, then 
 ```bash
 python3 scripts/resolve_release_version.py --json
 python3 scripts/finalize_release_changelog.py --json
-python3 scripts/validate_release_changelog.py --release-version v1.0.0 --json
+python3 scripts/validate_release_changelog.py --release-version vX.Y.Z --json
 ```
 
 The finalizer promotes releasable `Unreleased` entries into `## [vX.Y.Z] - YYYY-MM-DD`, adds a hidden semver hint for CI validation, and resets `Unreleased` to the canonical empty template so the next release only considers new entries. Publish that changelog update through a short-lived release-prep PR before creating the tag; the tag workflow validates the changelog content from the tagged commit itself.

--- a/product/dev_guides.md
+++ b/product/dev_guides.md
@@ -38,6 +38,10 @@ These notes clarify how this repository currently enforces this standard. They d
 
 ### 3) Current Local Gate Entry Points (Wrkr)
 
+- Focused local docs/install gate:
+  - `make test-focused-docs`
+- Focused local scan-status/progress gate:
+  - `make test-focused-scan`
 - Fast developer gate:
   - `make prepush`
 - Full architecture/risk gate:
@@ -46,6 +50,7 @@ These notes clarify how this repository currently enforces this standard. They d
   - `make test-risk-lane`
 - Acceptance scorecard gate:
   - `scripts/run_v1_acceptance.sh --mode=local`
+- Focused local helpers are additive only. They do not replace `make test-fast`, `make prepush`, required PR checks, or release validation lanes.
 
 ### 4) Scenario and Acceptance Contract Reality (Wrkr)
 

--- a/scripts/check_docs_consistency.sh
+++ b/scripts/check_docs_consistency.sh
@@ -63,6 +63,20 @@ readme_uses_landing_v2() {
   search_regex "^## Start Here$" "${REPO_ROOT}/README.md"
 }
 
+extract_current_supported_release() {
+  local changelog_path="$1"
+  local line=""
+  if [[ "${HAS_RG}" -eq 1 ]]; then
+    line="$(rg -m1 '^## \[v[0-9]+\.[0-9]+\.[0-9]+\]' "$changelog_path" || true)"
+  else
+    line="$(grep -m1 -E '^## \[v[0-9]+\.[0-9]+\.[0-9]+\]' "$changelog_path" || true)"
+  fi
+  if [[ -z "${line}" ]]; then
+    return 1
+  fi
+  printf '%s\n' "${line}" | sed -E 's/^## \[([^]]+)\].*/\1/'
+}
+
 for path in \
   "${REPO_ROOT}/README.md" \
   "${REPO_ROOT}/CODE_OF_CONDUCT.md" \
@@ -117,6 +131,12 @@ for path in \
   "${REPO_ROOT}/docs-site/public/robots.txt"; do
   require_file "$path"
 done
+
+CURRENT_SUPPORTED_RELEASE="$(extract_current_supported_release "${REPO_ROOT}/CHANGELOG.md" || true)"
+if [[ -z "${CURRENT_SUPPORTED_RELEASE}" ]]; then
+  fail "could not resolve current supported release from CHANGELOG.md"
+fi
+CURRENT_SUPPORTED_RELEASE_REGEX="${CURRENT_SUPPORTED_RELEASE//./\\.}"
 
 for path in \
   "${REPO_ROOT}/docs/intent/scan-org-repos-for-ai-agents-configs.md" \
@@ -203,11 +223,17 @@ require_pattern "${REPO_ROOT}/docs-site/public/robots.txt" "User-agent: Perplexi
 require_pattern "${REPO_ROOT}/docs-site/public/robots.txt" "User-agent: ChatGPT-User" "robots.txt missing ChatGPT-User allow rule"
 
 require_pattern "${REPO_ROOT}/README.md" "brew install Clyra-AI/tap/wrkr" "README missing canonical Homebrew install command"
+require_pattern "${REPO_ROOT}/README.md" "WRKR_VERSION=\"${CURRENT_SUPPORTED_RELEASE_REGEX}\"" "README pinned install version must track current supported release"
 require_pattern "${REPO_ROOT}/docs/install/minimal-dependencies.md" "go install github.com/Clyra-AI/wrkr/cmd/wrkr@\"\\$\\{WRKR_VERSION\\}\"" "install docs missing canonical pinned go install command"
+require_pattern "${REPO_ROOT}/docs/install/minimal-dependencies.md" "WRKR_VERSION=\"${CURRENT_SUPPORTED_RELEASE_REGEX}\"" "install docs pinned version must track current supported release"
 require_pattern "${REPO_ROOT}/docs/install/minimal-dependencies.md" "curl -fsSL https://api.github.com/repos/Clyra-AI/wrkr/releases/latest" "install docs missing latest-tag resolution path"
-require_pattern "${REPO_ROOT}/docs/trust/release-integrity.md" "scripts/test_uat_local.sh --release-version v1.0.0 --brew-formula Clyra-AI/tap/wrkr" "release integrity doc missing published install-path parity command"
+require_pattern "${REPO_ROOT}/docs/install/minimal-dependencies.md" "scripts/test_uat_local.sh --release-version ${CURRENT_SUPPORTED_RELEASE_REGEX} --skip-global-gates" "install docs release-smoke command must track current supported release"
+require_pattern "${REPO_ROOT}/docs/install/minimal-dependencies.md" "scripts/test_uat_local.sh --release-version ${CURRENT_SUPPORTED_RELEASE_REGEX} --brew-formula Clyra-AI/tap/wrkr --skip-global-gates" "install docs published brew smoke command must track current supported release"
+require_pattern "${REPO_ROOT}/docs/commands/action.md" "Clyra-AI/wrkr@${CURRENT_SUPPORTED_RELEASE_REGEX}" "action command docs must reference current supported release"
+require_pattern "${REPO_ROOT}/docs-site/public/llm/quickstart.md" "WRKR_VERSION=\"${CURRENT_SUPPORTED_RELEASE_REGEX}\"" "docs-site quickstart pinned install must track current supported release"
+require_pattern "${REPO_ROOT}/docs/trust/release-integrity.md" "scripts/test_uat_local.sh --release-version ${CURRENT_SUPPORTED_RELEASE_REGEX} --brew-formula Clyra-AI/tap/wrkr" "release integrity doc missing current install-path parity command"
 require_pattern "${REPO_ROOT}/docs/trust/release-integrity.md" "scripts/finalize_release_changelog\\.py --json" "release integrity doc missing changelog finalization command"
-require_pattern "${REPO_ROOT}/docs/trust/release-integrity.md" "scripts/validate_release_changelog\\.py --release-version v1.0.0 --json" "release integrity doc missing changelog validation command"
+require_pattern "${REPO_ROOT}/docs/trust/release-integrity.md" "scripts/validate_release_changelog\\.py --release-version vX\\.Y\\.Z --json" "release integrity doc missing changelog validation command"
 require_pattern "${REPO_ROOT}/docs-site/src/app/page.tsx" "/docs/start-here#install" "docs-site homepage missing start-here install pointer"
 require_pattern "${REPO_ROOT}/docs-site/src/app/page.tsx" "/scan" "docs-site homepage missing web bootstrap pointer"
 require_pattern "${REPO_ROOT}/docs/state_lifecycle.md" "^## Canonical artifact locations$" "state lifecycle doc missing canonical artifact table section"
@@ -227,6 +253,8 @@ require_pattern "${REPO_ROOT}/docs/commands/fix.md" "When --open-pr is set, wrkr
 require_pattern "${REPO_ROOT}/docs/faq.md" "^### Do I need Axym or Gait to run Wrkr\\?$" "FAQ missing standalone vs ecosystem entry"
 require_pattern "${REPO_ROOT}/CONTRIBUTING.md" "^## Docs Source of Truth$" "CONTRIBUTING missing docs source-of-truth section"
 require_pattern "${REPO_ROOT}/CONTRIBUTING.md" "make docs-site-install" "CONTRIBUTING missing docs-site validation command guidance"
+require_pattern "${REPO_ROOT}/CONTRIBUTING.md" "make test-focused-docs" "CONTRIBUTING missing focused docs validation command guidance"
+require_pattern "${REPO_ROOT}/CONTRIBUTING.md" "make test-focused-scan" "CONTRIBUTING missing focused scan validation command guidance"
 require_pattern "${REPO_ROOT}/CONTRIBUTING.md" "^## Required Toolchain$" "CONTRIBUTING missing required toolchain section"
 require_pattern "${REPO_ROOT}/CONTRIBUTING.md" "^## Optional Toolchain$" "CONTRIBUTING missing optional toolchain section"
 require_pattern "${REPO_ROOT}/CONTRIBUTING.md" "^## Go-Only Contributor Path \\(Default\\)$" "CONTRIBUTING missing Go-only contributor path section"
@@ -235,8 +263,13 @@ require_pattern "${REPO_ROOT}/CONTRIBUTING.md" "^## Determinism Requirements$" "
 require_pattern "${REPO_ROOT}/CONTRIBUTING.md" "^## Detector Authoring Guidance$" "CONTRIBUTING missing detector authoring guidance section"
 require_pattern "${REPO_ROOT}/CONTRIBUTING.md" "^## Pull Request Workflow$" "CONTRIBUTING missing pull request workflow section"
 require_pattern "${REPO_ROOT}/docs/map.md" "^## Source-of-truth model$" "docs map missing source-of-truth model section"
+require_pattern "${REPO_ROOT}/docs/map.md" "^## Focused local commands$" "docs map missing focused local commands section"
+require_pattern "${REPO_ROOT}/docs/map.md" "make test-focused-docs" "docs map missing focused docs validation command"
+require_pattern "${REPO_ROOT}/docs/map.md" "make test-focused-scan" "docs map missing focused scan validation command"
 require_pattern "${REPO_ROOT}/docs/map.md" "^## Required validation bundle$" "docs map missing required validation bundle section"
 require_pattern "${REPO_ROOT}/docs-site/public/llms.txt" "/docs/map/" "llms.txt missing docs source map reference"
+require_pattern "${REPO_ROOT}/product/dev_guides.md" "make test-focused-docs" "product dev guides missing focused docs validation command"
+require_pattern "${REPO_ROOT}/product/dev_guides.md" "make test-focused-scan" "product dev guides missing focused scan validation command"
 require_pattern "${REPO_ROOT}/.github/ISSUE_TEMPLATE/bug_report.yml" "^name: Bug report$" "bug issue template missing name header"
 require_pattern "${REPO_ROOT}/.github/ISSUE_TEMPLATE/bug_report.yml" "Contract surface affected" "bug issue template missing contract surface prompt"
 require_pattern "${REPO_ROOT}/.github/ISSUE_TEMPLATE/feature_request.yml" "^name: Feature request$" "feature issue template missing name header"

--- a/scripts/run_docs_smoke.sh
+++ b/scripts/run_docs_smoke.sh
@@ -28,6 +28,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
 fixture_path="scenarios/wrkr/scan-mixed-org/repos"
 state_path="$tmp_dir/state.json"
+target_state_path="$tmp_dir/target-state.json"
 config_path="$tmp_dir/config.yaml"
 baseline_path="$tmp_dir/wrkr-regress-baseline.json"
 evidence_dir="$tmp_dir/evidence"
@@ -37,6 +38,7 @@ manifest_path="$tmp_dir/wrkr-manifest.yaml"
 "$bin_path" init --non-interactive --path "$fixture_path" --config "$config_path" --json >/dev/null
 "$bin_path" scan --path "$fixture_path" --state "$state_path" --json >"$tmp_dir/scan.json"
 "$bin_path" scan --path "$fixture_path" --state "$state_path" --profile standard --json >"$tmp_dir/scan-standard.json"
+"$bin_path" scan --target "path:$fixture_path" --state "$target_state_path" --profile assessment --json --json-path "$tmp_dir/scan-target-copy.json" >"$tmp_dir/scan-target.json"
 (
   cd "$tmp_dir"
   "$bin_path" evidence --frameworks eu-ai-act,soc2 --state "$state_path" --json >"$tmp_dir/evidence-default.json"
@@ -68,6 +70,7 @@ root = pathlib.Path(sys.argv[1])
 required = {
     "scan.json": ["status", "findings", "ranked_findings", "inventory", "profile", "posture_score"],
     "scan-standard.json": ["status", "profile", "posture_score"],
+    "scan-target.json": ["status", "findings", "ranked_findings", "inventory", "profile", "posture_score", "target"],
     "evidence-default.json": ["status", "output_dir", "framework_coverage"],
     "evidence-managed.json": ["status", "output_dir", "manifest_path", "chain_path"],
     "score.json": ["score", "grade", "weighted_breakdown", "trend_delta"],
@@ -81,6 +84,11 @@ for name, keys in required.items():
     for key in keys:
         if key not in payload:
             raise SystemExit(f"{name} missing key {key}")
+
+scan_target_bytes = (root / "scan-target.json").read_bytes()
+scan_target_copy_bytes = (root / "scan-target-copy.json").read_bytes()
+if scan_target_bytes != scan_target_copy_bytes:
+    raise SystemExit("scan-target stdout/json-path payload mismatch")
 
 unsafe_payload = json.loads((root / "unsafe.err").read_text(encoding="utf-8"))
 err = unsafe_payload.get("error", {})

--- a/scripts/test_uat_local.sh
+++ b/scripts/test_uat_local.sh
@@ -53,8 +53,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-json_smoke_validator="$tmp_dir/check_json_smoke.go"
-cat >"$json_smoke_validator" <<'GO'
+root_json_smoke_validator="$tmp_dir/check_root_json_smoke.go"
+cat >"$root_json_smoke_validator" <<'GO'
 package main
 
 import (
@@ -99,7 +99,62 @@ func main() {
 }
 GO
 
-run_json_smoke() {
+version_json_smoke_validator="$tmp_dir/check_version_json_smoke.go"
+cat >"$version_json_smoke_validator" <<'GO'
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type versionPayload struct {
+	Status  string `json:"status"`
+	Version string `json:"version"`
+}
+
+func main() {
+	if len(os.Args) < 3 || len(os.Args) > 4 {
+		fmt.Fprintln(os.Stderr, "usage: go run <validator> <path> <label> [expected-version]")
+		os.Exit(6)
+	}
+
+	path := strings.TrimSpace(os.Args[1])
+	expectedVersion := ""
+	if len(os.Args) == 4 {
+		expectedVersion = strings.TrimSpace(os.Args[3])
+	}
+
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "version smoke read failure")
+		os.Exit(3)
+	}
+
+	var parsed versionPayload
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		fmt.Fprintln(os.Stderr, "version smoke parse failure")
+		os.Exit(3)
+	}
+
+	if strings.TrimSpace(parsed.Status) != "ok" {
+		fmt.Fprintln(os.Stderr, "version smoke status mismatch")
+		os.Exit(3)
+	}
+	if strings.TrimSpace(parsed.Version) == "" {
+		fmt.Fprintln(os.Stderr, "version smoke missing version")
+		os.Exit(3)
+	}
+	if expectedVersion != "" && strings.TrimSpace(parsed.Version) != expectedVersion {
+		fmt.Fprintln(os.Stderr, "version smoke version mismatch")
+		os.Exit(3)
+	}
+}
+GO
+
+run_root_json_smoke() {
   local label="$1"
   local bin_path="$2"
   local out_path="$tmp_dir/${label}.json"
@@ -110,7 +165,40 @@ run_json_smoke() {
   fi
 
   "$bin_path" --json >"$out_path"
-  go run "$json_smoke_validator" "$out_path" "$label"
+  go run "$root_json_smoke_validator" "$out_path" "$label"
+}
+
+run_version_json_smoke() {
+  local label="$1"
+  local bin_path="$2"
+  local expected_version="${3:-}"
+  local out_path="$tmp_dir/${label}-version.json"
+
+  if [[ ! -x "$bin_path" ]]; then
+    echo "binary is not executable for ${label}: $bin_path" >&2
+    exit 7
+  fi
+
+  "$bin_path" version --json >"$out_path"
+  go run "$version_json_smoke_validator" "$out_path" "$label" "$expected_version"
+}
+
+run_json_smoke() {
+  local label="$1"
+  local bin_path="$2"
+  local expected_version="${3:-}"
+
+  run_root_json_smoke "$label" "$bin_path"
+  run_version_json_smoke "$label" "$bin_path" "$expected_version"
+}
+
+run_install_smoke() {
+  local label="$1"
+  local bin_path="$2"
+  local expected_version="${3:-}"
+
+  run_json_smoke "$label" "$bin_path" "$expected_version"
+  run_docs_subset_smoke "$label" "$bin_path"
 }
 
 run_docs_subset_smoke() {
@@ -128,6 +216,7 @@ run_docs_subset_smoke() {
 run_go_install_smoke() {
   local label="$1"
   local install_target="$2"
+  local expected_version="${3:-}"
   local install_bin_dir="$tmp_dir/${label}-gobin"
   local install_bin="$install_bin_dir/wrkr"
 
@@ -140,8 +229,7 @@ run_go_install_smoke() {
     exit 7
   fi
 
-  run_json_smoke "$label" "$install_bin"
-  run_docs_subset_smoke "$label" "$install_bin"
+  run_install_smoke "$label" "$install_bin" "$expected_version"
 }
 
 if [[ "$skip_global_gates" != "true" ]]; then
@@ -158,8 +246,7 @@ fi
 
 source_bin="$tmp_dir/wrkr-source"
 go build -o "$source_bin" ./cmd/wrkr
-run_json_smoke "source" "$source_bin"
-run_docs_subset_smoke "source" "$source_bin"
+run_install_smoke "source" "$source_bin"
 run_go_install_smoke "go-install-local" "./cmd/wrkr"
 
 os_name="$(uname -s)"
@@ -210,7 +297,7 @@ fi
 
 if [[ -n "${release_tag:-}" ]]; then
   # This mirrors the README/docs install command pinned to a concrete release tag.
-  run_go_install_smoke "go-install-release-tag" "${go_install_module}@${release_tag}"
+  run_go_install_smoke "go-install-release-tag" "${go_install_module}@${release_tag}" "${release_tag}"
 fi
 
 release_extract_dir="$tmp_dir/release-extract"
@@ -230,8 +317,7 @@ if [[ -z "$release_bin" ]]; then
   exit 7
 fi
 
-run_json_smoke "release-installer" "$release_bin"
-run_docs_subset_smoke "release-installer" "$release_bin"
+run_install_smoke "release-installer" "$release_bin" "${release_tag:-}"
 
 if ! command -v brew >/dev/null 2>&1; then
   echo "homebrew is required for UAT homebrew-path checks" >&2

--- a/testinfra/hygiene/wave2_docs_contracts_test.go
+++ b/testinfra/hygiene/wave2_docs_contracts_test.go
@@ -1,6 +1,7 @@
 package hygiene
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,6 +71,72 @@ func TestInstallDocsSmokeGoOnlyPath(t *testing.T) {
 	}
 	if !strings.Contains(releaseIntegrity, "wrkr version --json") {
 		t.Fatal("release integrity docs missing install verification command")
+	}
+}
+
+func TestInstallDocsPinnedVersionSupportsCurrentReadmeCommands(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	currentRelease := currentSupportedReleaseFromChangelog(t, repoRoot)
+	readme := mustReadFile(t, filepath.Join(repoRoot, "README.md"))
+	installDoc := mustReadFile(t, filepath.Join(repoRoot, "docs/install/minimal-dependencies.md"))
+	quickstartLLM := mustReadFile(t, filepath.Join(repoRoot, "docs-site/public/llm/quickstart.md"))
+	actionDoc := mustReadFile(t, filepath.Join(repoRoot, "docs/commands/action.md"))
+
+	for path, content := range map[string]string{
+		"README.md":                            readme,
+		"docs/install/minimal-dependencies.md": installDoc,
+		"docs-site/public/llm/quickstart.md":   quickstartLLM,
+	} {
+		got := extractShellAssignedVersion(t, content, `WRKR_VERSION="`)
+		if got != currentRelease {
+			t.Fatalf("%s must pin %s, got %s", path, currentRelease, got)
+		}
+	}
+
+	for _, required := range []string{
+		"--progress auto",
+		"--json-path",
+		"--profile assessment",
+		"--target org:acme --target path:./your-repos",
+	} {
+		if !strings.Contains(readme, required) {
+			t.Fatalf("README contract changed; expected %q to remain covered by the install version guard", required)
+		}
+	}
+
+	for _, needle := range []string{
+		"- uses: Clyra-AI/wrkr@" + currentRelease,
+	} {
+		if !strings.Contains(actionDoc, needle) {
+			t.Fatalf("docs/commands/action.md must reference current supported release %s", currentRelease)
+		}
+	}
+}
+
+func TestMinimalDependenciesReleaseSmokeVersionIsCurrent(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	currentRelease := currentSupportedReleaseFromChangelog(t, repoRoot)
+	installDoc := mustReadFile(t, filepath.Join(repoRoot, "docs/install/minimal-dependencies.md"))
+	releaseIntegrity := mustReadFile(t, filepath.Join(repoRoot, "docs/trust/release-integrity.md"))
+
+	for _, required := range []string{
+		"scripts/test_uat_local.sh --release-version " + currentRelease + " --skip-global-gates",
+		"scripts/test_uat_local.sh --release-version " + currentRelease + " --brew-formula Clyra-AI/tap/wrkr --skip-global-gates",
+	} {
+		if !strings.Contains(installDoc, required) {
+			t.Fatalf("install docs missing current release-smoke command %q", required)
+		}
+	}
+
+	if !strings.Contains(releaseIntegrity, "scripts/test_uat_local.sh --release-version "+currentRelease+" --brew-formula Clyra-AI/tap/wrkr") {
+		t.Fatalf("release integrity docs must use current supported release %s for install-path UAT", currentRelease)
+	}
+	if !strings.Contains(releaseIntegrity, "python3 scripts/validate_release_changelog.py --release-version vX.Y.Z --json") {
+		t.Fatal("release integrity docs must keep release-version validation examples generic with vX.Y.Z")
 	}
 }
 
@@ -212,6 +279,71 @@ func TestDocsSourceOfTruthSectionsPresent(t *testing.T) {
 	}
 }
 
+func TestRequiredChecksRemainEnforced(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	content, err := os.ReadFile(filepath.Join(repoRoot, ".github", "required-checks.json"))
+	if err != nil {
+		t.Fatalf("read required checks contract: %v", err)
+	}
+
+	var payload struct {
+		RequiredChecks []string `json:"required_checks"`
+	}
+	if err := json.Unmarshal(content, &payload); err != nil {
+		t.Fatalf("parse required checks contract: %v", err)
+	}
+
+	for _, required := range []string{"fast-lane", "scan-contract", "wave-sequence", "windows-smoke"} {
+		found := false
+		for _, actual := range payload.RequiredChecks {
+			if actual == required {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("required checks contract missing %q: %v", required, payload.RequiredChecks)
+		}
+	}
+}
+
+func TestDocsMapListsFocusedValidationCommands(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	docsMap := mustReadFile(t, filepath.Join(repoRoot, "docs/map.md"))
+	contributing := mustReadFile(t, filepath.Join(repoRoot, "CONTRIBUTING.md"))
+	devGuides := mustReadFile(t, filepath.Join(repoRoot, "product/dev_guides.md"))
+	makefile := mustReadFile(t, filepath.Join(repoRoot, "Makefile"))
+
+	for _, required := range []string{
+		"make test-focused-docs",
+		"make test-focused-scan",
+		"make test-fast",
+	} {
+		if !strings.Contains(docsMap, required) {
+			t.Fatalf("docs map missing focused validation command %q", required)
+		}
+		if !strings.Contains(contributing, required) {
+			t.Fatalf("CONTRIBUTING missing focused validation command %q", required)
+		}
+		if !strings.Contains(devGuides, required) {
+			t.Fatalf("product/dev_guides.md missing focused validation command %q", required)
+		}
+	}
+	for _, target := range []string{
+		"test-focused-docs:",
+		"test-focused-scan:",
+		"test-fast:",
+	} {
+		if !strings.Contains(makefile, "\n"+target) && !strings.HasPrefix(makefile, target) {
+			t.Fatalf("Makefile missing focused validation target %q", strings.TrimSuffix(target, ":"))
+		}
+	}
+}
+
 func TestContributingContainsRequiredWorkflowSections(t *testing.T) {
 	t.Parallel()
 
@@ -324,6 +456,44 @@ func TestGovernancePolicyDocsPresent(t *testing.T) {
 	if !strings.Contains(skillsNotice, "docs/governance/content-visibility.md") {
 		t.Fatal("skills notice missing governance link")
 	}
+}
+
+func currentSupportedReleaseFromChangelog(t *testing.T, repoRoot string) string {
+	t.Helper()
+
+	changelog := mustReadFile(t, filepath.Join(repoRoot, "CHANGELOG.md"))
+	for _, line := range strings.Split(changelog, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "## [v") {
+			continue
+		}
+		end := strings.Index(line, "]")
+		if end <= len("## [") {
+			break
+		}
+		return line[len("## ["):end]
+	}
+	t.Fatal("could not resolve current supported release from CHANGELOG.md")
+	return ""
+}
+
+func extractShellAssignedVersion(t *testing.T, content, prefix string) string {
+	t.Helper()
+
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		value := strings.TrimPrefix(line, prefix)
+		value = strings.TrimSuffix(value, `"`)
+		if value == "" {
+			break
+		}
+		return value
+	}
+	t.Fatalf("could not find shell-assigned version prefix %q", prefix)
+	return ""
 }
 
 func TestReadmeContractSectionsPresent(t *testing.T) {


### PR DESCRIPTION
## Problem
- completed scans with source failures could still read as complete instead of partial to downstream automation
- hosted scan progress counters could drift when repo materialization failed, and audit-readiness docs had release-pin and validation guidance gaps

## Changes
- keep scan status partial when manifest failures exist and tighten hosted progress accounting across CLI and source materialization paths
- add targeted regression coverage for partial scan status, progress rendering, release-pin parity, and docs contract expectations
- add focused validation targets plus docs and script updates so install, quickstart, and release-smoke guidance stay aligned with the current supported release

## Validation
- `make prepush-full`

## Risks
- touches scan progress/status presentation, docs parity checks, and release-smoke helper scripts; full local validation including CodeQL passed before push

## Submodule Notes
- no submodule pointer changes
