### PR TITLE
fix: harden proof lifecycle release readiness

### DIFF
--- a/.github/action-ref-exceptions.yaml
+++ b/.github/action-ref-exceptions.yaml
@@ -1,0 +1,106 @@
+exceptions:
+  - workflow: .github/workflows/release.yml
+    action: actions/checkout@v6.0.2
+    owner: release-engineering
+    reason: audited Node24-ready setup action kept on upstream release tag until SHA pin refresh automation lands
+    scope: release checkout only
+    expires: 2026-08-31
+    review_command: scripts/check_actions_runtime.sh
+  - workflow: .github/workflows/release.yml
+    action: actions/setup-go@v6.3.0
+    owner: release-engineering
+    reason: audited Node24-ready setup action kept on upstream release tag until SHA pin refresh automation lands
+    scope: release Go setup only
+    expires: 2026-08-31
+    review_command: scripts/check_actions_runtime.sh
+  - workflow: .github/workflows/release.yml
+    action: actions/setup-python@v6.2.0
+    owner: release-engineering
+    reason: audited Node24-ready setup action kept on upstream release tag until SHA pin refresh automation lands
+    scope: release Python setup only
+    expires: 2026-08-31
+    review_command: scripts/check_actions_runtime.sh
+  - workflow: .github/workflows/release.yml
+    action: actions/setup-node@v6.3.0
+    owner: release-engineering
+    reason: audited Node24-ready setup action kept on upstream release tag until SHA pin refresh automation lands
+    scope: release docs-site Node setup only
+    expires: 2026-08-31
+    review_command: scripts/check_actions_runtime.sh
+  - workflow: .github/workflows/release.yml
+    action: actions/upload-artifact@v7.0.0
+    owner: release-engineering
+    reason: audited Node24-ready artifact action kept on upstream release tag until SHA pin refresh automation lands
+    scope: release scorecard and benchmark uploads only
+    expires: 2026-08-31
+    review_command: scripts/check_actions_runtime.sh
+  - workflow: .github/workflows/release.yml
+    action: goreleaser/goreleaser-action@v7.0.0
+    owner: release-engineering
+    reason: audited Node24-ready release action kept on upstream release tag until SHA pin refresh automation lands
+    scope: staged release artifact build only
+    expires: 2026-08-31
+    review_command: scripts/check_actions_runtime.sh
+  - workflow: .github/workflows/release.yml
+    action: anchore/sbom-action@v0
+    owner: release-engineering
+    reason: upstream release workflow action remains on moving tag while scanner compatibility is reviewed each release cycle
+    scope: dist SBOM generation only
+    expires: 2026-08-31
+    review_command: scripts/check_actions_runtime.sh
+  - workflow: .github/workflows/release.yml
+    action: anchore/scan-action@v4
+    owner: release-engineering
+    reason: upstream release workflow action remains on moving tag while scanner compatibility is reviewed each release cycle
+    scope: dist SBOM vulnerability scan only
+    expires: 2026-08-31
+    review_command: scripts/check_actions_runtime.sh
+  - workflow: .github/workflows/release.yml
+    action: sigstore/cosign-installer@v4.1.0
+    owner: release-engineering
+    reason: audited Node24-ready signing setup action kept on upstream release tag until SHA pin refresh automation lands
+    scope: cosign install for release signing only
+    expires: 2026-08-31
+    review_command: scripts/check_actions_runtime.sh
+  - workflow: .github/workflows/release.yml
+    action: actions/attest-build-provenance@v4.1.0
+    owner: release-engineering
+    reason: audited Node24-ready provenance action kept on upstream release tag until SHA pin refresh automation lands
+    scope: release artifact provenance attestation only
+    expires: 2026-08-31
+    review_command: scripts/check_actions_runtime.sh
+  - workflow: .github/workflows/docs.yml
+    action: actions/checkout@v6.0.2
+    owner: docs-platform
+    reason: audited Node24-ready setup action kept on upstream release tag until SHA pin refresh automation lands
+    scope: docs checkout only
+    expires: 2026-08-31
+    review_command: scripts/check_actions_runtime.sh
+  - workflow: .github/workflows/docs.yml
+    action: actions/setup-node@v6.3.0
+    owner: docs-platform
+    reason: audited Node24-ready setup action kept on upstream release tag until SHA pin refresh automation lands
+    scope: docs-site Node setup only
+    expires: 2026-08-31
+    review_command: scripts/check_actions_runtime.sh
+  - workflow: .github/workflows/docs.yml
+    action: actions/configure-pages@v5
+    owner: docs-platform
+    reason: upstream Pages setup action remains on moving tag while Pages compatibility is reviewed each docs release cycle
+    scope: GitHub Pages configuration only
+    expires: 2026-08-31
+    review_command: scripts/check_actions_runtime.sh
+  - workflow: .github/workflows/docs.yml
+    action: actions/upload-pages-artifact@v4.0.0
+    owner: docs-platform
+    reason: audited Node24-ready Pages artifact action kept on upstream release tag until SHA pin refresh automation lands
+    scope: docs-site static artifact upload only
+    expires: 2026-08-31
+    review_command: scripts/check_actions_runtime.sh
+  - workflow: .github/workflows/docs.yml
+    action: actions/deploy-pages@v4
+    owner: docs-platform
+    reason: upstream Pages deploy action remains on moving tag while Pages compatibility is reviewed each docs release cycle
+    scope: GitHub Pages deployment only
+    expires: 2026-08-31
+    review_command: scripts/check_actions_runtime.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Run gosec
         if: steps.changes.outputs.go == 'true' || steps.changes.outputs.workflow_or_policy == 'true'
         run: |
-          "$(go env GOPATH)/bin/gosec" ./...
+          "$(go env GOPATH)/bin/gosec" $(scripts/first_party_go_packages.sh)
 
       - name: Install golangci-lint
         if: steps.changes.outputs.go == 'true' || steps.changes.outputs.workflow_or_policy == 'true'
@@ -150,7 +150,7 @@ jobs:
       - name: Run golangci-lint
         if: steps.changes.outputs.go == 'true' || steps.changes.outputs.workflow_or_policy == 'true'
         run: |
-          "$(go env GOPATH)/bin/golangci-lint" run --timeout=5m
+          "$(go env GOPATH)/bin/golangci-lint" run --timeout=5m $(scripts/first_party_go_packages.sh)
 
       - name: Install govulncheck
         if: steps.changes.outputs.go == 'true' || steps.changes.outputs.workflow_or_policy == 'true'
@@ -207,4 +207,4 @@ jobs:
         run: |
           mkdir -p .tmp
           go build -o .tmp/wrkr ./cmd/wrkr
-          go test ./... -count=1
+          go test $(scripts/first_party_go_packages.sh) -count=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         run: python3 scripts/validate_release_changelog.py --release-version "${GITHUB_REF_NAME}" --json
 
       - name: Run deterministic tests
-        run: go test ./... -count=1
+        run: go test $(scripts/first_party_go_packages.sh) -count=1
 
       - name: Run docs parity, docs site, and UAT smoke
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
+- [semver:patch] Fixed scan managed artifact commits so interrupted proof, lifecycle, state, and manifest writes recover deterministically or fail closed.
+- [semver:patch] Fixed identity and inventory lifecycle mutations to share crash-consistent proof, lifecycle, state, and manifest commits.
+- [semver:patch] Fixed Go validation gates to test only first-party Wrkr packages even when docs-site dependencies are installed locally.
+- [semver:patch] Restored full Apache-2.0 license text for OSS scanner and evaluator compatibility.
 - [semver:patch] Fixed pinned install and release-smoke examples so documented first-value commands install a compatible Wrkr release.
 - [semver:patch] Fixed scan status so completed scans with source failures remain marked as partial instead of appearing complete to automation.
 - [semver:patch] Fixed hosted scan progress counters so failed repo materialization is counted once and pending progress remains accurate.
@@ -50,8 +54,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Security
 
+- [semver:patch] Tightened release and docs workflow action-ref governance with immutable pins or expiring owner-scoped exceptions.
 - [semver:patch] Raised Wrkr's active Go toolchain pin to `1.26.3` and updated `golang.org/x/net` to `v0.53.0` to clear `govulncheck` findings in binary-scanning CI lanes.
-- (none yet)
 
 ## Changelog maintenance process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,19 +16,19 @@ Wrkr is a deterministic, offline-first OSS CLI for AI tooling discovery, risk sc
 
 Node is not required for the default Go-only contribution path.
 
+Go validation uses `scripts/first_party_go_packages.sh` instead of root `./...`
+wildcards so ignored docs-site dependency trees cannot change local, CI, UAT, or
+release package scope.
+
 ## GitHub Actions Runtime Policy
 
 - Local Node `22+` is only for docs-site and maintainer tooling. It is not the same contract as the GitHub-hosted JavaScript runtime used by workflow actions.
 - Workflow action refs must stay on the audited Node24-ready set enforced by `scripts/check_actions_runtime.sh` and `make lint-fast`.
+- Release/docs moving action refs must either be SHA-pinned or listed in `.github/action-ref-exceptions.yaml` with an owner, reason, exact workflow scope, expiry, and review command.
 - Steady-state overrides are prohibited:
   - `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`
   - `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION`
-- Current bounded exceptions are limited to upstream-maintained actions that do not yet publish a Node24-ready release:
-  - `actions/configure-pages@v5`
-  - `actions/deploy-pages@v4`
-  - `Homebrew/actions/setup-homebrew@cced187498280712e078aaba62dc13a3e9cd80bf`
-  - `anchore/sbom-action@v0`
-  - `anchore/scan-action@v4`
+- Current bounded exceptions are tracked in `.github/action-ref-exceptions.yaml`.
 - Do not add new exceptions silently. If an exception changes, update workflow YAML, tests, and docs in the same PR.
 
 ## Go-Only Contributor Path (Default)
@@ -89,7 +89,7 @@ These commands do not replace `make test-fast`, `make prepush`, contract lanes, 
    - `gh workflow run release.yml --ref <branch>`
    - `gh workflow run docs.yml --ref <branch>`
    - `gh run watch --repo Clyra-AI/wrkr <run-id>`
-4. Document any bounded exception you touched and why no Node24-ready upstream release exists yet.
+4. Document any bounded exception you touched, its owner, expiry, exact workflow scope, review command, and why it is not SHA-pinned yet.
 3. Document contract impact:
    - CLI flags/help/JSON/exits changed?
    - schema/output changed?

--- a/LICENSE
+++ b/LICENSE
@@ -4,14 +4,198 @@ http://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+1. Definitions.
 
-    http://www.apache.org/licenses/LICENSE-2.0
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!) The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 GO ?= go
-PKGS := ./...
+PKG_LIST := scripts/first_party_go_packages.sh
 GOFILES := $(shell git ls-files '*.go')
 DOCS_SITE_NPM_CACHE ?= $(CURDIR)/.tmp/npm-cache
 
@@ -21,20 +21,20 @@ lint-fast:
 	@scripts/check_repo_hygiene.sh
 	@scripts/check_actions_runtime.sh
 	@scripts/check_branch_protection_contract.sh
-	@$(GO) vet $(PKGS)
+	@$(GO) vet $$($(PKG_LIST))
 
 lint: lint-fast
 
 test-fast:
-	@$(GO) test ./... -count=1
+	@$(GO) test $$($(PKG_LIST)) -count=1
 
 test: test-fast
 
 test-integration:
-	@$(GO) test ./... -run Integration -count=1
+	@$(GO) test $$($(PKG_LIST)) -run Integration -count=1
 
 test-e2e:
-	@$(GO) test ./... -run E2E -count=1
+	@$(GO) test $$($(PKG_LIST)) -run E2E -count=1
 
 test-contracts:
 	@$(GO) test ./testinfra/... -count=1

--- a/core/aggregate/controlbacklog/controlbacklog_test.go
+++ b/core/aggregate/controlbacklog/controlbacklog_test.go
@@ -495,18 +495,20 @@ func TestWorkflowSecretReferenceDoesNotClaimLeakedSecret(t *testing.T) {
 	}
 	if secretItem == nil {
 		t.Fatalf("expected secret-bearing workflow item, got %+v", backlog.Items)
+		return
 	}
-	if !containsString(secretItem.SecretSignalTypes, SecretReferenceDetected) {
-		t.Fatalf("expected secret reference signal, got %+v", secretItem.SecretSignalTypes)
+	item := *secretItem
+	if !containsString(item.SecretSignalTypes, SecretReferenceDetected) {
+		t.Fatalf("expected secret reference signal, got %+v", item.SecretSignalTypes)
 	}
-	if containsString(secretItem.SecretSignalTypes, SecretValueDetected) {
-		t.Fatalf("did not expect secret value signal, got %+v", secretItem.SecretSignalTypes)
+	if containsString(item.SecretSignalTypes, SecretValueDetected) {
+		t.Fatalf("did not expect secret value signal, got %+v", item.SecretSignalTypes)
 	}
-	if !containsString(secretItem.SecretSignalTypes, SecretUsedByWriteCapableWorkflow) {
-		t.Fatalf("expected write-capable workflow signal, got %+v", secretItem.SecretSignalTypes)
+	if !containsString(item.SecretSignalTypes, SecretUsedByWriteCapableWorkflow) {
+		t.Fatalf("expected write-capable workflow signal, got %+v", item.SecretSignalTypes)
 	}
-	if secretItem.RecommendedAction != ActionAttachEvidence {
-		t.Fatalf("expected attach_evidence, got %+v", secretItem)
+	if item.RecommendedAction != ActionAttachEvidence {
+		t.Fatalf("expected attach_evidence, got %+v", item)
 	}
 }
 

--- a/core/attribution/attribution_test.go
+++ b/core/attribution/attribution_test.go
@@ -39,15 +39,17 @@ func TestLocalFindsCommitIntroducingWorkflowLine(t *testing.T) {
 	result := Local(repoRoot, rel, &model.LocationRange{StartLine: 5, EndLine: 6})
 	if result == nil {
 		t.Fatal("expected attribution result")
+		return
 	}
-	if result.Source != SourceLocalGit || result.Confidence != ConfidenceHigh {
-		t.Fatalf("expected high-confidence local_git attribution, got %+v", result)
+	got := *result
+	if got.Source != SourceLocalGit || got.Confidence != ConfidenceHigh {
+		t.Fatalf("expected high-confidence local_git attribution, got %+v", got)
 	}
-	if result.CommitSHA == "" || result.Author != "Wrkr Test" {
-		t.Fatalf("expected commit sha and author, got %+v", result)
+	if got.CommitSHA == "" || got.Author != "Wrkr Test" {
+		t.Fatalf("expected commit sha and author, got %+v", got)
 	}
-	if !strings.HasPrefix(result.Timestamp, "2026-04-29T11:00:00") {
-		t.Fatalf("expected second commit timestamp, got %+v", result)
+	if !strings.HasPrefix(got.Timestamp, "2026-04-29T11:00:00") {
+		t.Fatalf("expected second commit timestamp, got %+v", got)
 	}
 }
 
@@ -57,9 +59,11 @@ func TestLocalReturnsExplicitLowConfidenceWhenGitMetadataMissing(t *testing.T) {
 	result := Local(t.TempDir(), ".github/workflows/release.yml", &model.LocationRange{StartLine: 1, EndLine: 1})
 	if result == nil {
 		t.Fatal("expected attribution result")
+		return
 	}
-	if result.Confidence != ConfidenceLow || result.MissingReason == "" {
-		t.Fatalf("expected explicit low-confidence missing attribution, got %+v", result)
+	got := *result
+	if got.Confidence != ConfidenceLow || got.MissingReason == "" {
+		t.Fatalf("expected explicit low-confidence missing attribution, got %+v", got)
 	}
 }
 
@@ -92,12 +96,14 @@ func TestLocalWithoutLineRangeFallsBackToLatestCommit(t *testing.T) {
 	result := Local(repoRoot, rel, nil)
 	if result == nil {
 		t.Fatal("expected attribution result")
+		return
 	}
-	if result.Confidence != ConfidenceLow || result.MissingReason != "line_range_unavailable" {
-		t.Fatalf("expected low-confidence latest-commit fallback, got %+v", result)
+	got := *result
+	if got.Confidence != ConfidenceLow || got.MissingReason != "line_range_unavailable" {
+		t.Fatalf("expected low-confidence latest-commit fallback, got %+v", got)
 	}
-	if result.CommitSHA == "" || result.Author != "Wrkr Test" {
-		t.Fatalf("expected latest commit metadata in fallback, got %+v", result)
+	if got.CommitSHA == "" || got.Author != "Wrkr Test" {
+		t.Fatalf("expected latest commit metadata in fallback, got %+v", got)
 	}
 }
 
@@ -127,12 +133,14 @@ func TestResolvePrefersGitHubEventMetadataWhenChangedFileMatches(t *testing.T) {
 	result := Resolve(LoadContext(repoRoot), ".github/workflows/release.yml", &model.LocationRange{StartLine: 1, EndLine: 1})
 	if result == nil {
 		t.Fatal("expected attribution result")
+		return
 	}
-	if result.Source != SourceGitHubEvent || result.PRNumber != 42 || result.ProviderURL == "" {
-		t.Fatalf("expected GitHub event attribution, got %+v", result)
+	got := *result
+	if got.Source != SourceGitHubEvent || got.PRNumber != 42 || got.ProviderURL == "" {
+		t.Fatalf("expected GitHub event attribution, got %+v", got)
 	}
-	if result.CommitSHA != "abc123def" || result.Author != "octocat" {
-		t.Fatalf("expected GitHub event commit metadata, got %+v", result)
+	if got.CommitSHA != "abc123def" || got.Author != "octocat" {
+		t.Fatalf("expected GitHub event commit metadata, got %+v", got)
 	}
 }
 
@@ -160,12 +168,14 @@ func TestResolveUnderstandsGitLabMergeRequestMetadata(t *testing.T) {
 	result := Resolve(LoadContext(repoRoot), "AGENTS.md", nil)
 	if result == nil {
 		t.Fatal("expected attribution result")
+		return
 	}
-	if result.Source != SourceGitLabEvent || result.PRNumber != 17 {
-		t.Fatalf("expected GitLab merge request attribution, got %+v", result)
+	got := *result
+	if got.Source != SourceGitLabEvent || got.PRNumber != 17 {
+		t.Fatalf("expected GitLab merge request attribution, got %+v", got)
 	}
-	if result.CommitSHA != "feedbeef" || result.Author != "gitlab-user" {
-		t.Fatalf("expected GitLab commit metadata, got %+v", result)
+	if got.CommitSHA != "feedbeef" || got.Author != "gitlab-user" {
+		t.Fatalf("expected GitLab commit metadata, got %+v", got)
 	}
 }
 

--- a/core/cli/identity.go
+++ b/core/cli/identity.go
@@ -57,7 +57,11 @@ func runIdentityList(args []string, stdout io.Writer, stderr io.Writer) int {
 	if code, handled := parseFlags(fs, args, stderr, jsonRequested || *jsonOut); handled {
 		return code
 	}
-	loaded, err := manifest.Load(manifest.ResolvePath(state.ResolvePath(*statePathFlag)))
+	resolvedStatePath := state.ResolvePath(*statePathFlag)
+	if err := preflightManagedArtifactRead(resolvedStatePath); err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
+	loaded, err := manifest.Load(manifest.ResolvePath(resolvedStatePath))
 	if err != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
 	}
@@ -101,6 +105,9 @@ func runIdentityShow(args []string, stdout io.Writer, stderr io.Writer) int {
 		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", "identity id is required", exitInvalidInput)
 	}
 	statePath := state.ResolvePath(*statePathFlag)
+	if err := preflightManagedArtifactRead(statePath); err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
 	loaded, err := manifest.Load(manifest.ResolvePath(statePath))
 	if err != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)

--- a/core/cli/lifecycle.go
+++ b/core/cli/lifecycle.go
@@ -38,6 +38,9 @@ func runLifecycle(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	resolvedStatePath := state.ResolvePath(*statePathFlag)
+	if err := preflightManagedArtifactRead(resolvedStatePath); err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
 	loaded, err := manifest.Load(manifest.ResolvePath(resolvedStatePath))
 	if err != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)

--- a/core/cli/managed_artifacts.go
+++ b/core/cli/managed_artifacts.go
@@ -336,29 +336,37 @@ func verifyManagedArtifactConsistency(statePath string) error {
 		return fmt.Errorf("managed artifact consistency state: %w", err)
 	}
 	manifestPath := manifest.ResolvePath(resolvedStatePath)
+	manifestExists := true
 	if _, err := os.Stat(manifestPath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil
+			manifestExists = false
+		} else {
+			return fmt.Errorf("managed artifact consistency manifest: %w", err)
 		}
-		return fmt.Errorf("managed artifact consistency manifest: %w", err)
 	}
-	loadedManifest, err := manifest.Load(manifestPath)
-	if err != nil {
-		return fmt.Errorf("managed artifact consistency manifest: %w", err)
-	}
-	if !reflect.DeepEqual(normalizedManagedIdentities(snapshot.Identities), normalizedManagedIdentities(loadedManifest.Identities)) {
-		return fmt.Errorf("managed artifact consistency mismatch: state and manifest identities differ")
+	if manifestExists {
+		loadedManifest, err := manifest.Load(manifestPath)
+		if err != nil {
+			return fmt.Errorf("managed artifact consistency manifest: %w", err)
+		}
+		if !reflect.DeepEqual(normalizedManagedIdentities(snapshot.Identities), normalizedManagedIdentities(loadedManifest.Identities)) {
+			return fmt.Errorf("managed artifact consistency mismatch: state and manifest identities differ")
+		}
 	}
 
 	lifecyclePath := lifecycle.ChainPath(resolvedStatePath)
+	lifecycleExists := true
 	if _, err := os.Stat(lifecyclePath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil
+			lifecycleExists = false
+		} else {
+			return fmt.Errorf("managed artifact consistency lifecycle chain: %w", err)
 		}
-		return fmt.Errorf("managed artifact consistency lifecycle chain: %w", err)
 	}
-	if _, err := lifecycle.LoadChain(lifecyclePath); err != nil {
-		return fmt.Errorf("managed artifact consistency lifecycle chain: %w", err)
+	if lifecycleExists {
+		if _, err := lifecycle.LoadChain(lifecyclePath); err != nil {
+			return fmt.Errorf("managed artifact consistency lifecycle chain: %w", err)
+		}
 	}
 
 	proofChainPath := proofemit.ChainPath(resolvedStatePath)
@@ -397,7 +405,6 @@ func verifyManagedArtifactConsistency(statePath string) error {
 	}
 	return nil
 }
-
 func normalizedManagedIdentities(records []manifest.IdentityRecord) []manifest.IdentityRecord {
 	out := append([]manifest.IdentityRecord(nil), model.FilterLegacyArtifactIdentityRecords(records)...)
 	sort.Slice(out, func(i, j int) bool {

--- a/core/cli/managed_artifacts.go
+++ b/core/cli/managed_artifacts.go
@@ -1,13 +1,27 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
 
+	"github.com/Clyra-AI/wrkr/core/lifecycle"
+	"github.com/Clyra-AI/wrkr/core/manifest"
+	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/proofemit"
+	"github.com/Clyra-AI/wrkr/core/state"
+	verifycore "github.com/Clyra-AI/wrkr/core/verify"
 	"github.com/Clyra-AI/wrkr/internal/atomicwrite"
+)
+
+const (
+	managedArtifactTransactionVersion = "v1"
+	managedArtifactTransactionName    = ".wrkr-managed-transaction.json"
 )
 
 type managedArtifactSnapshot struct {
@@ -15,6 +29,31 @@ type managedArtifactSnapshot struct {
 	existed bool
 	payload []byte
 	perm    os.FileMode
+}
+
+type managedArtifactFile struct {
+	label string
+	path  string
+}
+
+type managedArtifactTransaction struct {
+	journalPath string
+	snapshots   []managedArtifactSnapshot
+	completed   bool
+}
+
+type managedArtifactTransactionJournal struct {
+	Version   string                               `json:"version"`
+	Operation string                               `json:"operation"`
+	Artifacts []managedArtifactTransactionArtifact `json:"artifacts"`
+}
+
+type managedArtifactTransactionArtifact struct {
+	Label   string      `json:"label"`
+	Path    string      `json:"path"`
+	Existed bool        `json:"existed"`
+	Payload []byte      `json:"payload,omitempty"`
+	Perm    os.FileMode `json:"perm,omitempty"`
 }
 
 type scanArtifactPathEntry struct {
@@ -58,6 +97,319 @@ func captureManagedArtifacts(paths ...string) ([]managedArtifactSnapshot, error)
 		snapshots = append(snapshots, snapshot)
 	}
 	return snapshots, nil
+}
+
+func recoverManagedArtifactTransaction(statePath string) error {
+	journalPath := managedArtifactTransactionPath(statePath)
+	payload, err := os.ReadFile(journalPath) // #nosec G304 -- transaction metadata lives beside the caller-selected state path.
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read managed artifact transaction: %w", err)
+	}
+
+	var journal managedArtifactTransactionJournal
+	if err := json.Unmarshal(payload, &journal); err != nil {
+		return fmt.Errorf("parse managed artifact transaction: %w", err)
+	}
+	if strings.TrimSpace(journal.Version) != managedArtifactTransactionVersion {
+		return fmt.Errorf("managed artifact transaction has unsupported version %q", journal.Version)
+	}
+	if len(journal.Artifacts) == 0 {
+		return fmt.Errorf("managed artifact transaction has no artifacts")
+	}
+
+	root := filepath.Dir(journalPath)
+	snapshots := make([]managedArtifactSnapshot, 0, len(journal.Artifacts))
+	for _, artifact := range journal.Artifacts {
+		resolvedPath, resolveErr := managedArtifactPathFromJournal(root, artifact.Path)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		snapshots = append(snapshots, managedArtifactSnapshot{
+			path:    resolvedPath,
+			existed: artifact.Existed,
+			payload: append([]byte(nil), artifact.Payload...),
+			perm:    artifact.Perm,
+		})
+	}
+	if err := restoreManagedArtifacts(snapshots); err != nil {
+		return fmt.Errorf("recover managed artifact transaction: %w", err)
+	}
+	if err := os.Remove(journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove recovered managed artifact transaction: %w", err)
+	}
+	return nil
+}
+
+func beginManagedArtifactTransaction(statePath string, operation string, files []managedArtifactFile) (*managedArtifactTransaction, error) {
+	if err := recoverManagedArtifactTransaction(statePath); err != nil {
+		return nil, err
+	}
+	normalizedFiles, err := normalizeManagedArtifactFiles(files)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(normalizedFiles))
+	for _, file := range normalizedFiles {
+		paths = append(paths, file.path)
+	}
+	snapshots, err := captureManagedArtifacts(paths...)
+	if err != nil {
+		return nil, err
+	}
+	journalPath := managedArtifactTransactionPath(statePath)
+	journal, err := newManagedArtifactTransactionJournal(filepath.Dir(journalPath), operation, normalizedFiles, snapshots)
+	if err != nil {
+		return nil, err
+	}
+	encoded, err := json.MarshalIndent(journal, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal managed artifact transaction: %w", err)
+	}
+	encoded = append(encoded, '\n')
+	if err := atomicwrite.WriteFile(journalPath, encoded, 0o600); err != nil {
+		return nil, fmt.Errorf("write managed artifact transaction: %w", err)
+	}
+	return &managedArtifactTransaction{
+		journalPath: journalPath,
+		snapshots:   snapshots,
+	}, nil
+}
+
+func (tx *managedArtifactTransaction) Rollback(actionErr error) error {
+	if tx == nil {
+		return actionErr
+	}
+	if tx.completed {
+		return actionErr
+	}
+	restoreErr := restoreManagedArtifacts(tx.snapshots)
+	removeErr := os.Remove(tx.journalPath)
+	if errors.Is(removeErr, os.ErrNotExist) {
+		removeErr = nil
+	}
+	tx.completed = true
+
+	if restoreErr != nil && removeErr != nil {
+		return fmt.Errorf("%v (rollback restore failed: %v; transaction cleanup failed: %v)", actionErr, restoreErr, removeErr)
+	}
+	if restoreErr != nil {
+		return fmt.Errorf("%v (rollback restore failed: %v)", actionErr, restoreErr)
+	}
+	if removeErr != nil {
+		return fmt.Errorf("%v (transaction cleanup failed: %v)", actionErr, removeErr)
+	}
+	return actionErr
+}
+
+func (tx *managedArtifactTransaction) Complete() error {
+	if tx == nil || tx.completed {
+		return nil
+	}
+	if err := os.Remove(tx.journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove managed artifact transaction: %w", err)
+	}
+	tx.completed = true
+	return nil
+}
+
+func managedArtifactTransactionPath(statePath string) string {
+	cleanStatePath := filepath.Clean(strings.TrimSpace(statePath))
+	if cleanStatePath == "" || cleanStatePath == "." {
+		cleanStatePath = state.ResolvePath("")
+	}
+	dir := filepath.Dir(cleanStatePath)
+	if strings.TrimSpace(dir) == "" {
+		dir = "."
+	}
+	return filepath.Join(dir, managedArtifactTransactionName)
+}
+
+func normalizeManagedArtifactFiles(files []managedArtifactFile) ([]managedArtifactFile, error) {
+	out := make([]managedArtifactFile, 0, len(files))
+	seen := map[string]struct{}{}
+	for _, file := range files {
+		path, err := normalizeManagedArtifactPath(file.path)
+		if err != nil {
+			if strings.TrimSpace(file.path) == "" {
+				continue
+			}
+			return nil, err
+		}
+		if path == "" || path == "." {
+			continue
+		}
+		key := filepath.Clean(path)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		label := strings.TrimSpace(file.label)
+		if label == "" {
+			label = filepath.Base(key)
+		}
+		out = append(out, managedArtifactFile{label: label, path: key})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("managed artifact transaction requires at least one artifact")
+	}
+	return out, nil
+}
+
+func newManagedArtifactTransactionJournal(root string, operation string, files []managedArtifactFile, snapshots []managedArtifactSnapshot) (managedArtifactTransactionJournal, error) {
+	snapshotByPath := make(map[string]managedArtifactSnapshot, len(snapshots))
+	for _, snapshot := range snapshots {
+		snapshotByPath[filepath.Clean(snapshot.path)] = snapshot
+	}
+
+	artifacts := make([]managedArtifactTransactionArtifact, 0, len(files))
+	for _, file := range files {
+		snapshot, ok := snapshotByPath[filepath.Clean(file.path)]
+		if !ok {
+			return managedArtifactTransactionJournal{}, fmt.Errorf("missing managed artifact snapshot for %s", file.path)
+		}
+		portablePath, err := managedArtifactPathForJournal(root, file.path)
+		if err != nil {
+			return managedArtifactTransactionJournal{}, err
+		}
+		artifacts = append(artifacts, managedArtifactTransactionArtifact{
+			Label:   strings.TrimSpace(file.label),
+			Path:    portablePath,
+			Existed: snapshot.existed,
+			Payload: append([]byte(nil), snapshot.payload...),
+			Perm:    snapshot.perm,
+		})
+	}
+	return managedArtifactTransactionJournal{
+		Version:   managedArtifactTransactionVersion,
+		Operation: strings.TrimSpace(operation),
+		Artifacts: artifacts,
+	}, nil
+}
+
+func managedArtifactPathForJournal(root string, path string) (string, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve managed artifact transaction root: %w", err)
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve managed artifact path: %w", err)
+	}
+	rel, err := filepath.Rel(absRoot, absPath)
+	if err != nil {
+		return "", fmt.Errorf("relativize managed artifact path: %w", err)
+	}
+	return filepath.ToSlash(filepath.Clean(rel)), nil
+}
+
+func managedArtifactPathFromJournal(root string, journalPath string) (string, error) {
+	cleanPath := filepath.Clean(filepath.FromSlash(strings.TrimSpace(journalPath)))
+	if cleanPath == "" || cleanPath == "." || filepath.IsAbs(cleanPath) {
+		return "", fmt.Errorf("managed artifact transaction path must be relative: %q", journalPath)
+	}
+	return filepath.Clean(filepath.Join(root, cleanPath)), nil
+}
+
+func preflightManagedArtifactRead(statePath string) error {
+	if err := recoverManagedArtifactTransaction(statePath); err != nil {
+		return err
+	}
+	if _, err := os.Stat(filepath.Clean(strings.TrimSpace(statePath))); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("stat managed state artifact: %w", err)
+	}
+	return verifyManagedArtifactConsistency(statePath)
+}
+
+func verifyManagedArtifactConsistency(statePath string) error {
+	resolvedStatePath := filepath.Clean(strings.TrimSpace(statePath))
+	if resolvedStatePath == "" || resolvedStatePath == "." {
+		resolvedStatePath = state.ResolvePath("")
+	}
+	snapshot, err := state.Load(resolvedStatePath)
+	if err != nil {
+		return fmt.Errorf("managed artifact consistency state: %w", err)
+	}
+	manifestPath := manifest.ResolvePath(resolvedStatePath)
+	if _, err := os.Stat(manifestPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("managed artifact consistency manifest: %w", err)
+	}
+	loadedManifest, err := manifest.Load(manifestPath)
+	if err != nil {
+		return fmt.Errorf("managed artifact consistency manifest: %w", err)
+	}
+	if !reflect.DeepEqual(normalizedManagedIdentities(snapshot.Identities), normalizedManagedIdentities(loadedManifest.Identities)) {
+		return fmt.Errorf("managed artifact consistency mismatch: state and manifest identities differ")
+	}
+
+	lifecyclePath := lifecycle.ChainPath(resolvedStatePath)
+	if _, err := os.Stat(lifecyclePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("managed artifact consistency lifecycle chain: %w", err)
+	}
+	if _, err := lifecycle.LoadChain(lifecyclePath); err != nil {
+		return fmt.Errorf("managed artifact consistency lifecycle chain: %w", err)
+	}
+
+	proofChainPath := proofemit.ChainPath(resolvedStatePath)
+	if _, err := os.Stat(proofChainPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("managed artifact consistency proof chain: %w", err)
+	}
+	proofChain, err := proofemit.LoadChain(proofChainPath)
+	if err != nil {
+		return fmt.Errorf("managed artifact consistency proof chain: %w", err)
+	}
+	if proofChain != nil && len(proofChain.Records) > 0 {
+		if _, err := os.Stat(proofemit.SigningKeyPath(resolvedStatePath)); err != nil {
+			return fmt.Errorf("managed artifact consistency proof signing key: %w", err)
+		}
+		if _, err := os.Stat(proofemit.ChainAttestationPath(proofChainPath)); err != nil {
+			return fmt.Errorf("managed artifact consistency proof attestation: %w", err)
+		}
+		publicKey, keyErr := proofemit.LoadVerifierKey(resolvedStatePath)
+		var result verifycore.Result
+		if keyErr == nil {
+			result, err = verifycore.ChainWithPublicKey(proofChainPath, publicKey)
+		} else if errors.Is(keyErr, os.ErrNotExist) {
+			result, err = verifycore.Chain(proofChainPath)
+		} else {
+			return fmt.Errorf("managed artifact consistency proof signing key: %w", keyErr)
+		}
+		if err != nil {
+			return fmt.Errorf("managed artifact consistency proof verification: %w", err)
+		}
+		if !result.Intact {
+			return fmt.Errorf("managed artifact consistency proof verification failed: %s", result.Reason)
+		}
+	}
+	return nil
+}
+
+func normalizedManagedIdentities(records []manifest.IdentityRecord) []manifest.IdentityRecord {
+	out := append([]manifest.IdentityRecord(nil), model.FilterLegacyArtifactIdentityRecords(records)...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].AgentID != out[j].AgentID {
+			return out[i].AgentID < out[j].AgentID
+		}
+		if out[i].Repo != out[j].Repo {
+			return out[i].Repo < out[j].Repo
+		}
+		return out[i].Location < out[j].Location
+	})
+	return out
 }
 
 func captureManagedArtifact(path string) (managedArtifactSnapshot, error) {

--- a/core/cli/regress.go
+++ b/core/cli/regress.go
@@ -114,6 +114,9 @@ func runRegressRun(args []string, stdout io.Writer, stderr io.Writer) int {
 		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
 	}
 	resolvedStatePath := state.ResolvePath(*statePathFlag)
+	if err := preflightManagedArtifactRead(resolvedStatePath); err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
 	snapshot, err := state.Load(resolvedStatePath)
 	if err != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)

--- a/core/cli/report.go
+++ b/core/cli/report.go
@@ -103,6 +103,9 @@ func runReport(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	resolvedStatePath := state.ResolvePath(*statePathFlag)
+	if err := preflightManagedArtifactRead(resolvedStatePath); err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
 	snapshot, err := state.Load(resolvedStatePath)
 	if err != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -198,6 +198,9 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", jsonSinkErr.Error(), exitInvalidInput)
 	}
 	statePath := artifactPreflight.StatePath
+	if recoveryErr := recoverManagedArtifactTransaction(statePath); recoveryErr != nil {
+		return emitScanRuntimeError(stderr, jsonRequested || *jsonOut, recoveryErr)
+	}
 	materializedRoot := ""
 	if targetsNeedMaterializedRoot(targets) {
 		var rootErr error
@@ -582,17 +585,17 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	}
 	chainPath := artifactPreflight.LifecyclePath
 	proofChainPath := artifactPreflight.ProofChainPath
-	managedSnapshots, snapshotErr := captureManagedArtifacts(
-		statePath,
-		manifestPath,
-		chainPath,
-		proofChainPath,
-		artifactPreflight.ProofAttestationPath,
-		artifactPreflight.SigningKeyPath,
-		artifactPreflight.ReportPath,
-		artifactPreflight.SARIFPath,
-		jsonSink.outputPath,
-	)
+	transaction, snapshotErr := beginManagedArtifactTransaction(statePath, "scan", []managedArtifactFile{
+		{label: "state", path: statePath},
+		{label: "manifest", path: manifestPath},
+		{label: "lifecycle chain", path: chainPath},
+		{label: "proof chain", path: proofChainPath},
+		{label: "proof attestation", path: artifactPreflight.ProofAttestationPath},
+		{label: "proof signing key", path: artifactPreflight.SigningKeyPath},
+		{label: "report markdown", path: artifactPreflight.ReportPath},
+		{label: "sarif", path: artifactPreflight.SARIFPath},
+		{label: "json output", path: jsonSink.outputPath},
+	})
 	if snapshotErr != nil {
 		return emitScanFailure(snapshotErr)
 	}
@@ -610,26 +613,30 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		err = cleanupFailure(err)
 		statusTracker.Fail(err, artifactPaths)
 		progress.Finish(statusTracker.FooterData())
-		if restoreErr := restoreManagedArtifacts(managedSnapshots); restoreErr != nil {
-			return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", fmt.Sprintf("%v (rollback restore failed: %v)", err, restoreErr), exitRuntime)
-		}
-		return emitScanRuntimeError(stderr, jsonRequested || *jsonOut, err)
+		return emitScanRuntimeError(stderr, jsonRequested || *jsonOut, transaction.Rollback(err))
 	}
 	emitRolledBackScanError := func(code, message string, exitCode int) int {
 		if cleanupErr := finalizeSourceCleanup(false); cleanupErr != nil {
 			statusTracker.Fail(cleanupErr, artifactPaths)
 			progress.Finish(statusTracker.FooterData())
-			if restoreErr := restoreManagedArtifacts(managedSnapshots); restoreErr != nil {
-				return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", fmt.Sprintf("%v (rollback restore failed: %v)", cleanupErr, restoreErr), exitRuntime)
-			}
-			return emitScanRuntimeError(stderr, jsonRequested || *jsonOut, cleanupErr)
+			return emitScanRuntimeError(stderr, jsonRequested || *jsonOut, transaction.Rollback(cleanupErr))
 		}
 		statusTracker.Fail(errors.New(message), artifactPaths)
 		progress.Finish(statusTracker.FooterData())
-		if restoreErr := restoreManagedArtifacts(managedSnapshots); restoreErr != nil {
-			return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", fmt.Sprintf("%s (rollback restore failed: %v)", message, restoreErr), exitRuntime)
+		rollbackErr := transaction.Rollback(errors.New(message))
+		if rollbackErr != nil && rollbackErr.Error() != message {
+			return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", rollbackErr.Error(), exitRuntime)
 		}
 		return emitError(stderr, jsonRequested || *jsonOut, code, message, exitCode)
+	}
+	completeManagedScanTransaction := func() int {
+		if err := verifyManagedArtifactConsistency(statePath); err != nil {
+			return emitRolledBackScanFailure(err)
+		}
+		if err := transaction.Complete(); err != nil {
+			return emitRolledBackScanFailure(err)
+		}
+		return exitSuccess
 	}
 
 	if err := state.Save(statePath, snapshot); err != nil {
@@ -810,6 +817,9 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		if code := completeScanStatus(); code != exitSuccess {
 			return code
 		}
+		if code := completeManagedScanTransaction(); code != exitSuccess {
+			return code
+		}
 		progress.Finish(statusTracker.FooterData())
 		if *jsonOut {
 			return exitSuccess
@@ -833,11 +843,17 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		if code := completeScanStatus(); code != exitSuccess {
 			return code
 		}
+		if code := completeManagedScanTransaction(); code != exitSuccess {
+			return code
+		}
 		progress.Finish(statusTracker.FooterData())
 		return exitSuccess
 	}
 	if *explain {
 		if code := completeScanStatus(); code != exitSuccess {
+			return code
+		}
+		if code := completeManagedScanTransaction(); code != exitSuccess {
 			return code
 		}
 		progress.Finish(statusTracker.FooterData())
@@ -860,6 +876,9 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		return exitSuccess
 	}
 	if code := completeScanStatus(); code != exitSuccess {
+		return code
+	}
+	if code := completeManagedScanTransaction(); code != exitSuccess {
 		return code
 	}
 	progress.Finish(statusTracker.FooterData())

--- a/core/cli/scan_transaction_test.go
+++ b/core/cli/scan_transaction_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/Clyra-AI/wrkr/core/lifecycle"
@@ -84,6 +85,128 @@ func TestScanLateReportWriteFailureRollsBackManagedArtifacts(t *testing.T) {
 	assertOptionalTestFileEquals(t, proofPath, proofBefore)
 	assertOptionalTestFileEquals(t, attestationPath, attestationBefore)
 	assertOptionalTestFileEquals(t, signingKeyPath, signingKeyBefore)
+}
+
+func TestScanInterruptedAfterStateSaveRecoversManagedArtifacts(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	reposPath := filepath.Join(tmp, "repos")
+	repoPath := filepath.Join(reposPath, "alpha", ".codex")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoPath, "config.toml"), []byte("approval_policy = \"never\"\n"), 0o600); err != nil {
+		t.Fatalf("write codex config: %v", err)
+	}
+
+	statePath := filepath.Join(tmp, ".wrkr", "state.json")
+	var initialOut bytes.Buffer
+	var initialErr bytes.Buffer
+	if code := Run([]string{"scan", "--path", reposPath, "--state", statePath, "--json"}, &initialOut, &initialErr); code != exitSuccess {
+		t.Fatalf("initial scan failed: %d stdout=%q stderr=%q", code, initialOut.String(), initialErr.String())
+	}
+
+	stateBefore := readOptionalTestFile(t, statePath)
+	manifestPath := manifest.ResolvePath(statePath)
+	lifecyclePath := lifecycle.ChainPath(statePath)
+	proofPath := proofemit.ChainPath(statePath)
+	attestationPath := proofemit.ChainAttestationPath(proofPath)
+	signingKeyPath := proofemit.SigningKeyPath(statePath)
+	manifestBefore := readOptionalTestFile(t, manifestPath)
+	lifecycleBefore := readOptionalTestFile(t, lifecyclePath)
+	proofBefore := readOptionalTestFile(t, proofPath)
+	attestationBefore := readOptionalTestFile(t, attestationPath)
+	signingKeyBefore := readOptionalTestFile(t, signingKeyPath)
+
+	transaction, err := beginManagedArtifactTransaction(statePath, "scan", []managedArtifactFile{
+		{label: "state", path: statePath},
+		{label: "manifest", path: manifestPath},
+		{label: "lifecycle chain", path: lifecyclePath},
+		{label: "proof chain", path: proofPath},
+		{label: "proof attestation", path: attestationPath},
+		{label: "proof signing key", path: signingKeyPath},
+	})
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	transaction.completed = true // Simulate abrupt process interruption: leave journal behind and skip rollback.
+	if err := os.WriteFile(statePath, []byte(`{"version":"v1","findings":[]}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write interrupted state: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := Run([]string{"score", "--state", statePath, "--json"}, &out, &errOut); code != exitSuccess {
+		t.Fatalf("score after recovery failed: %d stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+
+	assertOptionalTestFileEquals(t, statePath, stateBefore)
+	assertOptionalTestFileEquals(t, manifestPath, manifestBefore)
+	assertOptionalTestFileEquals(t, lifecyclePath, lifecycleBefore)
+	assertOptionalTestFileEquals(t, proofPath, proofBefore)
+	assertOptionalTestFileEquals(t, attestationPath, attestationBefore)
+	assertOptionalTestFileEquals(t, signingKeyPath, signingKeyBefore)
+	if _, err := os.Stat(managedArtifactTransactionPath(statePath)); !os.IsNotExist(err) {
+		t.Fatalf("expected recovered transaction journal to be removed, stat err=%v", err)
+	}
+}
+
+func TestScanInterruptedAfterProofEmitFailsClosedOnManifestMismatch(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, ".wrkr", "state.json")
+	agentID := scanIdentityAgentID(t, statePath)
+	if strings.TrimSpace(agentID) == "" {
+		t.Fatal("expected scan fixture to produce an agent id")
+	}
+	manifestPath := manifest.ResolvePath(statePath)
+	loadedManifest, err := manifest.Load(manifestPath)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	loadedManifest.Identities = nil
+	if err := manifest.Save(manifestPath, loadedManifest); err != nil {
+		t.Fatalf("save mismatched manifest: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{"regress", "run", "--baseline", statePath, "--state", statePath, "--json"}, &out, &errOut)
+	if code != exitRuntime {
+		t.Fatalf("expected fail-closed runtime exit, got %d stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+	assertErrorEnvelopeCode(t, errOut.Bytes(), "runtime_failure", exitRuntime)
+	if !strings.Contains(errOut.String(), "state and manifest identities differ") {
+		t.Fatalf("expected consistency mismatch detail, got %q", errOut.String())
+	}
+}
+
+func TestManagedArtifactTransactionMetadataIsPortable(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, ".wrkr", "state.json")
+	reportPath := filepath.Join(tmp, "reports", "scan.md")
+	transaction, err := beginManagedArtifactTransaction(statePath, "scan", []managedArtifactFile{
+		{label: "state", path: statePath},
+		{label: "report markdown", path: reportPath},
+	})
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	defer func() {
+		_ = transaction.Rollback(nil)
+	}()
+
+	payload := readOptionalTestFile(t, managedArtifactTransactionPath(statePath))
+	if bytes.Contains(payload, []byte(tmp)) {
+		t.Fatalf("transaction metadata must not contain checkout/temp absolute paths: %s", payload)
+	}
+	if !bytes.Contains(payload, []byte("../reports/scan.md")) {
+		t.Fatalf("expected sidecar path to be stored relative to managed root, got %s", payload)
+	}
 }
 
 func TestScanLateSARIFWriteFailureRollsBackManagedArtifacts(t *testing.T) {

--- a/core/cli/scan_transaction_test.go
+++ b/core/cli/scan_transaction_test.go
@@ -183,6 +183,38 @@ func TestScanInterruptedAfterProofEmitFailsClosedOnManifestMismatch(t *testing.T
 	}
 }
 
+func TestScoreRejectsTamperedProofWhenLifecycleChainMissing(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, ".wrkr", "state.json")
+	if strings.TrimSpace(scanIdentityAgentID(t, statePath)) == "" {
+		t.Fatal("expected scan fixture to produce an agent id")
+	}
+
+	lifecyclePath := lifecycle.ChainPath(statePath)
+	if err := os.Remove(lifecyclePath); err != nil {
+		t.Fatalf("remove lifecycle chain: %v", err)
+	}
+
+	proofPath := proofemit.ChainPath(statePath)
+	attestationPath := proofemit.ChainAttestationPath(proofPath)
+	if err := os.Remove(attestationPath); err != nil {
+		t.Fatalf("remove proof attestation: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{"score", "--state", statePath, "--json"}, &out, &errOut)
+	if code != exitRuntime {
+		t.Fatalf("expected fail-closed runtime exit, got %d stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+	assertErrorEnvelopeCode(t, errOut.Bytes(), "runtime_failure", exitRuntime)
+	if !strings.Contains(errOut.String(), "managed artifact consistency proof attestation") {
+		t.Fatalf("expected proof-attestation consistency detail, got %q", errOut.String())
+	}
+}
+
 func TestManagedArtifactTransactionMetadataIsPortable(t *testing.T) {
 	t.Parallel()
 

--- a/core/cli/score.go
+++ b/core/cli/score.go
@@ -35,6 +35,9 @@ func runScore(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	resolvedStatePath := state.ResolvePath(*statePathFlag)
+	if err := preflightManagedArtifactRead(resolvedStatePath); err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+	}
 	snapshot, err := state.LoadScoreView(resolvedStatePath)
 	if err != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)

--- a/core/cli/state_mutation.go
+++ b/core/cli/state_mutation.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"io"
 	"strings"
 
@@ -36,6 +35,9 @@ func loadStateMutationContext(statePathRaw string) (stateMutationContext, error)
 			return stateMutationContext{}, err
 		}
 		return stateMutationContext{}, unsafeManagedArtifactPathError{err: err}
+	}
+	if err := preflightManagedArtifactRead(preflight.statePath); err != nil {
+		return stateMutationContext{}, err
 	}
 	snapshot, err := state.Load(preflight.statePath)
 	if err != nil {
@@ -133,37 +135,36 @@ func refreshDerivedMutationSnapshot(snapshot *state.Snapshot) error {
 }
 
 func commitStateMutationContext(ctx stateMutationContext, transition lifecycle.Transition, eventType string) error {
-	snapshots, err := captureManagedArtifacts(
-		ctx.preflight.statePath,
-		ctx.preflight.manifestPath,
-		ctx.preflight.lifecyclePath,
-		ctx.preflight.proofChainPath,
-		ctx.preflight.proofAttestationPath,
-		ctx.preflight.signingKeyPath,
-	)
+	transaction, err := beginManagedArtifactTransaction(ctx.preflight.statePath, "state_mutation", []managedArtifactFile{
+		{label: "state", path: ctx.preflight.statePath},
+		{label: "manifest", path: ctx.preflight.manifestPath},
+		{label: "lifecycle chain", path: ctx.preflight.lifecyclePath},
+		{label: "proof chain", path: ctx.preflight.proofChainPath},
+		{label: "proof attestation", path: ctx.preflight.proofAttestationPath},
+		{label: "proof signing key", path: ctx.preflight.signingKeyPath},
+	})
 	if err != nil {
 		return unsafeManagedArtifactPathError{err: err}
 	}
 	if err := state.Save(ctx.preflight.statePath, ctx.snapshot); err != nil {
-		return rollbackStateMutationError(err, snapshots)
+		return transaction.Rollback(err)
 	}
 	if err := lifecycle.SaveChain(ctx.preflight.lifecyclePath, ctx.lifecycleChain); err != nil {
-		return rollbackStateMutationError(err, snapshots)
+		return transaction.Rollback(err)
 	}
 	if err := proofemit.EmitIdentityTransition(ctx.preflight.statePath, transition, eventType); err != nil {
-		return rollbackStateMutationError(err, snapshots)
+		return transaction.Rollback(err)
 	}
 	if err := manifest.Save(ctx.preflight.manifestPath, ctx.manifest); err != nil {
-		return rollbackStateMutationError(err, snapshots)
+		return transaction.Rollback(err)
+	}
+	if err := verifyManagedArtifactConsistency(ctx.preflight.statePath); err != nil {
+		return transaction.Rollback(err)
+	}
+	if err := transaction.Complete(); err != nil {
+		return transaction.Rollback(err)
 	}
 	return nil
-}
-
-func rollbackStateMutationError(actionErr error, snapshots []managedArtifactSnapshot) error {
-	if restoreErr := restoreManagedArtifacts(snapshots); restoreErr != nil {
-		return fmt.Errorf("%v (rollback restore failed: %v)", actionErr, restoreErr)
-	}
-	return actionErr
 }
 
 func emitStateMutationError(stderr io.Writer, jsonOut bool, err error) int {

--- a/core/cli/state_mutation_test.go
+++ b/core/cli/state_mutation_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -110,6 +112,90 @@ func TestInventoryApproveRollsBackSavedStateOnProofEmitFailure(t *testing.T) {
 	assertOptionalTestFileEquals(t, proofChainPath, proofBefore)
 	assertOptionalTestFileEquals(t, proofAttestationPath, attestationBefore)
 	assertOptionalTestFileEquals(t, signingKeyPath, signingKeyBefore)
+}
+
+func TestIdentityApproveInterruptedAfterProofEmitRecovers(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	agentID := scanIdentityAgentID(t, statePath)
+	if strings.TrimSpace(agentID) == "" {
+		t.Fatal("expected scan fixture to produce an agent id")
+	}
+	manifestPath := manifest.ResolvePath(statePath)
+	lifecyclePath := lifecycle.ChainPath(statePath)
+	proofChainPath := proofemit.ChainPath(statePath)
+	proofAttestationPath := proofemit.ChainAttestationPath(proofChainPath)
+	signingKeyPath := proofemit.SigningKeyPath(statePath)
+
+	stateBefore := readOptionalTestFile(t, statePath)
+	manifestBefore := readOptionalTestFile(t, manifestPath)
+	lifecycleBefore := readOptionalTestFile(t, lifecyclePath)
+	proofBefore := readOptionalTestFile(t, proofChainPath)
+	attestationBefore := readOptionalTestFile(t, proofAttestationPath)
+	signingKeyBefore := readOptionalTestFile(t, signingKeyPath)
+
+	transaction, err := beginManagedArtifactTransaction(statePath, "state_mutation", []managedArtifactFile{
+		{label: "state", path: statePath},
+		{label: "manifest", path: manifestPath},
+		{label: "lifecycle chain", path: lifecyclePath},
+		{label: "proof chain", path: proofChainPath},
+		{label: "proof attestation", path: proofAttestationPath},
+		{label: "proof signing key", path: signingKeyPath},
+	})
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	transaction.completed = true // Simulate process interruption after a managed write and before cleanup.
+	if err := os.WriteFile(proofChainPath, []byte("{\"chain_id\":\"wrkr-proof\",\"records\":[]}\n"), 0o600); err != nil {
+		t.Fatalf("write interrupted proof chain: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := Run([]string{"report", "--state", statePath, "--json"}, &out, &errOut); code != exitSuccess {
+		t.Fatalf("report after recovery failed: %d stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+
+	assertOptionalTestFileEquals(t, statePath, stateBefore)
+	assertOptionalTestFileEquals(t, manifestPath, manifestBefore)
+	assertOptionalTestFileEquals(t, lifecyclePath, lifecycleBefore)
+	assertOptionalTestFileEquals(t, proofChainPath, proofBefore)
+	assertOptionalTestFileEquals(t, proofAttestationPath, attestationBefore)
+	assertOptionalTestFileEquals(t, signingKeyPath, signingKeyBefore)
+}
+
+func TestReportRejectsMismatchedLifecycleTransaction(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	agentID := scanIdentityAgentID(t, statePath)
+
+	loadedManifest, err := manifest.Load(manifest.ResolvePath(statePath))
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	for idx := range loadedManifest.Identities {
+		if loadedManifest.Identities[idx].AgentID == agentID {
+			loadedManifest.Identities[idx].Status = identity.StateRevoked
+		}
+	}
+	if err := manifest.Save(manifest.ResolvePath(statePath), loadedManifest); err != nil {
+		t.Fatalf("save mismatched manifest: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{"report", "--state", statePath, "--json"}, &out, &errOut)
+	if code != exitRuntime {
+		t.Fatalf("expected fail-closed runtime exit, got %d stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+	assertErrorEnvelopeCode(t, errOut.Bytes(), "runtime_failure", exitRuntime)
+	if !strings.Contains(errOut.String(), "state and manifest identities differ") {
+		t.Fatalf("expected consistency mismatch detail, got %q", errOut.String())
+	}
 }
 
 func TestScoreReflectsIdentityApproveWithoutRescan(t *testing.T) {

--- a/core/cli/verify.go
+++ b/core/cli/verify.go
@@ -42,6 +42,11 @@ func runVerify(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	chainPath, keyLookupPath := resolveVerifyPaths(*statePathFlag, *chainPathFlag)
+	if strings.TrimSpace(*chainPathFlag) == "" || strings.TrimSpace(*statePathFlag) != "" {
+		if err := recoverManagedArtifactTransaction(keyLookupPath); err != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
+		}
+	}
 	var (
 		result verifycore.Result
 		err    error

--- a/core/detect/parse_test.go
+++ b/core/detect/parse_test.go
@@ -32,9 +32,11 @@ func TestParseJSONFileStrictUnknownField(t *testing.T) {
 	parseErr := ParseJSONFileStrict("detector", root, "cfg.json", &parsed)
 	if parseErr == nil {
 		t.Fatal("expected parse error")
+		return
 	}
-	if parseErr.Detector != "detector" || parseErr.Format != "json" {
-		t.Fatalf("unexpected parse error shape: %#v", parseErr)
+	got := *parseErr
+	if got.Detector != "detector" || got.Format != "json" {
+		t.Fatalf("unexpected parse error shape: %#v", got)
 	}
 }
 
@@ -51,9 +53,11 @@ func TestParseJSONFileRejectsTrailingTopLevelDocument(t *testing.T) {
 	parseErr := ParseJSONFile("detector", root, "cfg.json", &parsed)
 	if parseErr == nil {
 		t.Fatal("expected parse error for trailing JSON document")
+		return
 	}
-	if parseErr.Format != "json" {
-		t.Fatalf("unexpected parse error format: %#v", parseErr)
+	got := *parseErr
+	if got.Format != "json" {
+		t.Fatalf("unexpected parse error format: %#v", got)
 	}
 }
 
@@ -89,9 +93,11 @@ func TestParseYAMLFileStrictUnknownField(t *testing.T) {
 	parseErr := ParseYAMLFileStrict("detector", root, "cfg.yaml", &parsed)
 	if parseErr == nil {
 		t.Fatal("expected parse error")
+		return
 	}
-	if parseErr.Format != "yaml" {
-		t.Fatalf("unexpected parse error format: %#v", parseErr)
+	got := *parseErr
+	if got.Format != "yaml" {
+		t.Fatalf("unexpected parse error format: %#v", got)
 	}
 }
 
@@ -127,9 +133,11 @@ func TestParseTOMLFileStrictUnknownField(t *testing.T) {
 	parseErr := ParseTOMLFileStrict("detector", root, "cfg.toml", &parsed)
 	if parseErr == nil {
 		t.Fatal("expected parse error")
+		return
 	}
-	if parseErr.Format != "toml" {
-		t.Fatalf("unexpected parse error format: %#v", parseErr)
+	got := *parseErr
+	if got.Format != "toml" {
+		t.Fatalf("unexpected parse error format: %#v", got)
 	}
 }
 
@@ -165,9 +173,11 @@ func TestStrictWrkrContractRejectsUnknownFields(t *testing.T) {
 	parseErr := ParseJSONFileStrict("detector", root, "wrkr.json", &parsed)
 	if parseErr == nil {
 		t.Fatal("expected strict parse error")
+		return
 	}
-	if parseErr.Format != "json" || parseErr.Detector != "detector" {
-		t.Fatalf("unexpected strict parse error: %#v", parseErr)
+	got := *parseErr
+	if got.Format != "json" || got.Detector != "detector" {
+		t.Fatalf("unexpected strict parse error: %#v", got)
 	}
 }
 
@@ -185,9 +195,11 @@ func TestReadFileWithinRootRejectsSymlinkEscape(t *testing.T) {
 	_, parseErr := ReadFileWithinRoot("detector", root, "cfg.json")
 	if parseErr == nil {
 		t.Fatal("expected unsafe_path parse error")
+		return
 	}
-	if parseErr.Kind != "unsafe_path" {
-		t.Fatalf("expected unsafe_path kind, got %#v", parseErr)
+	got := *parseErr
+	if got.Kind != "unsafe_path" {
+		t.Fatalf("expected unsafe_path kind, got %#v", got)
 	}
 }
 
@@ -200,9 +212,11 @@ func TestReadFileWithinRootHandlesDanglingSymlinkDeterministically(t *testing.T)
 	_, parseErr := ReadFileWithinRoot("detector", root, "cfg.json")
 	if parseErr == nil {
 		t.Fatal("expected file_not_found parse error")
+		return
 	}
-	if parseErr.Kind != "file_not_found" {
-		t.Fatalf("expected file_not_found kind, got %#v", parseErr)
+	got := *parseErr
+	if got.Kind != "file_not_found" {
+		t.Fatalf("expected file_not_found kind, got %#v", got)
 	}
 }
 
@@ -228,9 +242,11 @@ func TestReadFileWithinRootPermissionDenied(t *testing.T) {
 	_, parseErr := ReadFileWithinRoot("detector", root, "cfg.json")
 	if parseErr == nil {
 		t.Fatal("expected permission parse error")
+		return
 	}
-	if parseErr.Kind != "permission_denied" {
-		t.Fatalf("expected permission_denied kind, got %#v", parseErr)
+	got := *parseErr
+	if got.Kind != "permission_denied" {
+		t.Fatalf("expected permission_denied kind, got %#v", got)
 	}
 }
 

--- a/core/detect/workflowcap/analyze_test.go
+++ b/core/detect/workflowcap/analyze_test.go
@@ -176,9 +176,11 @@ func TestAnalyzeMalformedWorkflowReturnsParseError(t *testing.T) {
 	_, parseErr := Analyze(".github/workflows/bad.yml", []byte("jobs:\n  build:\n    steps: ["))
 	if parseErr == nil {
 		t.Fatal("expected parse error")
+		return
 	}
-	if parseErr.Kind != "parse_error" {
-		t.Fatalf("expected parse_error kind, got %+v", parseErr)
+	got := *parseErr
+	if got.Kind != "parse_error" {
+		t.Fatalf("expected parse_error kind, got %+v", got)
 	}
 }
 

--- a/core/lifecycle/lifecycle_test.go
+++ b/core/lifecycle/lifecycle_test.go
@@ -212,12 +212,15 @@ func TestReconcileLegacyAgentIDMigrationDoesNotFanOutApprovalState(t *testing.T)
 	}
 	if migrated == nil || fresh == nil {
 		t.Fatalf("expected deterministic successors, got %+v", next.Identities)
+		return
 	}
-	if migrated.Status != identity.StateActive {
-		t.Fatalf("expected first successor to inherit approved semantics, got %+v", *migrated)
+	migratedRecord := *migrated
+	freshRecord := *fresh
+	if migratedRecord.Status != identity.StateActive {
+		t.Fatalf("expected first successor to inherit approved semantics, got %+v", migratedRecord)
 	}
-	if fresh.Status != identity.StateDiscovered || fresh.ApprovalState != "missing" {
-		t.Fatalf("expected additional successor to persist discovered, got %+v", *fresh)
+	if freshRecord.Status != identity.StateDiscovered || freshRecord.ApprovalState != "missing" {
+		t.Fatalf("expected additional successor to persist discovered, got %+v", freshRecord)
 	}
 
 	var migratedTrigger, freshTrigger string

--- a/core/report/activation_test.go
+++ b/core/report/activation_test.go
@@ -55,21 +55,23 @@ func TestBuildActivationPrefersConcreteMySetupSignals(t *testing.T) {
 	}, nil, nil, 5)
 	if activation == nil {
 		t.Fatal("expected activation summary for my_setup target")
+		return
 	}
-	if !activation.SuppressedPolicyItems {
+	got := *activation
+	if !got.SuppressedPolicyItems {
 		t.Fatal("expected policy-only findings to be suppressed when concrete items exist")
 	}
-	if activation.EligibleCount != 2 {
-		t.Fatalf("expected 2 eligible items, got %d", activation.EligibleCount)
+	if got.EligibleCount != 2 {
+		t.Fatalf("expected 2 eligible items, got %d", got.EligibleCount)
 	}
-	if len(activation.Items) != 2 {
-		t.Fatalf("expected 2 activation items, got %d", len(activation.Items))
+	if len(got.Items) != 2 {
+		t.Fatalf("expected 2 activation items, got %d", len(got.Items))
 	}
-	if activation.Items[0].ToolType == "policy" || activation.Items[1].ToolType == "policy" {
-		t.Fatalf("policy findings must not appear in activation items: %+v", activation.Items)
+	if got.Items[0].ToolType == "policy" || got.Items[1].ToolType == "policy" {
+		t.Fatalf("policy findings must not appear in activation items: %+v", got.Items)
 	}
-	if activation.Items[0].FindingType != "mcp_server" {
-		t.Fatalf("expected first concrete activation item to preserve ranked order, got %+v", activation.Items[0])
+	if got.Items[0].FindingType != "mcp_server" {
+		t.Fatalf("expected first concrete activation item to preserve ranked order, got %+v", got.Items[0])
 	}
 }
 
@@ -90,12 +92,14 @@ func TestBuildActivationReturnsReasonWhenOnlyPolicyItemsExist(t *testing.T) {
 	}, nil, nil, 5)
 	if activation == nil {
 		t.Fatal("expected activation summary for my_setup target")
+		return
 	}
-	if activation.Reason != activationReasonNoConcreteItems {
-		t.Fatalf("unexpected activation reason: %+v", activation)
+	got := *activation
+	if got.Reason != activationReasonNoConcreteItems {
+		t.Fatalf("unexpected activation reason: %+v", got)
 	}
-	if len(activation.Items) != 0 {
-		t.Fatalf("expected no activation items, got %+v", activation.Items)
+	if len(got.Items) != 0 {
+		t.Fatalf("expected no activation items, got %+v", got.Items)
 	}
 }
 
@@ -105,9 +109,11 @@ func TestBuildActivationReturnsNilOutsideMySetup(t *testing.T) {
 	activation := BuildActivation("path", nil, nil, nil, 5)
 	if activation == nil {
 		t.Fatal("expected deterministic empty activation summary for path target")
+		return
 	}
-	if activation.Reason != activationReasonNoGovernFirst {
-		t.Fatalf("unexpected activation reason: %+v", activation)
+	got := *activation
+	if got.Reason != activationReasonNoGovernFirst {
+		t.Fatalf("unexpected activation reason: %+v", got)
 	}
 }
 
@@ -162,17 +168,19 @@ func TestBuildActivationAddsGovernFirstOrgItems(t *testing.T) {
 	activation := BuildActivation("org", nil, inventory, nil, 5)
 	if activation == nil {
 		t.Fatal("expected activation summary for org target")
+		return
 	}
-	if activation.TargetMode != "org" {
-		t.Fatalf("unexpected target mode: %+v", activation)
+	got := *activation
+	if got.TargetMode != "org" {
+		t.Fatalf("unexpected target mode: %+v", got)
 	}
-	if activation.EligibleCount != 2 || len(activation.Items) != 2 {
-		t.Fatalf("expected 2 govern-first items, got %+v", activation)
+	if got.EligibleCount != 2 || len(got.Items) != 2 {
+		t.Fatalf("expected 2 govern-first items, got %+v", got)
 	}
-	if activation.Items[0].ItemClass != activationClassProductionBacked {
-		t.Fatalf("expected production-target-backed item first, got %+v", activation.Items[0])
+	if got.Items[0].ItemClass != activationClassProductionBacked {
+		t.Fatalf("expected production-target-backed item first, got %+v", got.Items[0])
 	}
-	if activation.Items[1].ItemClass != activationClassUnknownWrite {
-		t.Fatalf("expected unknown-to-security item second, got %+v", activation.Items[1])
+	if got.Items[1].ItemClass != activationClassUnknownWrite {
+		t.Fatalf("expected unknown-to-security item second, got %+v", got.Items[1])
 	}
 }

--- a/core/report/report_test.go
+++ b/core/report/report_test.go
@@ -534,20 +534,22 @@ func TestBuildAgentActionBOMDerivesStableItemsFromSummary(t *testing.T) {
 	}
 	if first == nil {
 		t.Fatal("expected non-nil BOM")
+		return
 	}
-	if first.BOMID == "" || first.SchemaVersion != AgentActionBOMSchemaVersion {
-		t.Fatalf("unexpected BOM identity: %+v", first)
+	firstBOM := *first
+	if firstBOM.BOMID == "" || firstBOM.SchemaVersion != AgentActionBOMSchemaVersion {
+		t.Fatalf("unexpected BOM identity: %+v", firstBOM)
 	}
-	if len(first.Items) != 2 {
-		t.Fatalf("expected two BOM items, got %+v", first.Items)
+	if len(firstBOM.Items) != 2 {
+		t.Fatalf("expected two BOM items, got %+v", firstBOM.Items)
 	}
-	if first.Items[0].PathID != "apc-200000" {
-		t.Fatalf("expected govern-first ordering to be preserved, got %+v", first.Items)
+	if firstBOM.Items[0].PathID != "apc-200000" {
+		t.Fatalf("expected govern-first ordering to be preserved, got %+v", firstBOM.Items)
 	}
-	if first.Summary.ControlFirstItems != 1 || first.Summary.StandingPrivilegeItems != 1 || first.Summary.RuntimeProvenItems != 1 {
-		t.Fatalf("unexpected BOM summary counts: %+v", first.Summary)
+	if firstBOM.Summary.ControlFirstItems != 1 || firstBOM.Summary.StandingPrivilegeItems != 1 || firstBOM.Summary.RuntimeProvenItems != 1 {
+		t.Fatalf("unexpected BOM summary counts: %+v", firstBOM.Summary)
 	}
-	if !containsStringValue(first.Items[0].GraphRefs.NodeIDs, "node-1") || !containsStringValue(first.Items[0].ProofRefs, "path:apc-200000") {
+	if !containsStringValue(firstBOM.Items[0].GraphRefs.NodeIDs, "node-1") || !containsStringValue(firstBOM.Items[0].ProofRefs, "path:apc-200000") {
 		t.Fatalf("expected graph refs and path-specific proof refs on BOM item, got %+v", first.Items[0])
 	}
 	if !containsStringValue(first.ProofRefs, "proof_head:sha256:abc123") {
@@ -1330,18 +1332,20 @@ func TestBuildAssessmentSummaryIsPathCentricAndDeterministic(t *testing.T) {
 	summary := buildAssessmentSummary(paths, controlFirst, inventory, ProofReference{ChainPath: "state/proof-chain.json"})
 	if summary == nil {
 		t.Fatal("expected assessment summary")
+		return
 	}
-	if summary.GovernablePathCount != 2 || summary.WriteCapablePathCount != 1 || summary.ProductionBackedPathCount != 0 {
-		t.Fatalf("unexpected assessment counts: %+v", summary)
+	got := *summary
+	if got.GovernablePathCount != 2 || got.WriteCapablePathCount != 1 || got.ProductionBackedPathCount != 0 {
+		t.Fatalf("unexpected assessment counts: %+v", got)
 	}
-	if summary.TopPathToControlFirst == nil || summary.TopPathToControlFirst.PathID != paths[0].PathID {
-		t.Fatalf("expected top path to control first to point at %q, got %+v", paths[0].PathID, summary.TopPathToControlFirst)
+	if got.TopPathToControlFirst == nil || got.TopPathToControlFirst.PathID != paths[0].PathID {
+		t.Fatalf("expected top path to control first to point at %q, got %+v", paths[0].PathID, got.TopPathToControlFirst)
 	}
-	if summary.TopExecutionIdentityBacked == nil || summary.TopExecutionIdentityBacked.PathID != paths[1].PathID {
-		t.Fatalf("expected top execution-identity-backed path to point at %q, got %+v", paths[1].PathID, summary.TopExecutionIdentityBacked)
+	if got.TopExecutionIdentityBacked == nil || got.TopExecutionIdentityBacked.PathID != paths[1].PathID {
+		t.Fatalf("expected top execution-identity-backed path to point at %q, got %+v", paths[1].PathID, got.TopExecutionIdentityBacked)
 	}
-	if summary.OwnerlessExposure == nil || summary.OwnerlessExposure.ExplicitOwnerPaths != 1 || summary.OwnerlessExposure.InferredOwnerPaths != 1 {
-		t.Fatalf("expected ownerless exposure rollup, got %+v", summary.OwnerlessExposure)
+	if got.OwnerlessExposure == nil || got.OwnerlessExposure.ExplicitOwnerPaths != 1 || got.OwnerlessExposure.InferredOwnerPaths != 1 {
+		t.Fatalf("expected ownerless exposure rollup, got %+v", got.OwnerlessExposure)
 	}
 	if summary.IdentityExposureSummary == nil || summary.IdentityExposureSummary.TotalNonHumanIdentitiesObserved != 1 || summary.IdentityExposureSummary.IdentitiesBackingWriteCapablePaths != 1 {
 		t.Fatalf("expected identity exposure summary, got %+v", summary.IdentityExposureSummary)

--- a/core/risk/action_paths_test.go
+++ b/core/risk/action_paths_test.go
@@ -218,9 +218,11 @@ func TestBuildActionPathsDeduplicatesRepeatedEntriesAndStabilizesPathID(t *testi
 	}
 	if firstChoice == nil {
 		t.Fatal("expected control-first choice after dedupe")
+		return
 	}
-	if firstChoice.Path.PathID != firstPaths[0].PathID {
-		t.Fatalf("expected control-first choice to reference deduped path row, choice=%+v paths=%+v", firstChoice.Path, firstPaths)
+	selectedFirstChoice := *firstChoice
+	if selectedFirstChoice.Path.PathID != firstPaths[0].PathID {
+		t.Fatalf("expected control-first choice to reference deduped path row, choice=%+v paths=%+v", selectedFirstChoice.Path, firstPaths)
 	}
 	if firstPaths[0].PathID != secondPaths[0].PathID {
 		t.Fatalf("expected path_id to remain stable across repeat runs, first=%s second=%s", firstPaths[0].PathID, secondPaths[0].PathID)
@@ -231,8 +233,13 @@ func TestBuildActionPathsDeduplicatesRepeatedEntriesAndStabilizesPathID(t *testi
 	if !maps.Equal(sliceToSet(firstPaths[0].ApprovalGapReasons), sliceToSet([]string{"approval_source_missing", "deployment_gate_missing"})) {
 		t.Fatalf("expected merged approval gap reasons, got %+v", firstPaths[0].ApprovalGapReasons)
 	}
-	if secondChoice == nil || secondChoice.Path.PathID != secondPaths[0].PathID {
+	if secondChoice == nil {
 		t.Fatalf("expected repeat run control-first choice to reference deduped path, choice=%+v paths=%+v", secondChoice, secondPaths)
+		return
+	}
+	selectedSecondChoice := *secondChoice
+	if selectedSecondChoice.Path.PathID != secondPaths[0].PathID {
+		t.Fatalf("expected repeat run control-first choice to reference deduped path, choice=%+v paths=%+v", selectedSecondChoice, secondPaths)
 	}
 }
 

--- a/core/risk/govern_first_test.go
+++ b/core/risk/govern_first_test.go
@@ -125,21 +125,23 @@ func TestBuildIdentityExposureSummaryAndTargets(t *testing.T) {
 	})
 	if summary == nil {
 		t.Fatal("expected identity exposure summary")
+		return
 	}
-	if summary.TotalNonHumanIdentitiesObserved != 3 {
-		t.Fatalf("expected total identities=3, got %+v", summary)
+	got := *summary
+	if got.TotalNonHumanIdentitiesObserved != 3 {
+		t.Fatalf("expected total identities=3, got %+v", got)
 	}
-	if summary.IdentitiesBackingWriteCapablePaths != 2 {
-		t.Fatalf("expected write-backed identities=2, got %+v", summary)
+	if got.IdentitiesBackingWriteCapablePaths != 2 {
+		t.Fatalf("expected write-backed identities=2, got %+v", got)
 	}
-	if summary.IdentitiesBackingDeployCapablePaths != 1 {
-		t.Fatalf("expected deploy-backed identities=1, got %+v", summary)
+	if got.IdentitiesBackingDeployCapablePaths != 1 {
+		t.Fatalf("expected deploy-backed identities=1, got %+v", got)
 	}
-	if summary.IdentitiesWithUnresolvedOwnership != 1 {
-		t.Fatalf("expected unresolved-owner identities=1, got %+v", summary)
+	if got.IdentitiesWithUnresolvedOwnership != 1 {
+		t.Fatalf("expected unresolved-owner identities=1, got %+v", got)
 	}
-	if summary.IdentitiesWithUnknownExecutionLinked != 1 {
-		t.Fatalf("expected unknown execution correlation identities=1, got %+v", summary)
+	if got.IdentitiesWithUnknownExecutionLinked != 1 {
+		t.Fatalf("expected unknown execution correlation identities=1, got %+v", got)
 	}
 
 	review, revoke := BuildIdentityActionTargets(paths)
@@ -243,9 +245,11 @@ func TestBuildIdentityExposureSummarySeparatesOrgs(t *testing.T) {
 	})
 	if summary == nil {
 		t.Fatal("expected identity exposure summary")
+		return
 	}
-	if summary.TotalNonHumanIdentitiesObserved != 2 {
-		t.Fatalf("expected org-scoped identity totals=2, got %+v", summary)
+	got := *summary
+	if got.TotalNonHumanIdentitiesObserved != 2 {
+		t.Fatalf("expected org-scoped identity totals=2, got %+v", got)
 	}
 
 	review, revoke := BuildIdentityActionTargets(paths)

--- a/core/risk/risk_test.go
+++ b/core/risk/risk_test.go
@@ -327,15 +327,17 @@ func TestBuildActionPathsRanksAndSelectsControlFirst(t *testing.T) {
 	}
 	if choice == nil {
 		t.Fatal("expected action_path_to_control_first")
+		return
 	}
+	selectedChoice := *choice
 	if actionPaths[0].RecommendedAction != "control" {
 		t.Fatalf("expected control-ranked action path first, got %+v", actionPaths[0])
 	}
-	if choice.Path.RecommendedAction != "control" {
-		t.Fatalf("expected control-first choice, got %+v", choice.Path)
+	if selectedChoice.Path.RecommendedAction != "control" {
+		t.Fatalf("expected control-first choice, got %+v", selectedChoice.Path)
 	}
-	if choice.Summary.TotalPaths != 2 || choice.Summary.WriteCapablePaths != 2 || choice.Summary.ProductionTargetBackedPaths != 1 {
-		t.Fatalf("unexpected action-path summary: %+v", choice.Summary)
+	if selectedChoice.Summary.TotalPaths != 2 || selectedChoice.Summary.WriteCapablePaths != 2 || selectedChoice.Summary.ProductionTargetBackedPaths != 1 {
+		t.Fatalf("unexpected action-path summary: %+v", selectedChoice.Summary)
 	}
 }
 

--- a/internal/ci/actionruntime/check.go
+++ b/internal/ci/actionruntime/check.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -13,8 +14,10 @@ import (
 const (
 	IssueDeprecatedRuntimeUse  = "deprecated runtime use"
 	IssueDisallowedOverride    = "disallowed override policy"
+	IssueMovingRefException    = "moving action ref requires exception"
 	defaultWorkflowPatternYML  = ".github/workflows/*.yml"
 	defaultWorkflowPatternYAML = ".github/workflows/*.yaml"
+	defaultExceptionRegistry   = ".github/action-ref-exceptions.yaml"
 )
 
 var deprecatedRefs = map[string]struct{}{
@@ -61,8 +64,31 @@ type workflowStep struct {
 	Env  map[string]any `yaml:"env"`
 }
 
+type actionRefExceptionRegistry struct {
+	Exceptions []actionRefException `yaml:"exceptions"`
+}
+
+type actionRefException struct {
+	Action        string `yaml:"action"`
+	Workflow      string `yaml:"workflow"`
+	Owner         string `yaml:"owner"`
+	Reason        string `yaml:"reason"`
+	Scope         string `yaml:"scope"`
+	Expires       string `yaml:"expires"`
+	ReviewCommand string `yaml:"review_command"`
+}
+
+type actionRefExceptionKey struct {
+	workflow string
+	action   string
+}
+
 func Scan(root string) ([]Finding, error) {
 	files, err := workflowFiles(root)
+	if err != nil {
+		return nil, err
+	}
+	exceptions, err := loadActionRefExceptions(root)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +114,7 @@ func Scan(root string) ([]Finding, error) {
 		}
 
 		findings = append(findings, collectEnvFindings(path, "workflow env", wf.Env)...)
-		findings = append(findings, collectJobFindings(path, wf.Jobs)...)
+		findings = append(findings, collectJobFindings(path, wf.Jobs, exceptions)...)
 	}
 
 	sort.Slice(findings, func(i, j int) bool {
@@ -142,7 +168,7 @@ func workflowFiles(root string) ([]string, error) {
 	return files, nil
 }
 
-func collectJobFindings(relPath string, jobs map[string]workflowJob) []Finding {
+func collectJobFindings(relPath string, jobs map[string]workflowJob, exceptions map[actionRefExceptionKey]actionRefException) []Finding {
 	jobNames := make([]string, 0, len(jobs))
 	for name := range jobs {
 		jobNames = append(jobNames, name)
@@ -154,11 +180,11 @@ func collectJobFindings(relPath string, jobs map[string]workflowJob) []Finding {
 		job := jobs[jobName]
 		findings = append(findings, collectEnvFindings(relPath, "job "+jobName+" env", job.Env)...)
 		for idx, step := range job.Steps {
+			location := fmt.Sprintf("job %s step %d", jobName, idx+1)
+			if strings.TrimSpace(step.Name) != "" {
+				location += " " + strings.TrimSpace(step.Name)
+			}
 			if _, blocked := deprecatedRefs[strings.TrimSpace(step.Uses)]; blocked {
-				location := fmt.Sprintf("job %s step %d", jobName, idx+1)
-				if strings.TrimSpace(step.Name) != "" {
-					location += " " + strings.TrimSpace(step.Name)
-				}
 				findings = append(findings, Finding{
 					Issue:    IssueDeprecatedRuntimeUse,
 					Path:     relPath,
@@ -166,11 +192,110 @@ func collectJobFindings(relPath string, jobs map[string]workflowJob) []Finding {
 					Location: location,
 				})
 			}
+			if finding, ok := movingActionRefFinding(relPath, strings.TrimSpace(step.Uses), location, exceptions); ok {
+				findings = append(findings, finding)
+			}
 			findings = append(findings, collectEnvFindings(relPath, "job "+jobName+" step "+stepLabel(idx, step.Name)+" env", step.Env)...)
 			findings = append(findings, collectRunFindings(relPath, jobName, idx, step)...)
 		}
 	}
 	return findings
+}
+
+func loadActionRefExceptions(root string) (map[actionRefExceptionKey]actionRefException, error) {
+	path := filepath.Join(root, defaultExceptionRegistry)
+	payload, err := os.ReadFile(path) // #nosec G304 -- registry path is fixed under the caller-selected repository root.
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[actionRefExceptionKey]actionRefException{}, nil
+		}
+		return nil, fmt.Errorf("read action-ref exception registry: %w", err)
+	}
+	var registry actionRefExceptionRegistry
+	if err := yaml.Unmarshal(payload, &registry); err != nil {
+		return nil, fmt.Errorf("parse action-ref exception registry: %w", err)
+	}
+	out := make(map[actionRefExceptionKey]actionRefException, len(registry.Exceptions))
+	for _, exception := range registry.Exceptions {
+		key := actionRefExceptionKey{
+			workflow: filepath.ToSlash(filepath.Clean(strings.TrimSpace(exception.Workflow))),
+			action:   strings.TrimSpace(exception.Action),
+		}
+		if key.workflow == "." || key.action == "" {
+			continue
+		}
+		out[key] = exception
+	}
+	return out, nil
+}
+
+func movingActionRefFinding(relPath, uses, location string, exceptions map[actionRefExceptionKey]actionRefException) (Finding, bool) {
+	if !requiresMovingRefException(relPath, uses) {
+		return Finding{}, false
+	}
+	exception, ok := exceptions[actionRefExceptionKey{workflow: filepath.ToSlash(filepath.Clean(relPath)), action: uses}]
+	if !ok {
+		return actionRefFinding(relPath, uses, "missing exception", location), true
+	}
+	if strings.TrimSpace(exception.Owner) == "" {
+		return actionRefFinding(relPath, uses, "missing owner", location), true
+	}
+	if strings.TrimSpace(exception.Reason) == "" {
+		return actionRefFinding(relPath, uses, "missing reason", location), true
+	}
+	if strings.TrimSpace(exception.Scope) == "" {
+		return actionRefFinding(relPath, uses, "missing scope", location), true
+	}
+	if strings.TrimSpace(exception.ReviewCommand) == "" {
+		return actionRefFinding(relPath, uses, "missing review command", location), true
+	}
+	expires, err := time.Parse("2006-01-02", strings.TrimSpace(exception.Expires))
+	if err != nil {
+		return actionRefFinding(relPath, uses, "invalid expiry", location), true
+	}
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	if expires.Before(today) {
+		return actionRefFinding(relPath, uses, "expired exception", location), true
+	}
+	return Finding{}, false
+}
+
+func requiresMovingRefException(relPath, uses string) bool {
+	if strings.TrimSpace(uses) == "" || !isMovingActionRef(uses) {
+		return false
+	}
+	switch filepath.ToSlash(filepath.Clean(relPath)) {
+	case ".github/workflows/release.yml", ".github/workflows/docs.yml":
+		return true
+	default:
+		return false
+	}
+}
+
+func isMovingActionRef(uses string) bool {
+	at := strings.LastIndex(uses, "@")
+	if at < 0 || at == len(uses)-1 {
+		return false
+	}
+	ref := strings.TrimSpace(uses[at+1:])
+	if len(ref) != 40 {
+		return true
+	}
+	for _, ch := range ref {
+		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') && (ch < 'A' || ch > 'F') {
+			return true
+		}
+	}
+	return false
+}
+
+func actionRefFinding(relPath, uses, reason, location string) Finding {
+	return Finding{
+		Issue:    IssueMovingRefException,
+		Path:     relPath,
+		Subject:  strings.TrimSpace(uses) + " (" + reason + ")",
+		Location: location,
+	}
 }
 
 func collectEnvFindings(relPath, location string, values map[string]any) []Finding {

--- a/product/dev_guides.md
+++ b/product/dev_guides.md
@@ -243,7 +243,7 @@ Use this sequence whenever updating governance-critical tool pins (`gosec`, `gol
 | Tool | Purpose | Version | Execution |
 |------|---------|---------|-----------|
 | gofmt | Code formatting | Bundled with Go | `gofmt -w .` |
-| go vet | Static analysis | Bundled with Go | `go vet ./...` |
+| go vet | Static analysis | Bundled with Go | `go vet $(scripts/first_party_go_packages.sh)` |
 | golangci-lint | Lint aggregator | `v2.0.1` | `golangci-lint run ./...` |
 | gosec | Security static analysis | `v2.23.0` | `gosec ./...` |
 | govulncheck | Vulnerability database | `v1.1.4` | `govulncheck -mode=binary ./<binary>` |
@@ -296,7 +296,7 @@ Tests are organized into tiers by scope, speed, and when they run.
 ### Tier 1 — Unit
 
 - **What**: isolated component tests.
-- **How**: `go test ./...` (Go), `pytest` (Python).
+- **How**: `go test $(scripts/first_party_go_packages.sh)` (Go), `pytest` (Python).
 - **When**: every PR, every push, pre-push hook.
 - **Flags**: default (cached, parallel).
 
@@ -569,7 +569,7 @@ These minimums are for v1 launch. Scenario count grows with product surface — 
 ### Golden File Pattern
 
 - Assertion: `AssertGoldenJSON(t, repoRelativePath, value)` compares normalized JSON byte-for-byte.
-- Update: `UPDATE_GOLDEN=1 go test ./...` regenerates golden files.
+- Update: `UPDATE_GOLDEN=1 go test $(scripts/first_party_go_packages.sh)` regenerates golden files.
 - Platform normalization: newlines normalized before comparison.
 - Location: `testdata/` directories within each package, or `internal/integration/testdata/` for integration goldens.
 
@@ -631,10 +631,15 @@ Sequence:
   - `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`
   - `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION`
 - If an upstream action required for release/docs operations does not yet publish a Node24-ready release, the exception must be:
-  - explicit in repo docs
+  - explicit in `.github/action-ref-exceptions.yaml`
+  - assigned to an owner role
   - bounded to the minimum required workflows
+  - scoped to the exact action ref and workflow path
+  - given an expiry date
+  - paired with a review command that produces repeatable evidence
   - revisited on each runtime-uplift PR
   - accompanied by rerun evidence for the affected workflow class before merge
+- Expired, ownerless, scope-less, or review-less release/docs action-ref exceptions fail `scripts/check_actions_runtime.sh`.
 
 ## Pre-Push Enforcement
 

--- a/scripts/check_repo_hygiene.sh
+++ b/scripts/check_repo_hygiene.sh
@@ -41,3 +41,20 @@ if [[ -n "${tracked_wrkr_state}" ]]; then
   echo "${tracked_wrkr_state}" >&2
   exit 3
 fi
+
+license_markers=(
+  "1. Definitions."
+  "2. Grant of Copyright License."
+  "3. Grant of Patent License."
+  "4. Redistribution."
+  "7. Disclaimer of Warranty."
+  "8. Limitation of Liability."
+  "APPENDIX: How to apply the Apache License to your work."
+)
+
+for marker in "${license_markers[@]}"; do
+  if ! grep -Fq "$marker" LICENSE; then
+    echo "LICENSE missing Apache-2.0 full-text marker: $marker" >&2
+    exit 3
+  fi
+done

--- a/scripts/first_party_go_packages.sh
+++ b/scripts/first_party_go_packages.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+go_cmd="${GO:-go}"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root"
+
+roots=(
+  "cmd"
+  "core"
+  "internal"
+  "testinfra"
+  "scripts"
+  "scenarios"
+)
+
+patterns=()
+for root in "${roots[@]}"; do
+  if [[ ! -d "$root" ]]; then
+    echo "missing first-party Go package root: $root" >&2
+    exit 3
+  fi
+  patterns+=("./${root}/...")
+done
+
+"$go_cmd" list "${patterns[@]}"

--- a/scripts/first_party_go_packages.sh
+++ b/scripts/first_party_go_packages.sh
@@ -23,4 +23,6 @@ for root in "${roots[@]}"; do
   patterns+=("./${root}/...")
 done
 
-"$go_cmd" list "${patterns[@]}"
+"$go_cmd" list "${patterns[@]}" >/dev/null
+
+printf '%s\n' "${patterns[@]}"

--- a/scripts/run_docs_smoke.sh
+++ b/scripts/run_docs_smoke.sh
@@ -28,12 +28,14 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
 fixture_path="scenarios/wrkr/scan-mixed-org/repos"
 state_path="$tmp_dir/state.json"
-target_state_path="$tmp_dir/target-state.json"
+target_dir="$tmp_dir/target"
+target_state_path="$target_dir/target-state.json"
 config_path="$tmp_dir/config.yaml"
 baseline_path="$tmp_dir/wrkr-regress-baseline.json"
 evidence_dir="$tmp_dir/evidence"
 report_pdf="$tmp_dir/wrkr-report.pdf"
 manifest_path="$tmp_dir/wrkr-manifest.yaml"
+mkdir -p "$target_dir"
 
 "$bin_path" init --non-interactive --path "$fixture_path" --config "$config_path" --json >/dev/null
 "$bin_path" scan --path "$fixture_path" --state "$state_path" --json >"$tmp_dir/scan.json"

--- a/scripts/run_v1_acceptance.sh
+++ b/scripts/run_v1_acceptance.sh
@@ -102,7 +102,7 @@ if run_cmd "lane_fast" "make lint-fast"; then
 fi
 
 # Core lane checks.
-if run_cmd "lane_core" "go test ./... -count=1"; then
+if run_cmd "lane_core" "go test \$(scripts/first_party_go_packages.sh) -count=1"; then
   lane_core="pass"
 fi
 

--- a/scripts/test_uat_local.sh
+++ b/scripts/test_uat_local.sh
@@ -234,7 +234,7 @@ run_go_install_smoke() {
 
 if [[ "$skip_global_gates" != "true" ]]; then
   make lint-fast
-  go test ./... -count=1
+  go test $(scripts/first_party_go_packages.sh) -count=1
   make test-contracts
   scripts/validate_contracts.sh
   scripts/validate_scenarios.sh

--- a/testinfra/contracts/story1_contracts_test.go
+++ b/testinfra/contracts/story1_contracts_test.go
@@ -217,7 +217,9 @@ func TestActionPathsRemainUniqueForFrozenAgentEcosystemSubset(t *testing.T) {
 	}
 	if choice == nil {
 		t.Fatal("expected action_path_to_control_first output for frozen subset fixture")
+		return
 	}
+	selectedChoice := *choice
 
 	seen := map[string]struct{}{}
 	for _, path := range paths {
@@ -229,8 +231,8 @@ func TestActionPathsRemainUniqueForFrozenAgentEcosystemSubset(t *testing.T) {
 		}
 		seen[path.PathID] = struct{}{}
 	}
-	if choice.Path.PathID != paths[0].PathID {
-		t.Fatalf("expected control-first path to reference sorted action_paths row, choice=%+v paths=%+v", choice.Path, paths)
+	if selectedChoice.Path.PathID != paths[0].PathID {
+		t.Fatalf("expected control-first path to reference sorted action_paths row, choice=%+v paths=%+v", selectedChoice.Path, paths)
 	}
 }
 

--- a/testinfra/hygiene/actions_runtime_test.go
+++ b/testinfra/hygiene/actions_runtime_test.go
@@ -185,6 +185,143 @@ func TestCheckActionsRuntimePassesOnNode24ReadyRefs(t *testing.T) {
 	}
 }
 
+func TestMovingActionRefRequiresOwnedExpiryException(t *testing.T) {
+	t.Parallel()
+
+	fixtureRoot := t.TempDir()
+	writeWorkflowFixture(t, fixtureRoot, ".github/workflows/release.yml", releaseWorkflowWithAction("anchore/sbom-action@v0"))
+
+	_, stderr, err := runActionsRuntimeCheck(t, fixtureRoot)
+	if err == nil {
+		t.Fatal("expected runtime check to fail on moving release action without exception")
+	}
+	expected := "moving action ref requires exception: .github/workflows/release.yml -> anchore/sbom-action@v0 (missing exception)"
+	if !strings.Contains(stderr, expected) {
+		t.Fatalf("expected deterministic missing-exception message %q, got %q", expected, stderr)
+	}
+}
+
+func TestMovingActionRefExceptionRequiresOwner(t *testing.T) {
+	t.Parallel()
+
+	fixtureRoot := t.TempDir()
+	writeWorkflowFixture(t, fixtureRoot, ".github/workflows/release.yml", releaseWorkflowWithAction("anchore/sbom-action@v0"))
+	writeActionRefExceptionFixture(t, fixtureRoot, strings.Join([]string{
+		"exceptions:",
+		"  - workflow: .github/workflows/release.yml",
+		"    action: anchore/sbom-action@v0",
+		"    reason: scanner compatibility review",
+		"    scope: SBOM only",
+		"    expires: 2099-01-01",
+		"    review_command: scripts/check_actions_runtime.sh",
+		"",
+	}, "\n"))
+
+	_, stderr, err := runActionsRuntimeCheck(t, fixtureRoot)
+	if err == nil {
+		t.Fatal("expected runtime check to fail on exception without owner")
+	}
+	expected := "anchore/sbom-action@v0 (missing owner)"
+	if !strings.Contains(stderr, expected) {
+		t.Fatalf("expected missing-owner message %q, got %q", expected, stderr)
+	}
+}
+
+func TestExpiredActionRefExceptionFails(t *testing.T) {
+	t.Parallel()
+
+	fixtureRoot := t.TempDir()
+	writeWorkflowFixture(t, fixtureRoot, ".github/workflows/release.yml", releaseWorkflowWithAction("anchore/sbom-action@v0"))
+	writeActionRefExceptionFixture(t, fixtureRoot, strings.Join([]string{
+		"exceptions:",
+		"  - workflow: .github/workflows/release.yml",
+		"    action: anchore/sbom-action@v0",
+		"    owner: release-engineering",
+		"    reason: scanner compatibility review",
+		"    scope: SBOM only",
+		"    expires: 2000-01-01",
+		"    review_command: scripts/check_actions_runtime.sh",
+		"",
+	}, "\n"))
+
+	_, stderr, err := runActionsRuntimeCheck(t, fixtureRoot)
+	if err == nil {
+		t.Fatal("expected runtime check to fail on expired exception")
+	}
+	expected := "anchore/sbom-action@v0 (expired exception)"
+	if !strings.Contains(stderr, expected) {
+		t.Fatalf("expected expired-exception message %q, got %q", expected, stderr)
+	}
+}
+
+func TestActionRefExceptionScopeMustMatchWorkflow(t *testing.T) {
+	t.Parallel()
+
+	fixtureRoot := t.TempDir()
+	writeWorkflowFixture(t, fixtureRoot, ".github/workflows/release.yml", releaseWorkflowWithAction("anchore/sbom-action@v0"))
+	writeActionRefExceptionFixture(t, fixtureRoot, strings.Join([]string{
+		"exceptions:",
+		"  - workflow: .github/workflows/docs.yml",
+		"    action: anchore/sbom-action@v0",
+		"    owner: release-engineering",
+		"    reason: scanner compatibility review",
+		"    scope: SBOM only",
+		"    expires: 2099-01-01",
+		"    review_command: scripts/check_actions_runtime.sh",
+		"",
+	}, "\n"))
+
+	_, stderr, err := runActionsRuntimeCheck(t, fixtureRoot)
+	if err == nil {
+		t.Fatal("expected runtime check to fail when exception names a different workflow")
+	}
+	expected := "anchore/sbom-action@v0 (missing exception)"
+	if !strings.Contains(stderr, expected) {
+		t.Fatalf("expected workflow-scope mismatch to look like missing exact exception %q, got %q", expected, stderr)
+	}
+}
+
+func TestPinnedActionRefDoesNotRequireException(t *testing.T) {
+	t.Parallel()
+
+	fixtureRoot := t.TempDir()
+	writeWorkflowFixture(t, fixtureRoot, ".github/workflows/release.yml", releaseWorkflowWithAction("actions/checkout@0123456789abcdef0123456789abcdef01234567"))
+
+	stdout, stderr, err := runActionsRuntimeCheck(t, fixtureRoot)
+	if err != nil {
+		t.Fatalf("expected pinned action to pass without exception, got err=%v stderr=%q", err, stderr)
+	}
+	if !strings.Contains(stdout, "github actions runtime contract: pass") {
+		t.Fatalf("expected pass marker, got stdout=%q", stdout)
+	}
+}
+
+func TestActiveActionRefExceptionAllowsMovingReleaseRef(t *testing.T) {
+	t.Parallel()
+
+	fixtureRoot := t.TempDir()
+	writeWorkflowFixture(t, fixtureRoot, ".github/workflows/release.yml", releaseWorkflowWithAction("anchore/sbom-action@v0"))
+	writeActionRefExceptionFixture(t, fixtureRoot, strings.Join([]string{
+		"exceptions:",
+		"  - workflow: .github/workflows/release.yml",
+		"    action: anchore/sbom-action@v0",
+		"    owner: release-engineering",
+		"    reason: scanner compatibility review",
+		"    scope: SBOM only",
+		"    expires: 2099-01-01",
+		"    review_command: scripts/check_actions_runtime.sh",
+		"",
+	}, "\n"))
+
+	stdout, stderr, err := runActionsRuntimeCheck(t, fixtureRoot)
+	if err != nil {
+		t.Fatalf("expected active exception to pass, got err=%v stderr=%q", err, stderr)
+	}
+	if !strings.Contains(stdout, "github actions runtime contract: pass") {
+		t.Fatalf("expected pass marker, got stdout=%q", stdout)
+	}
+}
+
 func writeWorkflowFixture(t *testing.T, root, relPath, content string) {
 	t.Helper()
 
@@ -195,6 +332,25 @@ func writeWorkflowFixture(t *testing.T, root, relPath, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
+}
+
+func writeActionRefExceptionFixture(t *testing.T, root string, content string) {
+	t.Helper()
+
+	writeWorkflowFixture(t, root, ".github/action-ref-exceptions.yaml", content)
+}
+
+func releaseWorkflowWithAction(action string) string {
+	return strings.Join([]string{
+		"name: release",
+		"jobs:",
+		"  release-artifacts:",
+		"    runs-on: ubuntu-latest",
+		"    steps:",
+		"      - name: Release action",
+		"        uses: " + action,
+		"",
+	}, "\n")
 }
 
 func runActionsRuntimeCheck(t *testing.T, workflowRoot string) (string, string, error) {

--- a/testinfra/hygiene/go_package_scope_test.go
+++ b/testinfra/hygiene/go_package_scope_test.go
@@ -1,0 +1,104 @@
+package hygiene
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFirstPartyGoPackagesExcludeDocsSiteNodeModules(t *testing.T) {
+	repoRoot := mustFindRepoRoot(t)
+	fixturePath := filepath.Join(repoRoot, "docs-site", "node_modules", "flatted", "golang", "pkg", "flatted", "flatted.go")
+	if err := os.MkdirAll(filepath.Dir(fixturePath), 0o755); err != nil {
+		t.Fatalf("mkdir node_modules fixture: %v", err)
+	}
+	if err := os.WriteFile(fixturePath, []byte("package flatted\n"), 0o644); err != nil {
+		t.Fatalf("write node_modules fixture: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Remove(fixturePath)
+	})
+
+	stdout, stderr, err := runFirstPartyPackageList(t, repoRoot)
+	if err != nil {
+		t.Fatalf("first-party package list failed: %v stderr=%q", err, stderr)
+	}
+	if strings.Contains(stdout, "docs-site/node_modules") {
+		t.Fatalf("first-party package list included generated docs-site dependency package:\n%s", stdout)
+	}
+}
+
+func TestFirstPartyGoPackagesIncludeTrackedRoots(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	stdout, stderr, err := runFirstPartyPackageList(t, repoRoot)
+	if err != nil {
+		t.Fatalf("first-party package list failed: %v stderr=%q", err, stderr)
+	}
+	packages := strings.Fields(stdout)
+	required := []string{
+		"github.com/Clyra-AI/wrkr/cmd/wrkr",
+		"github.com/Clyra-AI/wrkr/core/cli",
+		"github.com/Clyra-AI/wrkr/internal/ci/actionruntime",
+		"github.com/Clyra-AI/wrkr/testinfra/hygiene",
+		"github.com/Clyra-AI/wrkr/scripts",
+		"github.com/Clyra-AI/wrkr/scenarios/wrkr/webmcp-declarations/repos/route-repo/server",
+	}
+	for _, want := range required {
+		if !containsString(packages, want) {
+			t.Fatalf("first-party package list missing %s\npackages:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestWorkflowGoTestsUseFirstPartyPackageList(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	checkedPaths := []string{
+		".github/workflows/pr.yml",
+		".github/workflows/release.yml",
+		"scripts/run_v1_acceptance.sh",
+		"scripts/test_uat_local.sh",
+		"Makefile",
+	}
+	for _, rel := range checkedPaths {
+		payload := mustReadFile(t, filepath.Join(repoRoot, filepath.Clean(rel)))
+		if strings.Contains(payload, "go test ./...") || strings.Contains(payload, "go vet ./...") {
+			t.Fatalf("%s reintroduced unsafe root wildcard Go package discovery", rel)
+		}
+		if !strings.Contains(payload, "first_party_go_packages.sh") && rel != "Makefile" {
+			t.Fatalf("%s must consume scripts/first_party_go_packages.sh for Go package scope", rel)
+		}
+	}
+	makefile := mustReadFile(t, filepath.Join(repoRoot, "Makefile"))
+	if !strings.Contains(makefile, "PKG_LIST := scripts/first_party_go_packages.sh") {
+		t.Fatalf("Makefile must centralize Go package scope through scripts/first_party_go_packages.sh")
+	}
+}
+
+func runFirstPartyPackageList(t *testing.T, repoRoot string) (string, string, error) {
+	t.Helper()
+
+	cmd := exec.Command("bash", "scripts/first_party_go_packages.sh")
+	cmd.Dir = repoRoot
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/testinfra/hygiene/go_package_scope_test.go
+++ b/testinfra/hygiene/go_package_scope_test.go
@@ -31,7 +31,7 @@ func TestFirstPartyGoPackagesExcludeDocsSiteNodeModules(t *testing.T) {
 	}
 }
 
-func TestFirstPartyGoPackagesIncludeTrackedRoots(t *testing.T) {
+func TestFirstPartyGoPackagesEmitTrackedRootPatterns(t *testing.T) {
 	t.Parallel()
 
 	repoRoot := mustFindRepoRoot(t)
@@ -39,18 +39,23 @@ func TestFirstPartyGoPackagesIncludeTrackedRoots(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first-party package list failed: %v stderr=%q", err, stderr)
 	}
-	packages := strings.Fields(stdout)
+	patterns := strings.Fields(stdout)
 	required := []string{
-		"github.com/Clyra-AI/wrkr/cmd/wrkr",
-		"github.com/Clyra-AI/wrkr/core/cli",
-		"github.com/Clyra-AI/wrkr/internal/ci/actionruntime",
-		"github.com/Clyra-AI/wrkr/testinfra/hygiene",
-		"github.com/Clyra-AI/wrkr/scripts",
-		"github.com/Clyra-AI/wrkr/scenarios/wrkr/webmcp-declarations/repos/route-repo/server",
+		"./cmd/...",
+		"./core/...",
+		"./internal/...",
+		"./testinfra/...",
+		"./scripts/...",
+		"./scenarios/...",
 	}
 	for _, want := range required {
-		if !containsString(packages, want) {
-			t.Fatalf("first-party package list missing %s\npackages:\n%s", want, stdout)
+		if !containsString(patterns, want) {
+			t.Fatalf("first-party package list missing %s\npatterns:\n%s", want, stdout)
+		}
+	}
+	for _, pattern := range patterns {
+		if strings.HasPrefix(pattern, "github.com/Clyra-AI/wrkr/") {
+			t.Fatalf("first-party package list must emit repo-relative patterns, got %q", pattern)
 		}
 	}
 }

--- a/testinfra/hygiene/repo_hygiene_test.go
+++ b/testinfra/hygiene/repo_hygiene_test.go
@@ -52,6 +52,48 @@ func TestNoTrackedWrkrLocalState(t *testing.T) {
 	}
 }
 
+func TestLicenseContainsFullApache20Text(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	content, err := os.ReadFile(filepath.Join(repoRoot, "LICENSE"))
+	if err != nil {
+		t.Fatalf("read LICENSE: %v", err)
+	}
+	text := string(content)
+	requiredMarkers := []string{
+		"TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION",
+		"1. Definitions.",
+		"2. Grant of Copyright License.",
+		"3. Grant of Patent License.",
+		"4. Redistribution.",
+		"7. Disclaimer of Warranty.",
+		"8. Limitation of Liability.",
+		"APPENDIX: How to apply the Apache License to your work.",
+	}
+	for _, marker := range requiredMarkers {
+		if !strings.Contains(text, marker) {
+			t.Fatalf("LICENSE missing Apache-2.0 full-text marker %q", marker)
+		}
+	}
+}
+
+func TestOSSTrustBaselineIncludesCanonicalLicense(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	content, err := os.ReadFile(filepath.Join(repoRoot, "LICENSE"))
+	if err != nil {
+		t.Fatalf("read LICENSE: %v", err)
+	}
+	if len(strings.Split(string(content), "\n")) < 180 {
+		t.Fatalf("LICENSE appears abbreviated; expected canonical Apache-2.0 full text")
+	}
+	if strings.Contains(string(content), "See the License for the specific language governing permissions and limitations under the License.\n#") {
+		t.Fatalf("LICENSE appears to contain an abbreviated notice glued to another document")
+	}
+}
+
 func mustFindRepoRoot(t *testing.T) string {
 	t.Helper()
 


### PR DESCRIPTION
## Problem

Wrkr's proof and lifecycle write paths could leave managed artifacts partially updated after an interruption, our Go validation lanes could accidentally expand into docs-site dependency trees, and release/docs workflow action refs were not governed by an owned, expiring exception registry. The repository license file also needed to be restored to the canonical Apache-2.0 text for OSS trust tooling.

## Changes

- add managed-artifact transaction journaling, recovery, and consistency preflight/verification across scan, lifecycle, identity, report, score, regress, and verify flows
- add crash-consistency and mismatch coverage for scan and state mutation paths
- scope Go validation commands to first-party Wrkr packages via `scripts/first_party_go_packages.sh` across local, CI, release, docs smoke, and UAT lanes
- require owned, scoped, expiring action-ref exceptions for moving refs in release/docs workflows and add hygiene coverage for the registry
- restore the full Apache-2.0 license text and enforce it in repo hygiene checks
- update changelog and contributor/developer docs to match the new proof, validation, and workflow-governance rules

## Validation

- `make prepush-full`

## Risks

- managed-artifact recovery now fails closed when state, manifest, lifecycle, or proof artifacts disagree; this is intentional but touches several CLI read paths
- first-party Go package scoping intentionally excludes docs-site dependency trees from Go validation lanes
- release/docs moving action refs now require matching exception metadata in `.github/action-ref-exceptions.yaml`

## Submodule Notes

- `factory` submodule clean
- no submodule pointer changes in this PR
