### PR TITLE
fix: align demo action BOM schema contracts

### DIFF
--- a/schemas/v1/agent-action-bom.schema.json
+++ b/schemas/v1/agent-action-bom.schema.json
@@ -79,6 +79,12 @@
         "path_context": {"$ref": "#/$defs/pathContext"},
         "standing_privilege": {"type": "boolean"},
         "standing_privilege_reasons": {"type": "array", "items": {"type": "string"}},
+        "control_state": {"$ref": "#/$defs/controlState"},
+        "control_state_reasons": {"type": "array", "items": {"type": "string"}},
+        "risk_zone": {"$ref": "#/$defs/riskZone"},
+        "risk_zone_reasons": {"type": "array", "items": {"type": "string"}},
+        "review_burden": {"$ref": "#/$defs/reviewBurden"},
+        "review_burden_reasons": {"type": "array", "items": {"type": "string"}},
         "action_classes": {"type": "array", "items": {"type": "string"}},
         "action_reasons": {"type": "array", "items": {"type": "string"}},
         "production_write": {"type": "boolean"},
@@ -97,6 +103,7 @@
         "runtime_evidence_status": {"type": "string", "enum": ["matched", "unmatched", "stale", "conflict"]},
         "runtime_evidence_classes": {"type": "array", "items": {"type": "string"}},
         "runtime_evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "gait_coverage": {"$ref": "#/$defs/gaitCoverage"},
         "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
         "evidence_strength": {"type": "string"},
         "inventory_risk": {"type": "string", "enum": ["production_backed", "write_capable", "credential_access", "visibility_only", "dependency_only"]},
@@ -142,6 +149,42 @@
         }
       },
       "additionalProperties": true
+    },
+    "controlState": {
+      "type": "string",
+      "enum": ["safe_by_default", "approval_required", "block_recommended", "evidence_required", "inventory_only"]
+    },
+    "riskZone": {
+      "type": "string",
+      "enum": ["coding_help", "repo_write", "credential_bearing", "ci_cd", "iac", "release", "production_data", "external_egress"]
+    },
+    "reviewBurden": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "gaitCoverage": {
+      "type": "object",
+      "required": ["policy_decision", "approval", "jit_credential", "freeze_window", "kill_switch", "action_outcome", "proof_verification"],
+      "properties": {
+        "policy_decision": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "approval": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "jit_credential": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "freeze_window": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "kill_switch": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "action_outcome": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "proof_verification": {"$ref": "#/$defs/gaitCoverageDetail"}
+      },
+      "additionalProperties": false
+    },
+    "gaitCoverageDetail": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": {"type": "string", "enum": ["present", "missing", "stale", "conflict", "not_applicable"]},
+        "reasons": {"type": "array", "items": {"type": "string"}},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
     },
     "graphRefs": {
       "type": "object",

--- a/schemas/v1/report/report-summary.schema.json
+++ b/schemas/v1/report/report-summary.schema.json
@@ -255,6 +255,13 @@
         "policy_status_reasons": {"type": "array", "items": {"type": "string"}},
         "policy_confidence": {"type": "string", "enum": ["high", "medium", "low"]},
         "policy_evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "control_state": {"$ref": "#/$defs/controlState"},
+        "control_state_reasons": {"type": "array", "items": {"type": "string"}},
+        "risk_zone": {"$ref": "#/$defs/riskZone"},
+        "risk_zone_reasons": {"type": "array", "items": {"type": "string"}},
+        "review_burden": {"$ref": "#/$defs/reviewBurden"},
+        "review_burden_reasons": {"type": "array", "items": {"type": "string"}},
+        "gait_coverage": {"$ref": "#/$defs/gaitCoverage"},
         "introduced_by": {"$ref": "#/$defs/introducedBy"},
         "inventory_risk": {"type": "string", "enum": ["production_backed", "write_capable", "credential_access", "visibility_only", "dependency_only"]},
         "control_priority": {"type": "string", "enum": ["control_first", "review_queue", "inventory_hygiene"]},
@@ -268,6 +275,42 @@
         "write_path_classes": {"type": "array", "items": {"type": "string"}},
         "governance_controls": {"type": "array", "items": {"type": "object"}}
       }
+    },
+    "controlState": {
+      "type": "string",
+      "enum": ["safe_by_default", "approval_required", "block_recommended", "evidence_required", "inventory_only"]
+    },
+    "riskZone": {
+      "type": "string",
+      "enum": ["coding_help", "repo_write", "credential_bearing", "ci_cd", "iac", "release", "production_data", "external_egress"]
+    },
+    "reviewBurden": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "gaitCoverage": {
+      "type": "object",
+      "required": ["policy_decision", "approval", "jit_credential", "freeze_window", "kill_switch", "action_outcome", "proof_verification"],
+      "properties": {
+        "policy_decision": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "approval": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "jit_credential": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "freeze_window": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "kill_switch": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "action_outcome": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "proof_verification": {"$ref": "#/$defs/gaitCoverageDetail"}
+      },
+      "additionalProperties": false
+    },
+    "gaitCoverageDetail": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": {"type": "string", "enum": ["present", "missing", "stale", "conflict", "not_applicable"]},
+        "reasons": {"type": "array", "items": {"type": "string"}},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
     },
     "actionPathToControlFirst": {
       "type": "object",

--- a/schemas/v1/risk/risk-report.schema.json
+++ b/schemas/v1/risk/risk-report.schema.json
@@ -69,12 +69,19 @@
         "shared_execution_identity": {"type": "boolean"},
         "standing_privilege": {"type": "boolean"},
         "standing_privilege_reasons": {"type": "array", "items": {"type": "string"}},
+        "control_state": {"$ref": "#/$defs/controlState"},
+        "control_state_reasons": {"type": "array", "items": {"type": "string"}},
+        "risk_zone": {"$ref": "#/$defs/riskZone"},
+        "risk_zone_reasons": {"type": "array", "items": {"type": "string"}},
+        "review_burden": {"$ref": "#/$defs/reviewBurden"},
+        "review_burden_reasons": {"type": "array", "items": {"type": "string"}},
         "policy_coverage_status": {"type": "string", "enum": ["none", "declared", "matched", "runtime_proven", "stale", "conflict"]},
         "policy_refs": {"type": "array", "items": {"type": "string"}},
         "policy_missing_reasons": {"type": "array", "items": {"type": "string"}},
         "policy_status_reasons": {"type": "array", "items": {"type": "string"}},
         "policy_confidence": {"type": "string", "enum": ["high", "medium", "low"]},
         "policy_evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "gait_coverage": {"$ref": "#/$defs/gaitCoverage"},
         "introduced_by": {"$ref": "#/$defs/introducedBy"},
         "inventory_risk": {"type": "string", "enum": ["production_backed", "write_capable", "credential_access", "visibility_only", "dependency_only"]},
         "control_priority": {"type": "string", "enum": ["control_first", "review_queue", "inventory_hygiene"]},
@@ -88,6 +95,42 @@
         "governance_controls": {"type": "array"}
       },
       "additionalProperties": true
+    },
+    "controlState": {
+      "type": "string",
+      "enum": ["safe_by_default", "approval_required", "block_recommended", "evidence_required", "inventory_only"]
+    },
+    "riskZone": {
+      "type": "string",
+      "enum": ["coding_help", "repo_write", "credential_bearing", "ci_cd", "iac", "release", "production_data", "external_egress"]
+    },
+    "reviewBurden": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "gaitCoverage": {
+      "type": "object",
+      "required": ["policy_decision", "approval", "jit_credential", "freeze_window", "kill_switch", "action_outcome", "proof_verification"],
+      "properties": {
+        "policy_decision": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "approval": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "jit_credential": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "freeze_window": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "kill_switch": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "action_outcome": {"$ref": "#/$defs/gaitCoverageDetail"},
+        "proof_verification": {"$ref": "#/$defs/gaitCoverageDetail"}
+      },
+      "additionalProperties": false
+    },
+    "gaitCoverageDetail": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": {"type": "string", "enum": ["present", "missing", "stale", "conflict", "not_applicable"]},
+        "reasons": {"type": "array", "items": {"type": "string"}},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
     },
     "credentialProvenance": {
       "type": "object",

--- a/testinfra/contracts/demo_action_bom_readiness_contracts_test.go
+++ b/testinfra/contracts/demo_action_bom_readiness_contracts_test.go
@@ -1,0 +1,190 @@
+package contracts
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestDemoActionBOMReadinessSchemasDeclareBuyerFacingPathFields(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	cases := []struct {
+		name       string
+		path       string
+		definition string
+	}{
+		{
+			name:       "agent action bom item",
+			path:       filepath.Join(repoRoot, "schemas", "v1", "agent-action-bom.schema.json"),
+			definition: "item",
+		},
+		{
+			name:       "risk report action path",
+			path:       filepath.Join(repoRoot, "schemas", "v1", "risk", "risk-report.schema.json"),
+			definition: "actionPath",
+		},
+		{
+			name:       "report summary action path",
+			path:       filepath.Join(repoRoot, "schemas", "v1", "report", "report-summary.schema.json"),
+			definition: "actionPath",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			schema := mustReadJSON(t, tc.path)
+			props := schemaDefinitionProperties(t, schema, tc.definition)
+			for _, field := range []string{
+				"control_state",
+				"control_state_reasons",
+				"risk_zone",
+				"risk_zone_reasons",
+				"review_burden",
+				"review_burden_reasons",
+				"gait_coverage",
+			} {
+				if _, ok := props[field].(map[string]any); !ok {
+					t.Fatalf("%s schema missing %s contract field: %v", tc.name, field, props)
+				}
+			}
+
+			assertSchemaEnum(t, schemaRef(t, schema, props["control_state"]), []string{
+				"safe_by_default",
+				"approval_required",
+				"block_recommended",
+				"evidence_required",
+				"inventory_only",
+			})
+			assertSchemaEnum(t, schemaRef(t, schema, props["risk_zone"]), []string{
+				"coding_help",
+				"repo_write",
+				"credential_bearing",
+				"ci_cd",
+				"iac",
+				"release",
+				"production_data",
+				"external_egress",
+			})
+			assertSchemaEnum(t, schemaRef(t, schema, props["review_burden"]), []string{
+				"low",
+				"medium",
+				"high",
+				"critical",
+			})
+			assertGaitCoverageContract(t, schemaRef(t, schema, props["gait_coverage"]))
+		})
+	}
+}
+
+func schemaDefinitionProperties(t *testing.T, schema map[string]any, definition string) map[string]any {
+	t.Helper()
+
+	defs, ok := schema["$defs"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema missing $defs: %v", schema)
+	}
+	def, ok := defs[definition].(map[string]any)
+	if !ok {
+		t.Fatalf("schema missing $defs.%s: %v", definition, defs)
+	}
+	props, ok := def["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema definition %s missing properties: %v", definition, def)
+	}
+	return props
+}
+
+func schemaRef(t *testing.T, schema map[string]any, node any) map[string]any {
+	t.Helper()
+
+	refNode, ok := node.(map[string]any)
+	if !ok {
+		t.Fatalf("schema node is not an object: %v", node)
+	}
+	ref, ok := refNode["$ref"].(string)
+	if !ok {
+		return refNode
+	}
+	if len(ref) <= len("#/$defs/") || ref[:len("#/$defs/")] != "#/$defs/" {
+		t.Fatalf("unsupported local schema ref %q", ref)
+	}
+	return schemaDefinition(t, schema, ref[len("#/$defs/"):])
+}
+
+func schemaDefinition(t *testing.T, schema map[string]any, definition string) map[string]any {
+	t.Helper()
+
+	defs, ok := schema["$defs"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema missing $defs: %v", schema)
+	}
+	def, ok := defs[definition].(map[string]any)
+	if !ok {
+		t.Fatalf("schema missing $defs.%s: %v", definition, defs)
+	}
+	return def
+}
+
+func assertSchemaEnum(t *testing.T, node map[string]any, want []string) {
+	t.Helper()
+
+	raw, ok := node["enum"].([]any)
+	if !ok {
+		t.Fatalf("schema node missing enum: %v", node)
+	}
+	got := make([]string, 0, len(raw))
+	for _, item := range raw {
+		value, ok := item.(string)
+		if !ok {
+			t.Fatalf("schema enum contains non-string value: %v", raw)
+		}
+		got = append(got, value)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected enum values\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func assertGaitCoverageContract(t *testing.T, node map[string]any) {
+	t.Helper()
+
+	requiredRaw, ok := node["required"].([]any)
+	if !ok {
+		t.Fatalf("gait coverage schema missing required controls: %v", node)
+	}
+	gotRequired := make([]string, 0, len(requiredRaw))
+	for _, item := range requiredRaw {
+		value, ok := item.(string)
+		if !ok {
+			t.Fatalf("gait coverage required contains non-string value: %v", requiredRaw)
+		}
+		gotRequired = append(gotRequired, value)
+	}
+	wantRequired := []string{
+		"policy_decision",
+		"approval",
+		"jit_credential",
+		"freeze_window",
+		"kill_switch",
+		"action_outcome",
+		"proof_verification",
+	}
+	if !reflect.DeepEqual(gotRequired, wantRequired) {
+		t.Fatalf("unexpected gait coverage required controls\ngot:  %v\nwant: %v", gotRequired, wantRequired)
+	}
+
+	props, ok := node["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("gait coverage schema missing properties: %v", node)
+	}
+	for _, field := range wantRequired {
+		if _, ok := props[field].(map[string]any); !ok {
+			t.Fatalf("gait coverage schema missing %s detail property: %v", field, props)
+		}
+	}
+}


### PR DESCRIPTION
## Problem
The demo Action BOM readiness work added buyer-facing action-path fields in report surfaces and docs, but the v1 JSON schemas were still missing those additive contract fields. That left schema validation behind the serialized/readme contract.

## Changes
- add `control_state`, `risk_zone`, `review_burden`, and `gait_coverage` schema fields to Agent Action BOM items
- add the same additive contract fields to report summary and risk report action-path schemas
- add a contract test that locks the shared enums and required Gait coverage keys across all three schemas

## Validation
- `make prepush-full`

## Risks
- additive schema-only change; no schema version bump
- no submodule pointer updates
