### PR TITLE
hotfix: keep docs-site dev deps in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,9 +38,11 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      - name: Install and validate docs site
+      - name: Install docs site dependencies
+        run: make docs-site-install
+
+      - name: Validate docs site
         run: |
-          make docs-site-install
           make docs-site-audit-prod
           make docs-site-lint
           make docs-site-build


### PR DESCRIPTION
## Problem
- post-merge monitoring on `main` found the `docs` workflow failing on merge commit `17ad67be06dff81b4bd2e9b1a3f6a3ed95d67ded`
- the docs workflow ran `make docs-site-install` under `NODE_ENV=production`, which caused `npm ci` to omit dev dependencies and left `eslint` unavailable during the same validation step

## Changes
- split docs-site dependency installation into its own workflow step without `NODE_ENV=production`
- keep `NODE_ENV=production` only on the follow-up validation/build step so the docs deploy path still exercises the production-mode site build

## Validation
- `make docs-site-install`
- `NODE_ENV=production make docs-site-audit-prod`
- `NODE_ENV=production make docs-site-lint`
- `NODE_ENV=production make docs-site-build`
- `NODE_ENV=production make docs-site-check`

## Risks
- low: the change is workflow-only and narrows the environment difference between dependency install and validation
