### PR TITLE
fix: serialize scan progress renderer writes

### DIFF
--- a/core/aggregate/inventory/privileges.go
+++ b/core/aggregate/inventory/privileges.go
@@ -38,7 +38,7 @@ const (
 
 	CredentialKindGitHubPAT           = "github_pat"
 	CredentialKindGitHubWorkflowToken = "github_workflow_token" // #nosec G101 -- Deterministic credential classification label, not a secret.
-	CredentialKindGitHubAppKey        = "github_app_key" // #nosec G101 -- Deterministic credential classification label, not a secret.
+	CredentialKindGitHubAppKey        = "github_app_key"        // #nosec G101 -- Deterministic credential classification label, not a secret.
 	CredentialKindDeployKey           = "deploy_key"
 	CredentialKindCloudAdminKey       = "cloud_admin_key"
 	CredentialKindCloudAccessKey      = "cloud_access_key"

--- a/core/attribution/provider_metadata.go
+++ b/core/attribution/provider_metadata.go
@@ -12,23 +12,23 @@ import (
 )
 
 const (
-	SourceGitHubEvent  = "github_event_payload"
-	SourceGitLabEvent  = "gitlab_merge_request_event"
-	SourceSidecar      = "source_metadata"
+	SourceGitHubEvent = "github_event_payload"
+	SourceGitLabEvent = "gitlab_merge_request_event"
+	SourceSidecar     = "source_metadata"
 )
 
 type Context struct {
-	RepoRoot    string
-	Candidates  []Candidate
+	RepoRoot   string
+	Candidates []Candidate
 }
 
 type Candidate struct {
-	Source      string
-	PRNumber    int
-	CommitSHA   string
-	Author      string
-	Timestamp   string
-	ProviderURL string
+	Source       string
+	PRNumber     int
+	CommitSHA    string
+	Author       string
+	Timestamp    string
+	ProviderURL  string
 	ChangedFiles []string
 }
 
@@ -220,9 +220,9 @@ func loadGitLabEventMetadata(repoRoot string) *Candidate {
 			Username string `json:"username"`
 		} `json:"user"`
 		ObjectAttributes struct {
-			IID       int    `json:"iid"`
-			URL       string `json:"url"`
-			UpdatedAt string `json:"updated_at"`
+			IID        int    `json:"iid"`
+			URL        string `json:"url"`
+			UpdatedAt  string `json:"updated_at"`
 			LastCommit struct {
 				ID string `json:"id"`
 			} `json:"last_commit"`

--- a/core/cli/scan_progress.go
+++ b/core/cli/scan_progress.go
@@ -108,6 +108,7 @@ type scanProgressState struct {
 
 type scanProgressReporter struct {
 	mu                sync.Mutex
+	renderMu          sync.Mutex
 	mode              scanProgressMode
 	renderer          scanProgressRenderer
 	statusSink        func(scanProgressSnapshot)
@@ -331,15 +332,16 @@ func (r *scanProgressReporter) ScanPhase(targetMode, targetValue, phase string) 
 		statusSink(snapshot)
 	}
 	if renderer != nil {
+		updates := make([]scanProgressUpdate, 0, 2)
 		if notice != "" {
-			renderer.Render(snapshot, scanProgressUpdate{
+			updates = append(updates, scanProgressUpdate{
 				Kind:        "notice",
 				TargetMode:  targetMode,
 				TargetValue: targetValue,
 				Message:     notice,
 			})
 		}
-		renderer.Render(snapshot, scanProgressUpdate{
+		updates = append(updates, scanProgressUpdate{
 			Kind:           "scan_phase",
 			TargetMode:     targetMode,
 			TargetValue:    targetValue,
@@ -347,6 +349,7 @@ func (r *scanProgressReporter) ScanPhase(targetMode, targetValue, phase string) 
 			DurationMillis: durationMillis,
 			Message:        phaseProgressMessage(phase),
 		})
+		r.render(snapshot, updates...)
 	}
 }
 
@@ -497,23 +500,22 @@ func (r *scanProgressReporter) Heartbeat() {
 }
 
 func (r *scanProgressReporter) Flush() {
-	if r == nil || r.renderer == nil {
+	if r == nil {
 		return
 	}
-	r.renderer.Flush()
+	r.flush()
 }
 
 func (r *scanProgressReporter) Finish(footer scanProgressFooter) {
-	if r == nil || r.renderer == nil {
+	if r == nil {
 		return
 	}
-	r.renderer.Render(r.snapshot(), scanProgressUpdate{
+	r.renderAndFlush(r.snapshot(), scanProgressUpdate{
 		Kind:        "footer",
 		TargetMode:  r.targetMode,
 		TargetValue: r.targetValue,
 		Footer:      footer,
 	})
-	r.renderer.Flush()
 }
 
 func (r *scanProgressReporter) snapshot() scanProgressSnapshot {
@@ -541,8 +543,9 @@ func (r *scanProgressReporter) emit(update scanProgressUpdate, mutate func(time.
 		r.state.progressMessage = strings.TrimSpace(update.Message)
 	}
 	snapshot := mutate(now)
+	updates := make([]scanProgressUpdate, 0, 2)
 	if r.pendingNotice != "" && r.renderer != nil {
-		r.renderer.Render(snapshot, scanProgressUpdate{
+		updates = append(updates, scanProgressUpdate{
 			Kind:        "notice",
 			TargetMode:  update.TargetMode,
 			TargetValue: update.TargetValue,
@@ -552,14 +555,47 @@ func (r *scanProgressReporter) emit(update scanProgressUpdate, mutate func(time.
 	}
 	renderer := r.renderer
 	statusSink := r.statusSink
+	if renderer != nil {
+		updates = append(updates, update)
+	}
 	r.mu.Unlock()
 
 	if statusSink != nil {
 		statusSink(snapshot)
 	}
 	if renderer != nil {
-		renderer.Render(snapshot, update)
+		r.render(snapshot, updates...)
 	}
+}
+
+func (r *scanProgressReporter) render(snapshot scanProgressSnapshot, updates ...scanProgressUpdate) {
+	if r == nil || r.renderer == nil || len(updates) == 0 {
+		return
+	}
+	r.renderMu.Lock()
+	defer r.renderMu.Unlock()
+	for _, update := range updates {
+		r.renderer.Render(snapshot, update)
+	}
+}
+
+func (r *scanProgressReporter) flush() {
+	if r == nil || r.renderer == nil {
+		return
+	}
+	r.renderMu.Lock()
+	defer r.renderMu.Unlock()
+	r.renderer.Flush()
+}
+
+func (r *scanProgressReporter) renderAndFlush(snapshot scanProgressSnapshot, update scanProgressUpdate) {
+	if r == nil || r.renderer == nil {
+		return
+	}
+	r.renderMu.Lock()
+	defer r.renderMu.Unlock()
+	r.renderer.Render(snapshot, update)
+	r.renderer.Flush()
 }
 
 func (r *scanProgressReporter) snapshotLocked(now time.Time) scanProgressSnapshot {

--- a/core/cli/scan_progress_model_test.go
+++ b/core/cli/scan_progress_model_test.go
@@ -1,6 +1,10 @@
 package cli
 
 import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -65,5 +69,58 @@ func TestScanProgressPercentDoesNotExceedHundredWhenFailuresAccumulate(t *testin
 	})
 	if overall > 100 || phase > 100 {
 		t.Fatalf("expected detector progress to stay bounded, got overall=%d phase=%d", overall, phase)
+	}
+}
+
+func TestScanProgressReporterSerializesConcurrentRendererWrites(t *testing.T) {
+	t.Parallel()
+
+	var errOut bytes.Buffer
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	progress := newScanProgressReporter(scanProgressReporterOptions{
+		RequestedMode:     scanProgressModeEvents,
+		Stderr:            &errOut,
+		StartedAt:         time.Unix(0, 0).UTC(),
+		TargetMode:        "path",
+		TargetValue:       "/tmp/repos",
+		HeartbeatInterval: time.Millisecond,
+	})
+	progress.Start(ctx)
+	progress.ScanPhase("path", "/tmp/repos", "source_acquire_start")
+
+	var wg sync.WaitGroup
+	for worker := 0; worker < 4; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < 50; i++ {
+				progress.Heartbeat()
+				progress.DetectorStart(detect.DetectorProgressEvent{
+					DetectorID: "codex",
+					Scope:      detect.Scope{Org: "local", Repo: "repo"},
+					Index:      worker + 1,
+					Total:      4,
+				})
+				progress.DetectorComplete(detect.DetectorProgressEvent{
+					DetectorID: "codex",
+					Scope:      detect.Scope{Org: "local", Repo: "repo"},
+					Index:      worker + 1,
+					Total:      4,
+				})
+				progress.Finish(scanProgressFooter{
+					Status:          "running",
+					CurrentPhase:    "detectors",
+					ProgressPercent: 80,
+				})
+			}
+		}(worker)
+	}
+	wg.Wait()
+	progress.Stop()
+
+	if !strings.Contains(errOut.String(), "progress") {
+		t.Fatalf("expected concurrent progress output")
 	}
 }


### PR DESCRIPTION
## Problem

The nightly risk lane failed in `go test -race ./... -count=1` on run https://github.com/Clyra-AI/wrkr/actions/runs/25538149133/job/75071692551. The race detector reported concurrent writes to scan progress renderers from the heartbeat goroutine and scan phase/footer rendering.

## Changes

- Serialize all scan progress renderer `Render` and `Flush` calls through a reporter-local mutex.
- Preserve state mutation and status sink behavior outside renderer serialization.
- Add a race-focused concurrent renderer stress test.
- Include `gofmt` cleanup produced by the profile `fmt` validation step.

## Validation

- `go test -race ./core/cli -run TestScanProgressReporterSerializesConcurrentRendererWrites -count=1`
- `go test -race ./core/cli -run 'TestScanAndReportExplainIncludeComplianceRollupLines|TestVerifyExplicitStateStillOverridesAmbientWRKRStatePath' -count=1 -timeout=15m`
- `go test -race ./testinfra/contracts -run 'TestScanFindingsCanonicalFields|TestStory7EvidenceOutputDirSafetyContracts|TestStory7SkillConflictAndExposureContracts' -count=1 -timeout=15m`
- `make prepush-full`

## Risk

Low: scoped to progress rendering synchronization and test coverage. No detector, scoring, proof, schema, or exit-code behavior changes.
