### PR TITLE
test: isolate my-setup scan state in cli tests

### DIFF
--- a/core/cli/root_test.go
+++ b/core/cli/root_test.go
@@ -310,11 +310,14 @@ func TestScanNoTargetJSONIncludesNextSteps(t *testing.T) {
 }
 
 func TestScanMySetupReturnsLocalMachineTarget(t *testing.T) {
-	t.Parallel()
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+	statePath := filepath.Join(tmpHome, "wrkr-state.json")
 
 	var out bytes.Buffer
 	var errOut bytes.Buffer
-	code := Run([]string{"scan", "--my-setup", "--json"}, &out, &errOut)
+	code := Run([]string{"scan", "--my-setup", "--state", statePath, "--json"}, &out, &errOut)
 	if code != 0 {
 		t.Fatalf("scan failed: %d %s", code, errOut.String())
 	}
@@ -335,6 +338,7 @@ func TestScanMySetupFindsEnvironmentKeysAndProjectMarkers(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 	t.Setenv("USERPROFILE", tmpHome)
+	statePath := filepath.Join(tmpHome, "wrkr-state.json")
 	t.Setenv("OPENAI_API_KEY", "redacted")
 	t.Setenv("ANTHROPIC_API_KEY", "redacted")
 
@@ -348,7 +352,7 @@ func TestScanMySetupFindsEnvironmentKeysAndProjectMarkers(t *testing.T) {
 
 	var out bytes.Buffer
 	var errOut bytes.Buffer
-	code := Run([]string{"scan", "--my-setup", "--json"}, &out, &errOut)
+	code := Run([]string{"scan", "--my-setup", "--state", statePath, "--json"}, &out, &errOut)
 	if code != 0 {
 		t.Fatalf("scan failed: %d %s", code, errOut.String())
 	}
@@ -388,6 +392,7 @@ func TestScanMySetupActivationPrefersConcreteSignals(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 	t.Setenv("USERPROFILE", tmpHome)
+	statePath := filepath.Join(tmpHome, "wrkr-state.json")
 	t.Setenv("OPENAI_API_KEY", "redacted")
 
 	if err := os.MkdirAll(filepath.Join(tmpHome, ".codex"), 0o755); err != nil {
@@ -405,7 +410,7 @@ func TestScanMySetupActivationPrefersConcreteSignals(t *testing.T) {
 
 	var out bytes.Buffer
 	var errOut bytes.Buffer
-	code := Run([]string{"scan", "--my-setup", "--json"}, &out, &errOut)
+	code := Run([]string{"scan", "--my-setup", "--state", statePath, "--json"}, &out, &errOut)
 	if code != 0 {
 		t.Fatalf("scan failed: %d %s", code, errOut.String())
 	}


### PR DESCRIPTION
## Problem
- the scheduled nightly run on 2026-05-09 timed out in `core/cli.TestScanMySetupReturnsLocalMachineTarget`
- the `--my-setup` tests were reading the real machine home directory and default repo state path, which made the race lane depend on local machine size and ambient proof-chain state

## Changes
- isolate `TestScanMySetupReturnsLocalMachineTarget` with a temp `HOME` and `USERPROFILE`
- pass an explicit temp `--state` path to the `--my-setup` test cluster
- remove the parallel marker from the test that now uses `t.Setenv`

## Validation
- `make prepush-full`
- `go test -race ./core/cli -run TestScanMySetupReturnsLocalMachineTarget -count=1 -timeout=2m -v`
- `go test -race ./core/cli -run 'TestScanMySetup(ReturnsLocalMachineTarget|FindsEnvironmentKeysAndProjectMarkers|ActivationPrefersConcreteSignals)' -count=1 -timeout=5m -v`

## Risks
- this changes only CLI test isolation and does not affect runtime scan behavior
- local full-repo race timing remains heavier on macOS than Linux CI, so the key signal here is that the original nightly repro no longer hangs

## Submodules
- no submodule pointer changes
