### PR TITLE
fix: reduce managed artifact read overhead

### DIFF
--- a/core/cli/managed_artifacts.go
+++ b/core/cli/managed_artifacts.go
@@ -24,6 +24,13 @@ const (
 	managedArtifactTransactionName    = ".wrkr-managed-transaction.json"
 )
 
+type managedArtifactVerificationMode uint8
+
+const (
+	managedArtifactVerificationStructural managedArtifactVerificationMode = iota
+	managedArtifactVerificationFull
+)
+
 type managedArtifactSnapshot struct {
 	path    string
 	existed bool
@@ -323,10 +330,10 @@ func preflightManagedArtifactRead(statePath string) error {
 		}
 		return fmt.Errorf("stat managed state artifact: %w", err)
 	}
-	return verifyManagedArtifactConsistency(statePath)
+	return verifyManagedArtifactConsistency(statePath, managedArtifactVerificationStructural)
 }
 
-func verifyManagedArtifactConsistency(statePath string) error {
+func verifyManagedArtifactConsistency(statePath string, mode managedArtifactVerificationMode) error {
 	resolvedStatePath := filepath.Clean(strings.TrimSpace(statePath))
 	if resolvedStatePath == "" || resolvedStatePath == "." {
 		resolvedStatePath = state.ResolvePath("")
@@ -370,11 +377,24 @@ func verifyManagedArtifactConsistency(statePath string) error {
 	}
 
 	proofChainPath := proofemit.ChainPath(resolvedStatePath)
-	if _, err := os.Stat(proofChainPath); err != nil {
+	proofChainInfo, err := os.Stat(proofChainPath)
+	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 		return fmt.Errorf("managed artifact consistency proof chain: %w", err)
+	}
+	if mode == managedArtifactVerificationStructural {
+		if proofChainInfo.Size() == 0 {
+			return nil
+		}
+		if _, err := os.Stat(proofemit.SigningKeyPath(resolvedStatePath)); err != nil {
+			return fmt.Errorf("managed artifact consistency proof signing key: %w", err)
+		}
+		if _, err := os.Stat(proofemit.ChainAttestationPath(proofChainPath)); err != nil {
+			return fmt.Errorf("managed artifact consistency proof attestation: %w", err)
+		}
+		return nil
 	}
 	proofChain, err := proofemit.LoadChain(proofChainPath)
 	if err != nil {
@@ -387,20 +407,22 @@ func verifyManagedArtifactConsistency(statePath string) error {
 		if _, err := os.Stat(proofemit.ChainAttestationPath(proofChainPath)); err != nil {
 			return fmt.Errorf("managed artifact consistency proof attestation: %w", err)
 		}
-		publicKey, keyErr := proofemit.LoadVerifierKey(resolvedStatePath)
-		var result verifycore.Result
-		if keyErr == nil {
-			result, err = verifycore.ChainWithPublicKey(proofChainPath, publicKey)
-		} else if errors.Is(keyErr, os.ErrNotExist) {
-			result, err = verifycore.Chain(proofChainPath)
-		} else {
-			return fmt.Errorf("managed artifact consistency proof signing key: %w", keyErr)
-		}
-		if err != nil {
-			return fmt.Errorf("managed artifact consistency proof verification: %w", err)
-		}
-		if !result.Intact {
-			return fmt.Errorf("managed artifact consistency proof verification failed: %s", result.Reason)
+		if mode == managedArtifactVerificationFull {
+			publicKey, keyErr := proofemit.LoadVerifierKey(resolvedStatePath)
+			var result verifycore.Result
+			if keyErr == nil {
+				result, err = verifycore.ChainWithPublicKey(proofChainPath, publicKey)
+			} else if errors.Is(keyErr, os.ErrNotExist) {
+				result, err = verifycore.Chain(proofChainPath)
+			} else {
+				return fmt.Errorf("managed artifact consistency proof signing key: %w", keyErr)
+			}
+			if err != nil {
+				return fmt.Errorf("managed artifact consistency proof verification: %w", err)
+			}
+			if !result.Intact {
+				return fmt.Errorf("managed artifact consistency proof verification failed: %s", result.Reason)
+			}
 		}
 	}
 	return nil

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -630,7 +630,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		return emitError(stderr, jsonRequested || *jsonOut, code, message, exitCode)
 	}
 	completeManagedScanTransaction := func() int {
-		if err := verifyManagedArtifactConsistency(statePath); err != nil {
+		if err := verifyManagedArtifactConsistency(statePath, managedArtifactVerificationFull); err != nil {
 			return emitRolledBackScanFailure(err)
 		}
 		if err := transaction.Complete(); err != nil {

--- a/core/cli/state_mutation.go
+++ b/core/cli/state_mutation.go
@@ -158,7 +158,7 @@ func commitStateMutationContext(ctx stateMutationContext, transition lifecycle.T
 	if err := manifest.Save(ctx.preflight.manifestPath, ctx.manifest); err != nil {
 		return transaction.Rollback(err)
 	}
-	if err := verifyManagedArtifactConsistency(ctx.preflight.statePath); err != nil {
+	if err := verifyManagedArtifactConsistency(ctx.preflight.statePath, managedArtifactVerificationFull); err != nil {
 		return transaction.Rollback(err)
 	}
 	if err := transaction.Complete(); err != nil {


### PR DESCRIPTION
## Problem
- the nightly workflow was failing in the performance budget lane
- short-lived read commands like `wrkr score` and `wrkr regress run` were paying managed-artifact proof verification overhead on every invocation
- that overhead pushed the p95 command budgets over the nightly thresholds even though the underlying benchmark and correctness lanes were healthy

## Changes
- split managed artifact verification into structural read-path checks and full write-path verification
- keep transaction recovery, state/manifest parity checks, lifecycle chain loading, proof-sidecar existence checks, and fail-closed behavior on read commands
- reserve full proof-chain loading and cryptographic verification for scan/state-mutation commit paths where we need the strongest invariant before persisting managed artifacts

## Validation
- `make prepush-full`
- `scripts/test_perf_budgets.sh`
- `go test ./core/cli ./core/regress ./core/state -count=1`

## Risks
- read-path preflight no longer fully parses and verifies the proof chain on every invocation, so explicit proof integrity checks remain concentrated in write paths and `wrkr verify`/evidence workflows by design
- focused tests around managed-artifact recovery and fail-closed behavior stayed green locally

## Submodule Notes
- no submodule pointer changes
