### PR TITLE
hotfix: isolate shared scenario scan state

### DIFF
--- a/internal/scenarios/epic11_scenario_test.go
+++ b/internal/scenarios/epic11_scenario_test.go
@@ -12,7 +12,8 @@ func TestScenarioExtensionDetectorExecution(t *testing.T) {
 
 	repoRoot := mustFindRepoRoot(t)
 	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "extension-detectors", "repos")
-	payload := runScenarioCommandJSON(t, []string{"scan", "--path", scanPath, "--json"})
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	payload := runScenarioCommandJSON(t, []string{"scan", "--path", scanPath, "--state", statePath, "--json"})
 
 	if errorsValue, present := payload["detector_errors"]; present {
 		if list, ok := errorsValue.([]any); ok && len(list) > 0 {

--- a/internal/scenarios/epic2_scenario_test.go
+++ b/internal/scenarios/epic2_scenario_test.go
@@ -17,10 +17,11 @@ func TestScenarioScanMixedOrgCoverage(t *testing.T) {
 
 	repoRoot := mustFindRepoRoot(t)
 	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "scan-mixed-org", "repos")
+	statePath := filepath.Join(t.TempDir(), "state.json")
 
 	var out bytes.Buffer
 	var errOut bytes.Buffer
-	code := cli.Run([]string{"scan", "--path", scanPath, "--json"}, &out, &errOut)
+	code := cli.Run([]string{"scan", "--path", scanPath, "--state", statePath, "--json"}, &out, &errOut)
 	if code != 0 {
 		t.Fatalf("scan failed with code %d: %s", code, errOut.String())
 	}
@@ -80,10 +81,11 @@ func TestScenarioPolicyCheckContracts(t *testing.T) {
 
 	repoRoot := mustFindRepoRoot(t)
 	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "policy-check", "repos")
+	statePath := filepath.Join(t.TempDir(), "state.json")
 
 	var out bytes.Buffer
 	var errOut bytes.Buffer
-	code := cli.Run([]string{"scan", "--path", scanPath, "--json"}, &out, &errOut)
+	code := cli.Run([]string{"scan", "--path", scanPath, "--state", statePath, "--json"}, &out, &errOut)
 	if code != 0 {
 		t.Fatalf("scan failed with code %d: %s", code, errOut.String())
 	}


### PR DESCRIPTION
## Problem
Post-merge monitoring on `main` failed after PR #212 landed. The failing `v1-acceptance` dry run hit `lane_risk`, where scenario tests were scanning shared fixture directories without explicit `--state` paths and could race on `.wrkr` managed artifacts.

## Changes
- add temp state paths to the remaining `internal/scenarios` tests that still scanned fixture repos in place
- isolate `scan-mixed-org`, `policy-check`, and `extension-detectors` scenario runs from shared `.wrkr` artifact writes
- keep the fix scoped to test determinism and post-merge acceptance stability

## Validation
- `go test ./internal/scenarios -count=1 -tags=scenario`
- `scripts/run_v1_acceptance.sh --mode=main`
- `make prepush-full`

## Risks
- Scope is limited to scenario tests; product scan behavior is unchanged
- Follow-up hotfix for post-merge failure on merge commit `a48553ee6f09afb5366d057971c4e72a9d45bb99`
