### PR TITLE
hotfix: add control evidence scenario fixture (r2)

### DIFF
--- a/scenarios/wrkr/control-evidence-state/repos/demo/.wrkr/provenance/control-metadata.json
+++ b/scenarios/wrkr/control-evidence-state/repos/demo/.wrkr/provenance/control-metadata.json
@@ -1,0 +1,14 @@
+{
+  "controls": [
+    {
+      "path": ".github/workflows/release.yml",
+      "control_resolution_state": "external_control_reference",
+      "control_evidence_refs": [
+        "github_team:platform/release-approvers"
+      ],
+      "approval_evidence_state": "declared",
+      "owner_evidence_state": "declared",
+      "proof_evidence_state": "unknown"
+    }
+  ]
+}


### PR DESCRIPTION
## Problem
The follow-up `main` pipeline after the Windows timing hotfix still failed in acceptance and v1 acceptance because the `control-metadata.json` scenario sidecar existed locally but was ignored by git, so CI never saw it.

## Changes
- force-track `scenarios/wrkr/control-evidence-state/repos/demo/.wrkr/provenance/control-metadata.json`

## Validation
- go test ./internal/scenarios -run TestControlEvidenceStateScenario -count=1 -tags=scenario
- go test ./internal/acceptance -run 'Test.*AgentActionBOM|Test.*Report' -count=1
- scripts/run_v1_acceptance.sh --mode=main
- make prepush-full

## Risks
- No runtime code changed in this hotfix. This is a deterministic test-fixture correction so CI and local runs use the same scenario inputs.
