### PR TITLE
fix: classify workflow secrets per subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - [semver:patch] Fixed pinned install and release-smoke examples so documented first-value commands install a compatible Wrkr release.
 - [semver:patch] Fixed scan status so completed scans with source failures remain marked as partial instead of appearing complete to automation.
 - [semver:patch] Fixed hosted scan progress counters so failed repo materialization is counted once and pending progress remains accurate.
+- [semver:patch] Fixed workflow credential classification so multiple secret references on one CI action path keep subject-specific PAT, cloud-admin, cloud-access, deploy-key, and generic secret kinds instead of inheriting the first aggregate match.
 - Fixed repo-level attack-path score spillover so high attack-path scores attach only to matching govern-first paths instead of every candidate path in the same repo.
 - Fixed tolerant detector parsing for additive third-party `package.json` metadata and reduced modern JS/WebMCP parse noise by recovering positive fallback signals while keeping diagnostics out of ranked risk surfaces.
 - Fixed remaining open detector manifests and MCP-adjacent configs to tolerate additive metadata instead of treating unknown fields as parse failures.

--- a/core/aggregate/privilegebudget/budget.go
+++ b/core/aggregate/privilegebudget/budget.go
@@ -1283,17 +1283,13 @@ func classifyCredentialKind(subject string, authSurfaces []string, permissions [
 	if kind, accessType, reasons, ok := classifyCredentialKindFromText(subjectText, subject, signals); ok {
 		return kind, accessType, mergeSortedEvidence(reasons)
 	}
-	if subjectText != "" {
-		if kind, accessType, reasons, ok := classifyCredentialKindFromPermissions(permissions, signals); ok {
-			return kind, accessType, mergeSortedEvidence(reasons)
-		}
-		return agginventory.CredentialKindStaticSecret, agginventory.CredentialAccessTypeStanding, []string{"subject:static_secret"}
-	}
 
 	candidates := append([]string(nil), authSurfaces...)
 	candidates = append(candidates, signals.EvidenceKV["credential_subject"]...)
-	candidates = append(candidates, signals.EvidenceKV["workflow_secret_refs"]...)
-	candidates = append(candidates, signals.EvidenceKV["credential_keys"]...)
+	if subjectText == "" {
+		candidates = append(candidates, signals.EvidenceKV["workflow_secret_refs"]...)
+		candidates = append(candidates, signals.EvidenceKV["credential_keys"]...)
+	}
 	aggregateText := normalizeToken(strings.Join(candidates, ","))
 	if kind, accessType, reasons, ok := classifyCredentialKindFromText(aggregateText, "", signals); ok {
 		return kind, accessType, mergeSortedEvidence(reasons)
@@ -1301,7 +1297,7 @@ func classifyCredentialKind(subject string, authSurfaces []string, permissions [
 	if kind, accessType, reasons, ok := classifyCredentialKindFromPermissions(permissions, signals); ok {
 		return kind, accessType, mergeSortedEvidence(reasons)
 	}
-	if aggregateText != "" {
+	if subjectText != "" || aggregateText != "" {
 		reasons := []string{"subject:static_secret"}
 		return agginventory.CredentialKindStaticSecret, agginventory.CredentialAccessTypeStanding, mergeSortedEvidence(reasons)
 	}

--- a/core/aggregate/privilegebudget/budget.go
+++ b/core/aggregate/privilegebudget/budget.go
@@ -1001,12 +1001,12 @@ func classifyCredentialProvenances(dataClass string, permissions []string, authS
 
 	scope := inferredCredentialScope(signals, authSurfaces)
 	evidenceLocation := credentialEvidenceLocation(signals)
-	for _, subject := range dedupeSorted(signals.EvidenceKV["credential_keys"]) {
+	for _, subject := range credentialSignalSubjects(signals.EvidenceKV["credential_keys"]) {
 		if candidate := credentialCandidateForSubject(subject, scope, []string{"credential_keys"}, authSurfaces, permissions, evidenceLocation, signals); candidate != nil {
 			candidates = append(candidates, candidate)
 		}
 	}
-	for _, subject := range dedupeSorted(signals.EvidenceKV["workflow_secret_refs"]) {
+	for _, subject := range credentialSignalSubjects(signals.EvidenceKV["workflow_secret_refs"]) {
 		if candidate := credentialCandidateForSubject(subject, agginventory.CredentialScopeWorkflow, []string{"workflow_secret_refs", "repo_workflow_secret_correlation"}, authSurfaces, permissions, evidenceLocation, signals); candidate != nil {
 			candidates = append(candidates, candidate)
 		}
@@ -1043,6 +1043,21 @@ func credentialCandidateForSubject(subject string, scope string, evidenceBasis [
 		EvidenceLocation:      evidenceLocation,
 		ClassificationReasons: reasons,
 	})
+}
+
+func credentialSignalSubjects(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := []string{}
+	for _, value := range values {
+		for _, item := range strings.Split(value, ",") {
+			if trimmed := strings.TrimSpace(item); trimmed != "" {
+				out = append(out, trimmed)
+			}
+		}
+	}
+	return dedupeSorted(out)
 }
 
 func workflowBuiltInTokenProvenance(permissions []string, signals findingSignals) *agginventory.CredentialProvenance {
@@ -1264,14 +1279,41 @@ func credentialProvenanceTypeFor(kind, accessType string) string {
 }
 
 func classifyCredentialKind(subject string, authSurfaces []string, permissions []string, signals findingSignals) (string, string, []string) {
-	candidates := []string{subject}
-	candidates = append(candidates, authSurfaces...)
+	subjectText := normalizeToken(subject)
+	if kind, accessType, reasons, ok := classifyCredentialKindFromText(subjectText, subject, signals); ok {
+		return kind, accessType, mergeSortedEvidence(reasons)
+	}
+	if subjectText != "" {
+		if kind, accessType, reasons, ok := classifyCredentialKindFromPermissions(permissions, signals); ok {
+			return kind, accessType, mergeSortedEvidence(reasons)
+		}
+		return agginventory.CredentialKindStaticSecret, agginventory.CredentialAccessTypeStanding, []string{"subject:static_secret"}
+	}
+
+	candidates := append([]string(nil), authSurfaces...)
 	candidates = append(candidates, signals.EvidenceKV["credential_subject"]...)
 	candidates = append(candidates, signals.EvidenceKV["workflow_secret_refs"]...)
 	candidates = append(candidates, signals.EvidenceKV["credential_keys"]...)
-	text := normalizeToken(strings.Join(candidates, ","))
-	reasons := []string{}
+	aggregateText := normalizeToken(strings.Join(candidates, ","))
+	if kind, accessType, reasons, ok := classifyCredentialKindFromText(aggregateText, "", signals); ok {
+		return kind, accessType, mergeSortedEvidence(reasons)
+	}
+	if kind, accessType, reasons, ok := classifyCredentialKindFromPermissions(permissions, signals); ok {
+		return kind, accessType, mergeSortedEvidence(reasons)
+	}
+	if aggregateText != "" {
+		reasons := []string{"subject:static_secret"}
+		return agginventory.CredentialKindStaticSecret, agginventory.CredentialAccessTypeStanding, mergeSortedEvidence(reasons)
+	}
+	return agginventory.CredentialKindUnknownDurable, agginventory.CredentialAccessTypeStanding, []string{"fallback:unknown_durable"}
+}
 
+func classifyCredentialKindFromText(text string, subject string, signals findingSignals) (string, string, []string, bool) {
+	text = normalizeToken(text)
+	if text == "" {
+		return "", "", nil, false
+	}
+	reasons := []string{}
 	addReason := func(value string) {
 		if strings.TrimSpace(value) != "" {
 			reasons = append(reasons, strings.TrimSpace(value))
@@ -1282,49 +1324,50 @@ func classifyCredentialKind(subject string, authSurfaces []string, permissions [
 	case hasAnySignalValue(signals, "workflow_builtin_token", "github_token") && normalizeToken(subject) == "github_token":
 		reasons = append(reasons, "subject:github_workflow_token")
 		reasons = append(reasons, prefixedEvidence("workflow_token_permission", signals.EvidenceKV["workflow_token_permission"])...)
-		return agginventory.CredentialKindGitHubWorkflowToken, agginventory.CredentialAccessTypeJIT, mergeSortedEvidence(reasons)
+		return agginventory.CredentialKindGitHubWorkflowToken, agginventory.CredentialAccessTypeJIT, reasons, true
 	case (strings.Contains(text, "github_app") || strings.Contains(text, "gh_app")) && (strings.Contains(text, "private_key") || strings.Contains(text, "app_key")):
 		addReason("subject:github_app_private_key")
-		return agginventory.CredentialKindGitHubAppKey, agginventory.CredentialAccessTypeStanding, mergeSortedEvidence(reasons)
+		return agginventory.CredentialKindGitHubAppKey, agginventory.CredentialAccessTypeStanding, reasons, true
 	case strings.Contains(text, "deploy_key") || strings.Contains(text, "ssh_key"):
 		addReason("subject:deploy_key")
-		return agginventory.CredentialKindDeployKey, agginventory.CredentialAccessTypeStanding, mergeSortedEvidence(reasons)
-	case strings.Contains(text, "pat") || strings.Contains(text, "personal_access_token") || strings.Contains(text, "github_token"):
-		addReason("subject:github_pat")
-		return agginventory.CredentialKindGitHubPAT, agginventory.CredentialAccessTypeStanding, mergeSortedEvidence(reasons)
+		return agginventory.CredentialKindDeployKey, agginventory.CredentialAccessTypeStanding, reasons, true
 	case hasCloudAdminSignal(text):
 		addReason("subject:cloud_admin_key")
-		return agginventory.CredentialKindCloudAdminKey, agginventory.CredentialAccessTypeStanding, mergeSortedEvidence(reasons)
+		return agginventory.CredentialKindCloudAdminKey, agginventory.CredentialAccessTypeStanding, reasons, true
 	case hasCloudAccessSignal(text):
 		addReason("subject:cloud_access_key")
-		return agginventory.CredentialKindCloudAccessKey, agginventory.CredentialAccessTypeStanding, mergeSortedEvidence(reasons)
+		return agginventory.CredentialKindCloudAccessKey, agginventory.CredentialAccessTypeStanding, reasons, true
+	case strings.Contains(text, "pat") || strings.Contains(text, "personal_access_token") || strings.Contains(text, "github_token"):
+		addReason("subject:github_pat")
+		return agginventory.CredentialKindGitHubPAT, agginventory.CredentialAccessTypeStanding, reasons, true
 	case strings.Contains(text, "oauth"):
 		addReason("subject:oauth")
-		return agginventory.CredentialKindDelegatedOAuth, agginventory.CredentialAccessTypeDelegated, mergeSortedEvidence(reasons)
+		return agginventory.CredentialKindDelegatedOAuth, agginventory.CredentialAccessTypeDelegated, reasons, true
 	case strings.Contains(text, "oidc") || strings.Contains(text, "workload_identity") || strings.Contains(text, "assume_role") || strings.Contains(text, "sts"):
 		addReason("subject:oidc_workload_identity")
 		if boolSignalState(signals.EvidenceKV["human_gate"]) == "true" || strings.Contains(stringSignalState(signals.EvidenceKV["approval_source"], ""), "manual") {
 			addReason("gate:jit_evidence")
-			return agginventory.CredentialKindJITCredential, agginventory.CredentialAccessTypeJIT, mergeSortedEvidence(reasons)
+			return agginventory.CredentialKindJITCredential, agginventory.CredentialAccessTypeJIT, reasons, true
 		}
-		return agginventory.CredentialKindOIDCWorkloadID, agginventory.CredentialAccessTypeWorkload, mergeSortedEvidence(reasons)
+		return agginventory.CredentialKindOIDCWorkloadID, agginventory.CredentialAccessTypeWorkload, reasons, true
 	case strings.Contains(text, "github_actor") || strings.Contains(text, "user_token") || strings.Contains(text, "bot_user"):
 		addReason("subject:inherited_human")
-		return agginventory.CredentialKindInheritedHuman, agginventory.CredentialAccessTypeInherited, mergeSortedEvidence(reasons)
-	case hasAnyPermission(permissions, map[string]struct{}{"id-token.write": {}}):
-		addReason("permission:id-token.write")
-		if boolSignalState(signals.EvidenceKV["human_gate"]) == "true" || strings.Contains(stringSignalState(signals.EvidenceKV["approval_source"], ""), "manual") {
-			addReason("gate:jit_evidence")
-			return agginventory.CredentialKindJITCredential, agginventory.CredentialAccessTypeJIT, mergeSortedEvidence(reasons)
-		}
-		return agginventory.CredentialKindOIDCWorkloadID, agginventory.CredentialAccessTypeWorkload, mergeSortedEvidence(reasons)
-	case text != "":
-		addReason("subject:static_secret")
-		return agginventory.CredentialKindStaticSecret, agginventory.CredentialAccessTypeStanding, mergeSortedEvidence(reasons)
+		return agginventory.CredentialKindInheritedHuman, agginventory.CredentialAccessTypeInherited, reasons, true
 	default:
-		addReason("fallback:unknown_durable")
-		return agginventory.CredentialKindUnknownDurable, agginventory.CredentialAccessTypeStanding, mergeSortedEvidence(reasons)
+		return "", "", nil, false
 	}
+}
+
+func classifyCredentialKindFromPermissions(permissions []string, signals findingSignals) (string, string, []string, bool) {
+	if !hasAnyPermission(permissions, map[string]struct{}{"id-token.write": {}}) {
+		return "", "", nil, false
+	}
+	reasons := []string{"permission:id-token.write"}
+	if boolSignalState(signals.EvidenceKV["human_gate"]) == "true" || strings.Contains(stringSignalState(signals.EvidenceKV["approval_source"], ""), "manual") {
+		reasons = append(reasons, "gate:jit_evidence")
+		return agginventory.CredentialKindJITCredential, agginventory.CredentialAccessTypeJIT, reasons, true
+	}
+	return agginventory.CredentialKindOIDCWorkloadID, agginventory.CredentialAccessTypeWorkload, reasons, true
 }
 
 func hasCloudAdminSignal(value string) bool {

--- a/core/aggregate/privilegebudget/budget_test.go
+++ b/core/aggregate/privilegebudget/budget_test.go
@@ -565,6 +565,23 @@ func TestBuildClassifiesWorkflowSecretRefsByIndividualSubject(t *testing.T) {
 	}
 }
 
+func TestClassifyCredentialKindKeepsAuthSurfaceFallbackForGenericSubjects(t *testing.T) {
+	t.Parallel()
+
+	kind, accessType, reasons := classifyCredentialKind(
+		"RELEASE_TOKEN",
+		[]string{"personal_access_token"},
+		[]string{"deploy.write", "id-token.write"},
+		findingSignals{},
+	)
+	if kind != agginventory.CredentialKindGitHubPAT || accessType != agginventory.CredentialAccessTypeStanding {
+		t.Fatalf("expected PAT standing access from auth surface fallback, got kind=%s access=%s reasons=%v", kind, accessType, reasons)
+	}
+	if !containsString(reasons, "subject:github_pat") {
+		t.Fatalf("expected github_pat reason in %v", reasons)
+	}
+}
+
 func TestBuildDerivesActionClassesAndStandingPrivilegeFromCredentialSignals(t *testing.T) {
 	t.Parallel()
 

--- a/core/aggregate/privilegebudget/budget_test.go
+++ b/core/aggregate/privilegebudget/budget_test.go
@@ -503,6 +503,68 @@ func TestBuildClassifiesBuiltInGitHubWorkflowTokenSeparatelyFromPATs(t *testing.
 	}
 }
 
+func TestBuildClassifiesWorkflowSecretRefsByIndividualSubject(t *testing.T) {
+	t.Parallel()
+
+	tools := []agginventory.Tool{{
+		ToolID:      "tool-1",
+		AgentID:     "wrkr:ci:acme",
+		ToolType:    "ci_agent",
+		Org:         "acme",
+		Repos:       []string{"acme/release"},
+		Permissions: []string{"deploy.write", "secret.read"},
+		DataClass:   "credentials",
+		Locations:   []agginventory.ToolLocation{{Repo: "acme/release", Location: ".github/workflows/release.yml"}},
+	}}
+	findings := []model.Finding{{
+		FindingType: "ci_autonomy",
+		ToolType:    "ci_agent",
+		Location:    ".github/workflows/release.yml",
+		Repo:        "acme/release",
+		Org:         "acme",
+		Evidence: []model.Evidence{
+			{Key: "workflow_secret_refs", Value: "BROAD_PAT"},
+			{Key: "workflow_secret_refs", Value: "BROAD_PAT,CLOUD_ADMIN_KEY"},
+			{Key: "workflow_secret_refs", Value: "CLOUD_ADMIN_KEY"},
+			{Key: "workflow_secret_refs", Value: "AWS_ACCESS_KEY_ID"},
+			{Key: "workflow_secret_refs", Value: "GCP_SERVICE_ACCOUNT"},
+			{Key: "workflow_secret_refs", Value: "PROD_DEPLOY_KEY"},
+			{Key: "workflow_secret_refs", Value: "RELEASE_TOKEN"},
+		},
+	}}
+
+	_, entries := Build(tools, nil, findings, nil)
+	if len(entries) != 1 {
+		t.Fatalf("expected one classified entry, got %+v", entries)
+	}
+	kindBySubject := map[string]string{}
+	for _, credential := range entries[0].Credentials {
+		if credential == nil {
+			continue
+		}
+		kindBySubject[credential.Subject] = credential.CredentialKind
+	}
+	expected := map[string]string{
+		"broad_pat":           agginventory.CredentialKindGitHubPAT,
+		"cloud_admin_key":     agginventory.CredentialKindCloudAdminKey,
+		"aws_access_key_id":   agginventory.CredentialKindCloudAccessKey,
+		"gcp_service_account": agginventory.CredentialKindCloudAccessKey,
+		"prod_deploy_key":     agginventory.CredentialKindDeployKey,
+		"release_token":       agginventory.CredentialKindStaticSecret,
+	}
+	for subject, want := range expected {
+		if got := kindBySubject[subject]; got != want {
+			t.Fatalf("expected %s to classify as %s, got %s from %+v", subject, want, got, entries[0].Credentials)
+		}
+	}
+	if got := kindBySubject["broad_pat,cloud_admin_key"]; got != "" {
+		t.Fatalf("did not expect comma-joined synthetic credential subject, got kind %s from %+v", got, entries[0].Credentials)
+	}
+	if entries[0].CredentialProvenance == nil || entries[0].CredentialProvenance.CredentialKind != agginventory.CredentialKindCloudAdminKey {
+		t.Fatalf("expected cloud_admin_key to win the rollup, got %+v", entries[0].CredentialProvenance)
+	}
+}
+
 func TestBuildDerivesActionClassesAndStandingPrivilegeFromCredentialSignals(t *testing.T) {
 	t.Parallel()
 

--- a/scenarios/wrkr/agent-action-bom-demo/expected/after-scan.json
+++ b/scenarios/wrkr/agent-action-bom-demo/expected/after-scan.json
@@ -11,7 +11,7 @@
       "read",
       "write"
     ],
-    "credential_kind": "github_pat",
+    "credential_kind": "cloud_admin_key",
     "control_state": "block_recommended",
     "risk_zone": "production_data",
     "review_burden": "critical",

--- a/scenarios/wrkr/agent-action-bom-demo/expected/before-scan.json
+++ b/scenarios/wrkr/agent-action-bom-demo/expected/before-scan.json
@@ -11,7 +11,7 @@
       "read",
       "write"
     ],
-    "credential_kind": "github_pat",
+    "credential_kind": "cloud_admin_key",
     "control_state": "block_recommended",
     "risk_zone": "production_data",
     "review_burden": "critical",


### PR DESCRIPTION
## Problem
Workflow credential classification could treat a comma-joined aggregate secret reference as one subject, which let the first broad match dominate later, more specific credential kinds on the same CI action path.

## Changes
- split workflow secret and credential key signal lists into individual normalized subjects before provenance classification
- prefer subject-local kind detection before falling back to aggregate text or permission-based inference
- add a regression test covering mixed PAT, cloud-admin, cloud-access, deploy-key, and generic secret references on one workflow path
- update the demo scenario golden outputs and changelog entry to reflect the corrected cloud-admin classification

## Validation
- `make prepush-full`

## Risks
- this changes credential-kind rollups for workflow findings with multiple secret references, so scenario and downstream evidence consumers now see the more specific subject-level classification
- no submodule pointer changes
