### PR TITLE
hotfix: stabilize live org progress assertion (r1)

### DIFF
--- a/core/cli/scan_progress_test.go
+++ b/core/cli/scan_progress_test.go
@@ -365,7 +365,9 @@ func TestScanJSONOrgProgressIsVisibleBeforeCommandCompletion(t *testing.T) {
 		}, &out, errOut)
 	}()
 
-	const want = "progress target=org org=acme event=repo_materialize repo_index=1 repo_total=1 repo=acme/a"
+	// This test only needs proof that progress is visible before the command exits.
+	// Other progress tests cover the later repo materialization milestones directly.
+	const want = "progress target=org org=acme event=scan_phase phase=source_acquire_start"
 	if !errOut.waitFor(want, 2*time.Second) {
 		t.Fatalf("expected live stderr progress before completion, got %q", errOut.String())
 	}


### PR DESCRIPTION
## Problem
- post-merge monitoring on `main` caught `core-matrix-windows-latest` failing in run `25532689864`
- `TestScanJSONOrgProgressIsVisibleBeforeCommandCompletion` was waiting for a later `repo_materialize` progress line, which can race on Windows under heavy parallel test load even when live progress is already visible

## Changes
- narrow the flaky assertion to the actual contract of the test: any live org progress must be observable before command completion
- keep the more specific repo-materialization coverage in the other scan progress tests

## Validation
- `go test ./core/cli -run TestScanJSONOrgProgressIsVisibleBeforeCommandCompletion -count=3`
- `make prepush-full`

## Risks
- touches only a Windows-flaky test assertion path in `core/cli/scan_progress_test.go`
- hotfix is scoped to the concrete post-merge failure seen on `main`

## Submodule Notes
- no submodule pointer changes
