### PR TITLE
fix: normalize control-state and MCP absence reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - [semver:minor] Changed report and schema terminology to present approval, owner, proof, policy, runtime, target, and credential findings as evidence states rather than unsupported missing-control claims.
 - [semver:patch] Changed buyer-facing report, backlog, and remediation wording to use evidence-scoped language for approval, ownership, proof, policy, runtime, target, and credential states.
+- [semver:minor] Changed MCP absence reporting to use coverage-qualified statuses so reduced coverage, unsupported declarations, parse-failed candidates, and unscanned repos do not render as absolute missing-server claims.
 
 ### Deprecated
 
@@ -27,7 +28,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- (none yet)
+- [semver:patch] Fixed govern-first projection so control state, queue, review burden, risk tier, and remediation stay semantically consistent for critical, contradictory, and control-first paths.
 
 ### Security
 

--- a/core/aggregate/controlbacklog/controlbacklog.go
+++ b/core/aggregate/controlbacklog/controlbacklog.go
@@ -289,6 +289,7 @@ func buildControlPathRefs(graph *aggattack.ControlPathGraph) map[string]controlP
 }
 
 func (b *builder) addActionPath(path risk.ActionPath) {
+	path = risk.ProjectActionPath(path)
 	graphRefs := b.graphRefsByPath[strings.TrimSpace(path.PathID)]
 	item := Item{
 		ID:                         backlogID("action_path", path.Org, path.Repo, path.Location, path.PathID),
@@ -1649,6 +1650,10 @@ func firstNonEmptyConfidenceLane(current, incoming string) string {
 }
 
 func queueFromActionPath(path risk.ActionPath) string {
+	if strings.TrimSpace(path.ReviewBurden) == risk.ReviewBurdenCritical ||
+		strings.TrimSpace(path.ControlPriority) == risk.ControlPriorityControlFirst {
+		return QueueControlFirst
+	}
 	switch strings.TrimSpace(path.ControlState) {
 	case risk.ControlStateBlockRecommend:
 		return QueueControlFirst

--- a/core/aggregate/controlbacklog/controlbacklog_test.go
+++ b/core/aggregate/controlbacklog/controlbacklog_test.go
@@ -274,6 +274,48 @@ func TestBacklogClosureDoesNotSayOwnerMissing(t *testing.T) {
 	}
 }
 
+func TestCriticalReviewBurdenRoutesToControlFirstQueue(t *testing.T) {
+	t.Parallel()
+
+	backlog := Build(Input{
+		ActionPaths: []risk.ActionPath{{
+			PathID:                   "apc-critical-queue",
+			Org:                      "acme",
+			Repo:                     "acme/release",
+			ToolType:                 "compiled_action",
+			Location:                 ".github/workflows/release.yml",
+			WriteCapable:             true,
+			CredentialAccess:         true,
+			StandingPrivilege:        true,
+			DeployWrite:              true,
+			ProductionWrite:          true,
+			MatchedProductionTargets: []string{"built_in:deploy_workflow"},
+			PolicyCoverageStatus:     risk.PolicyCoverageStatusMatched,
+			PolicyEvidenceRefs:       []string{"gait://release"},
+			GaitCoverage: &risk.GaitCoverage{
+				ProofVerification: risk.GaitCoverageDetail{
+					Status:       risk.GaitStatusPresent,
+					EvidenceRefs: []string{"proof_record:rec-111"},
+				},
+			},
+		}},
+	})
+
+	if len(backlog.Items) != 1 {
+		t.Fatalf("expected one backlog item, got %+v", backlog.Items)
+	}
+	item := backlog.Items[0]
+	if item.ReviewBurden != risk.ReviewBurdenCritical {
+		t.Fatalf("expected critical review burden, got %+v", item)
+	}
+	if item.Queue != QueueControlFirst {
+		t.Fatalf("expected critical review item to route to control_first queue, got %+v", item)
+	}
+	if item.ControlState == risk.ControlStateSafeByDefault {
+		t.Fatalf("did not expect safe_by_default on critical control-first backlog item, got %+v", item)
+	}
+}
+
 func TestSecurityVisibilityMapsApprovedToKnownApprovedInBacklog(t *testing.T) {
 	t.Parallel()
 

--- a/core/aggregate/scanquality/scanquality.go
+++ b/core/aggregate/scanquality/scanquality.go
@@ -12,6 +12,15 @@ import (
 
 const ReportVersion = "1"
 
+const (
+	SurfaceMCPServer                      = "mcp_server"
+	AbsenceStatusNotFoundCompleteCoverage = "not_found_with_complete_coverage"
+	AbsenceStatusNotFoundReducedCoverage  = "not_found_with_reduced_coverage"
+	AbsenceStatusNotScanned               = "not_scanned"
+	AbsenceStatusUnsupportedSurface       = "unsupported_surface"
+	AbsenceStatusCandidateParseFailed     = "candidate_parse_failed"
+)
+
 type Report struct {
 	ScanQualityVersion string                 `json:"scan_quality_version"`
 	Mode               string                 `json:"mode"`
@@ -19,6 +28,16 @@ type Report struct {
 	SuppressedPaths    []SuppressedPath       `json:"suppressed_paths,omitempty"`
 	ParseErrors        []ParseIssue           `json:"parse_errors,omitempty"`
 	DetectorErrors     []detect.DetectorError `json:"detector_errors,omitempty"`
+	AbsenceClaims      []AbsenceClaim         `json:"absence_claims,omitempty"`
+}
+
+type AbsenceClaim struct {
+	Org     string   `json:"org,omitempty"`
+	Repo    string   `json:"repo,omitempty"`
+	Surface string   `json:"surface"`
+	Status  string   `json:"status"`
+	Reasons []string `json:"reasons,omitempty"`
+	Impact  string   `json:"impact,omitempty"`
 }
 
 type DetectorHealth struct {
@@ -75,7 +94,32 @@ func Build(input Input) Report {
 	}
 	report.ParseErrors = collectParseIssues(input.Findings)
 	report.Detectors = collectDetectorHealth(input)
+	report.AbsenceClaims = buildAbsenceClaims(input, report.Detectors)
 	return report
+}
+
+func AbsenceClaimForSurface(report *Report, org string, repo string, surface string) *AbsenceClaim {
+	if report == nil {
+		return nil
+	}
+	org = strings.TrimSpace(org)
+	repo = strings.TrimSpace(repo)
+	surface = strings.TrimSpace(surface)
+	for _, item := range report.AbsenceClaims {
+		if strings.TrimSpace(item.Surface) != surface {
+			continue
+		}
+		if org != "" && strings.TrimSpace(item.Org) != org {
+			continue
+		}
+		if repo != "" && strings.TrimSpace(item.Repo) != repo {
+			continue
+		}
+		copyItem := item
+		copyItem.Reasons = append([]string(nil), item.Reasons...)
+		return &copyItem
+	}
+	return nil
 }
 
 func collectSuppressedPaths(scopes []detect.Scope) []SuppressedPath {
@@ -303,6 +347,151 @@ func collectDetectorHealth(input Input) []DetectorHealth {
 		return out[i].Detector < out[j].Detector
 	})
 	return out
+}
+
+func buildAbsenceClaims(input Input, detectors []DetectorHealth) []AbsenceClaim {
+	type countIndex map[string]int
+
+	authoritative := countIndex{}
+	candidates := countIndex{}
+	repoKeys := map[string]struct{}{}
+	for _, scope := range input.Scopes {
+		repoKeys[scopeKey(scope.Org, scope.Repo)] = struct{}{}
+	}
+	for _, finding := range input.Findings {
+		key := scopeKey(finding.Org, finding.Repo)
+		repoKeys[key] = struct{}{}
+		switch strings.TrimSpace(finding.FindingType) {
+		case "mcp_server":
+			authoritative[key]++
+		case "mcp_server_candidate", "webmcp_declaration":
+			candidates[key]++
+		}
+	}
+	byRepo := map[string][]DetectorHealth{}
+	for _, detector := range detectors {
+		if strings.TrimSpace(detector.Detector) != "mcp" && strings.TrimSpace(detector.Detector) != "webmcp" {
+			continue
+		}
+		key := scopeKey(detector.Org, detector.Repo)
+		repoKeys[key] = struct{}{}
+		byRepo[key] = append(byRepo[key], detector)
+	}
+
+	out := make([]AbsenceClaim, 0, len(repoKeys))
+	for key := range repoKeys {
+		if authoritative[key] > 0 {
+			continue
+		}
+		org, repo := splitScopeKey(key)
+		status, reasons := deriveMCPAbsenceStatus(byRepo[key], candidates[key])
+		if status == "" {
+			continue
+		}
+		out = append(out, AbsenceClaim{
+			Org:     org,
+			Repo:    repo,
+			Surface: SurfaceMCPServer,
+			Status:  status,
+			Reasons: reasons,
+			Impact:  absenceImpact(status),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Org != out[j].Org {
+			return out[i].Org < out[j].Org
+		}
+		if out[i].Repo != out[j].Repo {
+			return out[i].Repo < out[j].Repo
+		}
+		return out[i].Surface < out[j].Surface
+	})
+	return out
+}
+
+func deriveMCPAbsenceStatus(detectors []DetectorHealth, candidateCount int) (string, []string) {
+	if len(detectors) == 0 {
+		return AbsenceStatusNotScanned, []string{"detector_health:missing"}
+	}
+
+	reasonSet := map[string]struct{}{}
+	completeCoverage := true
+	parseFailure := false
+	unsupportedSurface := false
+	reducedCoverage := false
+	anyUnsupported := false
+	for _, detector := range detectors {
+		label := strings.TrimSpace(detector.Detector)
+		if label == "" {
+			label = "unknown"
+		}
+		reasonSet["detector:"+label+"="+strings.TrimSpace(detector.Status)] = struct{}{}
+		for _, reason := range detector.CoverageReasons {
+			trimmed := strings.TrimSpace(reason)
+			reasonSet[label+":"+trimmed] = struct{}{}
+			switch trimmed {
+			case "parse_failures", "partial_parse", "blocked_path", "detector_error", "generated_suppression", "skipped_file":
+				reducedCoverage = true
+			}
+		}
+		if detector.ParseFailures > 0 && detector.UnsupportedDeclarations == 0 {
+			parseFailure = true
+		}
+		if detector.Status != "complete" {
+			completeCoverage = false
+		}
+		if detector.UnsupportedDeclarations > 0 {
+			anyUnsupported = true
+		}
+	}
+	if candidateCount > 0 {
+		reasonSet["candidate_evidence:present"] = struct{}{}
+		reducedCoverage = true
+		completeCoverage = false
+	}
+	if anyUnsupported && !parseFailure && !reducedCoverage && candidateCount == 0 {
+		unsupportedSurface = true
+	}
+
+	switch {
+	case unsupportedSurface:
+		return AbsenceStatusUnsupportedSurface, sortedReasonKeys(reasonSet)
+	case parseFailure:
+		return AbsenceStatusCandidateParseFailed, sortedReasonKeys(reasonSet)
+	case reducedCoverage:
+		return AbsenceStatusNotFoundReducedCoverage, sortedReasonKeys(reasonSet)
+	case completeCoverage:
+		return AbsenceStatusNotFoundCompleteCoverage, sortedReasonKeys(reasonSet)
+	default:
+		return AbsenceStatusNotScanned, sortedReasonKeys(reasonSet)
+	}
+}
+
+func absenceImpact(status string) string {
+	switch strings.TrimSpace(status) {
+	case AbsenceStatusNotFoundCompleteCoverage:
+		return "Complete MCP coverage supported a clean negative result for the scanned surfaces."
+	case AbsenceStatusCandidateParseFailed:
+		return "At least one MCP candidate surface failed to parse, so absence is not authoritative."
+	case AbsenceStatusUnsupportedSurface:
+		return "Only unsupported MCP-style surfaces were seen, so absence is not authoritative."
+	case AbsenceStatusNotFoundReducedCoverage:
+		return "Coverage was reduced or only candidate MCP evidence was present, so absence is not authoritative."
+	default:
+		return "MCP coverage was not scanned for this repo, so absence is not authoritative."
+	}
+}
+
+func scopeKey(org string, repo string) string {
+	return strings.TrimSpace(org) + "|" + strings.TrimSpace(repo)
+}
+
+func splitScopeKey(key string) (string, string) {
+	parts := strings.SplitN(strings.TrimSpace(key), "|", 2)
+	if len(parts) != 2 {
+		return "", strings.TrimSpace(key)
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
 }
 
 func buildParsePathIndex(findings []model.Finding) map[detectorScopeKey]map[string]parsePathStatus {

--- a/core/aggregate/scanquality/scanquality_test.go
+++ b/core/aggregate/scanquality/scanquality_test.go
@@ -95,6 +95,10 @@ func TestScanQualityReportsReducedCoverageForParseFailures(t *testing.T) {
 	if !containsReason(mcp.CoverageReasons, "parse_failures") {
 		t.Fatalf("expected parse_failures reason, got %+v", mcp)
 	}
+	claim := findAbsenceClaim(t, report, "acme", "app", SurfaceMCPServer)
+	if claim.Status != AbsenceStatusCandidateParseFailed {
+		t.Fatalf("expected candidate_parse_failed absence claim, got %+v", claim)
+	}
 }
 
 func TestScanQualitySkipsGeneratedDependencyDirectoriesInGovernanceMode(t *testing.T) {
@@ -219,6 +223,10 @@ func TestScanQualityReportsCompleteMCPCoverageForCleanNegativeResult(t *testing.
 	if !containsReason(mcp.CoverageReasons, "no_candidate_inputs") {
 		t.Fatalf("expected no_candidate_inputs reason, got %+v", mcp)
 	}
+	claim := findAbsenceClaim(t, report, "acme", "app", SurfaceMCPServer)
+	if claim.Status != AbsenceStatusNotFoundCompleteCoverage {
+		t.Fatalf("expected complete-coverage absence claim, got %+v", claim)
+	}
 }
 
 func TestScanQualityMCPCandidatesMatchDetectorInputs(t *testing.T) {
@@ -246,6 +254,32 @@ func TestScanQualityMCPCandidatesMatchDetectorInputs(t *testing.T) {
 	}
 }
 
+func TestScanQualityReportsUnsupportedSurfaceAbsenceClaim(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".mcp.json"), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write mcp config: %v", err)
+	}
+
+	report := Build(Input{
+		Mode:   "governance",
+		Scopes: []detect.Scope{{Org: "acme", Repo: "app", Root: root}},
+		Findings: []model.Finding{{
+			FindingType: "parse_error",
+			Location:    ".mcp.json",
+			Repo:        "app",
+			Org:         "acme",
+			ParseError:  &model.ParseError{Kind: "schema_validation_error", Path: ".mcp.json", Detector: "mcp", Message: "unsupported declaration"},
+		}},
+	})
+
+	claim := findAbsenceClaim(t, report, "acme", "app", SurfaceMCPServer)
+	if claim.Status != AbsenceStatusUnsupportedSurface {
+		t.Fatalf("expected unsupported_surface absence claim, got %+v", claim)
+	}
+}
+
 func findDetectorHealth(t *testing.T, report Report, detector string) DetectorHealth {
 	t.Helper()
 	for _, item := range report.Detectors {
@@ -264,4 +298,15 @@ func containsReason(reasons []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func findAbsenceClaim(t *testing.T, report Report, org string, repo string, surface string) AbsenceClaim {
+	t.Helper()
+	for _, item := range report.AbsenceClaims {
+		if item.Org == org && item.Repo == repo && item.Surface == surface {
+			return item
+		}
+	}
+	t.Fatalf("expected absence claim for %s/%s surface=%s in %+v", org, repo, surface, report.AbsenceClaims)
+	return AbsenceClaim{}
 }

--- a/core/cli/mcp_list.go
+++ b/core/cli/mcp_list.go
@@ -57,7 +57,10 @@ func runMCPList(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	if len(payload.Rows) == 0 {
-		_, _ = fmt.Fprintln(stdout, "wrkr mcp-list no MCP servers found")
+		_, _ = fmt.Fprintln(stdout, renderMCPAbsenceLine(payload))
+		if strings.TrimSpace(payload.AbsenceImpact) != "" {
+			_, _ = fmt.Fprintf(stdout, "coverage impact: %s\n", strings.TrimSpace(payload.AbsenceImpact))
+		}
 		return exitSuccess
 	}
 
@@ -85,4 +88,23 @@ func runMCPList(args []string, stdout io.Writer, stderr io.Writer) int {
 		_, _ = fmt.Fprintf(stderr, "mcp-list diagnostic repo=%s status=%s\n", label, diagnostic.Status)
 	}
 	return exitSuccess
+}
+
+func renderMCPAbsenceLine(payload reportcore.MCPList) string {
+	switch strings.TrimSpace(payload.AbsenceStatus) {
+	case reportcore.MCPTrustUnavailable:
+		return "wrkr mcp-list MCP coverage status is unavailable"
+	case "not_found_with_complete_coverage":
+		return "wrkr mcp-list no MCP servers found (absence_status=not_found_with_complete_coverage)"
+	case "candidate_parse_failed":
+		return "wrkr mcp-list MCP server evidence not found because candidate surfaces failed to parse (absence_status=candidate_parse_failed)"
+	case "unsupported_surface":
+		return "wrkr mcp-list MCP server evidence not found on unsupported surfaces (absence_status=unsupported_surface)"
+	case "not_found_with_reduced_coverage":
+		return "wrkr mcp-list MCP server evidence not found with reduced coverage (absence_status=not_found_with_reduced_coverage)"
+	case "not_scanned":
+		return "wrkr mcp-list MCP coverage was not scanned, so no absence claim is supported (absence_status=not_scanned)"
+	default:
+		return "wrkr mcp-list MCP server evidence not found (absence_status=unknown)"
+	}
 }

--- a/core/cli/wave2_commands_test.go
+++ b/core/cli/wave2_commands_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/aggregate/scanquality"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/source"
 	"github.com/Clyra-AI/wrkr/core/state"
@@ -333,6 +334,38 @@ func TestMCPListRepoFilterAndExpectedServerDiagnostics(t *testing.T) {
 	firstDiagnostic := diagnostics[0].(map[string]any)
 	if firstDiagnostic["status"] != "candidate_only" {
 		t.Fatalf("expected candidate_only status, got %v", firstDiagnostic)
+	}
+}
+
+func TestMCPListTextQualifiesReducedCoverageAbsence(t *testing.T) {
+	t.Parallel()
+
+	statePath := writeWave2State(t, state.Snapshot{
+		ScanQuality: &scanquality.Report{
+			ScanQualityVersion: scanquality.ReportVersion,
+			Mode:               "governance",
+			AbsenceClaims: []scanquality.AbsenceClaim{{
+				Org:     "acme",
+				Repo:    "acme/payments",
+				Surface: scanquality.SurfaceMCPServer,
+				Status:  scanquality.AbsenceStatusNotFoundReducedCoverage,
+				Reasons: []string{"candidate_evidence:present"},
+				Impact:  "Coverage was reduced or only candidate MCP evidence was present, so absence is not authoritative.",
+			}},
+		},
+	})
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := Run([]string{"mcp-list", "--state", statePath, "--repo", "acme/payments"}, &out, &errOut); code != 0 {
+		t.Fatalf("mcp-list failed: code=%d stderr=%s", code, errOut.String())
+	}
+
+	if strings.Contains(out.String(), "no MCP servers found") {
+		t.Fatalf("did not expect absolute no-servers wording under reduced coverage, got %q", out.String())
+	}
+	if !strings.Contains(out.String(), "reduced coverage") || !strings.Contains(out.String(), "absence_status=not_found_with_reduced_coverage") {
+		t.Fatalf("expected reduced coverage wording, got %q", out.String())
 	}
 }
 

--- a/core/report/agent_action_bom.go
+++ b/core/report/agent_action_bom.go
@@ -295,8 +295,8 @@ func buildAgentActionBOM(summary Summary, findings []model.Finding) *AgentAction
 			ControlPriority:            controlPriorityForPath(path),
 			RiskTier:                   riskTierForPath(path),
 			RecommendedNextAction:      strings.TrimSpace(path.RecommendedAction),
-			Queue:                      firstNonEmptyValue(strings.TrimSpace(backlogItem.Queue), queueForControlPriority(controlPriorityForPath(path))),
-			FindingVisibility:          firstNonEmptyValue(strings.TrimSpace(backlogItem.FindingVisibility), visibilityForQueue(firstNonEmptyValue(strings.TrimSpace(backlogItem.Queue), queueForControlPriority(controlPriorityForPath(path))))),
+			Queue:                      firstNonEmptyValue(strings.TrimSpace(backlogItem.Queue), queueForActionPath(path)),
+			FindingVisibility:          firstNonEmptyValue(strings.TrimSpace(backlogItem.FindingVisibility), visibilityForQueue(firstNonEmptyValue(strings.TrimSpace(backlogItem.Queue), queueForActionPath(path)))),
 			Remediation:                firstNonEmptyValue(strings.TrimSpace(backlogItem.Remediation), risk.RemediationForActionPath(path)),
 			AttackPathRefs:             append([]string(nil), path.AttackPathRefs...),
 			SourceFindingKeys:          append([]string(nil), path.SourceFindingKeys...),
@@ -725,6 +725,14 @@ func queueForControlPriority(priority string) string {
 	default:
 		return controlbacklog.QueueReviewQueue
 	}
+}
+
+func queueForActionPath(path risk.ActionPath) string {
+	path = risk.ProjectActionPath(path)
+	if strings.TrimSpace(path.ReviewBurden) == risk.ReviewBurdenCritical {
+		return controlbacklog.QueueControlFirst
+	}
+	return queueForControlPriority(controlPriorityForPath(path))
 }
 
 func visibilityForQueue(queue string) string {

--- a/core/report/build.go
+++ b/core/report/build.go
@@ -1335,6 +1335,8 @@ func decorateControlBacklogFromActionPaths(backlog *controlbacklog.Backlog, path
 		copyBacklog.Items[idx].PolicyMissingReasons = uniqueStrings(append(append([]string(nil), item.PolicyMissingReasons...), path.PolicyMissingReasons...))
 		copyBacklog.Items[idx].PolicyEvidenceRefs = uniqueStrings(append(append([]string(nil), item.PolicyEvidenceRefs...), path.PolicyEvidenceRefs...))
 		copyBacklog.Items[idx].PolicyConfidence = firstNonEmptyValue(strings.TrimSpace(path.PolicyConfidence), strings.TrimSpace(item.PolicyConfidence))
+		copyBacklog.Items[idx].Queue = queueForActionPath(path)
+		copyBacklog.Items[idx].FindingVisibility = visibilityForQueue(copyBacklog.Items[idx].Queue)
 		copyBacklog.Items[idx].Remediation = risk.RemediationForActionPath(path)
 		if copyBacklog.Items[idx].CredentialProvenance == nil {
 			copyBacklog.Items[idx].CredentialProvenance = agginventory.CloneCredentialProvenance(path.CredentialProvenance)
@@ -1882,6 +1884,7 @@ func cloneScanQualityReport(in *scanquality.Report) *scanquality.Report {
 	copyReport.ParseErrors = append([]scanquality.ParseIssue(nil), in.ParseErrors...)
 	copyReport.DetectorErrors = append([]detect.DetectorError(nil), in.DetectorErrors...)
 	copyReport.Detectors = append([]scanquality.DetectorHealth(nil), in.Detectors...)
+	copyReport.AbsenceClaims = append([]scanquality.AbsenceClaim(nil), in.AbsenceClaims...)
 	return &copyReport
 }
 
@@ -1907,6 +1910,10 @@ func sanitizeScanQualityPublic(in *scanquality.Report) *scanquality.Report {
 	for idx := range copyReport.DetectorErrors {
 		copyReport.DetectorErrors[idx].Org = redactValue("org", copyReport.DetectorErrors[idx].Org, 6)
 		copyReport.DetectorErrors[idx].Repo = redactValue("repo", copyReport.DetectorErrors[idx].Repo, 6)
+	}
+	for idx := range copyReport.AbsenceClaims {
+		copyReport.AbsenceClaims[idx].Org = redactValue("org", copyReport.AbsenceClaims[idx].Org, 6)
+		copyReport.AbsenceClaims[idx].Repo = redactValue("repo", copyReport.AbsenceClaims[idx].Repo, 6)
 	}
 	return copyReport
 }

--- a/core/report/mcp_list.go
+++ b/core/report/mcp_list.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/aggregate/scanquality"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/source"
 	"github.com/Clyra-AI/wrkr/core/state"
@@ -23,13 +24,16 @@ const (
 )
 
 type MCPList struct {
-	Status      string              `json:"status"`
-	GeneratedAt string              `json:"generated_at"`
-	RepoFilter  string              `json:"repo_filter,omitempty"`
-	Rows        []MCPListRow        `json:"rows"`
-	Candidates  []MCPCandidate      `json:"candidates,omitempty"`
-	Diagnostics []MCPMissDiagnostic `json:"diagnostics,omitempty"`
-	Warnings    []string            `json:"warnings,omitempty"`
+	Status         string              `json:"status"`
+	GeneratedAt    string              `json:"generated_at"`
+	RepoFilter     string              `json:"repo_filter,omitempty"`
+	Rows           []MCPListRow        `json:"rows"`
+	Candidates     []MCPCandidate      `json:"candidates,omitempty"`
+	Diagnostics    []MCPMissDiagnostic `json:"diagnostics,omitempty"`
+	Warnings       []string            `json:"warnings,omitempty"`
+	AbsenceStatus  string              `json:"absence_status,omitempty"`
+	AbsenceReasons []string            `json:"absence_reasons,omitempty"`
+	AbsenceImpact  string              `json:"absence_impact,omitempty"`
 }
 
 type MCPListRow struct {
@@ -64,6 +68,7 @@ type MCPMissDiagnostic struct {
 	Repo                    string   `json:"repo"`
 	ExpectedServer          string   `json:"expected_server,omitempty"`
 	Status                  string   `json:"status"`
+	AbsenceStatus           string   `json:"absence_status,omitempty"`
 	CandidateFilesScanned   []string `json:"candidate_files_scanned,omitempty"`
 	ParsedConfigs           []string `json:"parsed_configs,omitempty"`
 	CandidatesFound         []string `json:"candidates_found,omitempty"`
@@ -71,6 +76,7 @@ type MCPMissDiagnostic struct {
 	GeneratedSuppressions   []string `json:"generated_suppressions,omitempty"`
 	UnsupportedDeclarations []string `json:"unsupported_declarations,omitempty"`
 	Explanation             []string `json:"explanation,omitempty"`
+	AbsenceImpact           string   `json:"absence_impact,omitempty"`
 }
 
 type MCPListOptions struct {
@@ -156,15 +162,19 @@ func BuildMCPListWithOptions(snapshot state.Snapshot, opts MCPListOptions) MCPLi
 
 	candidates := buildMCPCandidates(snapshot, repoFilter)
 	diagnostics := buildMCPMissDiagnostics(snapshot, repoFilter, rows, candidates, opts.ExpectedServers)
+	absenceStatus, absenceReasons, absenceImpact := mcpAbsenceSummary(snapshot.ScanQuality, repoFilter, rows, candidates, diagnostics)
 
 	return MCPList{
-		Status:      "ok",
-		GeneratedAt: ResolveGeneratedAtForCLI(snapshot, opts.GeneratedAt).Format(time.RFC3339),
-		RepoFilter:  repoFilter,
-		Rows:        rows,
-		Candidates:  candidates,
-		Diagnostics: diagnostics,
-		Warnings:    warnings,
+		Status:         "ok",
+		GeneratedAt:    ResolveGeneratedAtForCLI(snapshot, opts.GeneratedAt).Format(time.RFC3339),
+		RepoFilter:     repoFilter,
+		Rows:           rows,
+		Candidates:     candidates,
+		Diagnostics:    diagnostics,
+		Warnings:       warnings,
+		AbsenceStatus:  absenceStatus,
+		AbsenceReasons: absenceReasons,
+		AbsenceImpact:  absenceImpact,
 	}
 }
 
@@ -267,6 +277,7 @@ func buildMCPMissDiagnostics(snapshot state.Snapshot, repoFilter string, rows []
 				Org:                     org,
 				Repo:                    repo,
 				Status:                  deriveDiagnosticStatus(detail, false, false),
+				AbsenceStatus:           diagnosticAbsenceStatus(deriveDiagnosticStatus(detail, false, false)),
 				CandidateFilesScanned:   uniqueMCPListStrings(detail.candidateFilesScanned),
 				ParsedConfigs:           uniqueMCPListStrings(detail.parsedConfigs),
 				CandidatesFound:         uniqueMCPListStrings(detail.candidatesFound),
@@ -274,6 +285,7 @@ func buildMCPMissDiagnostics(snapshot state.Snapshot, repoFilter string, rows []
 				GeneratedSuppressions:   uniqueMCPListStrings(detail.generatedSuppressions),
 				UnsupportedDeclarations: uniqueMCPListStrings(detail.unsupportedDeclarations),
 				Explanation:             diagnosticExplanation(deriveDiagnosticStatus(detail, false, false)),
+				AbsenceImpact:           scanqualityAbsenceImpact(diagnosticAbsenceStatus(deriveDiagnosticStatus(detail, false, false))),
 			})
 		}
 		sortMCPDiagnostics(diagnostics)
@@ -295,6 +307,7 @@ func buildMCPMissDiagnostics(snapshot state.Snapshot, repoFilter string, rows []
 				Repo:                    repo,
 				ExpectedServer:          strings.TrimSpace(expected),
 				Status:                  status,
+				AbsenceStatus:           diagnosticAbsenceStatus(status),
 				CandidateFilesScanned:   uniqueMCPListStrings(detail.candidateFilesScanned),
 				ParsedConfigs:           uniqueMCPListStrings(detail.parsedConfigs),
 				CandidatesFound:         uniqueMCPListStrings(detail.candidatesFound),
@@ -302,6 +315,7 @@ func buildMCPMissDiagnostics(snapshot state.Snapshot, repoFilter string, rows []
 				GeneratedSuppressions:   uniqueMCPListStrings(detail.generatedSuppressions),
 				UnsupportedDeclarations: uniqueMCPListStrings(detail.unsupportedDeclarations),
 				Explanation:             diagnosticExplanation(status),
+				AbsenceImpact:           scanqualityAbsenceImpact(diagnosticAbsenceStatus(status)),
 			})
 		}
 	}
@@ -449,6 +463,81 @@ func diagnosticExplanation(status string) []string {
 		return []string{"Wrkr saw parse failures or generated suppression on MCP-bearing surfaces, so a negative result is coverage-reduced rather than authoritative"}
 	default:
 		return []string{"Wrkr did not find authoritative or candidate MCP evidence for the requested repo"}
+	}
+}
+
+func diagnosticAbsenceStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case "candidate_only", "reduced_coverage":
+		return scanquality.AbsenceStatusNotFoundReducedCoverage
+	case "not_detected":
+		return scanquality.AbsenceStatusNotFoundCompleteCoverage
+	default:
+		return ""
+	}
+}
+
+func mcpAbsenceSummary(report *scanquality.Report, repoFilter string, rows []MCPListRow, candidates []MCPCandidate, diagnostics []MCPMissDiagnostic) (string, []string, string) {
+	if len(rows) > 0 {
+		return "", nil, ""
+	}
+	if claim := mcpAbsenceClaim(report, repoFilter); claim != nil {
+		return claim.Status, append([]string(nil), claim.Reasons...), strings.TrimSpace(claim.Impact)
+	}
+
+	reasons := []string{"scan_quality:unavailable"}
+	if len(candidates) > 0 {
+		reasons = append(reasons, "candidate_evidence:present")
+		return scanquality.AbsenceStatusNotFoundReducedCoverage, uniqueMCPListStrings(reasons), scanqualityAbsenceImpact(scanquality.AbsenceStatusNotFoundReducedCoverage)
+	}
+	for _, diagnostic := range diagnostics {
+		if strings.TrimSpace(diagnostic.AbsenceStatus) == "" {
+			continue
+		}
+		reasons = append(reasons, diagnostic.Status)
+		return strings.TrimSpace(diagnostic.AbsenceStatus), uniqueMCPListStrings(reasons), scanqualityAbsenceImpact(strings.TrimSpace(diagnostic.AbsenceStatus))
+	}
+	return scanquality.AbsenceStatusNotScanned, uniqueMCPListStrings(reasons), scanqualityAbsenceImpact(scanquality.AbsenceStatusNotScanned)
+}
+
+func mcpAbsenceClaim(report *scanquality.Report, repoFilter string) *scanquality.AbsenceClaim {
+	if report == nil {
+		return nil
+	}
+	if strings.TrimSpace(repoFilter) != "" {
+		org := inferDiagnosticOrg(state.Snapshot{ScanQuality: report}, repoFilter)
+		if claim := scanquality.AbsenceClaimForSurface(report, org, repoFilter, scanquality.SurfaceMCPServer); claim != nil {
+			return claim
+		}
+		if claim := scanquality.AbsenceClaimForSurface(report, "", repoFilter, scanquality.SurfaceMCPServer); claim != nil {
+			return claim
+		}
+	}
+	for _, claim := range report.AbsenceClaims {
+		if strings.TrimSpace(claim.Surface) != scanquality.SurfaceMCPServer {
+			continue
+		}
+		copyClaim := claim
+		copyClaim.Reasons = append([]string(nil), claim.Reasons...)
+		return &copyClaim
+	}
+	return nil
+}
+
+func scanqualityAbsenceImpact(status string) string {
+	switch strings.TrimSpace(status) {
+	case scanquality.AbsenceStatusNotFoundCompleteCoverage:
+		return "Complete MCP coverage supported a clean negative result for the scanned surfaces."
+	case scanquality.AbsenceStatusCandidateParseFailed:
+		return "At least one MCP candidate surface failed to parse, so absence is not authoritative."
+	case scanquality.AbsenceStatusUnsupportedSurface:
+		return "Only unsupported MCP-style surfaces were seen, so absence is not authoritative."
+	case scanquality.AbsenceStatusNotFoundReducedCoverage:
+		return "Coverage was reduced or only candidate MCP evidence was present, so absence is not authoritative."
+	case scanquality.AbsenceStatusNotScanned:
+		return "MCP coverage was not scanned for this repo, so absence is not authoritative."
+	default:
+		return ""
 	}
 }
 

--- a/core/report/mcp_list.go
+++ b/core/report/mcp_list.go
@@ -471,7 +471,7 @@ func diagnosticAbsenceStatus(status string) string {
 	case "candidate_only", "reduced_coverage":
 		return scanquality.AbsenceStatusNotFoundReducedCoverage
 	case "not_detected":
-		return scanquality.AbsenceStatusNotFoundCompleteCoverage
+		return scanquality.AbsenceStatusNotScanned
 	default:
 		return ""
 	}
@@ -490,12 +490,17 @@ func mcpAbsenceSummary(report *scanquality.Report, repoFilter string, rows []MCP
 		reasons = append(reasons, "candidate_evidence:present")
 		return scanquality.AbsenceStatusNotFoundReducedCoverage, uniqueMCPListStrings(reasons), scanqualityAbsenceImpact(scanquality.AbsenceStatusNotFoundReducedCoverage)
 	}
+	status := ""
 	for _, diagnostic := range diagnostics {
-		if strings.TrimSpace(diagnostic.AbsenceStatus) == "" {
+		diagnosticStatus := strings.TrimSpace(diagnostic.AbsenceStatus)
+		if diagnosticStatus == "" {
 			continue
 		}
 		reasons = append(reasons, diagnostic.Status)
-		return strings.TrimSpace(diagnostic.AbsenceStatus), uniqueMCPListStrings(reasons), scanqualityAbsenceImpact(strings.TrimSpace(diagnostic.AbsenceStatus))
+		status = moreConservativeAbsenceStatus(status, diagnosticStatus)
+	}
+	if status != "" {
+		return status, uniqueMCPListStrings(reasons), scanqualityAbsenceImpact(status)
 	}
 	return scanquality.AbsenceStatusNotScanned, uniqueMCPListStrings(reasons), scanqualityAbsenceImpact(scanquality.AbsenceStatusNotScanned)
 }
@@ -504,24 +509,17 @@ func mcpAbsenceClaim(report *scanquality.Report, repoFilter string) *scanquality
 	if report == nil {
 		return nil
 	}
-	if strings.TrimSpace(repoFilter) != "" {
-		org := inferDiagnosticOrg(state.Snapshot{ScanQuality: report}, repoFilter)
-		if claim := scanquality.AbsenceClaimForSurface(report, org, repoFilter, scanquality.SurfaceMCPServer); claim != nil {
-			return claim
-		}
-		if claim := scanquality.AbsenceClaimForSurface(report, "", repoFilter, scanquality.SurfaceMCPServer); claim != nil {
-			return claim
-		}
-	}
+	matches := make([]scanquality.AbsenceClaim, 0)
 	for _, claim := range report.AbsenceClaims {
 		if strings.TrimSpace(claim.Surface) != scanquality.SurfaceMCPServer {
 			continue
 		}
-		copyClaim := claim
-		copyClaim.Reasons = append([]string(nil), claim.Reasons...)
-		return &copyClaim
+		if strings.TrimSpace(repoFilter) != "" && strings.TrimSpace(claim.Repo) != strings.TrimSpace(repoFilter) {
+			continue
+		}
+		matches = append(matches, claim)
 	}
-	return nil
+	return aggregateMCPAbsenceClaims(matches)
 }
 
 func scanqualityAbsenceImpact(status string) string {
@@ -538,6 +536,57 @@ func scanqualityAbsenceImpact(status string) string {
 		return "MCP coverage was not scanned for this repo, so absence is not authoritative."
 	default:
 		return ""
+	}
+}
+
+func aggregateMCPAbsenceClaims(claims []scanquality.AbsenceClaim) *scanquality.AbsenceClaim {
+	if len(claims) == 0 {
+		return nil
+	}
+	out := scanquality.AbsenceClaim{}
+	reasons := make([]string, 0)
+	for _, claim := range claims {
+		if strings.TrimSpace(out.Status) == "" {
+			out = claim
+		} else {
+			out.Status = moreConservativeAbsenceStatus(out.Status, claim.Status)
+		}
+		reasons = append(reasons, claim.Reasons...)
+		if strings.TrimSpace(out.Org) == "" && strings.TrimSpace(claim.Org) != "" {
+			out.Org = strings.TrimSpace(claim.Org)
+		}
+		if strings.TrimSpace(out.Repo) == "" && strings.TrimSpace(claim.Repo) != "" {
+			out.Repo = strings.TrimSpace(claim.Repo)
+		}
+	}
+	out.Reasons = uniqueMCPListStrings(reasons)
+	out.Impact = scanqualityAbsenceImpact(out.Status)
+	return &out
+}
+
+func moreConservativeAbsenceStatus(current string, candidate string) string {
+	if absenceStatusRank(candidate) < absenceStatusRank(current) {
+		return strings.TrimSpace(candidate)
+	}
+	return strings.TrimSpace(current)
+}
+
+func absenceStatusRank(status string) int {
+	switch strings.TrimSpace(status) {
+	case scanquality.AbsenceStatusNotScanned:
+		return 0
+	case scanquality.AbsenceStatusCandidateParseFailed:
+		return 1
+	case scanquality.AbsenceStatusUnsupportedSurface:
+		return 2
+	case scanquality.AbsenceStatusNotFoundReducedCoverage:
+		return 3
+	case scanquality.AbsenceStatusNotFoundCompleteCoverage:
+		return 4
+	case "":
+		return 5
+	default:
+		return 6
 	}
 }
 

--- a/core/report/mcp_list_test.go
+++ b/core/report/mcp_list_test.go
@@ -364,3 +364,62 @@ func TestBuildMCPListKeepsMCPParseErrorsAsReducedCoverage(t *testing.T) {
 		t.Fatalf("expected MCP parse failure to be preserved, got %+v", payload.Diagnostics[0])
 	}
 }
+
+func TestBuildMCPListCarriesCompleteCoverageAbsenceStatus(t *testing.T) {
+	t.Parallel()
+
+	payload := BuildMCPListWithOptions(state.Snapshot{
+		ScanQuality: &scanquality.Report{
+			ScanQualityVersion: scanquality.ReportVersion,
+			Mode:               "governance",
+			AbsenceClaims: []scanquality.AbsenceClaim{{
+				Org:     "acme",
+				Repo:    "acme/payments",
+				Surface: scanquality.SurfaceMCPServer,
+				Status:  scanquality.AbsenceStatusNotFoundCompleteCoverage,
+				Reasons: []string{"detector:mcp=complete", "mcp:no_candidate_inputs"},
+				Impact:  "Complete MCP coverage supported a clean negative result for the scanned surfaces.",
+			}},
+		},
+	}, MCPListOptions{
+		RepoFilter: "acme/payments",
+	})
+
+	if payload.AbsenceStatus != scanquality.AbsenceStatusNotFoundCompleteCoverage {
+		t.Fatalf("expected complete-coverage absence status, got %+v", payload)
+	}
+	if !containsString(payload.AbsenceReasons, "detector:mcp=complete") {
+		t.Fatalf("expected absence reasons to round-trip, got %+v", payload.AbsenceReasons)
+	}
+	if payload.AbsenceImpact == "" {
+		t.Fatalf("expected absence impact, got %+v", payload)
+	}
+}
+
+func TestBuildMCPListFallsBackToReducedCoverageWhenOnlyCandidatesExist(t *testing.T) {
+	t.Parallel()
+
+	payload := BuildMCPListWithOptions(state.Snapshot{
+		Findings: []source.Finding{
+			{
+				FindingType: "mcp_server_candidate",
+				ToolType:    "mcp",
+				Location:    "package.json",
+				Repo:        "acme/payments",
+				Org:         "acme",
+				Evidence: []model.Evidence{
+					{Key: "candidate_name", Value: "payments-mcp"},
+				},
+			},
+		},
+	}, MCPListOptions{
+		RepoFilter: "acme/payments",
+	})
+
+	if payload.AbsenceStatus != scanquality.AbsenceStatusNotFoundReducedCoverage {
+		t.Fatalf("expected reduced-coverage fallback, got %+v", payload)
+	}
+	if !containsString(payload.AbsenceReasons, "candidate_evidence:present") {
+		t.Fatalf("expected candidate evidence reason, got %+v", payload.AbsenceReasons)
+	}
+}

--- a/core/report/mcp_list_test.go
+++ b/core/report/mcp_list_test.go
@@ -303,6 +303,9 @@ func TestBuildMCPListEmitsNotDetectedDiagnosticWhenExpectedServerHasNoSignals(t 
 	if payload.Diagnostics[0].ExpectedServer != "payments-mcp" {
 		t.Fatalf("expected expected_server to round-trip, got %+v", payload.Diagnostics[0])
 	}
+	if payload.AbsenceStatus != scanquality.AbsenceStatusNotScanned {
+		t.Fatalf("expected missing scan-quality evidence to stay not_scanned, got %+v", payload)
+	}
 }
 
 func TestBuildMCPListIgnoresUnrelatedDependencyParseErrorsInDiagnostics(t *testing.T) {
@@ -421,5 +424,39 @@ func TestBuildMCPListFallsBackToReducedCoverageWhenOnlyCandidatesExist(t *testin
 	}
 	if !containsString(payload.AbsenceReasons, "candidate_evidence:present") {
 		t.Fatalf("expected candidate evidence reason, got %+v", payload.AbsenceReasons)
+	}
+}
+
+func TestBuildMCPListAggregatesMostConservativeAbsenceStatusAcrossRepos(t *testing.T) {
+	t.Parallel()
+
+	payload := BuildMCPListWithOptions(state.Snapshot{
+		ScanQuality: &scanquality.Report{
+			ScanQualityVersion: scanquality.ReportVersion,
+			Mode:               "governance",
+			AbsenceClaims: []scanquality.AbsenceClaim{
+				{
+					Org:     "acme",
+					Repo:    "acme/payments",
+					Surface: scanquality.SurfaceMCPServer,
+					Status:  scanquality.AbsenceStatusNotFoundCompleteCoverage,
+					Reasons: []string{"detector:mcp=complete"},
+				},
+				{
+					Org:     "acme",
+					Repo:    "acme/ops",
+					Surface: scanquality.SurfaceMCPServer,
+					Status:  scanquality.AbsenceStatusNotFoundReducedCoverage,
+					Reasons: []string{"candidate_evidence:present"},
+				},
+			},
+		},
+	}, MCPListOptions{})
+
+	if payload.AbsenceStatus != scanquality.AbsenceStatusNotFoundReducedCoverage {
+		t.Fatalf("expected most conservative aggregate absence status, got %+v", payload)
+	}
+	if !containsString(payload.AbsenceReasons, "detector:mcp=complete") || !containsString(payload.AbsenceReasons, "candidate_evidence:present") {
+		t.Fatalf("expected aggregate reasons to include all matching repo evidence, got %+v", payload.AbsenceReasons)
 	}
 }

--- a/core/report/render_markdown.go
+++ b/core/report/render_markdown.go
@@ -192,6 +192,21 @@ func RenderMarkdown(summary Summary) string {
 				strings.Join(detector.CoverageReasons, ","),
 			))
 		}
+		for _, claim := range summary.ScanQuality.AbsenceClaims {
+			if strings.TrimSpace(claim.Surface) == "" {
+				continue
+			}
+			reasons := "none"
+			if len(claim.Reasons) > 0 {
+				reasons = strings.Join(claim.Reasons, ",")
+			}
+			builder.WriteString(fmt.Sprintf("- %s absence_status=%s reasons=%s impact=%s\n",
+				claim.Surface,
+				claim.Status,
+				reasons,
+				firstNonEmptyValue(strings.TrimSpace(claim.Impact), "none"),
+			))
+		}
 		builder.WriteString("\n")
 	}
 

--- a/core/report/report_test.go
+++ b/core/report/report_test.go
@@ -270,6 +270,38 @@ func TestBuildSummaryCarriesScanQualityIntoReportAndBOM(t *testing.T) {
 	}
 }
 
+func TestNegativeClaimRenderMarkdownIncludesAbsenceClaimSummary(t *testing.T) {
+	t.Parallel()
+
+	markdown := RenderMarkdown(Summary{
+		GeneratedAt:  "2026-05-24T12:00:00Z",
+		Template:     "operator",
+		ShareProfile: "internal",
+		ScanQuality: &scanquality.Report{
+			ScanQualityVersion: scanquality.ReportVersion,
+			Mode:               "governance",
+			Detectors: []scanquality.DetectorHealth{
+				{Detector: "mcp", Status: "reduced", ParseFailures: 1, AttemptedFiles: 1, ParsedFiles: 0, CoverageReasons: []string{"parse_failures"}},
+			},
+			AbsenceClaims: []scanquality.AbsenceClaim{{
+				Org:     "acme",
+				Repo:    "acme/payments",
+				Surface: scanquality.SurfaceMCPServer,
+				Status:  scanquality.AbsenceStatusCandidateParseFailed,
+				Reasons: []string{"detector:mcp=reduced", "mcp:parse_failures"},
+				Impact:  "At least one MCP candidate surface failed to parse, so absence is not authoritative.",
+			}},
+		},
+	})
+
+	if !strings.Contains(markdown, "mcp_server absence_status=candidate_parse_failed") {
+		t.Fatalf("expected markdown to render absence status, got %q", markdown)
+	}
+	if !strings.Contains(markdown, "impact=At least one MCP candidate surface failed to parse") {
+		t.Fatalf("expected markdown to render absence impact, got %q", markdown)
+	}
+}
+
 func TestBuildSummaryKeepsDiagnosticsOutOfSecuritySurfaces(t *testing.T) {
 	t.Parallel()
 
@@ -1801,6 +1833,70 @@ func TestBuildSummaryDecoratesBacklogWithProjectedPosture(t *testing.T) {
 	}
 	if item.ApprovalStatus != "approved" {
 		t.Fatalf("expected user-managed approval status to be preserved, got %+v", item)
+	}
+}
+
+func TestControlStateConsistencyBuildSummaryNormalizesCriticalControlStateAcrossSurfaces(t *testing.T) {
+	t.Parallel()
+
+	summary, err := BuildSummary(BuildInput{
+		Snapshot: state.Snapshot{
+			RiskReport: &risk.Report{
+				ActionPaths: []risk.ActionPath{{
+					PathID:                   "apc-critical-summary",
+					Org:                      "acme",
+					Repo:                     "acme/release",
+					ToolType:                 "compiled_action",
+					Location:                 ".github/workflows/release.yml",
+					WriteCapable:             true,
+					CredentialAccess:         true,
+					StandingPrivilege:        true,
+					DeployWrite:              true,
+					ProductionWrite:          true,
+					MatchedProductionTargets: []string{"built_in:deploy_workflow"},
+					PolicyCoverageStatus:     risk.PolicyCoverageStatusMatched,
+					PolicyEvidenceRefs:       []string{"gait://release"},
+					GaitCoverage: &risk.GaitCoverage{
+						ProofVerification: risk.GaitCoverageDetail{
+							Status:       risk.GaitStatusPresent,
+							EvidenceRefs: []string{"proof_record:rec-111"},
+						},
+					},
+				}},
+			},
+			ControlBacklog: &controlbacklog.Backlog{
+				Items: []controlbacklog.Item{{
+					LinkedActionPathID: "apc-critical-summary",
+					Repo:               "acme/release",
+					Path:               ".github/workflows/release.yml",
+				}},
+			},
+		},
+		Template:    TemplateAgentActionBOM,
+		GeneratedAt: time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("build summary: %v", err)
+	}
+	if len(summary.ActionPaths) != 1 || summary.AgentActionBOM == nil || len(summary.AgentActionBOM.Items) != 1 || summary.ControlBacklog == nil || len(summary.ControlBacklog.Items) != 1 {
+		t.Fatalf("expected projected path, bom item, and backlog item, got summary=%+v", summary)
+	}
+
+	path := summary.ActionPaths[0]
+	item := summary.AgentActionBOM.Items[0]
+	backlogItem := summary.ControlBacklog.Items[0]
+
+	if path.ReviewBurden != risk.ReviewBurdenCritical || item.ReviewBurden != path.ReviewBurden || backlogItem.ReviewBurden != path.ReviewBurden {
+		t.Fatalf("expected critical review burden across surfaces, path=%+v item=%+v backlog=%+v", path, item, backlogItem)
+	}
+	if path.ControlState == risk.ControlStateSafeByDefault || item.ControlState != path.ControlState || backlogItem.ControlState != path.ControlState {
+		t.Fatalf("expected non-clean control state across surfaces, path=%+v item=%+v backlog=%+v", path, item, backlogItem)
+	}
+	if path.RiskTier != risk.RiskTierCritical || item.RiskTier != path.RiskTier {
+		t.Fatalf("expected critical risk tier across projected path and BOM, path=%+v item=%+v", path, item)
+	}
+	if item.Queue != controlbacklog.QueueControlFirst || backlogItem.Queue != controlbacklog.QueueControlFirst {
+		t.Fatalf("expected fail-closed queue across BOM and backlog, item=%+v backlog=%+v", item, backlogItem)
 	}
 }
 

--- a/core/risk/buyer_projection.go
+++ b/core/risk/buyer_projection.go
@@ -58,6 +58,7 @@ func ProjectActionPath(path ActionPath) ActionPath {
 	out.ControlState, out.ControlStateReasons = deriveControlState(out)
 	out.RiskZone, out.RiskZoneReasons = deriveRiskZone(out)
 	out.ReviewBurden, out.ReviewBurdenReasons = deriveReviewBurden(out)
+	out = normalizeProjectedControlState(out)
 	return out
 }
 
@@ -435,6 +436,130 @@ func deriveReviewBurden(path ActionPath) (string, []string) {
 		return ReviewBurdenMedium, dedupeSortedStrings(reasons)
 	default:
 		return ReviewBurdenLow, dedupeSortedStrings(reasons)
+	}
+}
+
+func normalizeProjectedControlState(path ActionPath) ActionPath {
+	out := path
+	addControlReason := func(reason string) {
+		if strings.TrimSpace(reason) == "" {
+			return
+		}
+		out.ControlStateReasons = dedupeSortedStrings(append(out.ControlStateReasons, strings.TrimSpace(reason)))
+	}
+	addReviewReason := func(reason string) {
+		if strings.TrimSpace(reason) == "" {
+			return
+		}
+		out.ReviewBurdenReasons = dedupeSortedStrings(append(out.ReviewBurdenReasons, strings.TrimSpace(reason)))
+	}
+
+	highImpact := out.ProductionWrite ||
+		out.DeployWrite ||
+		out.MergeExecute ||
+		out.StandingPrivilege ||
+		pathHasHighImpactMutableEndpoint(out) ||
+		pathHasSensitiveDataEndpoint(out)
+	contradictory := actionPathHasContradictoryControlEvidence(out)
+	criticalReview := strings.TrimSpace(out.ReviewBurden) == ReviewBurdenCritical
+
+	if contradictory {
+		if strings.TrimSpace(out.ControlPriority) != ControlPriorityControlFirst {
+			out.ControlPriority = ControlPriorityControlFirst
+			addControlReason("consistency:contradictory_control_routes_to_control_first")
+		}
+		if strings.TrimSpace(out.ControlState) != ControlStateBlockRecommend {
+			out.ControlState = ControlStateBlockRecommend
+			addControlReason("consistency:contradictory_control_blocks_clean_state")
+		}
+		if reviewBurdenRank(out.ReviewBurden) > reviewBurdenRank(ReviewBurdenCritical) {
+			out.ReviewBurden = ReviewBurdenCritical
+			addReviewReason("consistency:contradictory_control_requires_critical_review")
+		}
+		out.RiskTier = promoteRiskTier(out.RiskTier, minimumConsistencyRiskTier(highImpact))
+		return out
+	}
+
+	if strings.TrimSpace(out.ControlPriority) == ControlPriorityControlFirst && strings.TrimSpace(out.ControlState) == ControlStateSafeByDefault {
+		out.ControlState = ControlStateEvidenceNeeded
+		addControlReason("consistency:control_first_cannot_be_safe_by_default")
+	}
+
+	if criticalReview {
+		if strings.TrimSpace(out.ControlPriority) == ControlPriorityInventoryHygiene {
+			out.ControlPriority = ControlPriorityReviewQueue
+			addReviewReason("consistency:critical_review_cannot_stay_inventory_hygiene")
+		}
+		switch strings.TrimSpace(out.ControlState) {
+		case ControlStateSafeByDefault, ControlStateInventoryOnly:
+			switch {
+			case out.ApprovalGap:
+				out.ControlState = ControlStateApprovalNeeded
+				addControlReason("consistency:critical_review_requires_approval_or_evidence")
+			case highImpact:
+				out.ControlState = ControlStateBlockRecommend
+				addControlReason("consistency:critical_review_requires_fail_closed_state")
+			default:
+				out.ControlState = ControlStateEvidenceNeeded
+				addControlReason("consistency:critical_review_requires_approval_or_evidence")
+			}
+		}
+		out.RiskTier = promoteRiskTier(out.RiskTier, minimumConsistencyRiskTier(highImpact))
+	}
+
+	if strings.TrimSpace(out.ControlPriority) == ControlPriorityControlFirst {
+		out.RiskTier = promoteRiskTier(out.RiskTier, minimumConsistencyRiskTier(highImpact))
+	}
+
+	return out
+}
+
+func actionPathHasContradictoryControlEvidence(path ActionPath) bool {
+	if strings.TrimSpace(path.ControlResolutionState) == ControlResolutionStateContradictoryControl {
+		return true
+	}
+	for _, state := range []string{
+		path.ApprovalEvidenceState,
+		path.OwnerEvidenceState,
+		path.ProofEvidenceState,
+		path.RuntimeEvidenceState,
+		path.TargetEvidenceState,
+		path.CredentialEvidenceState,
+	} {
+		if normalizeEvidenceState(state) == EvidenceStateContradictory {
+			return true
+		}
+	}
+	return false
+}
+
+func minimumConsistencyRiskTier(highImpact bool) string {
+	if highImpact {
+		return RiskTierCritical
+	}
+	return RiskTierHigh
+}
+
+func promoteRiskTier(current, minimum string) string {
+	if riskTierRank(minimum) < riskTierRank(current) {
+		return minimum
+	}
+	if strings.TrimSpace(current) == "" {
+		return minimum
+	}
+	return strings.TrimSpace(current)
+}
+
+func riskTierRank(value string) int {
+	switch strings.TrimSpace(value) {
+	case RiskTierCritical:
+		return 0
+	case RiskTierHigh:
+		return 1
+	case RiskTierMedium:
+		return 2
+	default:
+		return 3
 	}
 }
 

--- a/core/risk/control_state_consistency_test.go
+++ b/core/risk/control_state_consistency_test.go
@@ -1,0 +1,100 @@
+package risk
+
+import (
+	"testing"
+
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+)
+
+func TestControlStateConsistencySafeByDefaultCannotBeControlFirstCritical(t *testing.T) {
+	t.Parallel()
+
+	paths := ProjectActionPaths([]ActionPath{{
+		PathID:            "apc-critical-consistency",
+		Org:               "acme",
+		Repo:              "acme/release",
+		ToolType:          "compiled_action",
+		Location:          ".github/workflows/release.yml",
+		WriteCapable:      true,
+		CredentialAccess:  true,
+		StandingPrivilege: true,
+		StandingPrivilegeReasons: []string{
+			"credential_authority:standing",
+		},
+		DeployWrite:              true,
+		ProductionWrite:          true,
+		MatchedProductionTargets: []string{"built_in:deploy_workflow"},
+		PolicyCoverageStatus:     PolicyCoverageStatusMatched,
+		PolicyEvidenceRefs:       []string{"gait://release"},
+		GaitCoverage: &GaitCoverage{
+			ProofVerification: GaitCoverageDetail{
+				Status:       GaitStatusPresent,
+				EvidenceRefs: []string{"proof_record:rec-123"},
+			},
+		},
+	}})
+
+	if len(paths) != 1 {
+		t.Fatalf("expected one projected path, got %+v", paths)
+	}
+	if paths[0].ControlPriority != ControlPriorityControlFirst {
+		t.Fatalf("expected control_first priority, got %+v", paths[0])
+	}
+	if paths[0].ReviewBurden != ReviewBurdenCritical {
+		t.Fatalf("expected critical review burden, got %+v", paths[0])
+	}
+	if paths[0].ControlState == ControlStateSafeByDefault {
+		t.Fatalf("did not expect safe_by_default on a critical control-first path, got %+v", paths[0])
+	}
+	if paths[0].RiskTier != RiskTierCritical {
+		t.Fatalf("expected critical risk tier for critical control-first path, got %+v", paths[0])
+	}
+}
+
+func TestControlStateConsistencyContradictoryControlEvidenceCannotRenderLowRisk(t *testing.T) {
+	t.Parallel()
+
+	paths := ProjectActionPaths([]ActionPath{{
+		PathID:               "apc-contradictory-consistency",
+		Org:                  "acme",
+		Repo:                 "acme/release",
+		ToolType:             "compiled_action",
+		Location:             ".github/workflows/release.yml",
+		WriteCapable:         true,
+		CredentialAccess:     true,
+		OperationalOwner:     "@acme/release",
+		OwnershipStatus:      "unresolved",
+		OwnershipState:       "conflicting_owner",
+		OwnershipEvidence:    []string{"codeowners:CODEOWNERS:*"},
+		OwnershipConflicts:   []string{"@acme/release", "@acme/security"},
+		ApprovalGap:          true,
+		ApprovalGapReasons:   []string{"approval_source_missing"},
+		PolicyCoverageStatus: PolicyCoverageStatusMatched,
+		GaitCoverage: &GaitCoverage{
+			ProofVerification: GaitCoverageDetail{
+				Status:       GaitStatusPresent,
+				EvidenceRefs: []string{"proof_record:rec-321"},
+			},
+		},
+		PathContext: &agginventory.PathContext{Kind: agginventory.PathContextRuntimeSource, Confidence: "high"},
+	}})
+
+	if len(paths) != 1 {
+		t.Fatalf("expected one projected path, got %+v", paths)
+	}
+	if paths[0].ControlResolutionState != ControlResolutionStateContradictoryControl {
+		t.Fatalf("expected contradictory control resolution state, got %+v", paths[0])
+	}
+	if paths[0].ReviewBurden != ReviewBurdenCritical {
+		t.Fatalf("expected contradictory control evidence to require critical review, got %+v", paths[0])
+	}
+	if paths[0].ControlPriority != ControlPriorityControlFirst {
+		t.Fatalf("expected contradictory control evidence to route to control-first, got %+v", paths[0])
+	}
+	if paths[0].RiskTier != RiskTierHigh && paths[0].RiskTier != RiskTierCritical {
+		t.Fatalf("expected contradictory control evidence to stay high-risk, got %+v", paths[0])
+	}
+	if paths[0].ControlState == ControlStateSafeByDefault || paths[0].ControlState == ControlStateInventoryOnly {
+		t.Fatalf("expected contradictory control evidence to avoid clean control states, got %+v", paths[0])
+	}
+}

--- a/core/risk/govern_first_model.go
+++ b/core/risk/govern_first_model.go
@@ -382,6 +382,10 @@ func sourceFindingKeyOrder(keys []string) string {
 }
 
 func RemediationForActionPath(path ActionPath) string {
+	path = ProjectActionPath(path)
+	if actionPathHasContradictoryControlEvidence(path) {
+		return "Control evidence is contradictory for this path; resolve the conflicting control or evidence signals, keep it in fail-closed review, and rerun the scan before treating it as governed."
+	}
 	if actionPathHasWeakOwnership(path) {
 		switch normalizeEvidenceState(path.OwnerEvidenceState) {
 		case EvidenceStateContradictory:

--- a/docs/commands/mcp-list.md
+++ b/docs/commands/mcp-list.md
@@ -24,7 +24,7 @@ wrkr mcp-list --state ./.wrkr/last-scan.json --json
 
 Run this after a saved state snapshot already exists from `wrkr scan`.
 
-Expected JSON keys: `status`, `generated_at`, additive `repo_filter`, `rows`, additive `candidates`, additive `diagnostics`, optional `warnings`.
+Expected JSON keys: `status`, `generated_at`, additive `repo_filter`, `rows`, additive `candidates`, additive `diagnostics`, optional `warnings`, and additive coverage-qualified absence fields `absence_status`, `absence_reasons`, and `absence_impact` when no authoritative MCP server rows are emitted.
 
 `warnings` is also used when Wrkr can prove the saved state may have incomplete MCP posture because known MCP-bearing declaration files failed to parse.
 
@@ -48,7 +48,15 @@ Each row includes:
 
 `candidates[]` is additive saved-state evidence for MCP-like package scripts, package dependencies, workspace hints, source literals, and WebMCP declarations that are not yet authoritative servers. Each candidate includes `candidate_name`, `org`, `repo`, `location`, `evidence_type`, `confidence`, `declaration_type`, `transport_hint`, optional `credential_refs`, and optional `unsupported_reason`.
 
-`diagnostics[]` is additive miss-explanation output. It is designed for questions like “we expected server X in repo Y; why was it not emitted?” Each diagnostic includes deterministic `status` (`found`, `candidate_only`, `reduced_coverage`, or `not_detected`) plus the supporting `candidate_files_scanned`, `parsed_configs`, `candidates_found`, `parse_failures`, `generated_suppressions`, and `unsupported_declarations`.
+`diagnostics[]` is additive miss-explanation output. It is designed for questions like “we expected server X in repo Y; why was it not emitted?” Each diagnostic includes deterministic `status` (`found`, `candidate_only`, `reduced_coverage`, or `not_detected`), additive `absence_status`, additive `absence_impact`, and the supporting `candidate_files_scanned`, `parsed_configs`, `candidates_found`, `parse_failures`, `generated_suppressions`, and `unsupported_declarations`.
+
+When `rows[]` is empty, Wrkr now qualifies absence claims instead of always saying “no MCP servers found.” The additive `absence_status` values are:
+
+- `not_found_with_complete_coverage`: complete MCP coverage found no authoritative servers.
+- `not_found_with_reduced_coverage`: coverage was reduced or only candidate evidence exists.
+- `not_scanned`: the saved state does not include MCP coverage facts for this repo/scope.
+- `unsupported_surface`: only unsupported MCP-style surfaces were encountered.
+- `candidate_parse_failed`: at least one MCP candidate surface failed to parse.
 
 ## Trust overlay contract
 
@@ -75,7 +83,7 @@ Use `wrkr ingest` when you have runtime policy or gateway evidence to correlate 
 `mcp-list` is discovery and privilege mapping only.
 
 - Wrkr inventories MCP posture from saved state.
-- Wrkr can explain candidate-only or coverage-reduced MCP misses from saved state, but it still does not probe endpoints live.
+- Wrkr can explain candidate-only, parse-failed, unsupported-surface, or coverage-reduced MCP misses from saved state, but it still does not probe endpoints live.
 - Wrkr does not probe MCP endpoints live.
 - Wrkr does not replace package or vulnerability scanners. Use dedicated tools such as Snyk for that class of assessment.
 - Gait remains an optional control-layer integration, not a hard prerequisite for Wrkr.

--- a/docs/trust/detection-coverage-matrix.md
+++ b/docs/trust/detection-coverage-matrix.md
@@ -18,6 +18,7 @@ description: "What Wrkr detects, what it does not detect, and why under determin
 - Static non-human execution identity signals for GitHub Apps, bot users, and service-account references from workflow/config artifacts.
 - Deterministic purpose, version, and config-fingerprint metadata for supported workflow, MCP, and agent-config surfaces when local files, static declaration evidence, or explicit `wrkr:purpose` annotations are available.
 - Deterministic confidence lanes that separate confirmed action paths, likely paths, semantic review candidates, and context-only evidence in buyer-facing output.
+- Coverage-qualified negative-claim posture for MCP surfaces so complete coverage, reduced coverage, unsupported declarations, parse-failed candidates, and unscanned repos do not collapse into the same absence wording.
 - Normalized credential-authority posture that distinguishes credential presence, workflow reference, path usability, access type, standing access, likely JIT, rotation evidence status, and source without exposing raw secret values.
 - Field-selection redaction metadata and stable pseudonym joins for buyer-facing report artifacts when customer, design-partner, external, or investor-safe share profiles are used.
 - Static policy/profile posture signals and ranked findings.
@@ -35,6 +36,8 @@ description: "What Wrkr detects, what it does not detect, and why under determin
 
 Wrkr is deterministic and file-based by default. Static discovery avoids nondeterministic live probing and keeps scan data local.
 `--enrich` is an optional volatility-aware overlay; fail-closed adapter behavior preserves scan safety while quality is explicitly surfaced in output.
+
+That same discipline applies to negative claims: Wrkr only uses absolute absence language when detector coverage is complete enough to support it. Reduced coverage, unsupported declarations, parse-failed candidate surfaces, and unscanned repos stay explicitly qualified in saved-state artifacts.
 
 ## Command anchors
 

--- a/schemas/v1/agent-action-bom.schema.json
+++ b/schemas/v1/agent-action-bom.schema.json
@@ -345,7 +345,33 @@
         "detector_errors": {
           "type": "array",
           "items": {"$ref": "#/$defs/detectorError"}
+        },
+        "absence_claims": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/absenceClaim"}
         }
+      },
+      "additionalProperties": false
+    },
+    "absenceClaim": {
+      "type": "object",
+      "required": ["surface", "status"],
+      "properties": {
+        "org": {"type": "string"},
+        "repo": {"type": "string"},
+        "surface": {"type": "string"},
+        "status": {
+          "type": "string",
+          "enum": [
+            "not_found_with_complete_coverage",
+            "not_found_with_reduced_coverage",
+            "not_scanned",
+            "unsupported_surface",
+            "candidate_parse_failed"
+          ]
+        },
+        "reasons": {"type": "array", "items": {"type": "string"}},
+        "impact": {"type": "string"}
       },
       "additionalProperties": false
     },

--- a/schemas/v1/report/report-summary.schema.json
+++ b/schemas/v1/report/report-summary.schema.json
@@ -515,7 +515,33 @@
         "detector_errors": {
           "type": "array",
           "items": {"$ref": "#/$defs/detectorError"}
+        },
+        "absence_claims": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/absenceClaim"}
         }
+      },
+      "additionalProperties": false
+    },
+    "absenceClaim": {
+      "type": "object",
+      "required": ["surface", "status"],
+      "properties": {
+        "org": {"type": "string"},
+        "repo": {"type": "string"},
+        "surface": {"type": "string"},
+        "status": {
+          "type": "string",
+          "enum": [
+            "not_found_with_complete_coverage",
+            "not_found_with_reduced_coverage",
+            "not_scanned",
+            "unsupported_surface",
+            "candidate_parse_failed"
+          ]
+        },
+        "reasons": {"type": "array", "items": {"type": "string"}},
+        "impact": {"type": "string"}
       },
       "additionalProperties": false
     },


### PR DESCRIPTION
## Problem
- Wave 3 of the control evidence state model needs govern-first consistency fixes so critical or contradictory paths do not project clean control states.
- MCP negative claims need coverage-qualified absence reporting so reduced coverage, unsupported surfaces, parse failures, and unscanned repos do not render as absolute absence claims.
- The plan validation filters also needed to exercise the new wave 3 tests directly.

## Changes
- Normalize projected control-state, review-burden, queue, and risk-tier behavior for critical and contradictory paths across risk, backlog, BOM, and report projection.
- Add MCP absence-status derivation and propagate additive absence status, reasons, and impact through scan quality, MCP list JSON/text, markdown, schemas, docs, and changelog.
- Add and align focused wave 3 tests so the documented story `go test -run` filters cover the new consistency and negative-claim cases.

## Validation
- `make prepush-full`
- `go test ./core/risk ./core/aggregate/controlbacklog ./core/report -run 'Test.*ControlStateConsistency|Test.*ReviewBurden|Test.*Queue|Test.*RiskTier' -count=1`
- `go test ./core/aggregate/scanquality ./core/report ./core/cli -run 'Test.*AbsenceStatus|Test.*MCPList|Test.*NegativeClaim|Test.*ScanQuality' -count=1`
- `make test-contracts`
- `make test-hardening`
- `make codeql`

## Risks
- Public report and schema semantics change additively but do tighten govern-first normalization and buyer-facing absence wording.
- MCP absence wording now depends on scan-quality evidence, so downstream consumers should prefer the canonical absence fields over assuming a flat missing-server result.
