### PR TITLE
hotfix: relax windows progress timing (r1)

### DIFF
--- a/core/cli/scan_progress_test.go
+++ b/core/cli/scan_progress_test.go
@@ -505,7 +505,7 @@ func TestScanStatusReportsInterruptedPartialPhase(t *testing.T) {
 	}()
 
 	const want = "progress target=org org=acme event=repo_materialize repo_index=1 repo_total=1 repo=acme/a"
-	if !errOut.waitFor(want, 2*time.Second) {
+	if !errOut.waitFor(want, 10*time.Second) {
 		t.Fatalf("expected materialize progress before cancellation, got %q", errOut.String())
 	}
 	cancel()


### PR DESCRIPTION
## Problem
The post-merge `main` Windows matrix failed in `TestScanStatusReportsInterruptedPartialPhase` because the test assumed `repo_materialize` progress would appear within 2 seconds.

## Changes
- widen the progress wait in `core/cli/scan_progress_test.go` from 2 seconds to 10 seconds

## Validation
- go test ./core/cli -run TestScanStatusReportsInterruptedPartialPhase -count=1
- make prepush-full

## Risks
- This is a test-only timing adjustment. It broadens the wait window for a cancellation/progress assertion without changing scan runtime behavior.
