### PR TITLE
feat: add enterprise evidence governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - [semver:minor] Added schema-backed external control evidence sidecars for local ownership, approval, provider, branch, deployment, and policy evidence.
 - [semver:minor] Added deterministic correlation for external ownership, approval, app catalog, ticket, policy, and provider evidence.
 - [semver:minor] Added branch protection, protected environment, deployment approval, required check, freeze window, and kill switch evidence for control reports.
+- [semver:minor] Added freshness and expiry metadata for imported and declared evidence across reports, backlog, and evidence bundles.
+- [semver:minor] Added versioned customer control declarations for owner mappings, target classes, accepted tooling, exceptions, non-prod declarations, and evidence links.
+- [semver:minor] Added contradiction detection for customer declarations, production targets, credentials, workflows, deployment constraints, and policy evidence.
 
 ### Changed
 
@@ -23,6 +26,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - [semver:minor] Changed MCP absence reporting to use coverage-qualified statuses so reduced coverage, unsupported declarations, parse-failed candidates, and unscanned repos do not render as absolute missing-server claims.
 - [semver:patch] Changed buyer-facing reports and Agent Action BOM summaries to lead with compact scan coverage summaries while preserving detector-level scan-quality details in appendix and evidence JSON.
 - [semver:minor] Changed runtime evidence reporting so static-only scans render runtime evidence as not collected or not applicable unless runtime evidence is required or needed for a control claim.
+- [semver:minor] Changed evidence resolution to use deterministic source precedence with conflict reasons across ownership and control outputs.
 - Updated command, trust, and schema documentation for evidence-state control resolution, target classification, action path type classification, coverage-qualified absence, runtime evidence framing, and report QA guardrails.
 
 ### Deprecated

--- a/core/aggregate/controlbacklog/controlbacklog.go
+++ b/core/aggregate/controlbacklog/controlbacklog.go
@@ -9,6 +9,7 @@ import (
 	aggattack "github.com/Clyra-AI/wrkr/core/aggregate/attackpath"
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/detect"
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
 	"github.com/Clyra-AI/wrkr/core/lifecycle"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/risk"
@@ -99,6 +100,8 @@ type Item struct {
 	OwnershipConfidence        float64                                 `json:"ownership_confidence,omitempty"`
 	OwnershipEvidence          []string                                `json:"ownership_evidence_basis,omitempty"`
 	OwnershipConflicts         []string                                `json:"ownership_conflicts,omitempty"`
+	EvidenceDecisions          []evidencepolicy.Decision               `json:"evidence_decisions,omitempty"`
+	Contradictions             []evidencepolicy.Contradiction          `json:"contradictions,omitempty"`
 	ControlResolutionState     string                                  `json:"control_resolution_state,omitempty"`
 	ControlResolutionReasons   []string                                `json:"control_resolution_reasons,omitempty"`
 	ControlEvidenceRefs        []string                                `json:"control_evidence_refs,omitempty"`
@@ -311,6 +314,8 @@ func (b *builder) addActionPath(path risk.ActionPath) {
 		OwnershipConfidence:        path.OwnershipConfidence,
 		OwnershipEvidence:          append([]string(nil), path.OwnershipEvidence...),
 		OwnershipConflicts:         append([]string(nil), path.OwnershipConflicts...),
+		EvidenceDecisions:          append([]evidencepolicy.Decision(nil), path.EvidenceDecisions...),
+		Contradictions:             append([]evidencepolicy.Contradiction(nil), path.Contradictions...),
 		ControlResolutionState:     strings.TrimSpace(path.ControlResolutionState),
 		ControlResolutionReasons:   append([]string(nil), path.ControlResolutionReasons...),
 		ControlEvidenceRefs:        append([]string(nil), path.ControlEvidenceRefs...),
@@ -493,6 +498,8 @@ func (b *builder) merge(item Item) {
 	}
 	current.OwnershipEvidence = mergeStrings(current.OwnershipEvidence, item.OwnershipEvidence)
 	current.OwnershipConflicts = mergeStrings(current.OwnershipConflicts, item.OwnershipConflicts)
+	current.EvidenceDecisions = mergeEvidenceDecisions(current.EvidenceDecisions, item.EvidenceDecisions)
+	current.Contradictions = mergeContradictions(current.Contradictions, item.Contradictions)
 	current.ControlResolutionState = firstNonEmptyString(current.ControlResolutionState, item.ControlResolutionState)
 	current.ControlResolutionReasons = mergeStrings(current.ControlResolutionReasons, item.ControlResolutionReasons)
 	current.ControlEvidenceRefs = mergeStrings(current.ControlEvidenceRefs, item.ControlEvidenceRefs)
@@ -1629,6 +1636,52 @@ func mergeStrings(a, b []string) []string {
 		out = append(out, value)
 	}
 	sort.Strings(out)
+	return out
+}
+
+func mergeEvidenceDecisions(current, incoming []evidencepolicy.Decision) []evidencepolicy.Decision {
+	if len(current) == 0 && len(incoming) == 0 {
+		return nil
+	}
+	byField := map[string]evidencepolicy.Decision{}
+	for _, item := range append(append([]evidencepolicy.Decision(nil), current...), incoming...) {
+		field := strings.TrimSpace(item.Field)
+		if field == "" {
+			continue
+		}
+		byField[field] = item
+	}
+	out := make([]evidencepolicy.Decision, 0, len(byField))
+	for _, item := range byField {
+		out = append(out, item)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Field < out[j].Field })
+	return out
+}
+
+func mergeContradictions(current, incoming []evidencepolicy.Contradiction) []evidencepolicy.Contradiction {
+	if len(current) == 0 && len(incoming) == 0 {
+		return nil
+	}
+	seen := map[string]evidencepolicy.Contradiction{}
+	for _, item := range append(append([]evidencepolicy.Contradiction(nil), current...), incoming...) {
+		key := strings.Join([]string{
+			strings.TrimSpace(item.Class),
+			strings.TrimSpace(item.ImpactedTarget),
+			strings.Join(item.ReasonCodes, "|"),
+		}, "|")
+		seen[key] = item
+	}
+	out := make([]evidencepolicy.Contradiction, 0, len(seen))
+	for _, item := range seen {
+		out = append(out, item)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Class != out[j].Class {
+			return out[i].Class < out[j].Class
+		}
+		return out[i].ImpactedTarget < out[j].ImpactedTarget
+	})
 	return out
 }
 

--- a/core/aggregate/inventory/inventory.go
+++ b/core/aggregate/inventory/inventory.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Clyra-AI/wrkr/core/aggregate/exposure"
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
 	"github.com/Clyra-AI/wrkr/core/identity"
 	"github.com/Clyra-AI/wrkr/core/manifest"
 	"github.com/Clyra-AI/wrkr/core/model"
@@ -16,15 +17,16 @@ import (
 )
 
 type ToolLocation struct {
-	Repo                string   `json:"repo" yaml:"repo"`
-	Location            string   `json:"location" yaml:"location"`
-	Owner               string   `json:"owner" yaml:"owner"`
-	OwnerSource         string   `json:"owner_source,omitempty" yaml:"owner_source,omitempty"`
-	OwnershipStatus     string   `json:"ownership_status,omitempty" yaml:"ownership_status,omitempty"`
-	OwnershipState      string   `json:"ownership_state,omitempty" yaml:"ownership_state,omitempty"`
-	OwnershipConfidence float64  `json:"ownership_confidence,omitempty" yaml:"ownership_confidence,omitempty"`
-	OwnershipEvidence   []string `json:"ownership_evidence_basis,omitempty" yaml:"ownership_evidence_basis,omitempty"`
-	OwnershipConflicts  []string `json:"ownership_conflicts,omitempty" yaml:"ownership_conflicts,omitempty"`
+	Repo                string                   `json:"repo" yaml:"repo"`
+	Location            string                   `json:"location" yaml:"location"`
+	Owner               string                   `json:"owner" yaml:"owner"`
+	OwnerSource         string                   `json:"owner_source,omitempty" yaml:"owner_source,omitempty"`
+	OwnershipStatus     string                   `json:"ownership_status,omitempty" yaml:"ownership_status,omitempty"`
+	OwnershipState      string                   `json:"ownership_state,omitempty" yaml:"ownership_state,omitempty"`
+	OwnershipConfidence float64                  `json:"ownership_confidence,omitempty" yaml:"ownership_confidence,omitempty"`
+	OwnershipEvidence   []string                 `json:"ownership_evidence_basis,omitempty" yaml:"ownership_evidence_basis,omitempty"`
+	OwnershipConflicts  []string                 `json:"ownership_conflicts,omitempty" yaml:"ownership_conflicts,omitempty"`
+	OwnershipDecision   *evidencepolicy.Decision `json:"ownership_decision,omitempty" yaml:"ownership_decision,omitempty"`
 }
 
 type Agent struct {
@@ -374,7 +376,7 @@ func Build(input BuildInput) Inventory {
 		if finding.Repo != "" {
 			item.repoSet[finding.Repo] = struct{}{}
 		}
-		owner := owners.ResolveWithMetadata(repoRoot(input.Manifest, finding.Repo), finding.Repo, findingOrg, finding.Location, ownerMetadata(input.Manifest, finding.Repo))
+		owner := owners.ResolveWithMetadataAt(repoRoot(input.Manifest, finding.Repo), finding.Repo, findingOrg, finding.Location, ownerMetadata(input.Manifest, finding.Repo), generatedAt)
 		locKey := finding.Repo + "::" + finding.Location
 		if _, exists := item.locSet[locKey]; !exists {
 			item.locSet[locKey] = struct{}{}
@@ -388,6 +390,7 @@ func Build(input BuildInput) Inventory {
 				OwnershipConfidence: owner.OwnershipConfidence,
 				OwnershipEvidence:   cloneStringSlice(owner.EvidenceBasis),
 				OwnershipConflicts:  cloneStringSlice(owner.ConflictOwners),
+				OwnershipDecision:   cloneEvidenceDecision(owner.EvidenceDecision),
 			})
 		}
 		for _, permission := range finding.Permissions {
@@ -1656,6 +1659,26 @@ func cloneStringSlice(values []string) []string {
 	out := make([]string, 0, len(values))
 	out = append(out, values...)
 	return out
+}
+
+func cloneEvidenceDecision(in *evidencepolicy.Decision) *evidencepolicy.Decision {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	out.SelectedEvidenceRefs = cloneStringSlice(in.SelectedEvidenceRefs)
+	out.ReasonCodes = cloneStringSlice(in.ReasonCodes)
+	out.ConflictReasonCodes = cloneStringSlice(in.ConflictReasonCodes)
+	if len(in.RejectedCandidates) > 0 {
+		out.RejectedCandidates = make([]evidencepolicy.Candidate, 0, len(in.RejectedCandidates))
+		for _, item := range in.RejectedCandidates {
+			copyItem := item
+			copyItem.EvidenceRefs = cloneStringSlice(item.EvidenceRefs)
+			copyItem.ReasonCodes = cloneStringSlice(item.ReasonCodes)
+			out.RejectedCandidates = append(out.RejectedCandidates, copyItem)
+		}
+	}
+	return &out
 }
 
 func findingAgentSymbol(finding model.Finding) string {

--- a/core/aggregate/inventory/privileges.go
+++ b/core/aggregate/inventory/privileges.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
 	"github.com/Clyra-AI/wrkr/core/model"
 )
 
@@ -141,6 +142,7 @@ type AgentPrivilegeMapEntry struct {
 	OwnershipConfidence      float64                    `json:"ownership_confidence,omitempty" yaml:"ownership_confidence,omitempty"`
 	OwnershipEvidence        []string                   `json:"ownership_evidence_basis,omitempty" yaml:"ownership_evidence_basis,omitempty"`
 	OwnershipConflicts       []string                   `json:"ownership_conflicts,omitempty" yaml:"ownership_conflicts,omitempty"`
+	OwnershipDecision        *evidencepolicy.Decision   `json:"ownership_decision,omitempty" yaml:"ownership_decision,omitempty"`
 	ApprovalGapReasons       []string                   `json:"approval_gap_reasons,omitempty" yaml:"approval_gap_reasons,omitempty"`
 	TrustDepth               *TrustDepth                `json:"trust_depth,omitempty" yaml:"trust_depth,omitempty"`
 	PullRequestWrite         bool                       `json:"pull_request_write,omitempty" yaml:"pull_request_write,omitempty"`

--- a/core/aggregate/privilegebudget/budget.go
+++ b/core/aggregate/privilegebudget/budget.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
 	"github.com/Clyra-AI/wrkr/core/identity"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/owners"
@@ -28,6 +29,7 @@ type ownershipCandidate struct {
 	ownershipConfidence float64
 	ownershipEvidence   []string
 	ownershipConflicts  []string
+	ownershipDecision   *evidencepolicy.Decision
 }
 
 func Build(
@@ -174,6 +176,7 @@ func Build(
 				OwnershipConfidence:      owner.OwnershipConfidence,
 				OwnershipEvidence:        cloneStringSlice(owner.EvidenceBasis),
 				OwnershipConflicts:       cloneStringSlice(owner.ConflictOwners),
+				OwnershipDecision:        cloneEvidenceDecision(owner.EvidenceDecision),
 				ApprovalGapReasons:       approvalReasons,
 				TrustDepth:               agginventory.CloneTrustDepth(tool.TrustDepth),
 				PullRequestWrite:         pullRequestWrite,
@@ -397,6 +400,7 @@ func buildInstanceEntries(
 			OwnershipConfidence:      owner.OwnershipConfidence,
 			OwnershipEvidence:        cloneStringSlice(owner.EvidenceBasis),
 			OwnershipConflicts:       cloneStringSlice(owner.ConflictOwners),
+			OwnershipDecision:        cloneEvidenceDecision(owner.EvidenceDecision),
 			ApprovalGapReasons:       approvalReasons,
 			TrustDepth:               agginventory.CloneTrustDepth(tool.TrustDepth),
 			PullRequestWrite:         pullRequestWrite,
@@ -1712,6 +1716,7 @@ func resolveOperationalOwner(tool agginventory.Tool, repos []string, location st
 			ownershipConfidence: confidence,
 			ownershipEvidence:   evidence,
 			ownershipConflicts:  conflicts,
+			ownershipDecision:   cloneEvidenceDecision(item.OwnershipDecision),
 		}
 	}
 	if len(candidates) == 0 {
@@ -1736,6 +1741,7 @@ func resolveOperationalOwner(tool agginventory.Tool, repos []string, location st
 				OwnershipConfidence: item.ownershipConfidence,
 				EvidenceBasis:       cloneStringSlice(item.ownershipEvidence),
 				ConflictOwners:      cloneStringSlice(item.ownershipConflicts),
+				EvidenceDecision:    cloneEvidenceDecision(item.ownershipDecision),
 			}
 		}
 	}
@@ -1759,6 +1765,7 @@ func resolveOperationalOwner(tool agginventory.Tool, repos []string, location st
 				OwnershipConfidence: item.ownershipConfidence,
 				EvidenceBasis:       cloneStringSlice(item.ownershipEvidence),
 				ConflictOwners:      cloneStringSlice(item.ownershipConflicts),
+				EvidenceDecision:    cloneEvidenceDecision(item.ownershipDecision),
 			}
 		}
 	}
@@ -2134,6 +2141,26 @@ func cloneStringSlice(values []string) []string {
 	out := make([]string, 0, len(values))
 	out = append(out, values...)
 	return out
+}
+
+func cloneEvidenceDecision(in *evidencepolicy.Decision) *evidencepolicy.Decision {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	out.SelectedEvidenceRefs = cloneStringSlice(in.SelectedEvidenceRefs)
+	out.ReasonCodes = cloneStringSlice(in.ReasonCodes)
+	out.ConflictReasonCodes = cloneStringSlice(in.ConflictReasonCodes)
+	if len(in.RejectedCandidates) > 0 {
+		out.RejectedCandidates = make([]evidencepolicy.Candidate, 0, len(in.RejectedCandidates))
+		for _, item := range in.RejectedCandidates {
+			copyItem := item
+			copyItem.EvidenceRefs = cloneStringSlice(item.EvidenceRefs)
+			copyItem.ReasonCodes = cloneStringSlice(item.ReasonCodes)
+			out.RejectedCandidates = append(out.RejectedCandidates, copyItem)
+		}
+	}
+	return &out
 }
 
 func cloneLocationRange(value *model.LocationRange) *model.LocationRange {

--- a/core/aggregate/privilegebudget/budget_test.go
+++ b/core/aggregate/privilegebudget/budget_test.go
@@ -950,6 +950,7 @@ func TestCredentialAuthoritySeparatesReferenceFromUsability(t *testing.T) {
 
 	if authority == nil {
 		t.Fatal("expected normalized credential authority")
+		return
 	}
 	if !authority.CredentialPresent || !authority.CredentialReferencedByWorkflow {
 		t.Fatalf("expected workflow reference authority, got %+v", authority)

--- a/core/attribution/attribution_test.go
+++ b/core/attribution/attribution_test.go
@@ -300,6 +300,38 @@ func TestLoadContextKeepsExplicitUnmatchedExternalEvidenceNonPresent(t *testing.
 	}
 }
 
+func TestResolveControlMetadataMatchesWildcardDeclarationPattern(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	payload := []byte(`schema_version: v1
+owners:
+  - repo: acme/demo
+    pattern: .github/workflows/*.yml
+    owner: "@acme/platform"
+targets:
+  - repo: acme/demo
+    pattern: .github/workflows/*.yml
+    target_class: test_demo_sandbox
+    non_production: true
+`)
+	if err := os.WriteFile(filepath.Join(repoRoot, "wrkr-control-declarations.yaml"), payload, 0o600); err != nil {
+		t.Fatalf("write control declarations: %v", err)
+	}
+
+	ctx := LoadContextAt(repoRoot, time.Date(2026, 5, 25, 18, 0, 0, 0, time.UTC))
+	metadata, ok := ResolveControlMetadata(ctx.ControlMetadata, ".github/workflows/release.yml")
+	if !ok {
+		t.Fatalf("expected wildcard declaration metadata to match location, got %+v", ctx.ControlMetadata)
+	}
+	if metadata.Owner != "@acme/platform" {
+		t.Fatalf("expected owner declaration to resolve through wildcard match, got %+v", metadata)
+	}
+	if metadata.TargetClass != "test_demo_sandbox" {
+		t.Fatalf("expected target declaration to resolve through wildcard match, got %+v", metadata)
+	}
+}
+
 func TestExpiredEvidenceCannotVerifyControl(t *testing.T) {
 	t.Parallel()
 

--- a/core/attribution/attribution_test.go
+++ b/core/attribution/attribution_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Clyra-AI/wrkr/core/model"
 )
@@ -296,6 +297,44 @@ func TestLoadContextKeepsExplicitUnmatchedExternalEvidenceNonPresent(t *testing.
 	}
 	if metadata.ConstraintEvidenceStatus != "unmatched" {
 		t.Fatalf("expected unmatched constraint status, got %+v", metadata)
+	}
+}
+
+func TestExpiredEvidenceCannotVerifyControl(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".wrkr", "provenance"), 0o755); err != nil {
+		t.Fatalf("mkdir provenance dir: %v", err)
+	}
+	payload := `{
+  "schema_version": "v1",
+  "generated_at": "2026-05-25T17:30:30Z",
+  "records": [
+    {
+      "record_kind": "external_control",
+      "source_type": "provider_export",
+      "source": "github_environment_export",
+      "repo": "acme/demo",
+      "path": ".github/workflows/release.yml",
+      "observed_at": "2026-05-25T17:00:00Z",
+      "valid_until": "2026-05-25T17:15:00Z",
+      "evidence_class": "deployment_approval",
+      "evidence_refs": ["evidence://fake/provider-export.json#approval"]
+    }
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(repoRoot, ".wrkr", "provenance", "external-control-evidence.json"), []byte(payload), 0o600); err != nil {
+		t.Fatalf("write external control evidence: %v", err)
+	}
+
+	ctx := LoadContextAt(repoRoot, time.Date(2026, 5, 25, 18, 0, 0, 0, time.UTC))
+	metadata, ok := ctx.ControlMetadata[".github/workflows/release.yml"]
+	if !ok {
+		t.Fatalf("expected external control metadata entry, got %+v", ctx.ControlMetadata)
+	}
+	if metadata.ApprovalEvidenceState != "unknown" {
+		t.Fatalf("expected expired evidence to stop verifying control, got %+v", metadata)
 	}
 }
 

--- a/core/attribution/control_metadata.go
+++ b/core/attribution/control_metadata.go
@@ -40,10 +40,6 @@ type controlMetadataPayload struct {
 	Controls []ControlMetadata `json:"controls"`
 }
 
-func loadControlMetadata(repoRoot string) map[string]ControlMetadata {
-	return loadControlMetadataAt(repoRoot, time.Time{})
-}
-
 func loadControlMetadataAt(repoRoot string, generatedAt time.Time) map[string]ControlMetadata {
 	if strings.TrimSpace(repoRoot) == "" {
 		return nil
@@ -445,23 +441,6 @@ func loadExternalControlMetadata(payload []byte, generatedAt time.Time) []Contro
 		out = append(out, item)
 	}
 	return out
-}
-
-func externalEvidenceState(sourceType string, status string) string {
-	switch normalizeExternalConstraintStatus(status) {
-	case "conflict":
-		return "contradictory"
-	case "stale":
-		return "unknown"
-	case "unmatched":
-		return "unknown"
-	}
-	switch strings.TrimSpace(sourceType) {
-	case "provider_export", "github_team_export", "backstage_export":
-		return "verified"
-	default:
-		return "declared"
-	}
 }
 
 func normalizeExternalConstraintStatus(value string) string {

--- a/core/attribution/control_metadata.go
+++ b/core/attribution/control_metadata.go
@@ -6,27 +6,34 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
+	"github.com/Clyra-AI/wrkr/core/config"
 	"github.com/Clyra-AI/wrkr/core/detect/gaitpolicy"
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
 )
 
 type ControlMetadata struct {
-	Path                      string   `json:"path"`
-	Owner                     string   `json:"owner,omitempty"`
-	OwnerSource               string   `json:"owner_source,omitempty"`
-	ControlResolutionState    string   `json:"control_resolution_state,omitempty"`
-	ControlResolutionReasons  []string `json:"control_resolution_reasons,omitempty"`
-	ControlEvidenceRefs       []string `json:"control_evidence_refs,omitempty"`
-	ConstraintEvidenceClasses []string `json:"constraint_evidence_classes,omitempty"`
-	ConstraintEvidenceRefs    []string `json:"constraint_evidence_refs,omitempty"`
-	ConstraintEvidenceStatus  string   `json:"constraint_evidence_status,omitempty"`
-	ApprovalEvidenceState     string   `json:"approval_evidence_state,omitempty"`
-	OwnerEvidenceState        string   `json:"owner_evidence_state,omitempty"`
-	ProofEvidenceState        string   `json:"proof_evidence_state,omitempty"`
-	RuntimeEvidenceState      string   `json:"runtime_evidence_state,omitempty"`
-	TargetEvidenceState       string   `json:"target_evidence_state,omitempty"`
-	CredentialEvidenceState   string   `json:"credential_evidence_state,omitempty"`
-	ExternalReferences        []string `json:"external_references,omitempty"`
+	Path                      string                    `json:"path"`
+	Owner                     string                    `json:"owner,omitempty"`
+	OwnerSource               string                    `json:"owner_source,omitempty"`
+	ControlResolutionState    string                    `json:"control_resolution_state,omitempty"`
+	ControlResolutionReasons  []string                  `json:"control_resolution_reasons,omitempty"`
+	ControlEvidenceRefs       []string                  `json:"control_evidence_refs,omitempty"`
+	ConstraintEvidenceClasses []string                  `json:"constraint_evidence_classes,omitempty"`
+	ConstraintEvidenceRefs    []string                  `json:"constraint_evidence_refs,omitempty"`
+	ConstraintEvidenceStatus  string                    `json:"constraint_evidence_status,omitempty"`
+	ApprovalEvidenceState     string                    `json:"approval_evidence_state,omitempty"`
+	OwnerEvidenceState        string                    `json:"owner_evidence_state,omitempty"`
+	ProofEvidenceState        string                    `json:"proof_evidence_state,omitempty"`
+	RuntimeEvidenceState      string                    `json:"runtime_evidence_state,omitempty"`
+	TargetEvidenceState       string                    `json:"target_evidence_state,omitempty"`
+	CredentialEvidenceState   string                    `json:"credential_evidence_state,omitempty"`
+	ExternalReferences        []string                  `json:"external_references,omitempty"`
+	TargetClass               string                    `json:"target_class,omitempty"`
+	TargetClassReasons        []string                  `json:"target_class_reasons,omitempty"`
+	TargetClassEvidenceRefs   []string                  `json:"target_class_evidence_refs,omitempty"`
+	EvidenceDecisions         []evidencepolicy.Decision `json:"evidence_decisions,omitempty"`
 }
 
 type controlMetadataPayload struct {
@@ -34,6 +41,10 @@ type controlMetadataPayload struct {
 }
 
 func loadControlMetadata(repoRoot string) map[string]ControlMetadata {
+	return loadControlMetadataAt(repoRoot, time.Time{})
+}
+
+func loadControlMetadataAt(repoRoot string, generatedAt time.Time) map[string]ControlMetadata {
 	if strings.TrimSpace(repoRoot) == "" {
 		return nil
 	}
@@ -50,7 +61,7 @@ func loadControlMetadata(repoRoot string) map[string]ControlMetadata {
 			continue
 		}
 		if strings.HasSuffix(path, "external-control-evidence.json") {
-			for _, item := range loadExternalControlMetadata(payload) {
+			for _, item := range loadExternalControlMetadata(payload, generatedAt) {
 				normalizedPath := filepath.ToSlash(strings.TrimSpace(item.Path))
 				if normalizedPath == "" {
 					continue
@@ -85,12 +96,23 @@ func loadControlMetadata(repoRoot string) map[string]ControlMetadata {
 			item.TargetEvidenceState = strings.TrimSpace(item.TargetEvidenceState)
 			item.CredentialEvidenceState = strings.TrimSpace(item.CredentialEvidenceState)
 			item.ExternalReferences = normalizeStringList(item.ExternalReferences)
+			item.TargetClass = strings.TrimSpace(item.TargetClass)
+			item.TargetClassReasons = normalizeStringList(item.TargetClassReasons)
+			item.TargetClassEvidenceRefs = normalizeStringList(item.TargetClassEvidenceRefs)
 
 			current := byPath[normalizedPath]
 			byPath[normalizedPath] = mergeControlMetadata(current, item)
 		}
 	}
-	for _, item := range loadGaitPolicyControlMetadata(repoRoot) {
+	for _, item := range loadDeclaredControlMetadata(repoRoot, generatedAt) {
+		normalizedPath := filepath.ToSlash(strings.TrimSpace(item.Path))
+		if normalizedPath == "" {
+			continue
+		}
+		current := byPath[normalizedPath]
+		byPath[normalizedPath] = mergeControlMetadata(current, item)
+	}
+	for _, item := range loadGaitPolicyControlMetadata(repoRoot, generatedAt) {
 		normalizedPath := filepath.ToSlash(strings.TrimSpace(item.Path))
 		if normalizedPath == "" {
 			continue
@@ -106,24 +128,189 @@ func loadControlMetadata(repoRoot string) map[string]ControlMetadata {
 
 func mergeControlMetadata(current, incoming ControlMetadata) ControlMetadata {
 	if strings.TrimSpace(current.Path) == "" {
-		return incoming
+		return finalizeControlMetadata(incoming)
 	}
-	current.Owner = firstNonEmptyMetadata(current.Owner, incoming.Owner)
-	current.OwnerSource = firstNonEmptyMetadata(current.OwnerSource, incoming.OwnerSource)
-	current.ControlResolutionState = firstNonEmptyMetadata(current.ControlResolutionState, incoming.ControlResolutionState)
+	current.Path = firstNonEmptyMetadata(current.Path, incoming.Path)
 	current.ControlResolutionReasons = normalizeStringList(append(append([]string(nil), current.ControlResolutionReasons...), incoming.ControlResolutionReasons...))
 	current.ControlEvidenceRefs = normalizeStringList(append(append([]string(nil), current.ControlEvidenceRefs...), incoming.ControlEvidenceRefs...))
 	current.ConstraintEvidenceClasses = normalizeStringList(append(append([]string(nil), current.ConstraintEvidenceClasses...), incoming.ConstraintEvidenceClasses...))
 	current.ConstraintEvidenceRefs = normalizeStringList(append(append([]string(nil), current.ConstraintEvidenceRefs...), incoming.ConstraintEvidenceRefs...))
 	current.ConstraintEvidenceStatus = mergeConstraintEvidenceStatus(current.ConstraintEvidenceStatus, incoming.ConstraintEvidenceStatus)
-	current.ApprovalEvidenceState = firstNonEmptyMetadata(current.ApprovalEvidenceState, incoming.ApprovalEvidenceState)
-	current.OwnerEvidenceState = firstNonEmptyMetadata(current.OwnerEvidenceState, incoming.OwnerEvidenceState)
 	current.ProofEvidenceState = firstNonEmptyMetadata(current.ProofEvidenceState, incoming.ProofEvidenceState)
 	current.RuntimeEvidenceState = firstNonEmptyMetadata(current.RuntimeEvidenceState, incoming.RuntimeEvidenceState)
 	current.TargetEvidenceState = firstNonEmptyMetadata(current.TargetEvidenceState, incoming.TargetEvidenceState)
 	current.CredentialEvidenceState = firstNonEmptyMetadata(current.CredentialEvidenceState, incoming.CredentialEvidenceState)
 	current.ExternalReferences = normalizeStringList(append(append([]string(nil), current.ExternalReferences...), incoming.ExternalReferences...))
-	return current
+	current.TargetClassReasons = normalizeStringList(append(append([]string(nil), current.TargetClassReasons...), incoming.TargetClassReasons...))
+	current.TargetClassEvidenceRefs = normalizeStringList(append(append([]string(nil), current.TargetClassEvidenceRefs...), incoming.TargetClassEvidenceRefs...))
+	current.EvidenceDecisions = mergeEvidenceDecisions(current.EvidenceDecisions, incoming.EvidenceDecisions)
+	current.TargetClass = firstNonEmptyMetadata(current.TargetClass, incoming.TargetClass)
+	return finalizeControlMetadata(current)
+}
+
+func finalizeControlMetadata(meta ControlMetadata) ControlMetadata {
+	if decision, ok := decisionForField(meta.EvidenceDecisions, evidencepolicy.FieldOwner); ok {
+		meta.Owner = strings.TrimSpace(decision.SelectedValue)
+		meta.OwnerSource = strings.TrimSpace(decision.SelectedSourceType)
+		meta.OwnerEvidenceState = decisionEvidenceState(decision, evidencepolicy.FieldOwner)
+		if decision.SelectedFreshnessState == evidencepolicy.FreshnessStateExpired || decision.SelectedFreshnessState == evidencepolicy.FreshnessStateStale {
+			meta.OwnerEvidenceState = "unknown"
+		}
+		meta.ControlEvidenceRefs = normalizeStringList(append(meta.ControlEvidenceRefs, decisionEvidenceRefs(decision)...))
+		if strings.TrimSpace(decision.ConflictState) == evidencepolicy.ConflictStateAmbiguous {
+			meta.ControlResolutionState = "contradictory_control"
+		}
+	}
+	if decision, ok := decisionForField(meta.EvidenceDecisions, evidencepolicy.FieldApproval); ok {
+		meta.ApprovalEvidenceState = decisionEvidenceState(decision, evidencepolicy.FieldApproval)
+		if decision.SelectedFreshnessState == evidencepolicy.FreshnessStateExpired || decision.SelectedFreshnessState == evidencepolicy.FreshnessStateStale {
+			meta.ApprovalEvidenceState = "unknown"
+			meta.ControlResolutionReasons = normalizeStringList(append(meta.ControlResolutionReasons, "approval_evidence:"+decision.SelectedFreshnessState))
+		}
+		meta.ControlEvidenceRefs = normalizeStringList(append(meta.ControlEvidenceRefs, decisionEvidenceRefs(decision)...))
+		if strings.TrimSpace(decision.ConflictState) == evidencepolicy.ConflictStateAmbiguous {
+			meta.ControlResolutionState = "contradictory_control"
+		}
+	}
+	if decision, ok := decisionForField(meta.EvidenceDecisions, evidencepolicy.FieldConstraint); ok {
+		meta.ConstraintEvidenceRefs = normalizeStringList(append(meta.ConstraintEvidenceRefs, decisionEvidenceRefs(decision)...))
+		switch {
+		case strings.TrimSpace(decision.ConflictState) == evidencepolicy.ConflictStateAmbiguous:
+			meta.ConstraintEvidenceStatus = "conflict"
+			meta.ControlResolutionState = "contradictory_control"
+		case decision.SelectedFreshnessState == evidencepolicy.FreshnessStateExpired || decision.SelectedFreshnessState == evidencepolicy.FreshnessStateStale:
+			meta.ConstraintEvidenceStatus = "stale"
+		case strings.TrimSpace(meta.ConstraintEvidenceStatus) == "":
+			meta.ConstraintEvidenceStatus = "matched"
+		}
+	}
+	if decision, ok := decisionForField(meta.EvidenceDecisions, evidencepolicy.FieldTarget); ok {
+		meta.TargetClass = strings.TrimSpace(decision.SelectedValue)
+		meta.TargetClassReasons = normalizeStringList(append(meta.TargetClassReasons, decision.ReasonCodes...))
+		meta.TargetClassEvidenceRefs = normalizeStringList(append(meta.TargetClassEvidenceRefs, decisionEvidenceRefs(decision)...))
+	}
+	if strings.TrimSpace(meta.ControlResolutionState) == "" {
+		for _, decision := range meta.EvidenceDecisions {
+			switch strings.TrimSpace(decision.SelectedSourceType) {
+			case evidencepolicy.SourceTypeProviderExport, evidencepolicy.SourceTypeGitHubTeamExport, evidencepolicy.SourceTypeBackstageExport, evidencepolicy.SourceTypeTicketExport:
+				meta.ControlResolutionState = "external_control_reference"
+			case evidencepolicy.SourceTypeSignedDeclaration, evidencepolicy.SourceTypeRepoPolicy, evidencepolicy.SourceTypePolicyConfig:
+				if strings.TrimSpace(meta.ControlResolutionState) == "" {
+					meta.ControlResolutionState = "declared_control"
+				}
+			}
+		}
+	}
+	return meta
+}
+
+func decisionForField(decisions []evidencepolicy.Decision, field string) (evidencepolicy.Decision, bool) {
+	for _, item := range decisions {
+		if strings.TrimSpace(item.Field) == strings.TrimSpace(field) {
+			return item, true
+		}
+	}
+	return evidencepolicy.Decision{}, false
+}
+
+func decisionEvidenceRefs(decision evidencepolicy.Decision) []string {
+	values := append([]string(nil), decision.SelectedEvidenceRefs...)
+	for _, item := range decision.RejectedCandidates {
+		values = append(values, item.EvidenceRefs...)
+	}
+	return normalizeStringList(values)
+}
+
+func decisionEvidenceState(decision evidencepolicy.Decision, field string) string {
+	switch strings.TrimSpace(decision.SelectedStatus) {
+	case "unmatched":
+		return "unknown"
+	case "conflict":
+		return "contradictory"
+	}
+	switch strings.TrimSpace(field) {
+	case evidencepolicy.FieldOwner:
+		switch evidencepolicy.NormalizeSourceType(decision.SelectedSourceType) {
+		case evidencepolicy.SourceTypeSignedDeclaration, evidencepolicy.SourceTypeCustomerOwnerMap:
+			return "declared"
+		case evidencepolicy.SourceTypeGitHubMetadata, evidencepolicy.SourceTypeRepoFallback:
+			return "inferred"
+		default:
+			return "verified"
+		}
+	default:
+		switch evidencepolicy.NormalizeSourceType(decision.SelectedSourceType) {
+		case evidencepolicy.SourceTypeProviderExport, evidencepolicy.SourceTypeGitHubTeamExport, evidencepolicy.SourceTypeBackstageExport, evidencepolicy.SourceTypeTicketExport:
+			return "verified"
+		case evidencepolicy.SourceTypeGitHubMetadata, evidencepolicy.SourceTypeRepoFallback:
+			return "inferred"
+		default:
+			return "declared"
+		}
+	}
+}
+
+func mergeEvidenceDecisions(current, incoming []evidencepolicy.Decision) []evidencepolicy.Decision {
+	if len(current) == 0 && len(incoming) == 0 {
+		return nil
+	}
+	byField := map[string][]evidencepolicy.Candidate{}
+	for _, item := range append(append([]evidencepolicy.Decision(nil), current...), incoming...) {
+		field := strings.TrimSpace(item.Field)
+		if field == "" {
+			continue
+		}
+		byField[field] = append(byField[field], decisionCandidates(item)...)
+	}
+	out := make([]evidencepolicy.Decision, 0, len(byField))
+	for field, candidates := range byField {
+		decision := evidencepolicy.ResolveDecision(candidates, time.Time{})
+		decision.Field = field
+		out = append(out, cloneDecision(decision))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Field < out[j].Field })
+	return out
+}
+
+func decisionCandidates(decision evidencepolicy.Decision) []evidencepolicy.Candidate {
+	out := []evidencepolicy.Candidate{{
+		Field:          decision.Field,
+		Value:          decision.SelectedValue,
+		SourceType:     decision.SelectedSourceType,
+		Source:         decision.SelectedSource,
+		EvidenceRefs:   normalizeStringList(append([]string(nil), decision.SelectedEvidenceRefs...)),
+		ObservedAt:     decision.SelectedObservedAt,
+		ValidUntil:     decision.SelectedValidUntil,
+		MaxAge:         decision.SelectedMaxAge,
+		Issuer:         decision.SelectedIssuer,
+		Confidence:     decision.SelectedConfidence,
+		FreshnessState: decision.SelectedFreshnessState,
+		Status:         decision.SelectedStatus,
+		ReasonCodes:    normalizeStringList(append([]string(nil), decision.ReasonCodes...)),
+	}}
+	for _, item := range decision.RejectedCandidates {
+		copyItem := item
+		copyItem.Field = decision.Field
+		out = append(out, copyItem)
+	}
+	return out
+}
+
+func cloneDecision(in evidencepolicy.Decision) evidencepolicy.Decision {
+	out := in
+	out.SelectedEvidenceRefs = normalizeStringList(append([]string(nil), in.SelectedEvidenceRefs...))
+	out.ReasonCodes = normalizeStringList(append([]string(nil), in.ReasonCodes...))
+	out.ConflictReasonCodes = normalizeStringList(append([]string(nil), in.ConflictReasonCodes...))
+	if len(in.RejectedCandidates) > 0 {
+		out.RejectedCandidates = make([]evidencepolicy.Candidate, 0, len(in.RejectedCandidates))
+		for _, item := range in.RejectedCandidates {
+			copyItem := item
+			copyItem.EvidenceRefs = normalizeStringList(append([]string(nil), item.EvidenceRefs...))
+			copyItem.ReasonCodes = normalizeStringList(append([]string(nil), item.ReasonCodes...))
+			out.RejectedCandidates = append(out.RejectedCandidates, copyItem)
+		}
+	}
+	return out
 }
 
 func normalizeStringList(values []string) []string {
@@ -167,17 +354,23 @@ type externalControlEvidencePayload struct {
 type externalControlEvidenceRecord struct {
 	RecordKind    string   `json:"record_kind"`
 	SourceType    string   `json:"source_type"`
+	Source        string   `json:"source"`
 	Repo          string   `json:"repo"`
 	Path          string   `json:"path"`
 	Workflow      string   `json:"workflow"`
 	Location      string   `json:"location"`
+	ObservedAt    string   `json:"observed_at"`
+	ValidUntil    string   `json:"valid_until"`
+	MaxAge        string   `json:"max_age"`
+	Issuer        string   `json:"issuer"`
+	Confidence    string   `json:"confidence"`
 	EvidenceClass string   `json:"evidence_class"`
 	Status        string   `json:"status"`
 	Owner         string   `json:"owner"`
 	EvidenceRefs  []string `json:"evidence_refs"`
 }
 
-func loadExternalControlMetadata(payload []byte) []ControlMetadata {
+func loadExternalControlMetadata(payload []byte, generatedAt time.Time) []ControlMetadata {
 	var decoded externalControlEvidencePayload
 	if err := json.Unmarshal(payload, &decoded); err != nil {
 		return nil
@@ -196,26 +389,58 @@ func loadExternalControlMetadata(payload []byte) []ControlMetadata {
 		}
 		item := ControlMetadata{
 			Path:                     path,
-			ControlResolutionState:   "external_control_reference",
 			ControlResolutionReasons: []string{"external_evidence:" + strings.TrimSpace(record.EvidenceClass)},
 			ControlEvidenceRefs:      normalizeStringList(record.EvidenceRefs),
 			ExternalReferences:       normalizeStringList(record.EvidenceRefs),
 			ConstraintEvidenceStatus: normalizeExternalConstraintStatus(record.Status),
 		}
-		if item.ConstraintEvidenceStatus == "conflict" {
-			item.ControlResolutionState = "contradictory_control"
-		}
 		switch strings.TrimSpace(record.EvidenceClass) {
 		case "owner_assignment":
-			item.Owner = strings.TrimSpace(record.Owner)
-			item.OwnerEvidenceState = externalEvidenceState(record.SourceType, record.Status)
+			item.EvidenceDecisions = append(item.EvidenceDecisions, evidencepolicy.ResolveDecision([]evidencepolicy.Candidate{{
+				Field:        evidencepolicy.FieldOwner,
+				Value:        strings.TrimSpace(record.Owner),
+				SourceType:   strings.TrimSpace(record.SourceType),
+				Source:       strings.TrimSpace(record.Source),
+				EvidenceRefs: normalizeStringList(record.EvidenceRefs),
+				ObservedAt:   strings.TrimSpace(record.ObservedAt),
+				ValidUntil:   strings.TrimSpace(record.ValidUntil),
+				MaxAge:       strings.TrimSpace(record.MaxAge),
+				Issuer:       strings.TrimSpace(record.Issuer),
+				Confidence:   strings.TrimSpace(record.Confidence),
+				Status:       strings.TrimSpace(record.Status),
+			}}, generatedAt))
 		case "approval", "branch_protection", "protected_environment", "deployment_approval", "required_check", "security_gate":
-			item.ApprovalEvidenceState = externalEvidenceState(record.SourceType, record.Status)
+			item.EvidenceDecisions = append(item.EvidenceDecisions, evidencepolicy.ResolveDecision([]evidencepolicy.Candidate{{
+				Field:        evidencepolicy.FieldApproval,
+				Value:        strings.TrimSpace(record.EvidenceClass),
+				SourceType:   strings.TrimSpace(record.SourceType),
+				Source:       strings.TrimSpace(record.Source),
+				EvidenceRefs: normalizeStringList(record.EvidenceRefs),
+				ObservedAt:   strings.TrimSpace(record.ObservedAt),
+				ValidUntil:   strings.TrimSpace(record.ValidUntil),
+				MaxAge:       strings.TrimSpace(record.MaxAge),
+				Issuer:       strings.TrimSpace(record.Issuer),
+				Confidence:   strings.TrimSpace(record.Confidence),
+				Status:       strings.TrimSpace(record.Status),
+			}}, generatedAt))
 		}
 		switch strings.TrimSpace(record.EvidenceClass) {
 		case "branch_protection", "protected_environment", "deployment_approval", "required_check", "security_gate", "freeze_window", "kill_switch":
 			item.ConstraintEvidenceClasses = []string{strings.TrimSpace(record.EvidenceClass)}
 			item.ConstraintEvidenceRefs = normalizeStringList(record.EvidenceRefs)
+			item.EvidenceDecisions = append(item.EvidenceDecisions, evidencepolicy.ResolveDecision([]evidencepolicy.Candidate{{
+				Field:        evidencepolicy.FieldConstraint,
+				Value:        strings.TrimSpace(record.EvidenceClass),
+				SourceType:   strings.TrimSpace(record.SourceType),
+				Source:       strings.TrimSpace(record.Source),
+				EvidenceRefs: normalizeStringList(record.EvidenceRefs),
+				ObservedAt:   strings.TrimSpace(record.ObservedAt),
+				ValidUntil:   strings.TrimSpace(record.ValidUntil),
+				MaxAge:       strings.TrimSpace(record.MaxAge),
+				Issuer:       strings.TrimSpace(record.Issuer),
+				Confidence:   strings.TrimSpace(record.Confidence),
+				Status:       strings.TrimSpace(record.Status),
+			}}, generatedAt))
 		}
 		out = append(out, item)
 	}
@@ -268,7 +493,7 @@ func mergeConstraintEvidenceStatus(current, incoming string) string {
 	return normalizeExternalConstraintStatus(incoming)
 }
 
-func loadGaitPolicyControlMetadata(repoRoot string) []ControlMetadata {
+func loadGaitPolicyControlMetadata(repoRoot string, generatedAt time.Time) []ControlMetadata {
 	constraints, err := gaitpolicy.LoadDeploymentConstraints(repoRoot)
 	if err != nil || len(constraints) == 0 {
 		return nil
@@ -330,16 +555,171 @@ func loadGaitPolicyControlMetadata(repoRoot string) []ControlMetadata {
 		}
 		out = append(out, ControlMetadata{
 			Path:                      path,
-			ControlResolutionState:    "declared_control",
 			ControlResolutionReasons:  normalizeStringList(reasons),
 			ControlEvidenceRefs:       normalizeStringList(refs),
 			ConstraintEvidenceClasses: normalizeStringList(classes),
 			ConstraintEvidenceRefs:    normalizeStringList(refs),
 			ConstraintEvidenceStatus:  "matched",
-			ApprovalEvidenceState:     approvalStateFromGaitConstraint(item),
+			EvidenceDecisions: append(
+				[]evidencepolicy.Decision{},
+				evidencepolicy.ResolveDecision([]evidencepolicy.Candidate{{
+					Field:        evidencepolicy.FieldApproval,
+					Value:        approvalStateFromGaitConstraint(item),
+					SourceType:   evidencepolicy.SourceTypeRepoPolicy,
+					Source:       item.PolicyPath,
+					EvidenceRefs: normalizeStringList(refs),
+					Status:       "matched",
+				}}, generatedAt),
+				evidencepolicy.ResolveDecision([]evidencepolicy.Candidate{{
+					Field:        evidencepolicy.FieldConstraint,
+					Value:        strings.Join(normalizeStringList(classes), ","),
+					SourceType:   evidencepolicy.SourceTypeRepoPolicy,
+					Source:       item.PolicyPath,
+					EvidenceRefs: normalizeStringList(refs),
+					Status:       "matched",
+				}}, generatedAt),
+			),
 		})
 	}
 	return out
+}
+
+func loadDeclaredControlMetadata(repoRoot string, generatedAt time.Time) []ControlMetadata {
+	doc, paths, err := config.LoadControlDeclarations(repoRoot)
+	if err != nil || len(paths) == 0 {
+		return nil
+	}
+	out := []ControlMetadata{}
+	for _, item := range doc.Owners {
+		for _, path := range declarationPaths(item.Path, item.Pattern, item.Paths) {
+			out = append(out, ControlMetadata{
+				Path: path,
+				EvidenceDecisions: []evidencepolicy.Decision{
+					evidencepolicy.ResolveDecision([]evidencepolicy.Candidate{{
+						Field:        evidencepolicy.FieldOwner,
+						Value:        strings.TrimSpace(item.Owner),
+						SourceType:   evidencepolicy.SourceTypeSignedDeclaration,
+						Source:       strings.Join(paths, "|"),
+						EvidenceRefs: normalizeStringList(item.EvidenceRefs),
+						ObservedAt:   strings.TrimSpace(item.ObservedAt),
+						ValidUntil:   strings.TrimSpace(item.ValidUntil),
+						MaxAge:       strings.TrimSpace(item.MaxAge),
+						Issuer:       firstNonEmptyMetadata(item.Issuer, doc.Issuer),
+						Confidence:   strings.TrimSpace(item.Confidence),
+					}}, generatedAt),
+				},
+			})
+		}
+	}
+	for _, item := range doc.Targets {
+		for _, path := range declarationPaths(item.Path, item.Pattern, item.Paths) {
+			targetValue := strings.TrimSpace(item.TargetClass)
+			if item.NonProduction && targetValue == "" {
+				targetValue = "test_demo_sandbox"
+			}
+			out = append(out, ControlMetadata{
+				Path: path,
+				EvidenceDecisions: []evidencepolicy.Decision{
+					evidencepolicy.ResolveDecision([]evidencepolicy.Candidate{{
+						Field:        evidencepolicy.FieldTarget,
+						Value:        targetValue,
+						SourceType:   evidencepolicy.SourceTypeSignedDeclaration,
+						Source:       strings.Join(paths, "|"),
+						EvidenceRefs: normalizeStringList(item.EvidenceRefs),
+						ObservedAt:   strings.TrimSpace(item.ObservedAt),
+						ValidUntil:   strings.TrimSpace(item.ValidUntil),
+						MaxAge:       strings.TrimSpace(item.MaxAge),
+						Issuer:       firstNonEmptyMetadata(item.Issuer, doc.Issuer),
+						Confidence:   strings.TrimSpace(item.Confidence),
+						ReasonCodes:  normalizeStringList([]string{"declaration:target_class", nonProductionReason(item.NonProduction)}),
+					}}, generatedAt),
+				},
+			})
+		}
+	}
+	for _, item := range doc.Controls {
+		path := filepath.ToSlash(firstNonEmptyMetadata(item.Workflow, item.Path))
+		if path == "" {
+			continue
+		}
+		refs := normalizeStringList(item.EvidenceRefs)
+		classes := []string{}
+		if strings.TrimSpace(item.Branch) != "" {
+			classes = append(classes, "branch_protection")
+		}
+		if strings.TrimSpace(item.Environment) != "" {
+			classes = append(classes, "protected_environment")
+		}
+		if item.ApprovalRequired {
+			classes = append(classes, "deployment_approval")
+		}
+		if len(item.RequiredChecks) > 0 {
+			classes = append(classes, "required_check")
+		}
+		if len(item.SecurityGates) > 0 {
+			classes = append(classes, "security_gate")
+		}
+		if len(item.FreezeWindows) > 0 {
+			classes = append(classes, "freeze_window")
+		}
+		if len(item.KillSwitches) > 0 {
+			classes = append(classes, "kill_switch")
+		}
+		out = append(out, ControlMetadata{
+			Path:                      path,
+			ConstraintEvidenceClasses: normalizeStringList(classes),
+			ConstraintEvidenceRefs:    refs,
+			EvidenceDecisions: []evidencepolicy.Decision{
+				evidencepolicy.ResolveDecision([]evidencepolicy.Candidate{{
+					Field:        evidencepolicy.FieldApproval,
+					Value:        firstNonEmptyMetadata(boolDecisionValue(item.ApprovalRequired), strings.TrimSpace(item.Environment), strings.TrimSpace(item.Branch)),
+					SourceType:   evidencepolicy.SourceTypeSignedDeclaration,
+					Source:       strings.Join(paths, "|"),
+					EvidenceRefs: refs,
+					ObservedAt:   strings.TrimSpace(item.ObservedAt),
+					ValidUntil:   strings.TrimSpace(item.ValidUntil),
+					MaxAge:       strings.TrimSpace(item.MaxAge),
+					Issuer:       firstNonEmptyMetadata(item.Issuer, doc.Issuer),
+					Confidence:   strings.TrimSpace(item.Confidence),
+				}}, generatedAt),
+				evidencepolicy.ResolveDecision([]evidencepolicy.Candidate{{
+					Field:        evidencepolicy.FieldConstraint,
+					Value:        strings.Join(normalizeStringList(classes), ","),
+					SourceType:   evidencepolicy.SourceTypeSignedDeclaration,
+					Source:       strings.Join(paths, "|"),
+					EvidenceRefs: refs,
+					ObservedAt:   strings.TrimSpace(item.ObservedAt),
+					ValidUntil:   strings.TrimSpace(item.ValidUntil),
+					MaxAge:       strings.TrimSpace(item.MaxAge),
+					Issuer:       firstNonEmptyMetadata(item.Issuer, doc.Issuer),
+					Confidence:   strings.TrimSpace(item.Confidence),
+				}}, generatedAt),
+			},
+		})
+	}
+	return out
+}
+
+func declarationPaths(pathValue, pattern string, values []string) []string {
+	out := normalizeStringList(append(append([]string(nil), values...), pathValue, pattern))
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func nonProductionReason(value bool) string {
+	if value {
+		return "declaration:non_production"
+	}
+	return ""
+}
+
+func boolDecisionValue(value bool) string {
+	if value {
+		return "approval_required"
+	}
+	return ""
 }
 
 func approvalStateFromGaitConstraint(item gaitpolicy.DeploymentConstraint) string {

--- a/core/attribution/control_metadata.go
+++ b/core/attribution/control_metadata.go
@@ -40,6 +40,43 @@ type controlMetadataPayload struct {
 	Controls []ControlMetadata `json:"controls"`
 }
 
+func ResolveControlMetadata(byPath map[string]ControlMetadata, location string) (ControlMetadata, bool) {
+	if len(byPath) == 0 {
+		return ControlMetadata{}, false
+	}
+	location = filepath.ToSlash(strings.TrimSpace(location))
+	if location == "" {
+		return ControlMetadata{}, false
+	}
+	keys := make([]string, 0, len(byPath))
+	for key := range byPath {
+		keys = append(keys, filepath.ToSlash(strings.TrimSpace(key)))
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		leftExact := keys[i] == location
+		rightExact := keys[j] == location
+		if leftExact != rightExact {
+			return leftExact
+		}
+		return keys[i] < keys[j]
+	})
+
+	matched := ControlMetadata{}
+	found := false
+	for _, key := range keys {
+		meta, ok := byPath[key]
+		if !ok || !controlMetadataPatternMatches(key, location) {
+			continue
+		}
+		matched = mergeControlMetadata(matched, meta)
+		found = true
+	}
+	if !found {
+		return ControlMetadata{}, false
+	}
+	return matched, true
+}
+
 func loadControlMetadataAt(repoRoot string, generatedAt time.Time) map[string]ControlMetadata {
 	if strings.TrimSpace(repoRoot) == "" {
 		return nil
@@ -120,6 +157,25 @@ func loadControlMetadataAt(repoRoot string, generatedAt time.Time) map[string]Co
 		return nil
 	}
 	return byPath
+}
+
+func controlMetadataPatternMatches(pattern, location string) bool {
+	pattern = strings.TrimPrefix(filepath.ToSlash(strings.TrimSpace(pattern)), "/")
+	location = strings.TrimPrefix(filepath.ToSlash(strings.TrimSpace(location)), "/")
+	if pattern == "" || location == "" {
+		return false
+	}
+	if pattern == "*" || pattern == location {
+		return true
+	}
+	if strings.HasSuffix(pattern, "/") {
+		return strings.HasPrefix(location, strings.TrimSuffix(pattern, "/"))
+	}
+	if strings.Contains(pattern, "*") {
+		ok, err := filepath.Match(pattern, location)
+		return err == nil && ok
+	}
+	return strings.HasSuffix(location, pattern)
 }
 
 func mergeControlMetadata(current, incoming ControlMetadata) ControlMetadata {

--- a/core/attribution/provider_metadata.go
+++ b/core/attribution/provider_metadata.go
@@ -46,11 +46,15 @@ type sourceMetadataPayload struct {
 }
 
 func LoadContext(repoRoot string) Context {
+	return LoadContextAt(repoRoot, time.Time{})
+}
+
+func LoadContextAt(repoRoot string, generatedAt time.Time) Context {
 	repoRoot = strings.TrimSpace(repoRoot)
 	return Context{
 		RepoRoot:        repoRoot,
 		Candidates:      loadCandidates(repoRoot),
-		ControlMetadata: loadControlMetadata(repoRoot),
+		ControlMetadata: loadControlMetadataAt(repoRoot, generatedAt),
 	}
 }
 

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -396,6 +396,9 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	}
 
 	now := time.Now().UTC().Truncate(time.Second)
+	if err := validateRepoControlDeclarations(manifestOut); err != nil {
+		return emitScanError("policy_schema_violation", err.Error(), exitPolicyViolation)
+	}
 	scanMethodology := buildScanMethodology(manifestOut, findings, scanStartedAt, now)
 	riskReport := risk.Score(findings, 5, now)
 	if err := checkScanContext(); err != nil {
@@ -504,8 +507,8 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	agginventory.ApplySecurityVisibilityToPrivilegeMap(&inventoryOut)
 	riskReport.ActionPaths, riskReport.ActionPathToControlFirst = risk.BuildActionPaths(riskReport.AttackPaths, &inventoryOut)
 	riskReport.ActionPaths = risk.DecoratePolicyCoverage(riskReport.ActionPaths, findings)
-	riskReport.ActionPaths = risk.DecorateIntroducedBy(riskReport.ActionPaths, repoAttributionContexts(manifestOut))
-	riskReport.ActionPaths = risk.DecorateControlMetadata(riskReport.ActionPaths, repoAttributionContexts(manifestOut))
+	riskReport.ActionPaths = risk.DecorateIntroducedBy(riskReport.ActionPaths, repoAttributionContexts(manifestOut, now))
+	riskReport.ActionPaths = risk.DecorateControlMetadata(riskReport.ActionPaths, repoAttributionContexts(manifestOut, now))
 
 	profileDef, profileErr := profilemodel.Builtin(*profileName)
 	if profileErr != nil {
@@ -1207,7 +1210,7 @@ func scanModesCompatible(previous, current string) bool {
 	return previous == "" || previous == current
 }
 
-func repoAttributionContexts(manifest source.Manifest) map[string]attribution.Context {
+func repoAttributionContexts(manifest source.Manifest, generatedAt time.Time) map[string]attribution.Context {
 	if len(manifest.Repos) == 0 {
 		return nil
 	}
@@ -1222,7 +1225,7 @@ func repoAttributionContexts(manifest source.Manifest) map[string]attribution.Co
 			repoRoot = strings.TrimSpace(repo.Location)
 		}
 		repoRoot = filepath.Clean(repoRoot)
-		ctx := attribution.LoadContext(repoRoot)
+		ctx := attribution.LoadContextAt(repoRoot, generatedAt)
 		for _, composite := range []string{"local::" + key, "::" + key} {
 			if existing := out[composite]; strings.TrimSpace(existing.RepoRoot) == "" {
 				out[composite] = ctx
@@ -1230,6 +1233,23 @@ func repoAttributionContexts(manifest source.Manifest) map[string]attribution.Co
 		}
 	}
 	return out
+}
+
+func validateRepoControlDeclarations(manifest source.Manifest) error {
+	for _, repo := range manifest.Repos {
+		repoRoot := strings.TrimSpace(repo.ScanRoot)
+		if repoRoot == "" {
+			repoRoot = strings.TrimSpace(repo.Location)
+		}
+		repoRoot = filepath.Clean(repoRoot)
+		if repoRoot == "" {
+			continue
+		}
+		if _, _, err := config.LoadControlDeclarations(repoRoot); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func hasIncompleteFilesystemVisibility(detectorErrors []detect.DetectorError, sourceFailures []source.RepoFailure) bool {

--- a/core/config/control_declarations.go
+++ b/core/config/control_declarations.go
@@ -106,6 +106,9 @@ func LoadControlDeclarations(root string) (ControlDeclarations, []string, error)
 	if len(used) == 0 {
 		return ControlDeclarations{}, nil, nil
 	}
+	if err := validateControlDeclarations(loaded); err != nil {
+		return ControlDeclarations{}, used, fmt.Errorf("validate merged control declarations: %w", err)
+	}
 	return loaded, used, nil
 }
 

--- a/core/config/control_declarations.go
+++ b/core/config/control_declarations.go
@@ -1,0 +1,343 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const ControlDeclarationsVersion = "v1"
+
+type ControlDeclarations struct {
+	SchemaVersion string                      `json:"schema_version" yaml:"schema_version"`
+	GeneratedAt   string                      `json:"generated_at,omitempty" yaml:"generated_at,omitempty"`
+	Issuer        string                      `json:"issuer,omitempty" yaml:"issuer,omitempty"`
+	SignatureRef  string                      `json:"signature_ref,omitempty" yaml:"signature_ref,omitempty"`
+	Owners        []ControlDeclarationOwner   `json:"owners,omitempty" yaml:"owners,omitempty"`
+	Targets       []ControlDeclarationTarget  `json:"targets,omitempty" yaml:"targets,omitempty"`
+	Controls      []ControlDeclarationControl `json:"controls,omitempty" yaml:"controls,omitempty"`
+}
+
+type ControlDeclarationOwner struct {
+	Repo          string   `json:"repo,omitempty" yaml:"repo,omitempty"`
+	Repos         []string `json:"repos,omitempty" yaml:"repos,omitempty"`
+	Path          string   `json:"path,omitempty" yaml:"path,omitempty"`
+	Pattern       string   `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+	Paths         []string `json:"paths,omitempty" yaml:"paths,omitempty"`
+	Owner         string   `json:"owner" yaml:"owner"`
+	EvidenceRefs  []string `json:"evidence_refs,omitempty" yaml:"evidence_refs,omitempty"`
+	ObservedAt    string   `json:"observed_at,omitempty" yaml:"observed_at,omitempty"`
+	ValidUntil    string   `json:"valid_until,omitempty" yaml:"valid_until,omitempty"`
+	MaxAge        string   `json:"max_age,omitempty" yaml:"max_age,omitempty"`
+	Issuer        string   `json:"issuer,omitempty" yaml:"issuer,omitempty"`
+	Confidence    string   `json:"confidence,omitempty" yaml:"confidence,omitempty"`
+	RedactionMode string   `json:"redaction_mode,omitempty" yaml:"redaction_mode,omitempty"`
+}
+
+type ControlDeclarationTarget struct {
+	Repo          string   `json:"repo,omitempty" yaml:"repo,omitempty"`
+	Repos         []string `json:"repos,omitempty" yaml:"repos,omitempty"`
+	Path          string   `json:"path,omitempty" yaml:"path,omitempty"`
+	Pattern       string   `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+	Paths         []string `json:"paths,omitempty" yaml:"paths,omitempty"`
+	TargetClass   string   `json:"target_class" yaml:"target_class"`
+	NonProduction bool     `json:"non_production,omitempty" yaml:"non_production,omitempty"`
+	EvidenceRefs  []string `json:"evidence_refs,omitempty" yaml:"evidence_refs,omitempty"`
+	ObservedAt    string   `json:"observed_at,omitempty" yaml:"observed_at,omitempty"`
+	ValidUntil    string   `json:"valid_until,omitempty" yaml:"valid_until,omitempty"`
+	MaxAge        string   `json:"max_age,omitempty" yaml:"max_age,omitempty"`
+	Issuer        string   `json:"issuer,omitempty" yaml:"issuer,omitempty"`
+	Confidence    string   `json:"confidence,omitempty" yaml:"confidence,omitempty"`
+	RedactionMode string   `json:"redaction_mode,omitempty" yaml:"redaction_mode,omitempty"`
+}
+
+type ControlDeclarationControl struct {
+	Repo             string   `json:"repo,omitempty" yaml:"repo,omitempty"`
+	Repos            []string `json:"repos,omitempty" yaml:"repos,omitempty"`
+	Path             string   `json:"path,omitempty" yaml:"path,omitempty"`
+	Workflow         string   `json:"workflow,omitempty" yaml:"workflow,omitempty"`
+	Environment      string   `json:"environment,omitempty" yaml:"environment,omitempty"`
+	Branch           string   `json:"branch,omitempty" yaml:"branch,omitempty"`
+	ApprovalRequired bool     `json:"approval_required,omitempty" yaml:"approval_required,omitempty"`
+	RequiredChecks   []string `json:"required_checks,omitempty" yaml:"required_checks,omitempty"`
+	SecurityGates    []string `json:"security_gates,omitempty" yaml:"security_gates,omitempty"`
+	FreezeWindows    []string `json:"freeze_windows,omitempty" yaml:"freeze_windows,omitempty"`
+	KillSwitches     []string `json:"kill_switches,omitempty" yaml:"kill_switches,omitempty"`
+	EvidenceRefs     []string `json:"evidence_refs,omitempty" yaml:"evidence_refs,omitempty"`
+	ObservedAt       string   `json:"observed_at,omitempty" yaml:"observed_at,omitempty"`
+	ValidUntil       string   `json:"valid_until,omitempty" yaml:"valid_until,omitempty"`
+	MaxAge           string   `json:"max_age,omitempty" yaml:"max_age,omitempty"`
+	Issuer           string   `json:"issuer,omitempty" yaml:"issuer,omitempty"`
+	Confidence       string   `json:"confidence,omitempty" yaml:"confidence,omitempty"`
+	RedactionMode    string   `json:"redaction_mode,omitempty" yaml:"redaction_mode,omitempty"`
+}
+
+func LoadControlDeclarations(root string) (ControlDeclarations, []string, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return ControlDeclarations{}, nil, nil
+	}
+	paths := []string{
+		filepath.Join(root, "wrkr-control-declarations.yaml"),
+		filepath.Join(root, ".wrkr", "control-declarations.yaml"),
+	}
+	loaded := ControlDeclarations{SchemaVersion: ControlDeclarationsVersion}
+	used := []string{}
+	for _, path := range paths {
+		payload, err := os.ReadFile(path) // #nosec G304 -- deterministic declaration lookup under the selected local root.
+		if err != nil {
+			continue
+		}
+		var decoded ControlDeclarations
+		if err := yaml.Unmarshal(payload, &decoded); err != nil {
+			return ControlDeclarations{}, used, fmt.Errorf("parse control declarations %s: %w", filepath.ToSlash(path), err)
+		}
+		if err := validateControlDeclarations(decoded); err != nil {
+			return ControlDeclarations{}, used, fmt.Errorf("validate control declarations %s: %w", filepath.ToSlash(path), err)
+		}
+		loaded = mergeControlDeclarations(loaded, decoded)
+		used = append(used, filepath.ToSlash(path))
+	}
+	if len(used) == 0 {
+		return ControlDeclarations{}, nil, nil
+	}
+	return loaded, used, nil
+}
+
+func validateControlDeclarations(doc ControlDeclarations) error {
+	version := strings.TrimSpace(doc.SchemaVersion)
+	if version == "" {
+		version = ControlDeclarationsVersion
+	}
+	if version != ControlDeclarationsVersion {
+		return fmt.Errorf("unsupported schema_version %q", doc.SchemaVersion)
+	}
+	if doc.GeneratedAt != "" {
+		if _, err := time.Parse(time.RFC3339, strings.TrimSpace(doc.GeneratedAt)); err != nil {
+			return fmt.Errorf("generated_at must be RFC3339")
+		}
+	}
+
+	seen := map[string]struct{}{}
+	for _, item := range doc.Owners {
+		if strings.TrimSpace(item.Owner) == "" {
+			return fmt.Errorf("owners.owner is required")
+		}
+		if err := validateDeclarationTiming(item.ObservedAt, item.ValidUntil, item.MaxAge); err != nil {
+			return err
+		}
+		if err := validateDeclarationPaths(pathValues(item.Path, item.Pattern, item.Paths)); err != nil {
+			return err
+		}
+		if err := validateEvidenceRefs(item.EvidenceRefs); err != nil {
+			return err
+		}
+		if err := validateRedactionMode(item.RedactionMode); err != nil {
+			return err
+		}
+		for _, scope := range declarationScopes(item.Repo, item.Repos, pathValues(item.Path, item.Pattern, item.Paths)) {
+			key := "owner|" + scope
+			if _, exists := seen[key]; exists {
+				return fmt.Errorf("duplicate owner scope %s", scope)
+			}
+			seen[key] = struct{}{}
+		}
+	}
+	for _, item := range doc.Targets {
+		if !validTargetClass(item.TargetClass) {
+			return fmt.Errorf("invalid target_class %q", item.TargetClass)
+		}
+		if err := validateDeclarationTiming(item.ObservedAt, item.ValidUntil, item.MaxAge); err != nil {
+			return err
+		}
+		if err := validateDeclarationPaths(pathValues(item.Path, item.Pattern, item.Paths)); err != nil {
+			return err
+		}
+		if err := validateEvidenceRefs(item.EvidenceRefs); err != nil {
+			return err
+		}
+		if err := validateRedactionMode(item.RedactionMode); err != nil {
+			return err
+		}
+		for _, scope := range declarationScopes(item.Repo, item.Repos, pathValues(item.Path, item.Pattern, item.Paths)) {
+			key := "target|" + scope
+			if _, exists := seen[key]; exists {
+				return fmt.Errorf("duplicate target scope %s", scope)
+			}
+			seen[key] = struct{}{}
+		}
+	}
+	for _, item := range doc.Controls {
+		if err := validateDeclarationTiming(item.ObservedAt, item.ValidUntil, item.MaxAge); err != nil {
+			return err
+		}
+		if err := validateDeclarationPaths(pathValues(item.Path, item.Workflow, nil)); err != nil {
+			return err
+		}
+		if err := validateEvidenceRefs(item.EvidenceRefs); err != nil {
+			return err
+		}
+		if err := validateRedactionMode(item.RedactionMode); err != nil {
+			return err
+		}
+		for _, scope := range declarationScopes(item.Repo, item.Repos, pathValues(item.Path, item.Workflow, nil)) {
+			key := "control|" + scope
+			if _, exists := seen[key]; exists {
+				return fmt.Errorf("duplicate control scope %s", scope)
+			}
+			seen[key] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func mergeControlDeclarations(base, incoming ControlDeclarations) ControlDeclarations {
+	out := base
+	if strings.TrimSpace(out.SchemaVersion) == "" {
+		out.SchemaVersion = ControlDeclarationsVersion
+	}
+	if strings.TrimSpace(out.GeneratedAt) == "" {
+		out.GeneratedAt = strings.TrimSpace(incoming.GeneratedAt)
+	}
+	if strings.TrimSpace(out.Issuer) == "" {
+		out.Issuer = strings.TrimSpace(incoming.Issuer)
+	}
+	if strings.TrimSpace(out.SignatureRef) == "" {
+		out.SignatureRef = strings.TrimSpace(incoming.SignatureRef)
+	}
+	out.Owners = append(out.Owners, incoming.Owners...)
+	out.Targets = append(out.Targets, incoming.Targets...)
+	out.Controls = append(out.Controls, incoming.Controls...)
+	sort.Slice(out.Owners, func(i, j int) bool {
+		return declarationSortKey(out.Owners[i].Repo, out.Owners[i].Repos, pathValues(out.Owners[i].Path, out.Owners[i].Pattern, out.Owners[i].Paths)) < declarationSortKey(out.Owners[j].Repo, out.Owners[j].Repos, pathValues(out.Owners[j].Path, out.Owners[j].Pattern, out.Owners[j].Paths))
+	})
+	sort.Slice(out.Targets, func(i, j int) bool {
+		return declarationSortKey(out.Targets[i].Repo, out.Targets[i].Repos, pathValues(out.Targets[i].Path, out.Targets[i].Pattern, out.Targets[i].Paths)) < declarationSortKey(out.Targets[j].Repo, out.Targets[j].Repos, pathValues(out.Targets[j].Path, out.Targets[j].Pattern, out.Targets[j].Paths))
+	})
+	sort.Slice(out.Controls, func(i, j int) bool {
+		return declarationSortKey(out.Controls[i].Repo, out.Controls[i].Repos, pathValues(out.Controls[i].Path, out.Controls[i].Workflow, nil)) < declarationSortKey(out.Controls[j].Repo, out.Controls[j].Repos, pathValues(out.Controls[j].Path, out.Controls[j].Workflow, nil))
+	})
+	return out
+}
+
+func validateDeclarationTiming(observedAt, validUntil, maxAge string) error {
+	observedAt = strings.TrimSpace(observedAt)
+	validUntil = strings.TrimSpace(validUntil)
+	maxAge = strings.TrimSpace(maxAge)
+	var observed time.Time
+	if observedAt != "" {
+		parsed, err := time.Parse(time.RFC3339, observedAt)
+		if err != nil {
+			return fmt.Errorf("observed_at must be RFC3339")
+		}
+		observed = parsed
+	}
+	if validUntil != "" {
+		expires, err := time.Parse(time.RFC3339, validUntil)
+		if err != nil {
+			return fmt.Errorf("valid_until must be RFC3339")
+		}
+		if !observed.IsZero() && expires.Before(observed) {
+			return fmt.Errorf("valid_until must not precede observed_at")
+		}
+	}
+	if maxAge != "" {
+		if _, err := time.ParseDuration(maxAge); err != nil {
+			return fmt.Errorf("max_age must be a valid duration")
+		}
+	}
+	return nil
+}
+
+func validateDeclarationPaths(values []string) error {
+	for _, value := range values {
+		trimmed := filepath.ToSlash(strings.TrimSpace(value))
+		if trimmed == "" {
+			continue
+		}
+		if filepath.IsAbs(trimmed) || strings.HasPrefix(trimmed, "../") || strings.Contains(trimmed, "/../") {
+			return fmt.Errorf("unsafe declaration path %q", value)
+		}
+	}
+	return nil
+}
+
+func validateEvidenceRefs(values []string) error {
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(trimmed, "evidence://"),
+			strings.HasPrefix(trimmed, "proof://"),
+			strings.HasPrefix(trimmed, "policy://"),
+			strings.HasPrefix(trimmed, "file://"):
+		default:
+			return fmt.Errorf("unsupported evidence ref %q", value)
+		}
+	}
+	return nil
+}
+
+func validateRedactionMode(value string) error {
+	switch strings.TrimSpace(value) {
+	case "", "none", "hash", "omit":
+		return nil
+	default:
+		return fmt.Errorf("invalid redaction_mode %q", value)
+	}
+}
+
+func validTargetClass(value string) bool {
+	switch strings.TrimSpace(value) {
+	case "production_impacting", "release_adjacent", "customer_data_adjacent", "internal_tooling", "developer_productivity", "test_demo_sandbox", "unknown":
+		return true
+	default:
+		return false
+	}
+}
+
+func declarationScopes(repo string, repos []string, paths []string) []string {
+	values := []string{}
+	allRepos := append([]string(nil), repos...)
+	if strings.TrimSpace(repo) != "" {
+		allRepos = append(allRepos, repo)
+	}
+	if len(allRepos) == 0 {
+		allRepos = []string{"*"}
+	}
+	if len(paths) == 0 {
+		paths = []string{"*"}
+	}
+	for _, repoValue := range allRepos {
+		for _, pathValue := range paths {
+			values = append(values, strings.TrimSpace(repoValue)+"::"+filepath.ToSlash(strings.TrimSpace(pathValue)))
+		}
+	}
+	sort.Strings(values)
+	return values
+}
+
+func pathValues(pathValue, pattern string, values []string) []string {
+	out := append([]string(nil), values...)
+	for _, item := range []string{pathValue, pattern} {
+		if strings.TrimSpace(item) != "" {
+			out = append(out, item)
+		}
+	}
+	if len(out) == 0 {
+		return []string{"*"}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func declarationSortKey(repo string, repos []string, paths []string) string {
+	return strings.Join(append(append([]string{strings.TrimSpace(repo)}, repos...), paths...), "|")
+}

--- a/core/config/control_declarations_test.go
+++ b/core/config/control_declarations_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestControlDeclarationsLoadFromRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	payload := []byte(`schema_version: v1
+issuer: security-platform
+owners:
+  - repo: acme/payments
+    path: .github/workflows/release.yml
+    owner: "@acme/platform"
+    evidence_refs:
+      - evidence://customer/owners.yaml#payments
+targets:
+  - repo: acme/payments
+    path: .github/workflows/release.yml
+    target_class: test_demo_sandbox
+    non_production: true
+    evidence_refs:
+      - evidence://customer/targets.yaml#payments
+`)
+	if err := os.WriteFile(filepath.Join(root, "wrkr-control-declarations.yaml"), payload, 0o600); err != nil {
+		t.Fatalf("write declarations: %v", err)
+	}
+
+	loaded, paths, err := LoadControlDeclarations(root)
+	if err != nil {
+		t.Fatalf("load declarations: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("expected one declaration path, got %v", paths)
+	}
+	if len(loaded.Owners) != 1 || loaded.Owners[0].Owner != "@acme/platform" {
+		t.Fatalf("expected owner declaration, got %+v", loaded)
+	}
+	if len(loaded.Targets) != 1 || !loaded.Targets[0].NonProduction {
+		t.Fatalf("expected non-production target declaration, got %+v", loaded)
+	}
+}
+
+func TestInvalidControlDeclarationFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	payload := []byte(`schema_version: v1
+owners:
+  - repo: acme/payments
+    path: ../outside.yml
+    owner: "@acme/platform"
+`)
+	if err := os.WriteFile(filepath.Join(root, "wrkr-control-declarations.yaml"), payload, 0o600); err != nil {
+		t.Fatalf("write declarations: %v", err)
+	}
+
+	if _, _, err := LoadControlDeclarations(root); err == nil {
+		t.Fatal("expected invalid declaration to fail closed")
+	}
+}

--- a/core/config/control_declarations_test.go
+++ b/core/config/control_declarations_test.go
@@ -63,3 +63,34 @@ owners:
 		t.Fatal("expected invalid declaration to fail closed")
 	}
 }
+
+func TestDuplicateControlDeclarationAcrossFilesFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".wrkr"), 0o750); err != nil {
+		t.Fatalf("mkdir .wrkr: %v", err)
+	}
+	first := []byte(`schema_version: v1
+owners:
+  - repo: acme/payments
+    path: .github/workflows/release.yml
+    owner: "@acme/platform"
+`)
+	second := []byte(`schema_version: v1
+owners:
+  - repo: acme/payments
+    path: .github/workflows/release.yml
+    owner: "@acme/security"
+`)
+	if err := os.WriteFile(filepath.Join(root, "wrkr-control-declarations.yaml"), first, 0o600); err != nil {
+		t.Fatalf("write root declarations: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".wrkr", "control-declarations.yaml"), second, 0o600); err != nil {
+		t.Fatalf("write nested declarations: %v", err)
+	}
+
+	if _, _, err := LoadControlDeclarations(root); err == nil {
+		t.Fatal("expected duplicate cross-file scope to fail closed")
+	}
+}

--- a/core/evidencepolicy/evidencepolicy.go
+++ b/core/evidencepolicy/evidencepolicy.go
@@ -1,0 +1,368 @@
+package evidencepolicy
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	SourceTypeProviderExport    = "provider_export"
+	SourceTypeGitHubTeamExport  = "github_team_export"
+	SourceTypeBackstageExport   = "backstage_export"
+	SourceTypeTicketExport      = "ticket_export"
+	SourceTypeSignedDeclaration = "signed_declaration"
+	SourceTypeCustomerOwnerMap  = "customer_owner_map"
+	SourceTypeRepoPolicy        = "repo_policy"
+	SourceTypePolicyConfig      = "policy_config"
+	SourceTypeCodeowners        = "codeowners"
+	SourceTypeCustomOwnerMap    = "custom_owner_mapping"
+	SourceTypeServiceCatalog    = "service_catalog"
+	SourceTypeBackstageCatalog  = "backstage_catalog"
+	SourceTypeAppCatalog        = "app_catalog"
+	SourceTypeGitHubMetadata    = "github_metadata"
+	SourceTypeRepoFallback      = "repo_fallback"
+	SourceTypeRuntime           = "runtime"
+	SourceTypeUnknown           = "unknown"
+
+	FreshnessStateFresh   = "fresh"
+	FreshnessStateStale   = "stale"
+	FreshnessStateExpired = "expired"
+	FreshnessStateUnknown = "unknown"
+
+	ConflictStateResolved  = "resolved"
+	ConflictStateAmbiguous = "ambiguous"
+
+	FieldOwner      = "owner"
+	FieldApproval   = "approval"
+	FieldConstraint = "constraint"
+	FieldTarget     = "target_class"
+	FieldPolicy     = "policy"
+)
+
+type Candidate struct {
+	Field          string   `json:"field,omitempty"`
+	Value          string   `json:"value,omitempty"`
+	SourceType     string   `json:"source_type,omitempty"`
+	Source         string   `json:"source,omitempty"`
+	EvidenceRefs   []string `json:"evidence_refs,omitempty"`
+	ObservedAt     string   `json:"observed_at,omitempty"`
+	ValidUntil     string   `json:"valid_until,omitempty"`
+	MaxAge         string   `json:"max_age,omitempty"`
+	Issuer         string   `json:"issuer,omitempty"`
+	Confidence     string   `json:"confidence,omitempty"`
+	FreshnessState string   `json:"freshness_state,omitempty"`
+	Status         string   `json:"status,omitempty"`
+	ReasonCodes    []string `json:"reason_codes,omitempty"`
+}
+
+type Decision struct {
+	Field                  string      `json:"field"`
+	SelectedValue          string      `json:"selected_value,omitempty"`
+	SelectedSourceType     string      `json:"selected_source_type,omitempty"`
+	SelectedSource         string      `json:"selected_source,omitempty"`
+	SelectedEvidenceRefs   []string    `json:"selected_evidence_refs,omitempty"`
+	SelectedObservedAt     string      `json:"selected_observed_at,omitempty"`
+	SelectedValidUntil     string      `json:"selected_valid_until,omitempty"`
+	SelectedMaxAge         string      `json:"selected_max_age,omitempty"`
+	SelectedIssuer         string      `json:"selected_issuer,omitempty"`
+	SelectedConfidence     string      `json:"selected_confidence,omitempty"`
+	SelectedFreshnessState string      `json:"selected_freshness_state,omitempty"`
+	SelectedStatus         string      `json:"selected_status,omitempty"`
+	ConflictState          string      `json:"conflict_state,omitempty"`
+	ReasonCodes            []string    `json:"reason_codes,omitempty"`
+	ConflictReasonCodes    []string    `json:"conflict_reason_codes,omitempty"`
+	RejectedCandidates     []Candidate `json:"rejected_candidates,omitempty"`
+}
+
+type Contradiction struct {
+	Class             string   `json:"class"`
+	ReasonCodes       []string `json:"reason_codes,omitempty"`
+	EvidenceRefs      []string `json:"evidence_refs,omitempty"`
+	ImpactedTarget    string   `json:"impacted_target_class,omitempty"`
+	RecommendedAction string   `json:"recommended_action,omitempty"`
+}
+
+func NormalizeSourceType(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case SourceTypeProviderExport, SourceTypeGitHubTeamExport, SourceTypeBackstageExport,
+		SourceTypeTicketExport, SourceTypeSignedDeclaration, SourceTypeCustomerOwnerMap,
+		SourceTypeRepoPolicy, SourceTypePolicyConfig, SourceTypeCodeowners,
+		SourceTypeCustomOwnerMap, SourceTypeServiceCatalog, SourceTypeBackstageCatalog,
+		SourceTypeAppCatalog, SourceTypeGitHubMetadata, SourceTypeRepoFallback, SourceTypeRuntime:
+		return strings.ToLower(strings.TrimSpace(value))
+	default:
+		if strings.TrimSpace(value) == "" {
+			return SourceTypeUnknown
+		}
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func SourcePrecedenceRank(sourceType string) int {
+	switch NormalizeSourceType(sourceType) {
+	case SourceTypeProviderExport, SourceTypeGitHubTeamExport, SourceTypeBackstageExport, SourceTypeTicketExport:
+		return 0
+	case SourceTypeSignedDeclaration, SourceTypeCustomerOwnerMap:
+		return 1
+	case SourceTypeRepoPolicy, SourceTypePolicyConfig, SourceTypeCodeowners, SourceTypeCustomOwnerMap:
+		return 2
+	case SourceTypeServiceCatalog, SourceTypeBackstageCatalog, SourceTypeAppCatalog:
+		return 3
+	case SourceTypeGitHubMetadata:
+		return 4
+	case SourceTypeRepoFallback:
+		return 5
+	case SourceTypeRuntime:
+		return 6
+	default:
+		return 99
+	}
+}
+
+func SourcePrecedenceKey(sourceType string) string {
+	return fmt.Sprintf("%02d_%s", SourcePrecedenceRank(sourceType), NormalizeSourceType(sourceType))
+}
+
+func EvaluateFreshness(generatedAt time.Time, observedAt, validUntil, maxAge, status string) (string, []string, error) {
+	observedAt = strings.TrimSpace(observedAt)
+	validUntil = strings.TrimSpace(validUntil)
+	maxAge = strings.TrimSpace(maxAge)
+	status = strings.TrimSpace(status)
+	reasons := []string{}
+
+	var observed time.Time
+	if observedAt != "" {
+		parsedObserved, err := time.Parse(time.RFC3339, observedAt)
+		if err != nil {
+			return "", nil, fmt.Errorf("observed_at must be RFC3339: %w", err)
+		}
+		observed = parsedObserved.UTC()
+	}
+
+	var expiry time.Time
+	switch {
+	case validUntil != "":
+		parsedValidUntil, err := time.Parse(time.RFC3339, validUntil)
+		if err != nil {
+			return "", nil, fmt.Errorf("valid_until must be RFC3339: %w", err)
+		}
+		expiry = parsedValidUntil.UTC()
+		reasons = append(reasons, "freshness:valid_until_present")
+	case maxAge != "" && !observed.IsZero():
+		duration, err := time.ParseDuration(maxAge)
+		if err != nil {
+			return "", nil, fmt.Errorf("max_age must be a valid duration: %w", err)
+		}
+		expiry = observed.Add(duration)
+		reasons = append(reasons, "freshness:max_age_present")
+	case maxAge != "" && observed.IsZero():
+		return "", nil, fmt.Errorf("max_age requires observed_at")
+	}
+
+	if !expiry.IsZero() && !observed.IsZero() && expiry.Before(observed) {
+		return "", nil, fmt.Errorf("validity window precedes observed_at")
+	}
+
+	if status == "stale" {
+		reasons = append(reasons, "freshness:status_stale")
+	}
+
+	if !expiry.IsZero() && !generatedAt.IsZero() {
+		reference := generatedAt.UTC()
+		if reference.After(expiry) {
+			return FreshnessStateExpired, uniqueSorted(append(reasons, "freshness:expired")...), nil
+		}
+		if status == "stale" {
+			return FreshnessStateStale, uniqueSorted(reasons...), nil
+		}
+		return FreshnessStateFresh, uniqueSorted(append(reasons, "freshness:fresh")...), nil
+	}
+
+	if status == "stale" {
+		return FreshnessStateStale, uniqueSorted(reasons...), nil
+	}
+	return FreshnessStateUnknown, uniqueSorted(append(reasons, "freshness:unknown")...), nil
+}
+
+func ResolveDecision(candidates []Candidate, generatedAt time.Time) Decision {
+	normalized := normalizeCandidates(candidates, generatedAt)
+	if len(normalized) == 0 {
+		return Decision{}
+	}
+
+	topRank := SourcePrecedenceRank(normalized[0].SourceType)
+	top := make([]Candidate, 0, len(normalized))
+	rejected := make([]Candidate, 0, len(normalized))
+	for _, candidate := range normalized {
+		if SourcePrecedenceRank(candidate.SourceType) == topRank {
+			top = append(top, candidate)
+			continue
+		}
+		rejected = append(rejected, candidate)
+	}
+
+	selected := top[0]
+	field := strings.TrimSpace(selected.Field)
+	reasons := []string{"precedence:selected:" + NormalizeSourceType(selected.SourceType)}
+	conflictState := ""
+	conflictReasons := []string{}
+
+	distinctTopValues := map[string]struct{}{}
+	for _, candidate := range top {
+		distinctTopValues[candidate.Value] = struct{}{}
+	}
+	if len(distinctTopValues) > 1 {
+		conflictState = ConflictStateAmbiguous
+		conflictReasons = append(conflictReasons, "precedence:equal_precedence_conflict")
+		reasons = append(reasons, "precedence:stable_tiebreak_applied")
+	} else if len(top) > 1 {
+		reasons = append(reasons, "precedence:equal_precedence_corroboration")
+	}
+
+	for _, candidate := range normalized[len(top):] {
+		if strings.TrimSpace(candidate.Value) == strings.TrimSpace(selected.Value) {
+			reasons = append(reasons, "precedence:lower_precedence_corroboration")
+			continue
+		}
+		if conflictState == "" {
+			conflictState = ConflictStateResolved
+		}
+		conflictReasons = append(conflictReasons, "precedence:lower_precedence_disagreement")
+	}
+
+	decision := Decision{
+		Field:                  field,
+		SelectedValue:          strings.TrimSpace(selected.Value),
+		SelectedSourceType:     NormalizeSourceType(selected.SourceType),
+		SelectedSource:         strings.TrimSpace(selected.Source),
+		SelectedEvidenceRefs:   cloneStrings(selected.EvidenceRefs),
+		SelectedObservedAt:     strings.TrimSpace(selected.ObservedAt),
+		SelectedValidUntil:     strings.TrimSpace(selected.ValidUntil),
+		SelectedMaxAge:         strings.TrimSpace(selected.MaxAge),
+		SelectedIssuer:         strings.TrimSpace(selected.Issuer),
+		SelectedConfidence:     strings.TrimSpace(selected.Confidence),
+		SelectedFreshnessState: normalizeFreshnessState(selected.FreshnessState),
+		SelectedStatus:         strings.TrimSpace(selected.Status),
+		ConflictState:          conflictState,
+		ReasonCodes:            uniqueSorted(reasons...),
+		ConflictReasonCodes:    uniqueSorted(conflictReasons...),
+		RejectedCandidates:     cloneCandidates(rejected),
+	}
+
+	if len(top) > 1 {
+		for _, candidate := range top[1:] {
+			decision.RejectedCandidates = append(decision.RejectedCandidates, candidate)
+		}
+		decision.RejectedCandidates = normalizeCandidates(decision.RejectedCandidates, generatedAt)
+	}
+	return decision
+}
+
+func normalizeCandidates(candidates []Candidate, generatedAt time.Time) []Candidate {
+	out := make([]Candidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		normalized := candidate
+		normalized.Field = strings.TrimSpace(normalized.Field)
+		normalized.Value = strings.TrimSpace(normalized.Value)
+		normalized.SourceType = NormalizeSourceType(normalized.SourceType)
+		normalized.Source = strings.TrimSpace(normalized.Source)
+		normalized.EvidenceRefs = uniqueSorted(normalized.EvidenceRefs...)
+		normalized.ObservedAt = strings.TrimSpace(normalized.ObservedAt)
+		normalized.ValidUntil = strings.TrimSpace(normalized.ValidUntil)
+		normalized.MaxAge = strings.TrimSpace(normalized.MaxAge)
+		normalized.Issuer = strings.TrimSpace(normalized.Issuer)
+		normalized.Confidence = strings.TrimSpace(normalized.Confidence)
+		normalized.Status = strings.TrimSpace(normalized.Status)
+		if normalized.FreshnessState == "" {
+			freshness, reasons, err := EvaluateFreshness(generatedAt, normalized.ObservedAt, normalized.ValidUntil, normalized.MaxAge, normalized.Status)
+			if err == nil {
+				normalized.FreshnessState = freshness
+				normalized.ReasonCodes = uniqueSorted(append(normalized.ReasonCodes, reasons...)...)
+			}
+		} else {
+			normalized.FreshnessState = normalizeFreshnessState(normalized.FreshnessState)
+		}
+		if normalized.Value == "" && len(normalized.EvidenceRefs) == 0 {
+			continue
+		}
+		out = append(out, normalized)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if SourcePrecedenceRank(out[i].SourceType) != SourcePrecedenceRank(out[j].SourceType) {
+			return SourcePrecedenceRank(out[i].SourceType) < SourcePrecedenceRank(out[j].SourceType)
+		}
+		if out[i].Value != out[j].Value {
+			return out[i].Value < out[j].Value
+		}
+		if out[i].Source != out[j].Source {
+			return out[i].Source < out[j].Source
+		}
+		if out[i].ObservedAt != out[j].ObservedAt {
+			return out[i].ObservedAt > out[j].ObservedAt
+		}
+		if joined := strings.Join(out[i].EvidenceRefs, "|"); joined != strings.Join(out[j].EvidenceRefs, "|") {
+			return joined < strings.Join(out[j].EvidenceRefs, "|")
+		}
+		return filepath.ToSlash(out[i].Field) < filepath.ToSlash(out[j].Field)
+	})
+	return out
+}
+
+func normalizeFreshnessState(value string) string {
+	switch strings.TrimSpace(value) {
+	case FreshnessStateFresh:
+		return FreshnessStateFresh
+	case FreshnessStateStale:
+		return FreshnessStateStale
+	case FreshnessStateExpired:
+		return FreshnessStateExpired
+	default:
+		return FreshnessStateUnknown
+	}
+}
+
+func cloneStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := append([]string(nil), values...)
+	sort.Strings(out)
+	return out
+}
+
+func cloneCandidates(values []Candidate) []Candidate {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]Candidate, 0, len(values))
+	for _, value := range values {
+		item := value
+		item.EvidenceRefs = cloneStrings(item.EvidenceRefs)
+		item.ReasonCodes = cloneStrings(item.ReasonCodes)
+		out = append(out, item)
+	}
+	return out
+}
+
+func uniqueSorted(values ...string) []string {
+	set := map[string]struct{}{}
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		set[trimmed] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/core/evidencepolicy/evidencepolicy.go
+++ b/core/evidencepolicy/evidencepolicy.go
@@ -253,9 +253,7 @@ func ResolveDecision(candidates []Candidate, generatedAt time.Time) Decision {
 	}
 
 	if len(top) > 1 {
-		for _, candidate := range top[1:] {
-			decision.RejectedCandidates = append(decision.RejectedCandidates, candidate)
-		}
+		decision.RejectedCandidates = append(decision.RejectedCandidates, top[1:]...)
 		decision.RejectedCandidates = normalizeCandidates(decision.RejectedCandidates, generatedAt)
 	}
 	return decision

--- a/core/evidencepolicy/evidencepolicy_test.go
+++ b/core/evidencepolicy/evidencepolicy_test.go
@@ -1,0 +1,129 @@
+package evidencepolicy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResolveDecisionVerifiedProviderBeatsCodeowners(t *testing.T) {
+	t.Parallel()
+
+	decision := ResolveDecision([]Candidate{
+		{
+			Field:      FieldOwner,
+			Value:      "@acme/platform",
+			SourceType: SourceTypeCodeowners,
+			Source:     "CODEOWNERS",
+		},
+		{
+			Field:      FieldOwner,
+			Value:      "@acme/security",
+			SourceType: SourceTypeProviderExport,
+			Source:     "github_team_export",
+			ObservedAt: "2026-05-25T17:00:00Z",
+			ValidUntil: "2026-05-26T17:00:00Z",
+		},
+	}, time.Date(2026, 5, 25, 17, 30, 30, 0, time.UTC))
+
+	if decision.SelectedValue != "@acme/security" {
+		t.Fatalf("expected provider export to win, got %+v", decision)
+	}
+	if decision.SelectedSourceType != SourceTypeProviderExport {
+		t.Fatalf("expected provider export source type, got %+v", decision)
+	}
+	if decision.ConflictState != ConflictStateResolved {
+		t.Fatalf("expected resolved conflict state, got %+v", decision)
+	}
+	if len(decision.RejectedCandidates) != 1 || decision.RejectedCandidates[0].Value != "@acme/platform" {
+		t.Fatalf("expected rejected lower-precedence candidate, got %+v", decision)
+	}
+}
+
+func TestResolveDecisionAmbiguousEqualPrecedenceConflict(t *testing.T) {
+	t.Parallel()
+
+	decision := ResolveDecision([]Candidate{
+		{
+			Field:      FieldOwner,
+			Value:      "@acme/platform",
+			SourceType: SourceTypeProviderExport,
+			Source:     "provider-a",
+			ObservedAt: "2026-05-25T17:00:00Z",
+		},
+		{
+			Field:      FieldOwner,
+			Value:      "@acme/security",
+			SourceType: SourceTypeProviderExport,
+			Source:     "provider-b",
+			ObservedAt: "2026-05-25T17:01:00Z",
+		},
+	}, time.Date(2026, 5, 25, 17, 30, 30, 0, time.UTC))
+
+	if decision.ConflictState != ConflictStateAmbiguous {
+		t.Fatalf("expected ambiguous conflict state, got %+v", decision)
+	}
+	if len(decision.ConflictReasonCodes) == 0 {
+		t.Fatalf("expected conflict reasons, got %+v", decision)
+	}
+}
+
+func TestEvaluateFreshness(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 25, 18, 0, 0, 0, time.UTC)
+
+	state, _, err := EvaluateFreshness(now, "2026-05-25T17:00:00Z", "2026-05-26T17:00:00Z", "", "")
+	if err != nil || state != FreshnessStateFresh {
+		t.Fatalf("expected fresh evidence, got state=%q err=%v", state, err)
+	}
+
+	state, _, err = EvaluateFreshness(now, "2026-05-25T17:00:00Z", "2026-05-25T17:30:00Z", "", "")
+	if err != nil || state != FreshnessStateExpired {
+		t.Fatalf("expected expired evidence, got state=%q err=%v", state, err)
+	}
+
+	state, _, err = EvaluateFreshness(now, "2026-05-25T17:00:00Z", "", "", "stale")
+	if err != nil || state != FreshnessStateStale {
+		t.Fatalf("expected stale evidence, got state=%q err=%v", state, err)
+	}
+
+	state, _, err = EvaluateFreshness(now, "2026-05-25T17:00:00Z", "", "", "")
+	if err != nil || state != FreshnessStateUnknown {
+		t.Fatalf("expected unknown freshness, got state=%q err=%v", state, err)
+	}
+}
+
+func TestFreshnessStateFromValidityWindow(t *testing.T) {
+	t.Parallel()
+
+	state, _, err := EvaluateFreshness(
+		time.Date(2026, 5, 25, 18, 0, 0, 0, time.UTC),
+		"2026-05-25T17:00:00Z",
+		"2026-05-25T19:00:00Z",
+		"",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("evaluate freshness: %v", err)
+	}
+	if state != FreshnessStateFresh {
+		t.Fatalf("expected fresh validity-window state, got %q", state)
+	}
+}
+
+func TestFreshnessStableWithGeneratedAt(t *testing.T) {
+	t.Parallel()
+
+	generatedAt := time.Date(2026, 5, 25, 18, 0, 0, 0, time.UTC)
+	first, _, err := EvaluateFreshness(generatedAt, "2026-05-25T17:00:00Z", "2026-05-26T17:00:00Z", "", "")
+	if err != nil {
+		t.Fatalf("evaluate first freshness: %v", err)
+	}
+	second, _, err := EvaluateFreshness(generatedAt, "2026-05-25T17:00:00Z", "2026-05-26T17:00:00Z", "", "")
+	if err != nil {
+		t.Fatalf("evaluate second freshness: %v", err)
+	}
+	if first != second {
+		t.Fatalf("expected deterministic freshness state, got %q and %q", first, second)
+	}
+}

--- a/core/ingest/ingest.go
+++ b/core/ingest/ingest.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/state"
 	"github.com/Clyra-AI/wrkr/internal/atomicwrite"
@@ -73,6 +74,7 @@ type Record struct {
 	ValidUntil          string   `json:"valid_until,omitempty"`
 	MaxAge              string   `json:"max_age,omitempty"`
 	Confidence          string   `json:"confidence,omitempty"`
+	FreshnessState      string   `json:"freshness_state,omitempty"`
 	RedactionHints      []string `json:"redaction_hints,omitempty"`
 	EvidenceClass       string   `json:"evidence_class"`
 	Status              string   `json:"status,omitempty"`
@@ -108,6 +110,8 @@ type Correlation struct {
 	Owners           []string `json:"owners,omitempty"`
 	UnmatchedReasons []string `json:"unmatched_reasons,omitempty"`
 	LatestObservedAt string   `json:"latest_observed_at,omitempty"`
+	FreshnessState   string   `json:"freshness_state,omitempty"`
+	FreshnessStates  []string `json:"freshness_states,omitempty"`
 }
 
 type Summary struct {
@@ -178,9 +182,13 @@ func Normalize(bundle Bundle) (Bundle, error) {
 	if strings.TrimSpace(bundle.GeneratedAt) == "" {
 		bundle.GeneratedAt = time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
 	}
+	generatedAt, err := time.Parse(time.RFC3339, bundle.GeneratedAt)
+	if err != nil {
+		return Bundle{}, fmt.Errorf("runtime evidence generated_at must be RFC3339")
+	}
 	records := make([]Record, 0, len(bundle.Records))
 	for _, record := range bundle.Records {
-		normalized, err := normalizeRecord(record)
+		normalized, err := normalizeRecord(record, generatedAt)
 		if err != nil {
 			return Bundle{}, err
 		}
@@ -278,6 +286,8 @@ func Correlate(snapshot state.Snapshot, artifactPath string, bundle Bundle) Summ
 		item.RecordIDs = mergeStrings(append(append([]string(nil), item.RecordIDs...), record.RecordID)...)
 		item.RequiredChecks = mergeStrings(append(append([]string(nil), item.RequiredChecks...), record.RequiredChecks...)...)
 		item.Owners = mergeStrings(append(append([]string(nil), item.Owners...), record.Owner)...)
+		item.FreshnessStates = mergeStrings(append(append([]string(nil), item.FreshnessStates...), record.FreshnessState)...)
+		item.FreshnessState = mergeFreshnessState(item.FreshnessState, record.FreshnessState)
 		if item.LatestObservedAt == "" || strings.TrimSpace(record.ObservedAt) > item.LatestObservedAt {
 			item.LatestObservedAt = strings.TrimSpace(record.ObservedAt)
 		}
@@ -316,7 +326,7 @@ func Correlate(snapshot state.Snapshot, artifactPath string, bundle Bundle) Summ
 	}
 }
 
-func normalizeRecord(record Record) (Record, error) {
+func normalizeRecord(record Record, generatedAt time.Time) (Record, error) {
 	record.RecordKind = normalizeRecordKind(record.RecordKind, record)
 	record.SourceType = normalizeSourceType(record.SourceType)
 	record.PathID = strings.TrimSpace(record.PathID)
@@ -343,6 +353,7 @@ func normalizeRecord(record Record) (Record, error) {
 	record.ValidUntil = strings.TrimSpace(record.ValidUntil)
 	record.MaxAge = strings.TrimSpace(record.MaxAge)
 	record.Confidence = strings.TrimSpace(record.Confidence)
+	record.FreshnessState = strings.TrimSpace(record.FreshnessState)
 	record.RedactionHints = mergeStrings(record.RedactionHints...)
 	record.EvidenceClass = normalizeEvidenceClass(record.EvidenceClass)
 	record.Status = normalizeRecordStatus(record.Status)
@@ -379,6 +390,11 @@ func normalizeRecord(record Record) (Record, error) {
 			return Record{}, fmt.Errorf("external control evidence record max_age must be a valid duration for %s", fallbackRecordLabel(label))
 		}
 	}
+	freshnessState, _, err := evidencepolicy.EvaluateFreshness(generatedAt, record.ObservedAt, record.ValidUntil, record.MaxAge, record.Status)
+	if err != nil {
+		return Record{}, fmt.Errorf("external control evidence record freshness is invalid for %s: %w", fallbackRecordLabel(label), err)
+	}
+	record.FreshnessState = freshnessState
 	if record.EvidenceClass == "" {
 		return Record{}, fmt.Errorf("runtime evidence record evidence_class is required for %s", fallbackRecordLabel(label))
 	}
@@ -882,27 +898,15 @@ func normalizeRecordKind(value string, record Record) string {
 }
 
 func normalizeSourceType(value string) string {
-	return strings.ToLower(strings.TrimSpace(value))
+	return evidencepolicy.NormalizeSourceType(value)
 }
 
 func sourcePrecedenceSortKey(record Record) string {
-	switch normalizeSourceType(record.SourceType) {
-	case "provider_export", "github_team_export", "backstage_export":
-		return "00_provider_export"
-	case "customer_owner_map", "ticket_export":
-		return "10_customer_declaration"
-	case "repo_policy", "policy_config":
-		return "20_repo_policy"
-	case "app_catalog":
-		return "30_app_catalog"
-	case "":
-		if normalizeRecordKind(record.RecordKind, record) == RecordKindRuntime {
-			return "40_runtime"
-		}
-		return "90_unspecified"
-	default:
-		return "80_" + normalizeSourceType(record.SourceType)
+	sourceType := normalizeSourceType(record.SourceType)
+	if sourceType == evidencepolicy.SourceTypeUnknown && normalizeRecordKind(record.RecordKind, record) == RecordKindRuntime {
+		sourceType = evidencepolicy.SourceTypeRuntime
 	}
+	return evidencepolicy.SourcePrecedenceKey(sourceType)
 }
 
 func normalizeOwnerValue(value string) string {
@@ -984,4 +988,47 @@ func mergeStrings(values ...string) []string {
 		return nil
 	}
 	return out
+}
+
+func mergeFreshnessState(current, incoming string) string {
+	switch normalizeFreshnessState(current) {
+	case evidencepolicy.FreshnessStateExpired:
+		return evidencepolicy.FreshnessStateExpired
+	case evidencepolicy.FreshnessStateStale:
+		if normalizeFreshnessState(incoming) == evidencepolicy.FreshnessStateExpired {
+			return evidencepolicy.FreshnessStateExpired
+		}
+		return evidencepolicy.FreshnessStateStale
+	case evidencepolicy.FreshnessStateUnknown:
+		switch normalizeFreshnessState(incoming) {
+		case evidencepolicy.FreshnessStateExpired, evidencepolicy.FreshnessStateStale:
+			return normalizeFreshnessState(incoming)
+		default:
+			return evidencepolicy.FreshnessStateUnknown
+		}
+	case evidencepolicy.FreshnessStateFresh:
+		switch normalizeFreshnessState(incoming) {
+		case evidencepolicy.FreshnessStateExpired, evidencepolicy.FreshnessStateStale, evidencepolicy.FreshnessStateUnknown:
+			return normalizeFreshnessState(incoming)
+		default:
+			return evidencepolicy.FreshnessStateFresh
+		}
+	default:
+		return normalizeFreshnessState(incoming)
+	}
+}
+
+func normalizeFreshnessState(value string) string {
+	switch strings.TrimSpace(value) {
+	case evidencepolicy.FreshnessStateFresh:
+		return evidencepolicy.FreshnessStateFresh
+	case evidencepolicy.FreshnessStateStale:
+		return evidencepolicy.FreshnessStateStale
+	case evidencepolicy.FreshnessStateExpired:
+		return evidencepolicy.FreshnessStateExpired
+	case evidencepolicy.FreshnessStateUnknown:
+		return evidencepolicy.FreshnessStateUnknown
+	default:
+		return ""
+	}
 }

--- a/core/ingest/schema/external-control-evidence.schema.json
+++ b/core/ingest/schema/external-control-evidence.schema.json
@@ -38,6 +38,7 @@
             "provider_export",
             "github_team_export",
             "backstage_export",
+            "signed_declaration",
             "customer_owner_map",
             "ticket_export",
             "repo_policy",
@@ -116,6 +117,10 @@
         },
         "confidence": {
           "type": "string"
+        },
+        "freshness_state": {
+          "type": "string",
+          "enum": ["fresh", "stale", "expired", "unknown"]
         },
         "redaction_hints": {
           "type": "array",

--- a/core/owners/owners.go
+++ b/core/owners/owners.go
@@ -7,7 +7,10 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
+	"github.com/Clyra-AI/wrkr/core/config"
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
 	"gopkg.in/yaml.v3"
 )
 
@@ -15,11 +18,18 @@ type rule struct {
 	pattern       string
 	owner         string
 	source        string
+	sourceType    string
 	evidenceBasis string
 	evidenceRefs  []string
 	priority      int
 	inferred      bool
 	repoScopes    []string
+	observedAt    string
+	validUntil    string
+	maxAge        string
+	issuer        string
+	confidence    string
+	status        string
 }
 
 const (
@@ -54,6 +64,7 @@ type Resolution struct {
 	OwnershipConfidence float64
 	EvidenceBasis       []string
 	ConflictOwners      []string
+	EvidenceDecision    *evidencepolicy.Decision
 }
 
 type Metadata struct {
@@ -66,11 +77,16 @@ func Resolve(root, repo, org, location string) Resolution {
 }
 
 func ResolveWithMetadata(root, repo, org, location string, metadata Metadata) Resolution {
+	return ResolveWithMetadataAt(root, repo, org, location, metadata, time.Time{})
+}
+
+func ResolveWithMetadataAt(root, repo, org, location string, metadata Metadata, generatedAt time.Time) Resolution {
 	rules := loadCodeowners(root)
 	rules = append(rules, loadOwnerMappings(root)...)
 	rules = append(rules, loadServiceCatalog(root)...)
 	rules = append(rules, loadBackstageCatalog(root)...)
 	rules = append(rules, loadExternalOwnerMappings(root)...)
+	rules = append(rules, loadDeclaredOwnerMappings(root)...)
 	rules = append(rules, rulesFromMetadata(repo, org, metadata)...)
 	normalized := normalizePath(location)
 	candidates := make([]rule, 0)
@@ -81,7 +97,7 @@ func ResolveWithMetadata(root, repo, org, location string, metadata Metadata) Re
 	}
 	candidates = collapseCandidatesBySource(candidates)
 	if len(candidates) > 0 {
-		return resolveCandidates(candidates, repo, org)
+		return resolveCandidates(candidates, repo, org, generatedAt)
 	}
 	if strings.TrimSpace(repo) == "" {
 		return Resolution{
@@ -100,6 +116,14 @@ func ResolveWithMetadata(root, repo, org, location string, metadata Metadata) Re
 		OwnershipState:      OwnershipStateInferred,
 		OwnershipConfidence: 0.45,
 		EvidenceBasis:       []string{"repo_fallback:repo_name"},
+		EvidenceDecision: &evidencepolicy.Decision{
+			Field:                  evidencepolicy.FieldOwner,
+			SelectedValue:          FallbackOwner(repo, org),
+			SelectedSourceType:     evidencepolicy.SourceTypeRepoFallback,
+			SelectedSource:         evidencepolicy.SourceTypeRepoFallback,
+			SelectedFreshnessState: evidencepolicy.FreshnessStateUnknown,
+			ReasonCodes:            []string{"precedence:selected:repo_fallback"},
+		},
 	}
 }
 
@@ -141,6 +165,7 @@ func parseRulesWithSource(content, source, evidencePath string, priority int, in
 			pattern:       pattern,
 			owner:         strings.TrimSpace(parts[1]),
 			source:        source,
+			sourceType:    source,
 			evidenceBasis: source + ":" + evidencePath + ":" + pattern,
 			priority:      priority,
 			inferred:      inferred,
@@ -219,6 +244,7 @@ func ownerMappingRules(items []ownerMapping, evidencePath, source string, priori
 				pattern:       pattern,
 				owner:         owner,
 				source:        source,
+				sourceType:    source,
 				evidenceBasis: source + ":" + evidencePath + ":" + pattern,
 				evidenceRefs:  nil,
 				priority:      priority,
@@ -382,6 +408,7 @@ func parseBackstageCatalogDoc(payload []byte, evidencePath string) []rule {
 		pattern:       "*",
 		owner:         owner,
 		source:        OwnerSourceBackstage,
+		sourceType:    OwnerSourceBackstage,
 		evidenceBasis: OwnerSourceBackstage + ":" + evidencePath + ":spec.owner",
 		evidenceRefs:  nil,
 		priority:      3,
@@ -402,6 +429,11 @@ type externalOwnerEvidenceRecord struct {
 	Path          string   `json:"path"`
 	Location      string   `json:"location"`
 	ObservedAt    string   `json:"observed_at"`
+	ValidUntil    string   `json:"valid_until"`
+	MaxAge        string   `json:"max_age"`
+	Issuer        string   `json:"issuer"`
+	Confidence    string   `json:"confidence"`
+	Status        string   `json:"status"`
 	EvidenceClass string   `json:"evidence_class"`
 	Owner         string   `json:"owner"`
 	EvidenceRefs  []string `json:"evidence_refs"`
@@ -434,34 +466,44 @@ func loadExternalOwnerMappings(root string) []rule {
 		if pattern == "" {
 			pattern = "*"
 		}
+		sourceType := externalOwnerSourceType(record.SourceType)
 		out = append(out, rule{
 			pattern:       pattern,
 			owner:         owner,
-			source:        externalOwnerSource(record.SourceType),
-			evidenceBasis: externalOwnerSource(record.SourceType) + ":" + filepath.ToSlash(filepath.Join(".wrkr", "provenance", "external-control-evidence.json")) + ":" + pattern,
+			source:        uniqueExternalOwnerSource(sourceType, record.Source, pattern, record.ObservedAt, record.EvidenceRefs),
+			sourceType:    sourceType,
+			evidenceBasis: sourceType + ":" + filepath.ToSlash(filepath.Join(".wrkr", "provenance", "external-control-evidence.json")) + ":" + pattern,
 			evidenceRefs:  uniqueSorted(record.EvidenceRefs),
 			priority:      externalOwnerPriority(record.SourceType),
 			inferred:      false,
 			repoScopes:    externalOwnerRepoScopes(record.Repo),
+			observedAt:    strings.TrimSpace(record.ObservedAt),
+			validUntil:    strings.TrimSpace(record.ValidUntil),
+			maxAge:        strings.TrimSpace(record.MaxAge),
+			issuer:        strings.TrimSpace(record.Issuer),
+			confidence:    strings.TrimSpace(record.Confidence),
+			status:        strings.TrimSpace(record.Status),
 		})
 	}
 	return out
 }
 
-func externalOwnerSource(sourceType string) string {
+func externalOwnerSourceType(sourceType string) string {
 	switch strings.TrimSpace(sourceType) {
 	case OwnerSourceGitHubTeam:
 		return OwnerSourceGitHubTeam
 	case OwnerSourceAppCatalog:
 		return OwnerSourceAppCatalog
 	case OwnerSourceCustomerMap:
-		return OwnerSourceCustomerMap
+		return evidencepolicy.SourceTypeSignedDeclaration
 	case OwnerSourceProvider:
 		return OwnerSourceProvider
 	case "backstage_export":
-		return OwnerSourceBackstage
+		return evidencepolicy.SourceTypeBackstageExport
+	case evidencepolicy.SourceTypeTicketExport:
+		return evidencepolicy.SourceTypeTicketExport
 	default:
-		return strings.TrimSpace(sourceType)
+		return evidencepolicy.NormalizeSourceType(sourceType)
 	}
 }
 
@@ -483,6 +525,16 @@ func externalOwnerRepoScopes(repo string) []string {
 	return []string{normalizeRepoScope(repo)}
 }
 
+func uniqueExternalOwnerSource(sourceType, source, pattern, observedAt string, refs []string) string {
+	return strings.Join([]string{
+		sourceType,
+		strings.TrimSpace(source),
+		strings.TrimSpace(pattern),
+		strings.TrimSpace(observedAt),
+		strings.Join(uniqueSorted(refs), "|"),
+	}, "::")
+}
+
 func rulesFromMetadata(repo, org string, metadata Metadata) []rule {
 	owners := make([]string, 0)
 	for _, team := range metadata.Teams {
@@ -502,6 +554,7 @@ func rulesFromMetadata(repo, org string, metadata Metadata) []rule {
 			pattern:       "*",
 			owner:         owner,
 			source:        OwnerSourceGitHub,
+			sourceType:    OwnerSourceGitHub,
 			evidenceBasis: OwnerSourceGitHub + ":" + strings.TrimSpace(repo),
 			evidenceRefs:  nil,
 			priority:      4,
@@ -568,74 +621,85 @@ func normalizeRepoScope(value string) string {
 	return strings.Trim(strings.ToLower(strings.TrimSpace(value)), "@/")
 }
 
-func resolveCandidates(candidates []rule, repo, org string) Resolution {
-	byOwner := map[string][]rule{}
+func resolveCandidates(candidates []rule, repo, org string, generatedAt time.Time) Resolution {
+	evidenceCandidates := make([]evidencepolicy.Candidate, 0, len(candidates))
 	for _, item := range candidates {
 		owner := normalizeOwner(item.owner)
 		if owner == "" {
 			continue
 		}
-		byOwner[owner] = append(byOwner[owner], item)
+		evidenceCandidates = append(evidenceCandidates, evidencepolicy.Candidate{
+			Field:          evidencepolicy.FieldOwner,
+			Value:          owner,
+			SourceType:     firstNonEmptyOwner(item.sourceType, item.source),
+			Source:         item.source,
+			EvidenceRefs:   append([]string{item.evidenceBasis}, item.evidenceRefs...),
+			ObservedAt:     item.observedAt,
+			ValidUntil:     item.validUntil,
+			MaxAge:         item.maxAge,
+			Issuer:         item.issuer,
+			Confidence:     item.confidence,
+			Status:         item.status,
+			FreshnessState: evidencepolicy.FreshnessStateUnknown,
+		})
 	}
-	if len(byOwner) == 0 {
+	decision := evidencepolicy.ResolveDecision(evidenceCandidates, generatedAt)
+	if strings.TrimSpace(decision.SelectedValue) == "" {
 		if strings.TrimSpace(repo) == "" {
-			return Resolution{OwnerSource: OwnerSourceMissing, OwnershipStatus: OwnershipStatusUnresolved, OwnershipState: OwnershipStateMissing, EvidenceBasis: []string{"owner_resolution:no_owner_candidate"}}
+			return Resolution{
+				OwnerSource:      OwnerSourceMissing,
+				OwnershipStatus:  OwnershipStatusUnresolved,
+				OwnershipState:   OwnershipStateMissing,
+				EvidenceBasis:    []string{"owner_resolution:no_owner_candidate"},
+				EvidenceDecision: &decision,
+			}
 		}
+		fallback := FallbackOwner(repo, org)
 		return Resolution{
-			Owner:               FallbackOwner(repo, org),
+			Owner:               fallback,
 			OwnerSource:         OwnerSourceRepoFallback,
 			OwnershipStatus:     OwnershipStatusInferred,
 			OwnershipState:      OwnershipStateInferred,
 			OwnershipConfidence: 0.45,
 			EvidenceBasis:       []string{"repo_fallback:repo_name"},
+			EvidenceDecision: &evidencepolicy.Decision{
+				Field:                  evidencepolicy.FieldOwner,
+				SelectedValue:          fallback,
+				SelectedSourceType:     evidencepolicy.SourceTypeRepoFallback,
+				SelectedSource:         evidencepolicy.SourceTypeRepoFallback,
+				SelectedFreshnessState: evidencepolicy.FreshnessStateUnknown,
+				ReasonCodes:            []string{"precedence:selected:repo_fallback"},
+			},
 		}
 	}
-	owners := make([]string, 0, len(byOwner))
-	for owner := range byOwner {
-		owners = append(owners, owner)
-	}
-	sort.Strings(owners)
-	if len(owners) > 1 {
-		return Resolution{
-			Owner:               FallbackOwner(repo, org),
-			OwnerSource:         OwnerSourceConflict,
-			OwnershipStatus:     OwnershipStatusUnresolved,
-			OwnershipState:      OwnershipStateConflicting,
-			OwnershipConfidence: 0.2,
-			EvidenceBasis:       evidenceBasisForCandidates(candidates),
-			ConflictOwners:      owners,
-		}
-	}
-	items := byOwner[owners[0]]
-	sort.Slice(items, func(i, j int) bool {
-		if items[i].priority != items[j].priority {
-			return items[i].priority < items[j].priority
-		}
-		if items[i].source != items[j].source {
-			return items[i].source < items[j].source
-		}
-		return items[i].evidenceBasis < items[j].evidenceBasis
-	})
-	best := items[0]
+
 	status := OwnershipStatusExplicit
 	state := OwnershipStateExplicit
-	confidence := 0.9
-	if best.inferred {
+	confidence := ownershipConfidenceForDecision(decision)
+	if decision.ConflictState == evidencepolicy.ConflictStateAmbiguous {
+		status = OwnershipStatusUnresolved
+		state = OwnershipStateConflicting
+		confidence = 0.2
+	}
+	if ownershipSourceIsInferred(decision.SelectedSourceType) {
 		status = OwnershipStatusInferred
 		state = OwnershipStateInferred
-		confidence = 0.65
 	}
-	if best.source == OwnerSourceCodeowners || best.source == OwnerSourceCustomMap {
-		confidence = 0.95
-	}
-	return Resolution{
-		Owner:               owners[0],
-		OwnerSource:         best.source,
+
+	resolution := Resolution{
+		Owner:               strings.TrimSpace(decision.SelectedValue),
+		OwnerSource:         strings.TrimSpace(decision.SelectedSourceType),
 		OwnershipStatus:     status,
 		OwnershipState:      state,
 		OwnershipConfidence: confidence,
-		EvidenceBasis:       evidenceBasisForCandidates(items),
+		EvidenceBasis:       evidenceBasisForCandidates(candidates),
+		EvidenceDecision:    &decision,
 	}
+	if decision.ConflictState == evidencepolicy.ConflictStateAmbiguous {
+		resolution.OwnerSource = OwnerSourceConflict
+		resolution.ConflictOwners = conflictOwnersFromDecision(decision)
+	}
+	return resolution
 }
 
 func collapseCandidatesBySource(candidates []rule) []rule {
@@ -670,6 +734,84 @@ func evidenceBasisForCandidates(candidates []rule) []string {
 		values = append(values, item.evidenceRefs...)
 	}
 	return uniqueSorted(values)
+}
+
+func ownershipSourceIsInferred(sourceType string) bool {
+	switch evidencepolicy.NormalizeSourceType(sourceType) {
+	case OwnerSourceGitHub, evidencepolicy.SourceTypeRepoFallback:
+		return true
+	default:
+		return false
+	}
+}
+
+func ownershipConfidenceForDecision(decision evidencepolicy.Decision) float64 {
+	switch evidencepolicy.NormalizeSourceType(decision.SelectedSourceType) {
+	case evidencepolicy.SourceTypeProviderExport, evidencepolicy.SourceTypeGitHubTeamExport, evidencepolicy.SourceTypeBackstageExport:
+		return 0.98
+	case evidencepolicy.SourceTypeSignedDeclaration:
+		return 0.94
+	case evidencepolicy.SourceTypeCodeowners, evidencepolicy.SourceTypeCustomOwnerMap:
+		return 0.95
+	case evidencepolicy.SourceTypeServiceCatalog, evidencepolicy.SourceTypeBackstageCatalog, evidencepolicy.SourceTypeAppCatalog:
+		return 0.9
+	case evidencepolicy.SourceTypeGitHubMetadata:
+		return 0.65
+	case evidencepolicy.SourceTypeRepoFallback:
+		return 0.45
+	default:
+		return 0.75
+	}
+}
+
+func conflictOwnersFromDecision(decision evidencepolicy.Decision) []string {
+	values := []string{decision.SelectedValue}
+	for _, item := range decision.RejectedCandidates {
+		values = append(values, item.Value)
+	}
+	return uniqueSorted(values)
+}
+
+func loadDeclaredOwnerMappings(root string) []rule {
+	doc, paths, err := config.LoadControlDeclarations(root)
+	if err != nil || len(paths) == 0 || len(doc.Owners) == 0 {
+		return nil
+	}
+	out := make([]rule, 0, len(doc.Owners))
+	for _, item := range doc.Owners {
+		owner := normalizeOwner(item.Owner)
+		if owner == "" {
+			continue
+		}
+		patterns := mappingPatterns(ownerMapping{
+			Path:    item.Path,
+			Pattern: item.Pattern,
+			Paths:   item.Paths,
+		})
+		if len(patterns) == 0 {
+			patterns = []string{"*"}
+		}
+		repoScopes := mappingRepos(ownerMapping{Repo: item.Repo, Repos: item.Repos})
+		for _, pattern := range patterns {
+			out = append(out, rule{
+				pattern:       pattern,
+				owner:         owner,
+				source:        strings.Join([]string{evidencepolicy.SourceTypeSignedDeclaration, strings.Join(paths, "|"), pattern, strings.TrimSpace(item.ObservedAt)}, "::"),
+				sourceType:    evidencepolicy.SourceTypeSignedDeclaration,
+				evidenceBasis: evidencepolicy.SourceTypeSignedDeclaration + ":" + filepath.ToSlash(filepath.Join("wrkr-control-declarations.yaml")) + ":" + pattern,
+				evidenceRefs:  uniqueSorted(item.EvidenceRefs),
+				priority:      1,
+				inferred:      false,
+				repoScopes:    repoScopes,
+				observedAt:    strings.TrimSpace(item.ObservedAt),
+				validUntil:    strings.TrimSpace(item.ValidUntil),
+				maxAge:        strings.TrimSpace(item.MaxAge),
+				issuer:        firstNonEmptyOwner(item.Issuer, doc.Issuer),
+				confidence:    strings.TrimSpace(item.Confidence),
+			})
+		}
+	}
+	return out
 }
 
 func normalizeOwner(owner string) string {

--- a/core/owners/owners_test.go
+++ b/core/owners/owners_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
 )
 
 func TestResolveOwnerFromCodeowners(t *testing.T) {
@@ -110,7 +112,7 @@ func TestResolveParsesServiceCatalogAndBackstageOwners(t *testing.T) {
 	}
 }
 
-func TestResolveSurfacesConflictingOwnersDeterministically(t *testing.T) {
+func TestResolveUsesPrecedenceAndPreservesLowerPriorityOwnerDisagreement(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -122,20 +124,14 @@ func TestResolveSurfacesConflictingOwnersDeterministically(t *testing.T) {
 	}
 
 	resolution := Resolve(root, "acme/app", "acme", "AGENTS.md")
-	if resolution.OwnerSource != OwnerSourceConflict || resolution.OwnershipState != OwnershipStateConflicting {
-		t.Fatalf("expected conflict state, got %+v", resolution)
+	if resolution.Owner != "@acme/platform" || resolution.OwnerSource != OwnerSourceCodeowners {
+		t.Fatalf("expected CODEOWNERS to win precedence, got %+v", resolution)
 	}
-	want := []string{"@acme/platform", "@acme/security"}
-	if len(resolution.ConflictOwners) != len(want) {
-		t.Fatalf("expected conflict owners %v, got %+v", want, resolution)
+	if resolution.EvidenceDecision == nil || resolution.EvidenceDecision.ConflictState != evidencepolicy.ConflictStateResolved {
+		t.Fatalf("expected resolved precedence decision, got %+v", resolution)
 	}
-	for idx := range want {
-		if resolution.ConflictOwners[idx] != want[idx] {
-			t.Fatalf("expected deterministic conflict owners %v, got %+v", want, resolution.ConflictOwners)
-		}
-	}
-	if resolution.OwnershipConfidence >= 0.5 {
-		t.Fatalf("expected low confidence for conflict, got %+v", resolution)
+	if len(resolution.EvidenceDecision.RejectedCandidates) != 1 || resolution.EvidenceDecision.RejectedCandidates[0].Value != "@acme/security" {
+		t.Fatalf("expected lower-priority owner disagreement to be preserved, got %+v", resolution)
 	}
 }
 
@@ -196,7 +192,7 @@ func TestOwnerResolutionUsesExternalEvidenceRefs(t *testing.T) {
 	if resolution.Owner != "@acme/platform" {
 		t.Fatalf("expected external owner evidence to resolve owner, got %+v", resolution)
 	}
-	if resolution.OwnerSource != OwnerSourceCustomerMap {
+	if resolution.OwnerSource != evidencepolicy.SourceTypeSignedDeclaration {
 		t.Fatalf("expected external owner source, got %+v", resolution)
 	}
 	if !hasEvidenceBasis(resolution.EvidenceBasis, "evidence://fake/customer-owner-map.yaml#payments-service") {

--- a/core/report/agent_action_bom.go
+++ b/core/report/agent_action_bom.go
@@ -11,6 +11,7 @@ import (
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/aggregate/scanquality"
 	"github.com/Clyra-AI/wrkr/core/attribution"
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
 	"github.com/Clyra-AI/wrkr/core/ingest"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/risk"
@@ -85,6 +86,8 @@ type AgentActionBOMItem struct {
 	OwnerSource                  string                                 `json:"owner_source,omitempty"`
 	OwnershipStatus              string                                 `json:"ownership_status,omitempty"`
 	OwnershipState               string                                 `json:"ownership_state,omitempty"`
+	EvidenceDecisions            []evidencepolicy.Decision              `json:"evidence_decisions,omitempty"`
+	Contradictions               []evidencepolicy.Contradiction         `json:"contradictions,omitempty"`
 	ControlResolutionState       string                                 `json:"control_resolution_state,omitempty"`
 	ControlResolutionReasons     []string                               `json:"control_resolution_reasons,omitempty"`
 	ControlEvidenceRefs          []string                               `json:"control_evidence_refs,omitempty"`
@@ -249,6 +252,8 @@ func buildAgentActionBOM(summary Summary, findings []model.Finding) *AgentAction
 			OwnerSource:                  strings.TrimSpace(path.OwnerSource),
 			OwnershipStatus:              strings.TrimSpace(path.OwnershipStatus),
 			OwnershipState:               strings.TrimSpace(path.OwnershipState),
+			EvidenceDecisions:            append([]evidencepolicy.Decision(nil), path.EvidenceDecisions...),
+			Contradictions:               append([]evidencepolicy.Contradiction(nil), path.Contradictions...),
 			ControlResolutionState:       strings.TrimSpace(path.ControlResolutionState),
 			ControlResolutionReasons:     append([]string(nil), path.ControlResolutionReasons...),
 			ControlEvidenceRefs:          append([]string(nil), path.ControlEvidenceRefs...),

--- a/core/report/render_markdown.go
+++ b/core/report/render_markdown.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Clyra-AI/wrkr/core/aggregate/scanquality"
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
 	"github.com/Clyra-AI/wrkr/core/risk"
 )
 
@@ -124,6 +125,9 @@ func RenderMarkdown(summary Summary) string {
 					item.Queue,
 					item.Remediation,
 				))
+				if len(item.Contradictions) > 0 {
+					builder.WriteString(fmt.Sprintf("  contradictions=%s\n", markdownContradictions(item.Contradictions)))
+				}
 			}
 			builder.WriteString("\n")
 		}
@@ -251,6 +255,9 @@ func RenderMarkdown(summary Summary) string {
 				item.PolicyStatus,
 				item.Remediation,
 			))
+			if len(item.Contradictions) > 0 {
+				builder.WriteString(fmt.Sprintf("  contradictions=%s\n", markdownContradictions(item.Contradictions)))
+			}
 			if item.GaitCoverage != nil {
 				builder.WriteString(fmt.Sprintf("  gait=policy:%s approval:%s jit:%s freeze:%s kill:%s outcome:%s proof:%s\n",
 					item.GaitCoverage.PolicyDecision.Status,
@@ -327,6 +334,21 @@ func RenderMarkdown(summary Summary) string {
 		builder.WriteString("\n")
 	}
 	return builder.String()
+}
+
+func markdownContradictions(items []evidencepolicy.Contradiction) string {
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		label := strings.TrimSpace(item.Class)
+		if len(item.ReasonCodes) > 0 {
+			label = label + ":" + strings.Join(item.ReasonCodes, ",")
+		}
+		parts = append(parts, strings.Trim(label, ":"))
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, " | ")
 }
 
 func renderTriggerClassSuffix(triggerClass string) string {

--- a/core/report/render_markdown_test.go
+++ b/core/report/render_markdown_test.go
@@ -1,0 +1,61 @@
+package report
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
+)
+
+func TestContradictionMarkdownIsEvidenceScoped(t *testing.T) {
+	t.Parallel()
+
+	markdown := RenderMarkdown(Summary{
+		GeneratedAt:  "2026-05-25T18:00:00Z",
+		Template:     string(TemplateAgentActionBOM),
+		ShareProfile: string(ShareProfileInternal),
+		AgentActionBOM: &AgentActionBOM{
+			BOMID: "bom-1",
+			Summary: AgentActionBOMSummary{
+				TotalItems:         1,
+				ControlFirstItems:  1,
+				CoverageConfidence: "high",
+			},
+			Items: []AgentActionBOMItem{{
+				Repo:                   "acme/release",
+				Location:               ".github/workflows/release.yml",
+				ConfidenceLane:         "confirmed_action_path",
+				ActionPathType:         "ci_cd_workflow",
+				ControlState:           "block_recommended",
+				RiskZone:               "release",
+				TargetClass:            "production_impacting",
+				ReviewBurden:           "critical",
+				ControlPriority:        "control_first",
+				RiskTier:               "critical",
+				ControlResolutionState: "contradictory_control",
+				ApprovalEvidenceState:  "unknown",
+				OwnerEvidenceState:     "unknown",
+				ProofEvidenceState:     "unknown",
+				RuntimeEvidenceState:   "unknown",
+				Confidence:             "high",
+				EvidenceStrength:       "high",
+				Queue:                  "control_first",
+				Remediation:            "Resolve contradictory evidence.",
+				Contradictions: []evidencepolicy.Contradiction{{
+					Class:       "non_prod_vs_credential",
+					ReasonCodes: []string{"contradiction:non_prod_declared_with_production_credential"},
+					EvidenceRefs: []string{
+						"evidence://customer/declarations.yaml#non-prod",
+						"credential:static_secret",
+					},
+				}},
+			}},
+		},
+	})
+	if !strings.Contains(markdown, "contradictions=") {
+		t.Fatalf("expected contradiction summary in markdown, got %q", markdown)
+	}
+	if strings.Contains(markdown, "ghp_") {
+		t.Fatalf("expected markdown to stay evidence-scoped, got %q", markdown)
+	}
+}

--- a/core/risk/action_paths.go
+++ b/core/risk/action_paths.go
@@ -11,6 +11,7 @@ import (
 	aggattack "github.com/Clyra-AI/wrkr/core/aggregate/attackpath"
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/attribution"
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/owners"
 	riskattack "github.com/Clyra-AI/wrkr/core/risk/attackpath"
@@ -72,6 +73,8 @@ type ActionPath struct {
 	OwnershipConfidence        float64                                 `json:"ownership_confidence,omitempty"`
 	OwnershipEvidence          []string                                `json:"ownership_evidence_basis,omitempty"`
 	OwnershipConflicts         []string                                `json:"ownership_conflicts,omitempty"`
+	EvidenceDecisions          []evidencepolicy.Decision               `json:"evidence_decisions,omitempty"`
+	Contradictions             []evidencepolicy.Contradiction          `json:"contradictions,omitempty"`
 	ControlResolutionState     string                                  `json:"control_resolution_state,omitempty"`
 	ControlResolutionReasons   []string                                `json:"control_resolution_reasons,omitempty"`
 	ControlEvidenceRefs        []string                                `json:"control_evidence_refs,omitempty"`
@@ -240,6 +243,7 @@ func buildActionPath(
 		OwnershipConfidence:        entry.OwnershipConfidence,
 		OwnershipEvidence:          dedupeSortedStrings(entry.OwnershipEvidence),
 		OwnershipConflicts:         dedupeSortedStrings(entry.OwnershipConflicts),
+		EvidenceDecisions:          ownershipDecisionSlice(entry.OwnershipDecision),
 		ApprovalGapReasons:         dedupeSortedStrings(entry.ApprovalGapReasons),
 		WritePathClasses:           dedupeSortedStrings(entry.WritePathClasses),
 		ActionClasses:              dedupeSortedStrings(entry.ActionClasses),
@@ -407,6 +411,8 @@ func mergeActionPath(current, incoming ActionPath) ActionPath {
 	merged.OwnershipConfidence = mergeOwnershipConfidence(current, incoming)
 	merged.OwnershipEvidence = dedupeSortedStrings(append(append([]string(nil), current.OwnershipEvidence...), incoming.OwnershipEvidence...))
 	merged.OwnershipConflicts = dedupeSortedStrings(append(append([]string(nil), current.OwnershipConflicts...), incoming.OwnershipConflicts...))
+	merged.EvidenceDecisions = mergeEvidenceDecisions(current.EvidenceDecisions, incoming.EvidenceDecisions)
+	merged.Contradictions = mergeContradictions(current.Contradictions, incoming.Contradictions)
 	merged.ControlResolutionState = chooseControlResolutionState(current.ControlResolutionState, incoming.ControlResolutionState)
 	merged.ControlResolutionReasons = dedupeSortedStrings(append(append([]string(nil), current.ControlResolutionReasons...), incoming.ControlResolutionReasons...))
 	merged.ControlEvidenceRefs = dedupeSortedStrings(append(append([]string(nil), current.ControlEvidenceRefs...), incoming.ControlEvidenceRefs...))
@@ -570,6 +576,83 @@ func dedupeSortedStrings(values []string) []string {
 		out = append(out, value)
 	}
 	sort.Strings(out)
+	return out
+}
+
+func ownershipDecisionSlice(decision *evidencepolicy.Decision) []evidencepolicy.Decision {
+	if decision == nil {
+		return nil
+	}
+	return []evidencepolicy.Decision{cloneEvidenceDecision(*decision)}
+}
+
+func mergeEvidenceDecisions(current, incoming []evidencepolicy.Decision) []evidencepolicy.Decision {
+	if len(current) == 0 && len(incoming) == 0 {
+		return nil
+	}
+	byField := map[string]evidencepolicy.Decision{}
+	for _, item := range append(append([]evidencepolicy.Decision(nil), current...), incoming...) {
+		field := strings.TrimSpace(item.Field)
+		if field == "" {
+			continue
+		}
+		byField[field] = cloneEvidenceDecision(item)
+	}
+	out := make([]evidencepolicy.Decision, 0, len(byField))
+	for _, item := range byField {
+		out = append(out, item)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Field < out[j].Field })
+	return out
+}
+
+func mergeContradictions(current, incoming []evidencepolicy.Contradiction) []evidencepolicy.Contradiction {
+	if len(current) == 0 && len(incoming) == 0 {
+		return nil
+	}
+	seen := map[string]evidencepolicy.Contradiction{}
+	for _, item := range append(append([]evidencepolicy.Contradiction(nil), current...), incoming...) {
+		key := strings.Join([]string{
+			strings.TrimSpace(item.Class),
+			strings.TrimSpace(item.ImpactedTarget),
+			strings.Join(dedupeSortedStrings(item.ReasonCodes), "|"),
+		}, "|")
+		seen[key] = cloneContradiction(item)
+	}
+	out := make([]evidencepolicy.Contradiction, 0, len(seen))
+	for _, item := range seen {
+		out = append(out, item)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Class != out[j].Class {
+			return out[i].Class < out[j].Class
+		}
+		return out[i].ImpactedTarget < out[j].ImpactedTarget
+	})
+	return out
+}
+
+func cloneEvidenceDecision(in evidencepolicy.Decision) evidencepolicy.Decision {
+	out := in
+	out.SelectedEvidenceRefs = dedupeSortedStrings(append([]string(nil), in.SelectedEvidenceRefs...))
+	out.ReasonCodes = dedupeSortedStrings(append([]string(nil), in.ReasonCodes...))
+	out.ConflictReasonCodes = dedupeSortedStrings(append([]string(nil), in.ConflictReasonCodes...))
+	if len(in.RejectedCandidates) > 0 {
+		out.RejectedCandidates = make([]evidencepolicy.Candidate, 0, len(in.RejectedCandidates))
+		for _, item := range in.RejectedCandidates {
+			copyItem := item
+			copyItem.EvidenceRefs = dedupeSortedStrings(append([]string(nil), item.EvidenceRefs...))
+			copyItem.ReasonCodes = dedupeSortedStrings(append([]string(nil), item.ReasonCodes...))
+			out.RejectedCandidates = append(out.RejectedCandidates, copyItem)
+		}
+	}
+	return out
+}
+
+func cloneContradiction(in evidencepolicy.Contradiction) evidencepolicy.Contradiction {
+	out := in
+	out.ReasonCodes = dedupeSortedStrings(append([]string(nil), in.ReasonCodes...))
+	out.EvidenceRefs = dedupeSortedStrings(append([]string(nil), in.EvidenceRefs...))
 	return out
 }
 

--- a/core/risk/action_paths_test.go
+++ b/core/risk/action_paths_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
 	"github.com/Clyra-AI/wrkr/core/model"
 	riskattack "github.com/Clyra-AI/wrkr/core/risk/attackpath"
 )
@@ -693,6 +694,105 @@ func TestEvidenceStateContradictoryOwnerSignals(t *testing.T) {
 	}
 	if paths[0].ControlResolutionState != ControlResolutionStateContradictoryControl {
 		t.Fatalf("expected contradictory control resolution state, got %+v", paths[0])
+	}
+}
+
+func TestNonProdDeclarationContradictedByProductionSecret(t *testing.T) {
+	t.Parallel()
+
+	paths := ProjectActionPaths([]ActionPath{{
+		PathID:           "apc-non-prod-secret",
+		Org:              "acme",
+		Repo:             "acme/release",
+		ToolType:         "compiled_action",
+		Location:         ".github/workflows/release.yml",
+		WriteCapable:     true,
+		ProductionWrite:  true,
+		CredentialAccess: true,
+		EvidenceDecisions: []evidencepolicy.Decision{{
+			Field:                  evidencepolicy.FieldTarget,
+			SelectedValue:          TargetClassTestDemoSandbox,
+			SelectedSourceType:     evidencepolicy.SourceTypeSignedDeclaration,
+			SelectedSource:         "wrkr-control-declarations.yaml",
+			SelectedEvidenceRefs:   []string{"evidence://customer/declarations.yaml#non-prod"},
+			SelectedFreshnessState: evidencepolicy.FreshnessStateFresh,
+			ReasonCodes:            []string{"declaration:non_production"},
+		}},
+		CredentialAuthority: &agginventory.CredentialAuthority{
+			CredentialPresent:      true,
+			CredentialUsableByPath: true,
+			ReasonCodes:            []string{"credential:static_secret"},
+		},
+	}})
+	if len(paths) != 1 {
+		t.Fatalf("expected one projected path, got %+v", paths)
+	}
+	if paths[0].TargetEvidenceState != EvidenceStateContradictory {
+		t.Fatalf("expected contradictory target evidence state, got %+v", paths[0])
+	}
+	if len(paths[0].Contradictions) == 0 {
+		t.Fatalf("expected contradiction payload, got %+v", paths[0])
+	}
+}
+
+func TestDeclarationDoesNotBypassContradictionCheck(t *testing.T) {
+	t.Parallel()
+
+	paths := ProjectActionPaths([]ActionPath{{
+		PathID:          "apc-declaration-contradiction",
+		Org:             "acme",
+		Repo:            "acme/release",
+		ToolType:        "compiled_action",
+		Location:        ".github/workflows/release.yml",
+		WriteCapable:    true,
+		ProductionWrite: true,
+		EvidenceDecisions: []evidencepolicy.Decision{{
+			Field:                  evidencepolicy.FieldTarget,
+			SelectedValue:          TargetClassTestDemoSandbox,
+			SelectedSourceType:     evidencepolicy.SourceTypeSignedDeclaration,
+			SelectedSource:         "wrkr-control-declarations.yaml",
+			SelectedEvidenceRefs:   []string{"evidence://customer/declarations.yaml#non-prod"},
+			SelectedFreshnessState: evidencepolicy.FreshnessStateFresh,
+			ReasonCodes:            []string{"declaration:non_production"},
+		}},
+	}})
+	if len(paths) != 1 {
+		t.Fatalf("expected one projected path, got %+v", paths)
+	}
+	if paths[0].ControlResolutionState != ControlResolutionStateContradictoryControl {
+		t.Fatalf("expected contradiction to keep control-first posture, got %+v", paths[0])
+	}
+}
+
+func TestContradictionRanksControlFirst(t *testing.T) {
+	t.Parallel()
+
+	paths := ProjectActionPaths([]ActionPath{{
+		PathID:          "apc-contradiction-rank",
+		Org:             "acme",
+		Repo:            "acme/release",
+		ToolType:        "compiled_action",
+		Location:        ".github/workflows/release.yml",
+		WriteCapable:    true,
+		ProductionWrite: true,
+		EvidenceDecisions: []evidencepolicy.Decision{{
+			Field:                  evidencepolicy.FieldTarget,
+			SelectedValue:          TargetClassTestDemoSandbox,
+			SelectedSourceType:     evidencepolicy.SourceTypeSignedDeclaration,
+			SelectedSource:         "wrkr-control-declarations.yaml",
+			SelectedEvidenceRefs:   []string{"evidence://customer/declarations.yaml#non-prod"},
+			SelectedFreshnessState: evidencepolicy.FreshnessStateFresh,
+			ReasonCodes:            []string{"declaration:non_production"},
+		}},
+	}})
+	if len(paths) != 1 {
+		t.Fatalf("expected one projected path, got %+v", paths)
+	}
+	if paths[0].ControlPriority != ControlPriorityControlFirst {
+		t.Fatalf("expected contradiction to rank control first, got %+v", paths[0])
+	}
+	if paths[0].ReviewBurden != ReviewBurdenCritical {
+		t.Fatalf("expected contradiction to require critical review, got %+v", paths[0])
 	}
 }
 

--- a/core/risk/buyer_projection.go
+++ b/core/risk/buyer_projection.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
 )
 
 const (
@@ -46,8 +47,18 @@ func ProjectActionPath(path ActionPath) ActionPath {
 	out := path
 	out.ConfidenceLane, out.ConfidenceLaneReasons = deriveConfidenceLane(out)
 	out = projectEvidenceStates(out)
-	out.TargetClass, out.TargetClassReasons, out.TargetClassEvidenceRefs = deriveTargetClass(out)
+	derivedTargetClass, derivedTargetReasons, derivedTargetRefs := deriveTargetClass(out)
+	out.TargetClass = chooseTargetClass(out.TargetClass, derivedTargetClass)
+	out.TargetClassReasons = dedupeSortedStrings(append(append([]string(nil), out.TargetClassReasons...), derivedTargetReasons...))
+	out.TargetClassEvidenceRefs = dedupeSortedStrings(append(append([]string(nil), out.TargetClassEvidenceRefs...), derivedTargetRefs...))
 	out.ActionPathType, out.ActionPathTypeReasons, out.ActionPathTypeEvidenceRefs = deriveActionPathType(out)
+	out.Contradictions = deriveContradictions(out)
+	if len(out.Contradictions) > 0 {
+		out.TargetEvidenceState = EvidenceStateContradictory
+		out.ControlEvidenceRefs = dedupeSortedStrings(append(out.ControlEvidenceRefs, contradictionEvidenceRefs(out.Contradictions)...))
+		out.ControlResolutionReasons = dedupeSortedStrings(append(out.ControlResolutionReasons, contradictionReasonCodes(out.Contradictions)...))
+		out.ControlResolutionState, out.ControlResolutionReasons = deriveControlResolutionState(out, out.ControlResolutionReasons)
+	}
 
 	model := deriveGovernFirstModel(out)
 	out.InventoryRisk = model.inventoryRisk
@@ -533,6 +544,9 @@ func actionPathHasContradictoryControlEvidence(path ActionPath) bool {
 	if strings.TrimSpace(path.ControlResolutionState) == ControlResolutionStateContradictoryControl {
 		return true
 	}
+	if len(path.Contradictions) > 0 {
+		return true
+	}
 	for _, state := range []string{
 		path.ApprovalEvidenceState,
 		path.OwnerEvidenceState,
@@ -542,6 +556,81 @@ func actionPathHasContradictoryControlEvidence(path ActionPath) bool {
 		path.CredentialEvidenceState,
 	} {
 		if normalizeEvidenceState(state) == EvidenceStateContradictory {
+			return true
+		}
+	}
+	return false
+}
+
+func deriveContradictions(path ActionPath) []evidencepolicy.Contradiction {
+	decision, ok := evidenceDecisionForField(path, evidencepolicy.FieldTarget)
+	if !ok {
+		return nil
+	}
+	selectedTarget := strings.TrimSpace(decision.SelectedValue)
+	if selectedTarget == "" {
+		return nil
+	}
+	if selectedTarget != TargetClassTestDemoSandbox && !containsReasonCode(decision.ReasonCodes, "declaration:non_production") {
+		return nil
+	}
+
+	contradictions := []evidencepolicy.Contradiction{}
+	baseRefs := decisionEvidenceRefs(decision)
+	add := func(class string, reason string, refs []string) {
+		contradictions = append(contradictions, evidencepolicy.Contradiction{
+			Class:             class,
+			ReasonCodes:       dedupeSortedStrings([]string{reason}),
+			EvidenceRefs:      dedupeSortedStrings(append(baseRefs, refs...)),
+			ImpactedTarget:    path.TargetClass,
+			RecommendedAction: "Refresh the declaration or remove the production-bearing signal before treating this path as non-production.",
+		})
+	}
+
+	if path.ProductionWrite || len(path.MatchedProductionTargets) > 0 || path.TargetClass == TargetClassProductionImpacting {
+		add("non_prod_vs_production_target", "contradiction:non_prod_declared_with_production_target", append([]string(nil), path.TargetClassEvidenceRefs...))
+	}
+	if path.CredentialAccess {
+		refs := []string{}
+		if path.CredentialAuthority != nil {
+			refs = append(refs, path.CredentialAuthority.ReasonCodes...)
+		}
+		if path.CredentialProvenance != nil {
+			refs = append(refs, path.CredentialProvenance.EvidenceBasis...)
+		}
+		add("non_prod_vs_credential", "contradiction:non_prod_declared_with_production_credential", refs)
+	}
+	if path.DeployWrite {
+		add("non_prod_vs_deploy", "contradiction:non_prod_declared_with_deploy_write", append([]string(nil), path.PolicyRefs...))
+	}
+	if path.MergeExecute || path.PullRequestWrite {
+		add("non_prod_vs_release_permission", "contradiction:non_prod_declared_with_release_permission", append([]string(nil), path.PolicyRefs...))
+	}
+	if len(path.ConstraintEvidenceClasses) > 0 {
+		add("non_prod_vs_protected_constraint", "contradiction:non_prod_declared_with_protected_constraint", append([]string(nil), path.ConstraintEvidenceRefs...))
+	}
+	return mergeContradictions(nil, contradictions)
+}
+
+func contradictionEvidenceRefs(items []evidencepolicy.Contradiction) []string {
+	refs := []string{}
+	for _, item := range items {
+		refs = append(refs, item.EvidenceRefs...)
+	}
+	return dedupeSortedStrings(refs)
+}
+
+func contradictionReasonCodes(items []evidencepolicy.Contradiction) []string {
+	reasons := []string{}
+	for _, item := range items {
+		reasons = append(reasons, item.ReasonCodes...)
+	}
+	return dedupeSortedStrings(reasons)
+}
+
+func containsReasonCode(values []string, want string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == strings.TrimSpace(want) {
 			return true
 		}
 	}

--- a/core/risk/evidence_state.go
+++ b/core/risk/evidence_state.go
@@ -61,7 +61,7 @@ func DecorateControlMetadata(paths []ActionPath, repoContexts map[string]attribu
 		if ctx.ControlMetadata == nil {
 			continue
 		}
-		meta, ok := ctx.ControlMetadata[strings.TrimSpace(out[i].Location)]
+		meta, ok := attribution.ResolveControlMetadata(ctx.ControlMetadata, strings.TrimSpace(out[i].Location))
 		if !ok {
 			continue
 		}

--- a/core/risk/evidence_state.go
+++ b/core/risk/evidence_state.go
@@ -5,6 +5,7 @@ import (
 
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/attribution"
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
 	"github.com/Clyra-AI/wrkr/core/owners"
 )
 
@@ -82,6 +83,10 @@ func DecorateControlMetadata(paths []ActionPath, repoContexts map[string]attribu
 		out[i].RuntimeEvidenceState = chooseEvidenceState(out[i].RuntimeEvidenceState, meta.RuntimeEvidenceState)
 		out[i].TargetEvidenceState = chooseEvidenceState(out[i].TargetEvidenceState, meta.TargetEvidenceState)
 		out[i].CredentialEvidenceState = chooseEvidenceState(out[i].CredentialEvidenceState, meta.CredentialEvidenceState)
+		out[i].TargetClass = chooseTargetClass(out[i].TargetClass, meta.TargetClass)
+		out[i].TargetClassReasons = dedupeSortedStrings(append(append([]string(nil), out[i].TargetClassReasons...), meta.TargetClassReasons...))
+		out[i].TargetClassEvidenceRefs = dedupeSortedStrings(append(append([]string(nil), out[i].TargetClassEvidenceRefs...), meta.TargetClassEvidenceRefs...))
+		out[i].EvidenceDecisions = mergeEvidenceDecisions(out[i].EvidenceDecisions, meta.EvidenceDecisions)
 	}
 	return out
 }
@@ -146,6 +151,19 @@ func projectEvidenceStates(path ActionPath) ActionPath {
 }
 
 func deriveApprovalEvidenceState(path ActionPath) (string, []string, []string) {
+	if decision, ok := evidenceDecisionForField(path, evidencepolicy.FieldApproval); ok {
+		refs := decisionEvidenceRefs(decision)
+		switch {
+		case strings.TrimSpace(decision.ConflictState) == evidencepolicy.ConflictStateAmbiguous:
+			return EvidenceStateContradictory, []string{"approval_evidence:conflict"}, refs
+		case decisionFreshnessExpired(decision):
+			return EvidenceStateUnknown, []string{"approval_evidence:expired"}, refs
+		case decisionFreshnessStale(decision):
+			return EvidenceStateUnknown, []string{"approval_evidence:stale"}, refs
+		default:
+			return decisionEvidenceState(decision, evidencepolicy.FieldApproval), []string{"approval_evidence:precedence_selected"}, refs
+		}
+	}
 	reasons := []string{}
 	refs := []string{}
 	approvalSatisfied := false
@@ -180,6 +198,20 @@ func deriveApprovalEvidenceState(path ActionPath) (string, []string, []string) {
 }
 
 func deriveOwnerEvidenceState(path ActionPath) (string, []string, []string) {
+	if decision, ok := evidenceDecisionForField(path, evidencepolicy.FieldOwner); ok {
+		refs := decisionEvidenceRefs(decision)
+		switch {
+		case strings.TrimSpace(decision.ConflictState) == evidencepolicy.ConflictStateAmbiguous:
+			reasons := []string{"owner_evidence:conflict"}
+			return EvidenceStateContradictory, dedupeSortedStrings(append(reasons, path.OwnershipConflicts...)), refs
+		case decisionFreshnessExpired(decision):
+			return EvidenceStateUnknown, []string{"owner_evidence:expired"}, refs
+		case decisionFreshnessStale(decision):
+			return EvidenceStateUnknown, []string{"owner_evidence:stale"}, refs
+		default:
+			return decisionEvidenceState(decision, evidencepolicy.FieldOwner), []string{"owner_evidence:precedence_selected"}, refs
+		}
+	}
 	reasons := []string{}
 	refs := dedupeSortedStrings(path.OwnershipEvidence)
 	switch {
@@ -367,7 +399,10 @@ func deriveControlResolutionState(path ActionPath, fieldReasons []string) (strin
 		normalizeEvidenceState(path.ApprovalEvidenceState) == EvidenceStateContradictory,
 		normalizeEvidenceState(path.OwnerEvidenceState) == EvidenceStateContradictory,
 		normalizeEvidenceState(path.ProofEvidenceState) == EvidenceStateContradictory,
-		normalizeEvidenceState(path.RuntimeEvidenceState) == EvidenceStateContradictory:
+		normalizeEvidenceState(path.RuntimeEvidenceState) == EvidenceStateContradictory,
+		normalizeEvidenceState(path.TargetEvidenceState) == EvidenceStateContradictory,
+		normalizeEvidenceState(path.CredentialEvidenceState) == EvidenceStateContradictory,
+		len(path.Contradictions) > 0:
 		return ControlResolutionStateContradictoryControl, dedupeSortedStrings(append(reasons, "control_resolution:contradictory"))
 	case seed == ControlResolutionStateExternalControlReference:
 		return ControlResolutionStateExternalControlReference, dedupeSortedStrings(append(reasons, "control_resolution:external_control_reference"))
@@ -379,6 +414,61 @@ func deriveControlResolutionState(path ActionPath, fieldReasons []string) (strin
 		return chooseControlResolutionState(ControlResolutionStateDetectedControl, seed), dedupeSortedStrings(append(reasons, "control_resolution:detected_control"))
 	default:
 		return chooseControlResolutionState(ControlResolutionStateNoVisibleControl, seed), dedupeSortedStrings(append(reasons, "control_resolution:no_visible_control"))
+	}
+}
+
+func evidenceDecisionForField(path ActionPath, field string) (evidencepolicy.Decision, bool) {
+	for _, item := range path.EvidenceDecisions {
+		if strings.TrimSpace(item.Field) == strings.TrimSpace(field) {
+			return item, true
+		}
+	}
+	return evidencepolicy.Decision{}, false
+}
+
+func decisionEvidenceRefs(decision evidencepolicy.Decision) []string {
+	values := append([]string(nil), decision.SelectedEvidenceRefs...)
+	for _, item := range decision.RejectedCandidates {
+		values = append(values, item.EvidenceRefs...)
+	}
+	return dedupeSortedStrings(values)
+}
+
+func decisionFreshnessExpired(decision evidencepolicy.Decision) bool {
+	return strings.TrimSpace(decision.SelectedFreshnessState) == evidencepolicy.FreshnessStateExpired
+}
+
+func decisionFreshnessStale(decision evidencepolicy.Decision) bool {
+	return strings.TrimSpace(decision.SelectedFreshnessState) == evidencepolicy.FreshnessStateStale
+}
+
+func decisionEvidenceState(decision evidencepolicy.Decision, field string) string {
+	switch strings.TrimSpace(decision.SelectedStatus) {
+	case "unmatched":
+		return EvidenceStateUnknown
+	case "conflict":
+		return EvidenceStateContradictory
+	}
+	sourceType := evidencepolicy.NormalizeSourceType(decision.SelectedSourceType)
+	switch strings.TrimSpace(field) {
+	case evidencepolicy.FieldOwner:
+		switch sourceType {
+		case evidencepolicy.SourceTypeSignedDeclaration, evidencepolicy.SourceTypeCustomerOwnerMap:
+			return EvidenceStateDeclared
+		case evidencepolicy.SourceTypeGitHubMetadata, evidencepolicy.SourceTypeRepoFallback:
+			return EvidenceStateInferred
+		default:
+			return EvidenceStateVerified
+		}
+	default:
+		switch sourceType {
+		case evidencepolicy.SourceTypeProviderExport, evidencepolicy.SourceTypeGitHubTeamExport, evidencepolicy.SourceTypeBackstageExport, evidencepolicy.SourceTypeTicketExport:
+			return EvidenceStateVerified
+		case evidencepolicy.SourceTypeGitHubMetadata, evidencepolicy.SourceTypeRepoFallback:
+			return EvidenceStateInferred
+		default:
+			return EvidenceStateDeclared
+		}
 	}
 }
 

--- a/docs/commands/ingest.md
+++ b/docs/commands/ingest.md
@@ -26,7 +26,7 @@ Runtime and external-control records are normalized and sorted deterministically
 - `observed_at` in RFC3339 format
 - `evidence_class`
 
-External-control sidecars should validate against `schemas/v1/evidence/external-control-evidence.schema.json` and use `record_kind=external_control` plus a deterministic `source_type` such as `provider_export`, `repo_policy`, `app_catalog`, `ticket_export`, or `customer_owner_map`.
+External-control sidecars should validate against `schemas/v1/evidence/external-control-evidence.schema.json` and use `record_kind=external_control` plus a deterministic `source_type` such as `provider_export`, `signed_declaration`, `repo_policy`, `app_catalog`, `ticket_export`, or `customer_owner_map`.
 
 Each record must also provide at least one deterministic correlation key: `path_id`, `agent_id`, `repo` + `location`, `repo` + `workflow`, `repo` + `environment`, `service`, `policy_ref`, `proof_ref`, `target`, or graph refs.
 
@@ -48,7 +48,9 @@ Normalized evidence classes:
 - `security_gate`
 - `other` for explicit legacy/unknown carry-through
 
-Additional additive keys may include `tool`, `repo`, `service`, `workflow`, `environment`, `path`, `target`, `action_classes`, `policy_ref`, `proof_ref`, `graph_node_refs`, `graph_edge_refs`, `status`, `issuer`, `valid_until`, `max_age`, `confidence`, `redaction_hints`, `owner`, `required_checks`, `branch`, and `evidence_refs`.
+Additional additive keys may include `tool`, `repo`, `service`, `workflow`, `environment`, `path`, `target`, `action_classes`, `policy_ref`, `proof_ref`, `graph_node_refs`, `graph_edge_refs`, `status`, `issuer`, `valid_until`, `max_age`, `confidence`, `freshness_state`, `redaction_hints`, `owner`, `required_checks`, `branch`, and `evidence_refs`.
+
+Wrkr normalizes external-control records with deterministic source precedence and freshness metadata. Correlation summaries now preserve additive `freshness_state` / `freshness_states` so stale or expired evidence is visible without silently verifying a control.
 
 ## Safety and failure modes
 

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -11,6 +11,8 @@ wrkr scan status --state <path> [--json]
 
 Scan-time `action_paths[*]` are evidence-scoped. `control_resolution_state` and the canonical `approval_evidence_state`, `owner_evidence_state`, `proof_evidence_state`, `runtime_evidence_state`, `target_evidence_state`, and `credential_evidence_state` fields explain what Wrkr could verify, what was only declared or inferred, and what remained unknown in the scanned inputs. `action_path_type` keeps plain-source, CI/CD, automation-bot, AI-assisted, and agent-framework paths distinct so downstream reports do not overclaim agent behavior where the evidence only supports a broader action path.
 
+When imported or declared enterprise evidence is present, `action_paths[*]` may also emit additive `evidence_decisions[]` and `contradictions[]`. These preserve the selected source, freshness state (`fresh`, `stale`, `expired`, `unknown`), rejected candidates, stable reason codes, and contradiction evidence refs instead of flattening everything into one winner string.
+
 Start here with one of these first-value paths:
 
 ```bash
@@ -43,6 +45,8 @@ Acquisition behavior is fail-closed by target:
 - Hosted GitHub materialization is sparse by default: Wrkr fetches detector-relevant files such as agent instructions, MCP/Codex/Cursor/Claude configs, skills, workflows, policy files, dependency manifests, and AI/MCP declaration surfaces instead of every repository blob.
 - If a repo already contains deterministic provenance sidecars under `.wrkr/provenance/`, Wrkr can project PR-level `introduced_by` metadata from `source-metadata.json`, `github-event.json`, or `gitlab-event.json` without live provider calls.
 - If a repo contains `.wrkr/provenance/external-control-evidence.json`, Wrkr can also project local ownership, approval, branch-protection, protected-environment, required-check, security-gate, freeze-window, and kill-switch evidence into govern-first path posture without live provider calls.
+- If a repo contains `wrkr-control-declarations.yaml` or `.wrkr/control-declarations.yaml`, Wrkr loads versioned customer declarations for owner mappings, target classes, non-production declarations, and control evidence links as local declared evidence only.
+- Invalid control declarations fail closed with `policy_schema_violation` (exit `3`) instead of being ignored.
 - Repo-local Gait policy `controls.deployment_constraints[]` declarations are treated as declared control evidence for branch, environment, approval, required-check, freeze-window, kill-switch, and security-gate context when present.
 - Hosted scans do not fetch broad source-code extensions by default. Use `--mode deep` or `--allow-source-materialization` only when you explicitly want generic source files such as `.go`, `.py`, `.js`, or `.ts` to be materialized for deeper static detector coverage.
 - Hosted GitHub API base resolution order is: `--github-api`, config `github_api_base`, then `WRKR_GITHUB_API_BASE`.

--- a/docs/decisions/wave21-control-declarations-and-evidence-governance.md
+++ b/docs/decisions/wave21-control-declarations-and-evidence-governance.md
@@ -1,0 +1,29 @@
+# ADR: Wave 21 Control Declarations And Evidence Governance
+
+Date: 2026-05-25
+Status: accepted
+
+## Context
+
+Wave 2 of the enterprise-evidence rollout needs Wrkr to accept customer-supplied control context without turning local declarations into invisible assumptions. Before this change, Wrkr could ingest repo-local control sidecars and Gait deployment constraints, but it still merged path-level control signals with first-non-empty behavior, did not model freshness on imported evidence, and had no versioned declaration artifact for owner mappings, non-production declarations, target classes, or declared control links.
+
+## Decision
+
+1. Add versioned local declaration loading for `wrkr-control-declarations.yaml` and `.wrkr/control-declarations.yaml`.
+2. Validate declarations deterministically at scan time and fail closed on invalid schema, unsafe paths, duplicate scopes, or unsupported evidence refs.
+3. Normalize imported and declared control evidence through one shared evidence-decision model that preserves source precedence, freshness, rejected candidates, and contradiction payloads.
+4. Treat customer declarations as declared evidence only. They can influence owners, targets, and control posture, but they cannot bypass freshness checks or contradiction detection.
+5. Surface additive `evidence_decisions[]` and `contradictions[]` in action-path, backlog, BOM, and report JSON so higher-precedence wins remain explainable and auditable.
+
+## Rationale
+
+- Customer context is useful only when Wrkr can prove where it came from, when it expires, and why it beat or lost to other sources.
+- Fail-closed declaration validation preserves deterministic behavior and avoids silently weakening the control model.
+- A shared evidence-decision layer keeps precedence rules aligned across ingest, ownership, attribution, risk projection, and reporting.
+- Contradictions such as “declared non-production but production-bearing in practice” are high-value governance findings and should stay visible.
+
+## Consequences
+
+- `wrkr scan` can now load versioned customer declarations from the repo root without live provider calls.
+- Imported and declared evidence now carries freshness semantics (`fresh`, `stale`, `expired`, `unknown`) instead of only raw timestamps.
+- Higher-precedence source wins no longer erase lower-precedence disagreements; they remain visible in additive decision payloads and can still escalate to contradictions when ambiguity or production-bearing conflicts exist.

--- a/scenarios/wrkr/agent-action-bom-demo/expected/after-ingest.json
+++ b/scenarios/wrkr/agent-action-bom-demo/expected/after-ingest.json
@@ -30,6 +30,9 @@
       "gait_runtime",
       "proof_runtime"
     ],
+    "source_types": [
+      "unknown"
+    ],
     "policy_refs": [
       "gait://release-control"
     ],
@@ -44,6 +47,10 @@
       "demo-app:policy_decision:2026-04-29T19:40:00Z",
       "demo-app:proof_verification:2026-04-29T19:42:00Z"
     ],
-    "latest_observed_at": "2026-04-29T19:42:00Z"
+    "latest_observed_at": "2026-04-29T19:42:00Z",
+    "freshness_state": "unknown",
+    "freshness_states": [
+      "unknown"
+    ]
   }
 ]

--- a/schemas/v1/README.md
+++ b/schemas/v1/README.md
@@ -5,7 +5,9 @@ This directory contains versioned JSON/YAML schemas for Wrkr runtime and artifac
 - `cli/`: shared CLI success/error envelope contracts.
 - `agent-action-bom.schema.json`: canonical Agent Action BOM artifact contract for report and evidence outputs.
 - `evidence/external-control-evidence.schema.json`: canonical local sidecar contract for imported ownership, approval, branch, deployment, and policy control evidence.
+- Local declaration inputs now also include versioned `wrkr-control-declarations.yaml` / `.wrkr/control-declarations.yaml` semantics for declared owners, target classes, non-production paths, and control evidence links.
 - Agent Action BOM, report summary, and risk-report schemas now also carry additive policy-coverage, buyer-facing action-path posture (`control_state`, `risk_zone`, `review_burden`), normalized runtime-evidence/Gait coverage projection, additive imported control-evidence correlation metadata (`constraint_evidence_classes`, `constraint_evidence_refs`, external-control record counts, repo/service/workflow/environment correlation keys), optional `introduced_by` attribution fields, and the additive `github_workflow_token` credential kind used by the demo-readiness control-loop workflows.
+- Action-path and BOM contracts also carry additive `evidence_decisions[]` and `contradictions[]` for source precedence, freshness, rejected candidates, and enterprise-evidence conflicts.
 - `findings/`: finding and extension-detector descriptor contracts.
 - `inventory/` and `risk/`: deterministic privilege, credential-provenance, action-path, and govern-first contracts.
 - `manifest/`: open `wrkr-manifest.yaml` interoperability specification.
@@ -16,6 +18,7 @@ Canonical enum additions in the v1 schema line include:
 
 - `control_resolution_state`: `detected_control`, `declared_control`, `external_control_reference`, `no_visible_control`, `not_applicable`, `contradictory_control`
 - canonical evidence states: `verified`, `declared`, `inferred`, `unknown`, `contradictory`
+- freshness states: `fresh`, `stale`, `expired`, `unknown`
 - `target_class`: `production_impacting`, `release_adjacent`, `customer_data_adjacent`, `internal_tooling`, `developer_productivity`, `test_demo_sandbox`, `unknown`
 - `action_path_type`: `ai_assisted_workflow`, `agent_framework`, `automation_bot`, `ci_cd_workflow`, `legacy_script`, `plain_source_code`, `unknown_executable_path`
 - coverage-qualified absence states: `not_found_with_complete_coverage`, `not_found_with_reduced_coverage`, `not_scanned`, `unsupported_surface`, `candidate_parse_failed`

--- a/schemas/v1/agent-action-bom.schema.json
+++ b/schemas/v1/agent-action-bom.schema.json
@@ -88,6 +88,8 @@
         "owner_source": {"type": "string"},
         "ownership_status": {"type": "string"},
         "ownership_state": {"type": "string"},
+        "evidence_decisions": {"type": "array", "items": {"$ref": "#/$defs/evidenceDecision"}},
+        "contradictions": {"type": "array", "items": {"$ref": "#/$defs/contradiction"}},
         "control_resolution_state": {"type": "string", "enum": ["detected_control", "declared_control", "external_control_reference", "no_visible_control", "not_applicable", "contradictory_control"]},
         "control_resolution_reasons": {"type": "array", "items": {"type": "string"}},
         "control_evidence_refs": {"type": "array", "items": {"type": "string"}},
@@ -193,6 +195,58 @@
         }
       },
       "additionalProperties": true
+    },
+    "evidenceCandidate": {
+      "type": "object",
+      "properties": {
+        "field": {"type": "string"},
+        "value": {"type": "string"},
+        "source_type": {"type": "string"},
+        "source": {"type": "string"},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "observed_at": {"type": "string"},
+        "valid_until": {"type": "string"},
+        "max_age": {"type": "string"},
+        "issuer": {"type": "string"},
+        "confidence": {"type": "string"},
+        "freshness_state": {"type": "string", "enum": ["fresh", "stale", "expired", "unknown"]},
+        "status": {"type": "string"},
+        "reason_codes": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "evidenceDecision": {
+      "type": "object",
+      "properties": {
+        "field": {"type": "string"},
+        "selected_value": {"type": "string"},
+        "selected_source_type": {"type": "string"},
+        "selected_source": {"type": "string"},
+        "selected_evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "selected_observed_at": {"type": "string"},
+        "selected_valid_until": {"type": "string"},
+        "selected_max_age": {"type": "string"},
+        "selected_issuer": {"type": "string"},
+        "selected_confidence": {"type": "string"},
+        "selected_freshness_state": {"type": "string", "enum": ["fresh", "stale", "expired", "unknown"]},
+        "selected_status": {"type": "string"},
+        "conflict_state": {"type": "string", "enum": ["resolved", "ambiguous"]},
+        "reason_codes": {"type": "array", "items": {"type": "string"}},
+        "conflict_reason_codes": {"type": "array", "items": {"type": "string"}},
+        "rejected_candidates": {"type": "array", "items": {"$ref": "#/$defs/evidenceCandidate"}}
+      },
+      "additionalProperties": false
+    },
+    "contradiction": {
+      "type": "object",
+      "properties": {
+        "class": {"type": "string"},
+        "reason_codes": {"type": "array", "items": {"type": "string"}},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "impacted_target_class": {"type": "string"},
+        "recommended_action": {"type": "string"}
+      },
+      "additionalProperties": false
     },
     "controlState": {
       "type": "string",

--- a/schemas/v1/evidence/external-control-evidence.schema.json
+++ b/schemas/v1/evidence/external-control-evidence.schema.json
@@ -38,6 +38,7 @@
             "provider_export",
             "github_team_export",
             "backstage_export",
+            "signed_declaration",
             "customer_owner_map",
             "ticket_export",
             "repo_policy",
@@ -116,6 +117,10 @@
         },
         "confidence": {
           "type": "string"
+        },
+        "freshness_state": {
+          "type": "string",
+          "enum": ["fresh", "stale", "expired", "unknown"]
         },
         "redaction_hints": {
           "type": "array",

--- a/schemas/v1/report/report-summary.schema.json
+++ b/schemas/v1/report/report-summary.schema.json
@@ -314,6 +314,8 @@
         "target_class": {"type": "string", "enum": ["production_impacting", "release_adjacent", "customer_data_adjacent", "internal_tooling", "developer_productivity", "test_demo_sandbox", "unknown"]},
         "target_class_reasons": {"type": "array", "items": {"type": "string"}},
         "target_class_evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "evidence_decisions": {"type": "array", "items": {"$ref": "#/$defs/evidenceDecision"}},
+        "contradictions": {"type": "array", "items": {"$ref": "#/$defs/contradiction"}},
         "action_path_type": {"type": "string", "enum": ["ai_assisted_workflow", "agent_framework", "automation_bot", "ci_cd_workflow", "legacy_script", "plain_source_code", "unknown_executable_path"]},
         "action_path_type_reasons": {"type": "array", "items": {"type": "string"}},
         "action_path_type_evidence_refs": {"type": "array", "items": {"type": "string"}},
@@ -362,6 +364,58 @@
         "governance_controls": {"type": "array", "items": {"type": "object"}},
         "action_lineage": {"$ref": "#/$defs/actionLineage"}
       }
+    },
+    "evidenceCandidate": {
+      "type": "object",
+      "properties": {
+        "field": {"type": "string"},
+        "value": {"type": "string"},
+        "source_type": {"type": "string"},
+        "source": {"type": "string"},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "observed_at": {"type": "string"},
+        "valid_until": {"type": "string"},
+        "max_age": {"type": "string"},
+        "issuer": {"type": "string"},
+        "confidence": {"type": "string"},
+        "freshness_state": {"type": "string", "enum": ["fresh", "stale", "expired", "unknown"]},
+        "status": {"type": "string"},
+        "reason_codes": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "evidenceDecision": {
+      "type": "object",
+      "properties": {
+        "field": {"type": "string"},
+        "selected_value": {"type": "string"},
+        "selected_source_type": {"type": "string"},
+        "selected_source": {"type": "string"},
+        "selected_evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "selected_observed_at": {"type": "string"},
+        "selected_valid_until": {"type": "string"},
+        "selected_max_age": {"type": "string"},
+        "selected_issuer": {"type": "string"},
+        "selected_confidence": {"type": "string"},
+        "selected_freshness_state": {"type": "string", "enum": ["fresh", "stale", "expired", "unknown"]},
+        "selected_status": {"type": "string"},
+        "conflict_state": {"type": "string", "enum": ["resolved", "ambiguous"]},
+        "reason_codes": {"type": "array", "items": {"type": "string"}},
+        "conflict_reason_codes": {"type": "array", "items": {"type": "string"}},
+        "rejected_candidates": {"type": "array", "items": {"$ref": "#/$defs/evidenceCandidate"}}
+      },
+      "additionalProperties": false
+    },
+    "contradiction": {
+      "type": "object",
+      "properties": {
+        "class": {"type": "string"},
+        "reason_codes": {"type": "array", "items": {"type": "string"}},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "impacted_target_class": {"type": "string"},
+        "recommended_action": {"type": "string"}
+      },
+      "additionalProperties": false
     },
     "controlState": {
       "type": "string",

--- a/schemas/v1/risk/risk-report.schema.json
+++ b/schemas/v1/risk/risk-report.schema.json
@@ -62,6 +62,8 @@
         "target_class": {"type": "string", "enum": ["production_impacting", "release_adjacent", "customer_data_adjacent", "internal_tooling", "developer_productivity", "test_demo_sandbox", "unknown"]},
         "target_class_reasons": {"type": "array", "items": {"type": "string"}},
         "target_class_evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "evidence_decisions": {"type": "array", "items": {"$ref": "#/$defs/evidenceDecision"}},
+        "contradictions": {"type": "array", "items": {"$ref": "#/$defs/contradiction"}},
         "action_path_type": {"type": "string", "enum": ["ai_assisted_workflow", "agent_framework", "automation_bot", "ci_cd_workflow", "legacy_script", "plain_source_code", "unknown_executable_path"]},
         "action_path_type_reasons": {"type": "array", "items": {"type": "string"}},
         "action_path_type_evidence_refs": {"type": "array", "items": {"type": "string"}},
@@ -125,6 +127,58 @@
         "action_lineage": {"$ref": "#/$defs/actionLineage"}
       },
       "additionalProperties": true
+    },
+    "evidenceCandidate": {
+      "type": "object",
+      "properties": {
+        "field": {"type": "string"},
+        "value": {"type": "string"},
+        "source_type": {"type": "string"},
+        "source": {"type": "string"},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "observed_at": {"type": "string"},
+        "valid_until": {"type": "string"},
+        "max_age": {"type": "string"},
+        "issuer": {"type": "string"},
+        "confidence": {"type": "string"},
+        "freshness_state": {"type": "string", "enum": ["fresh", "stale", "expired", "unknown"]},
+        "status": {"type": "string"},
+        "reason_codes": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "evidenceDecision": {
+      "type": "object",
+      "properties": {
+        "field": {"type": "string"},
+        "selected_value": {"type": "string"},
+        "selected_source_type": {"type": "string"},
+        "selected_source": {"type": "string"},
+        "selected_evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "selected_observed_at": {"type": "string"},
+        "selected_valid_until": {"type": "string"},
+        "selected_max_age": {"type": "string"},
+        "selected_issuer": {"type": "string"},
+        "selected_confidence": {"type": "string"},
+        "selected_freshness_state": {"type": "string", "enum": ["fresh", "stale", "expired", "unknown"]},
+        "selected_status": {"type": "string"},
+        "conflict_state": {"type": "string", "enum": ["resolved", "ambiguous"]},
+        "reason_codes": {"type": "array", "items": {"type": "string"}},
+        "conflict_reason_codes": {"type": "array", "items": {"type": "string"}},
+        "rejected_candidates": {"type": "array", "items": {"$ref": "#/$defs/evidenceCandidate"}}
+      },
+      "additionalProperties": false
+    },
+    "contradiction": {
+      "type": "object",
+      "properties": {
+        "class": {"type": "string"},
+        "reason_codes": {"type": "array", "items": {"type": "string"}},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "impacted_target_class": {"type": "string"},
+        "recommended_action": {"type": "string"}
+      },
+      "additionalProperties": false
     },
     "controlState": {
       "type": "string",


### PR DESCRIPTION
## Problem
- Wave 2 of the evidence ingest and control-context plan needed deterministic source precedence, freshness/expiry handling, versioned customer declarations, and contradiction-aware enterprise control semantics.
- The existing Wave 1 support could ingest external evidence, but it still collapsed control and ownership data with ad hoc merge rules and did not preserve explainable source decisions end to end.

## Changes
- Added a shared evidence-governance layer for precedence, freshness, and conflict decisions.
- Added versioned control declaration loading and validation for `wrkr-control-declarations.yaml` and `.wrkr/control-declarations.yaml`.
- Threaded additive evidence decisions, freshness, and contradiction payloads through ingest, ownership resolution, attribution, risk projection, backlog, BOM, markdown rendering, docs, and public schemas.
- Added ADR, changelog, contract fixtures, and scenario updates for the new Wave 2 behavior.

## Validation
- `make prepush-full`
- `make test-hardening`
- `make test-contracts`
- `go test ./internal/scenarios -run TestScenarioAgentActionBOMDemoContract -count=1 -tags=scenario -v`

## Risks
- Public JSON and schema surfaces gain additive fields and precedence-driven behavior changes for ownership/control resolution.
- Customer declarations now fail closed on invalid inputs, which is intentional but changes scan behavior when malformed declaration files are present.
