### PR TITLE
feat: add governance disposition queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - [semver:minor] Added freshness and expiry metadata for imported and declared evidence across reports, backlog, and evidence bundles.
 - [semver:minor] Added versioned customer control declarations for owner mappings, target classes, accepted tooling, exceptions, non-prod declarations, and evidence links.
 - [semver:minor] Added contradiction detection for customer declarations, production targets, credentials, workflows, deployment constraints, and policy evidence.
+- [semver:minor] Added accepted-risk and suppression governance with expiry, ownership, scope, evidence state, rescan behavior, and appendix visibility.
+- [semver:minor] Added lifecycle and ownership control queues for ownerless, inferred-owner, stale-lifecycle, and credential-bearing governance gaps.
 
 ### Changed
 

--- a/core/aggregate/controlbacklog/controlbacklog.go
+++ b/core/aggregate/controlbacklog/controlbacklog.go
@@ -5,12 +5,15 @@ import (
 	"encoding/hex"
 	"sort"
 	"strings"
+	"time"
 
 	aggattack "github.com/Clyra-AI/wrkr/core/aggregate/attackpath"
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/detect"
 	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
+	"github.com/Clyra-AI/wrkr/core/governancequeue"
 	"github.com/Clyra-AI/wrkr/core/lifecycle"
+	"github.com/Clyra-AI/wrkr/core/manifest"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/risk"
 )
@@ -22,6 +25,7 @@ const (
 	SignalClassSupportingSecurity    = "supporting_security_signal"
 	QueueControlFirst                = "control_first"
 	QueueReviewQueue                 = "review_queue"
+	QueueAcceptedRisk                = "accepted_risk_queue"
 	QueueInventoryHygiene            = "inventory_hygiene"
 	QueueDebugOnly                   = "debug_only"
 	FindingVisibilityPrimary         = "primary"
@@ -54,6 +58,11 @@ const (
 	ConfidenceHigh                   = "high"
 	ConfidenceMedium                 = "medium"
 	ConfidenceLow                    = "low"
+	GovernanceKindAcceptedRisk       = "accepted_risk"
+	GovernanceKindSuppression        = "suppression"
+	GovernanceStatusActive           = "active"
+	GovernanceStatusExpired          = "expired"
+	GovernanceStatusInvalid          = "invalid"
 	SecretReferenceDetected          = "secret_reference_detected"
 	SecretValueDetected              = "secret_value_detected"
 	SecretScopeUnknown               = "secret_scope_unknown" // #nosec G101 -- governance enum label, not credential material.
@@ -77,12 +86,28 @@ type Summary struct {
 	RemediateActionItems      int `json:"remediate_action_items"`
 	ControlFirstQueueItems    int `json:"control_first_queue_items,omitempty"`
 	ReviewQueueItems          int `json:"review_queue_items,omitempty"`
+	AcceptedRiskQueueItems    int `json:"accepted_risk_queue_items,omitempty"`
 	InventoryHygieneItems     int `json:"inventory_hygiene_items,omitempty"`
 	DebugOnlyQueueItems       int `json:"debug_only_queue_items,omitempty"`
+	LifecycleQueueItems       int `json:"lifecycle_queue_items,omitempty"`
+}
+
+type GovernanceDisposition struct {
+	Kind               string   `json:"kind"`
+	Status             string   `json:"status"`
+	Reason             string   `json:"reason"`
+	Scope              string   `json:"scope"`
+	Issuer             string   `json:"issuer,omitempty"`
+	ExpiresAt          string   `json:"expires_at,omitempty"`
+	EvidenceState      string   `json:"evidence_state,omitempty"`
+	VisibilityBehavior string   `json:"visibility_behavior,omitempty"`
+	RescanBehavior     string   `json:"rescan_behavior,omitempty"`
+	EvidenceRefs       []string `json:"evidence_refs,omitempty"`
 }
 
 type Item struct {
 	ID                         string                                  `json:"id"`
+	AgentID                    string                                  `json:"agent_id,omitempty"`
 	Repo                       string                                  `json:"repo"`
 	Path                       string                                  `json:"path"`
 	ControlSurfaceType         string                                  `json:"control_surface_type"`
@@ -133,6 +158,8 @@ type Item struct {
 	ConfidenceRaise            []string                                `json:"confidence_raise,omitempty"`
 	SLA                        string                                  `json:"sla"`
 	ClosureCriteria            string                                  `json:"closure_criteria"`
+	GovernanceDisposition      *GovernanceDisposition                  `json:"governance_disposition,omitempty"`
+	LifecycleQueue             *governancequeue.Item                   `json:"lifecycle_queue,omitempty"`
 	SecretSignalTypes          []string                                `json:"secret_signal_types,omitempty"`
 	LinkedFindingIDs           []string                                `json:"linked_finding_ids,omitempty"`
 	LinkedActionPathID         string                                  `json:"linked_action_path_id,omitempty"`
@@ -172,8 +199,10 @@ type SecurityTestRecipe struct {
 
 type Input struct {
 	Mode             string
+	GeneratedAt      time.Time
 	Findings         []model.Finding
 	Inventory        *agginventory.Inventory
+	Identities       []manifest.IdentityRecord
 	LifecycleGaps    []lifecycle.Gap
 	ActionPaths      []risk.ActionPath
 	ControlPathGraph *aggattack.ControlPathGraph
@@ -229,9 +258,14 @@ type builder struct {
 	findingsByLocation map[string][]model.Finding
 	toolByLocation     map[string]agginventory.Tool
 	locationByKey      map[string]agginventory.ToolLocation
+	actionPathByKey    map[string]risk.ActionPath
+	actionPathByAgent  map[string]risk.ActionPath
 	writeByLocation    map[string]bool
+	identityByAgent    map[string]manifest.IdentityRecord
+	identityByRepoPath map[string]manifest.IdentityRecord
 	itemsByKey         map[string]Item
 	graphRefsByPath    map[string]controlPathRefs
+	generatedAt        time.Time
 }
 
 type controlPathRefs struct {
@@ -244,9 +278,17 @@ func newBuilder(input Input) *builder {
 		findingsByLocation: map[string][]model.Finding{},
 		toolByLocation:     map[string]agginventory.Tool{},
 		locationByKey:      map[string]agginventory.ToolLocation{},
+		actionPathByKey:    map[string]risk.ActionPath{},
+		actionPathByAgent:  map[string]risk.ActionPath{},
 		writeByLocation:    map[string]bool{},
+		identityByAgent:    map[string]manifest.IdentityRecord{},
+		identityByRepoPath: map[string]manifest.IdentityRecord{},
 		itemsByKey:         map[string]Item{},
 		graphRefsByPath:    buildControlPathRefs(input.ControlPathGraph),
+		generatedAt:        input.GeneratedAt.UTC(),
+	}
+	if b.generatedAt.IsZero() {
+		b.generatedAt = time.Now().UTC().Truncate(time.Second)
 	}
 	for _, finding := range input.Findings {
 		key := locationKey(finding.Org, finding.Repo, finding.Location)
@@ -262,6 +304,22 @@ func newBuilder(input Input) *builder {
 				b.toolByLocation[key] = tool
 				b.locationByKey[key] = loc
 			}
+		}
+	}
+	for _, path := range input.ActionPaths {
+		projected := risk.ProjectActionPath(path)
+		key := locationKey(projected.Org, projected.Repo, projected.Location)
+		b.actionPathByKey[key] = projected
+		if agentID := strings.TrimSpace(projected.AgentID); agentID != "" {
+			b.actionPathByAgent[agentID] = projected
+		}
+	}
+	for _, record := range input.Identities {
+		if agentID := strings.TrimSpace(record.AgentID); agentID != "" {
+			b.identityByAgent[agentID] = record
+		}
+		if repoPathKey := strings.TrimSpace(record.Repo) + "|" + strings.TrimSpace(record.Location); repoPathKey != "|" {
+			b.identityByRepoPath[repoPathKey] = record
 		}
 	}
 	return b
@@ -298,6 +356,7 @@ func (b *builder) addActionPath(path risk.ActionPath) {
 	graphRefs := b.graphRefsByPath[strings.TrimSpace(path.PathID)]
 	item := Item{
 		ID:                         backlogID("action_path", path.Org, path.Repo, path.Location, path.PathID),
+		AgentID:                    strings.TrimSpace(path.AgentID),
 		Repo:                       strings.TrimSpace(path.Repo),
 		Path:                       strings.TrimSpace(path.Location),
 		ControlSurfaceType:         controlSurfaceType(path.ToolType, path.Location, path.CredentialAccess, false),
@@ -398,6 +457,7 @@ func (b *builder) addFinding(finding model.Finding, mode string) {
 	isSecret := isSecretFinding(finding)
 	item := Item{
 		ID:                  backlogID("finding", finding.Org, finding.Repo, finding.Location, finding.FindingType, finding.RuleID, finding.Detector),
+		AgentID:             strings.TrimSpace(tool.AgentID),
 		Repo:                strings.TrimSpace(finding.Repo),
 		Path:                strings.TrimSpace(finding.Location),
 		ControlSurfaceType:  controlSurfaceType(finding.ToolType, finding.Location, writeCapable, isSecret),
@@ -489,6 +549,9 @@ func (b *builder) merge(item Item) {
 	if confidencePriority(item.Confidence) < confidencePriority(current.Confidence) {
 		current.Confidence = item.Confidence
 	}
+	if current.AgentID == "" {
+		current.AgentID = item.AgentID
+	}
 	if current.Owner == "" {
 		current.Owner = item.Owner
 		current.OwnerSource = item.OwnerSource
@@ -520,6 +583,9 @@ func (b *builder) merge(item Item) {
 	if current.LinkedActionPathID == "" {
 		current.LinkedActionPathID = item.LinkedActionPathID
 	}
+	if current.LifecycleQueue == nil {
+		current.LifecycleQueue = item.LifecycleQueue
+	}
 	if strings.TrimSpace(current.Remediation) == "" {
 		current.Remediation = item.Remediation
 	}
@@ -528,27 +594,37 @@ func (b *builder) merge(item Item) {
 }
 
 func (b *builder) addLifecycleGap(gap lifecycle.Gap) {
+	linkedPath := b.actionPathByAgent[strings.TrimSpace(gap.AgentID)]
+	if strings.TrimSpace(linkedPath.PathID) == "" {
+		linkedPath = b.actionPathByKey[locationKey(gap.Org, gap.Repo, gap.Location)]
+	}
+	graphRefs := b.graphRefsByPath[strings.TrimSpace(linkedPath.PathID)]
 	item := Item{
-		ID:                 backlogID("lifecycle_gap", gap.AgentID, gap.ReasonCode, gap.Repo, gap.Location),
-		Repo:               strings.TrimSpace(gap.Repo),
-		Path:               strings.TrimSpace(gap.Location),
-		ControlSurfaceType: controlSurfaceType(gap.ToolType, gap.Location, gap.WriteCapable, gap.CredentialAccess),
-		ControlPathType:    controlPathType(gap.ToolType, gap.Location, gap.WriteCapable, gap.CredentialAccess),
-		Capabilities:       lifecycleGapCapabilities(gap),
-		WritePathClasses:   lifecycleGapWritePathClasses(gap),
-		Owner:              strings.TrimSpace(gap.Owner),
-		OwnershipStatus:    strings.TrimSpace(gap.OwnershipStatus),
-		EvidenceSource:     "lifecycle_gap",
-		EvidenceBasis:      append([]string{gap.ReasonCode}, gap.EvidenceBasis...),
-		ApprovalStatus:     "unapproved",
-		SecurityVisibility: agginventory.SecurityVisibilityNeedsReview,
-		Queue:              QueueReviewQueue,
-		FindingVisibility:  FindingVisibilityPrimary,
-		SignalClass:        SignalClassUniqueWrkrSignal,
-		RecommendedAction:  lifecycleGapRecommendedAction(gap),
-		Remediation:        remediationForLifecycleGap(gap),
-		LinkedFindingIDs:   []string{gap.GapID},
-		SecretSignalTypes:  lifecycleGapSecretSignalTypes(gap),
+		ID:                       backlogID("lifecycle_gap", gap.AgentID, gap.ReasonCode, gap.Repo, gap.Location),
+		AgentID:                  strings.TrimSpace(gap.AgentID),
+		Repo:                     strings.TrimSpace(gap.Repo),
+		Path:                     strings.TrimSpace(gap.Location),
+		ControlSurfaceType:       controlSurfaceType(gap.ToolType, gap.Location, gap.WriteCapable, gap.CredentialAccess),
+		ControlPathType:          controlPathType(gap.ToolType, gap.Location, gap.WriteCapable, gap.CredentialAccess),
+		Capabilities:             lifecycleGapCapabilities(gap),
+		WritePathClasses:         lifecycleGapWritePathClasses(gap),
+		Owner:                    strings.TrimSpace(gap.Owner),
+		OwnershipStatus:          strings.TrimSpace(gap.OwnershipStatus),
+		EvidenceSource:           "lifecycle_gap",
+		EvidenceBasis:            append([]string{gap.ReasonCode}, gap.EvidenceBasis...),
+		ApprovalStatus:           "unapproved",
+		SecurityVisibility:       agginventory.SecurityVisibilityNeedsReview,
+		Queue:                    QueueReviewQueue,
+		FindingVisibility:        FindingVisibilityPrimary,
+		SignalClass:              SignalClassUniqueWrkrSignal,
+		RecommendedAction:        lifecycleGapRecommendedAction(gap),
+		Remediation:              remediationForLifecycleGap(gap),
+		LinkedFindingIDs:         []string{gap.GapID},
+		LinkedActionPathID:       strings.TrimSpace(linkedPath.PathID),
+		LinkedControlPathNodeIDs: append([]string(nil), graphRefs.nodeIDs...),
+		LinkedControlPathEdgeIDs: append([]string(nil), graphRefs.edgeIDs...),
+		SecretSignalTypes:        lifecycleGapSecretSignalTypes(gap),
+		LifecycleQueue:           lifecycleQueueForGap(gap),
 	}
 	item.Capability = capabilitySummary(item.Capabilities)
 	item.GovernanceControls = agginventory.BuildGovernanceControls(agginventory.GovernanceControlInput{
@@ -571,7 +647,7 @@ func (b *builder) addLifecycleGap(gap lifecycle.Gap) {
 func (b *builder) items() []Item {
 	items := make([]Item, 0, len(b.itemsByKey))
 	for _, item := range b.itemsByKey {
-		items = append(items, normalizeItem(item))
+		items = append(items, b.decorateGovernance(normalizeItem(item)))
 	}
 	sort.Slice(items, func(i, j int) bool {
 		if queuePriority(items[i].Queue) != queuePriority(items[j].Queue) {
@@ -608,10 +684,15 @@ func summarize(items []Item) Summary {
 			summary.ControlFirstQueueItems++
 		case QueueReviewQueue:
 			summary.ReviewQueueItems++
+		case QueueAcceptedRisk:
+			summary.AcceptedRiskQueueItems++
 		case QueueInventoryHygiene:
 			summary.InventoryHygieneItems++
 		case QueueDebugOnly:
 			summary.DebugOnlyQueueItems++
+		}
+		if item.LifecycleQueue != nil {
+			summary.LifecycleQueueItems++
 		}
 		switch item.SignalClass {
 		case SignalClassUniqueWrkrSignal:
@@ -629,6 +710,162 @@ func summarize(items []Item) Summary {
 		}
 	}
 	return summary
+}
+
+func SummarizeItems(items []Item) Summary {
+	return summarize(items)
+}
+
+func lifecycleQueueForGap(gap lifecycle.Gap) *governancequeue.Item {
+	item := lifecycle.QueueItemFromGap(gap)
+	return &item
+}
+
+func (b *builder) decorateGovernance(item Item) Item {
+	record, ok := b.matchIdentityRecord(item)
+	if !ok {
+		return item
+	}
+	disposition := governanceDispositionForRecord(item, record, b.generatedAt)
+	if disposition == nil {
+		return item
+	}
+	item.GovernanceDisposition = disposition
+	switch disposition.Status {
+	case GovernanceStatusExpired:
+		item.EvidenceGaps = mergeStrings(item.EvidenceGaps, []string{"governance_record_expired"})
+	case GovernanceStatusInvalid:
+		item.EvidenceGaps = mergeStrings(item.EvidenceGaps, []string{"governance_record_invalid"})
+	case GovernanceStatusActive:
+		switch disposition.Kind {
+		case GovernanceKindAcceptedRisk:
+			item.SecurityVisibility = agginventory.SecurityVisibilityAcceptedRisk
+			item.Queue = QueueAcceptedRisk
+			item.FindingVisibility = FindingVisibilityAppendix
+		case GovernanceKindSuppression:
+			item.Queue = QueueInventoryHygiene
+			item.FindingVisibility = FindingVisibilityAppendix
+		}
+	}
+	return normalizeItem(item)
+}
+
+func (b *builder) matchIdentityRecord(item Item) (manifest.IdentityRecord, bool) {
+	if agentID := strings.TrimSpace(item.AgentID); agentID != "" {
+		if record, ok := b.identityByAgent[agentID]; ok {
+			return record, true
+		}
+	}
+	if key := strings.TrimSpace(item.Repo) + "|" + strings.TrimSpace(item.Path); key != "|" {
+		if record, ok := b.identityByRepoPath[key]; ok {
+			return record, true
+		}
+	}
+	return manifest.IdentityRecord{}, false
+}
+
+func governanceDispositionForRecord(item Item, record manifest.IdentityRecord, generatedAt time.Time) *GovernanceDisposition {
+	approval := record.Approval
+	reason := strings.TrimSpace(approval.DecisionReason)
+	if reason == "" {
+		reason = strings.TrimSpace(approval.ExclusionReason)
+	}
+	scope := strings.TrimSpace(approval.Scope)
+	if scope == "" {
+		scope = "control_path"
+	}
+	issuer := strings.TrimSpace(approval.Approver)
+	if issuer == "" {
+		issuer = strings.TrimSpace(approval.Owner)
+	}
+	evidenceState := governanceEvidenceState(item)
+	expiresAt := strings.TrimSpace(approval.Expires)
+	evidenceRefs := governanceEvidenceRefs(record)
+	kind := ""
+	visibilityBehavior := ""
+	rescanBehavior := ""
+	switch {
+	case approval.AcceptedRisk || strings.TrimSpace(record.ApprovalState) == "accepted_risk" || strings.TrimSpace(record.ApprovalState) == "risk_accepted":
+		kind = GovernanceKindAcceptedRisk
+		visibilityBehavior = QueueAcceptedRisk
+		rescanBehavior = "repromote_on_expiry"
+	case strings.TrimSpace(approval.ExclusionReason) != "" || strings.TrimSpace(record.ApprovalState) == "excluded":
+		kind = GovernanceKindSuppression
+		visibilityBehavior = FindingVisibilityAppendix
+		rescanBehavior = "retain_appendix_until_expiry"
+	default:
+		return nil
+	}
+
+	status := GovernanceStatusActive
+	if strings.TrimSpace(reason) == "" || strings.TrimSpace(approval.Owner) == "" || expiresAt == "" {
+		status = GovernanceStatusInvalid
+	} else if expiresAt != "" {
+		parsed, err := time.Parse(time.RFC3339, expiresAt)
+		if err != nil {
+			status = GovernanceStatusInvalid
+		} else if !generatedAt.IsZero() && generatedAt.After(parsed.UTC()) {
+			status = GovernanceStatusExpired
+		}
+	}
+
+	return &GovernanceDisposition{
+		Kind:               kind,
+		Status:             status,
+		Reason:             reason,
+		Scope:              scope,
+		Issuer:             issuer,
+		ExpiresAt:          expiresAt,
+		EvidenceState:      evidenceState,
+		VisibilityBehavior: visibilityBehavior,
+		RescanBehavior:     rescanBehavior,
+		EvidenceRefs:       evidenceRefs,
+	}
+}
+
+func governanceEvidenceState(item Item) string {
+	values := []string{
+		strings.TrimSpace(item.ApprovalEvidenceState),
+		strings.TrimSpace(item.OwnerEvidenceState),
+		strings.TrimSpace(item.ProofEvidenceState),
+		strings.TrimSpace(item.RuntimeEvidenceState),
+		strings.TrimSpace(item.TargetEvidenceState),
+		strings.TrimSpace(item.CredentialEvidenceState),
+	}
+	if containsState(values, risk.EvidenceStateContradictory) {
+		return risk.EvidenceStateContradictory
+	}
+	if containsState(values, risk.EvidenceStateUnknown) {
+		return risk.EvidenceStateUnknown
+	}
+	if containsState(values, risk.EvidenceStateInferred) {
+		return risk.EvidenceStateInferred
+	}
+	if containsState(values, risk.EvidenceStateDeclared) {
+		return risk.EvidenceStateDeclared
+	}
+	if containsState(values, risk.EvidenceStateVerified) {
+		return risk.EvidenceStateVerified
+	}
+	return risk.EvidenceStateUnknown
+}
+
+func containsState(values []string, want string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func governanceEvidenceRefs(record manifest.IdentityRecord) []string {
+	values := []string{
+		"manifest://identity/" + strings.TrimSpace(record.AgentID),
+		strings.TrimSpace(record.Approval.ControlID),
+		strings.TrimSpace(record.Approval.EvidenceURL),
+	}
+	return mergeStrings(values, nil)
 }
 
 func includeFinding(finding model.Finding, mode string) bool {
@@ -1283,6 +1520,7 @@ func findingID(finding model.Finding) string {
 }
 
 func normalizeItem(item Item) Item {
+	item.AgentID = strings.TrimSpace(item.AgentID)
 	item.Repo = strings.TrimSpace(item.Repo)
 	item.Path = strings.TrimSpace(item.Path)
 	item.ControlSurfaceType = fallback(item.ControlSurfaceType, ControlSurfaceAIAgent)
@@ -1315,6 +1553,18 @@ func normalizeItem(item Item) Item {
 	item.ConfidenceLaneReasons = mergeStrings(item.ConfidenceLaneReasons, nil)
 	item.SecretSignalTypes = mergeStrings(item.SecretSignalTypes, nil)
 	item.LinkedFindingIDs = mergeStrings(item.LinkedFindingIDs, nil)
+	if item.GovernanceDisposition != nil {
+		item.GovernanceDisposition.Kind = strings.TrimSpace(item.GovernanceDisposition.Kind)
+		item.GovernanceDisposition.Status = strings.TrimSpace(item.GovernanceDisposition.Status)
+		item.GovernanceDisposition.Reason = strings.TrimSpace(item.GovernanceDisposition.Reason)
+		item.GovernanceDisposition.Scope = strings.TrimSpace(item.GovernanceDisposition.Scope)
+		item.GovernanceDisposition.Issuer = strings.TrimSpace(item.GovernanceDisposition.Issuer)
+		item.GovernanceDisposition.ExpiresAt = strings.TrimSpace(item.GovernanceDisposition.ExpiresAt)
+		item.GovernanceDisposition.EvidenceState = strings.TrimSpace(item.GovernanceDisposition.EvidenceState)
+		item.GovernanceDisposition.VisibilityBehavior = strings.TrimSpace(item.GovernanceDisposition.VisibilityBehavior)
+		item.GovernanceDisposition.RescanBehavior = strings.TrimSpace(item.GovernanceDisposition.RescanBehavior)
+		item.GovernanceDisposition.EvidenceRefs = mergeStrings(item.GovernanceDisposition.EvidenceRefs, nil)
+	}
 	item.SecurityTestRecipes = mergeSecurityTestRecipes(item.SecurityTestRecipes, nil)
 	item.GovernanceControls = mergeGovernanceControls(nil, item.GovernanceControls)
 	return item
@@ -1561,10 +1811,12 @@ func queuePriority(value string) int {
 		return 0
 	case QueueReviewQueue:
 		return 1
-	case QueueInventoryHygiene:
+	case QueueAcceptedRisk:
 		return 2
-	case QueueDebugOnly:
+	case QueueInventoryHygiene:
 		return 3
+	case QueueDebugOnly:
+		return 4
 	default:
 		return 99
 	}
@@ -1754,7 +2006,7 @@ func visibilityForQueue(queue string) string {
 	switch strings.TrimSpace(queue) {
 	case QueueControlFirst, QueueReviewQueue:
 		return FindingVisibilityPrimary
-	case QueueInventoryHygiene:
+	case QueueAcceptedRisk, QueueInventoryHygiene:
 		return FindingVisibilityAppendix
 	default:
 		return FindingVisibilityDebug

--- a/core/aggregate/controlbacklog/controlbacklog_test.go
+++ b/core/aggregate/controlbacklog/controlbacklog_test.go
@@ -5,9 +5,13 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	aggattack "github.com/Clyra-AI/wrkr/core/aggregate/attackpath"
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/governancequeue"
+	"github.com/Clyra-AI/wrkr/core/lifecycle"
+	"github.com/Clyra-AI/wrkr/core/manifest"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/risk"
 )
@@ -236,6 +240,157 @@ func TestActionPathConfidenceLaneCarriesIntoBacklog(t *testing.T) {
 	}
 	if !containsString(item.ConfidenceLaneReasons, "surface:prompt_or_instruction") {
 		t.Fatalf("expected confidence lane reasons to carry through, got %+v", item.ConfidenceLaneReasons)
+	}
+}
+
+func TestAcceptedRiskMovesBacklogItemToAcceptedRiskQueue(t *testing.T) {
+	t.Parallel()
+
+	generatedAt := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	backlog := Build(Input{
+		GeneratedAt: generatedAt,
+		Identities: []manifest.IdentityRecord{{
+			AgentID:       "wrkr:codex-app:acme",
+			Repo:          "app",
+			Location:      "AGENTS.md",
+			ApprovalState: "accepted_risk",
+			Approval: manifest.Approval{
+				Owner:          "platform-security",
+				Approver:       "platform-security",
+				Scope:          "control_path",
+				Expires:        generatedAt.Add(48 * time.Hour).Format(time.RFC3339),
+				DecisionReason: "time_bounded_exception",
+			},
+		}},
+		ActionPaths: []risk.ActionPath{{
+			PathID:                   "apc-accepted-risk",
+			AgentID:                  "wrkr:codex-app:acme",
+			Org:                      "acme",
+			Repo:                     "app",
+			ToolType:                 "codex",
+			Location:                 "AGENTS.md",
+			ApprovalGap:              true,
+			ApprovalEvidenceState:    risk.EvidenceStateUnknown,
+			SecurityVisibilityStatus: agginventory.SecurityVisibilityNeedsReview,
+			ControlState:             risk.ControlStateApprovalNeeded,
+			ReviewBurden:             risk.ReviewBurdenMedium,
+			RecommendedAction:        "approve",
+		}},
+	})
+
+	if len(backlog.Items) != 1 {
+		t.Fatalf("expected one backlog item, got %+v", backlog.Items)
+	}
+	item := backlog.Items[0]
+	if item.GovernanceDisposition == nil {
+		t.Fatalf("expected governance disposition, got %+v", item)
+	}
+	if item.GovernanceDisposition.Kind != GovernanceKindAcceptedRisk {
+		t.Fatalf("expected accepted-risk governance disposition, got %+v", item.GovernanceDisposition)
+	}
+	if item.Queue != QueueAcceptedRisk {
+		t.Fatalf("expected accepted-risk queue, got %+v", item)
+	}
+	if item.FindingVisibility != FindingVisibilityAppendix {
+		t.Fatalf("expected appendix visibility for accepted-risk item, got %+v", item)
+	}
+	if backlog.Summary.AcceptedRiskQueueItems != 1 {
+		t.Fatalf("expected accepted-risk summary count, got %+v", backlog.Summary)
+	}
+}
+
+func TestExpiredAcceptedRiskRepromotesBacklogItem(t *testing.T) {
+	t.Parallel()
+
+	generatedAt := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	backlog := Build(Input{
+		GeneratedAt: generatedAt,
+		Identities: []manifest.IdentityRecord{{
+			AgentID:       "wrkr:codex-app:acme",
+			Repo:          "app",
+			Location:      "AGENTS.md",
+			ApprovalState: "accepted_risk",
+			Approval: manifest.Approval{
+				Owner:          "platform-security",
+				Approver:       "platform-security",
+				Scope:          "control_path",
+				Expires:        generatedAt.Add(-2 * time.Hour).Format(time.RFC3339),
+				DecisionReason: "expired_exception",
+			},
+		}},
+		ActionPaths: []risk.ActionPath{{
+			PathID:                   "apc-expired-risk",
+			AgentID:                  "wrkr:codex-app:acme",
+			Org:                      "acme",
+			Repo:                     "app",
+			ToolType:                 "codex",
+			Location:                 "AGENTS.md",
+			ApprovalGap:              true,
+			ApprovalEvidenceState:    risk.EvidenceStateUnknown,
+			SecurityVisibilityStatus: agginventory.SecurityVisibilityNeedsReview,
+			ControlState:             risk.ControlStateApprovalNeeded,
+			ReviewBurden:             risk.ReviewBurdenHigh,
+			RecommendedAction:        "approve",
+		}},
+	})
+
+	if len(backlog.Items) != 1 {
+		t.Fatalf("expected one backlog item, got %+v", backlog.Items)
+	}
+	item := backlog.Items[0]
+	if item.GovernanceDisposition == nil || item.GovernanceDisposition.Status != GovernanceStatusExpired {
+		t.Fatalf("expected expired governance disposition, got %+v", item.GovernanceDisposition)
+	}
+	if item.Queue == QueueAcceptedRisk {
+		t.Fatalf("expected expired accepted risk to repromote into a primary queue, got %+v", item)
+	}
+	if item.FindingVisibility != FindingVisibilityPrimary {
+		t.Fatalf("expected primary visibility after accepted-risk expiry, got %+v", item)
+	}
+	if !containsString(item.EvidenceGaps, "governance_record_expired") {
+		t.Fatalf("expected governance_record_expired evidence gap, got %+v", item.EvidenceGaps)
+	}
+}
+
+func TestLifecycleGapCarriesNormalizedLifecycleQueue(t *testing.T) {
+	t.Parallel()
+
+	backlog := Build(Input{
+		LifecycleGaps: []lifecycle.Gap{{
+			GapID:            "gap-credentialed",
+			ReasonCode:       lifecycle.GapInactiveCredentialed,
+			Severity:         "high",
+			AgentID:          "wrkr:codex-app:acme",
+			ToolType:         "codex",
+			Org:              "acme",
+			Repo:             "app",
+			Location:         "AGENTS.md",
+			Present:          true,
+			LifecycleState:   "under_review",
+			ApprovalStatus:   "accepted_risk",
+			OwnershipStatus:  "unresolved",
+			CredentialAccess: true,
+			WriteCapable:     true,
+			EvidenceBasis:    []string{"approval_status:accepted_risk", "credential_access:true"},
+			Message:          "identity still has credentialed posture while not in an active approved lifecycle state",
+		}},
+	})
+
+	if len(backlog.Items) != 1 {
+		t.Fatalf("expected one backlog item, got %+v", backlog.Items)
+	}
+	item := backlog.Items[0]
+	if item.LifecycleQueue == nil {
+		t.Fatalf("expected lifecycle queue metadata, got %+v", item)
+	}
+	if item.LifecycleQueue.ReasonCode != lifecycle.GapInactiveCredentialed || item.LifecycleQueue.Severity != "high" {
+		t.Fatalf("expected lifecycle queue reason/severity, got %+v", item.LifecycleQueue)
+	}
+	if item.LifecycleQueue.CredentialStatus != governancequeue.CredentialStatusPresent {
+		t.Fatalf("expected credential-bearing lifecycle queue item, got %+v", item.LifecycleQueue)
+	}
+	if backlog.Summary.LifecycleQueueItems != 1 {
+		t.Fatalf("expected lifecycle queue summary count, got %+v", backlog.Summary)
 	}
 }
 

--- a/core/aggregate/inventory/inventory.go
+++ b/core/aggregate/inventory/inventory.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Clyra-AI/wrkr/core/aggregate/exposure"
 	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
+	"github.com/Clyra-AI/wrkr/core/governancequeue"
 	"github.com/Clyra-AI/wrkr/core/identity"
 	"github.com/Clyra-AI/wrkr/core/manifest"
 	"github.com/Clyra-AI/wrkr/core/model"
@@ -167,6 +168,7 @@ type Inventory struct {
 	RepoExposureSummaries []exposure.RepoExposureSummary `json:"repo_exposure_summaries" yaml:"repo_exposure_summaries"`
 	PrivilegeBudget       PrivilegeBudget                `json:"privilege_budget" yaml:"privilege_budget"`
 	AgentPrivilegeMap     []AgentPrivilegeMapEntry       `json:"agent_privilege_map" yaml:"agent_privilege_map"`
+	LifecycleQueue        []governancequeue.Item         `json:"lifecycle_queue,omitempty" yaml:"lifecycle_queue,omitempty"`
 	Summary               Summary                        `json:"summary" yaml:"summary"`
 }
 

--- a/core/cli/inventory_mutations.go
+++ b/core/cli/inventory_mutations.go
@@ -84,6 +84,12 @@ func runInventoryMutation(action string, args []string, stdout io.Writer, stderr
 			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
 		}
 		mutation.ExpiresAt = expiresAt
+	case "exclude":
+		expiresAt, err := parseRequiredFutureExpiry(*expires, now)
+		if err != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
+		}
+		mutation.ExpiresAt = expiresAt
 	}
 
 	resolvedStatePath := state.ResolvePath(*statePathFlag)

--- a/core/cli/inventory_mutations_test.go
+++ b/core/cli/inventory_mutations_test.go
@@ -87,7 +87,7 @@ func TestInventoryApproveWritesApprovalProofRecordAtomically(t *testing.T) {
 	}
 }
 
-func TestInventoryAcceptRiskRequiresExpiry(t *testing.T) {
+func TestInventoryAcceptRiskRequiresGovernanceFields(t *testing.T) {
 	tmp := t.TempDir()
 	statePath, agentID := writeInventoryMutationFixture(t, tmp)
 
@@ -99,6 +99,31 @@ func TestInventoryAcceptRiskRequiresExpiry(t *testing.T) {
 	}
 	if out.Len() != 0 {
 		t.Fatalf("expected no stdout on invalid input, got %q", out.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(errOut.Bytes(), &payload); err != nil {
+		t.Fatalf("parse error payload: %v", err)
+	}
+	errObj, _ := payload["error"].(map[string]any)
+	if errObj["code"] != "invalid_input" {
+		t.Fatalf("expected invalid_input, got %v", payload)
+	}
+}
+
+func TestInventoryExcludeRequiresOwnerAndExpiry(t *testing.T) {
+	tmp := t.TempDir()
+	statePath, agentID := writeInventoryMutationFixture(t, tmp)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{
+		"inventory", "exclude", agentID,
+		"--reason", "retired_control_path",
+		"--state", statePath,
+		"--json",
+	}, &out, &errOut)
+	if code != exitInvalidInput {
+		t.Fatalf("expected exit 6, got %d stdout=%q stderr=%q", code, out.String(), errOut.String())
 	}
 	var payload map[string]any
 	if err := json.Unmarshal(errOut.Bytes(), &payload); err != nil {

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -542,10 +542,13 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		Inventory:   &inventoryOut,
 		Transitions: transitions,
 	})
+	inventoryOut.LifecycleQueue = lifecycle.BuildQueue(lifecycleGaps)
 	controlBacklog := controlbacklog.Build(controlbacklog.Input{
 		Mode:             scanMode,
+		GeneratedAt:      now,
 		Findings:         findings,
 		Inventory:        &inventoryOut,
+		Identities:       nextManifest.Identities,
 		LifecycleGaps:    lifecycleGaps,
 		ActionPaths:      riskReport.ActionPaths,
 		ControlPathGraph: riskReport.ControlPathGraph,

--- a/core/cli/state_mutation.go
+++ b/core/cli/state_mutation.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"io"
 	"strings"
+	"time"
 
 	proof "github.com/Clyra-AI/proof"
 	aggattack "github.com/Clyra-AI/wrkr/core/aggregate/attackpath"
@@ -79,6 +80,12 @@ func refreshDerivedMutationSnapshot(snapshot *state.Snapshot) error {
 	}
 	if snapshot.Inventory != nil {
 		agginventory.RefreshIdentityGovernance(snapshot.Inventory, snapshot.Identities)
+		snapshot.LifecycleGaps = lifecycle.DetectGaps(lifecycle.GapInput{
+			Identities:  snapshot.Identities,
+			Inventory:   snapshot.Inventory,
+			Transitions: snapshot.Transitions,
+		})
+		snapshot.Inventory.LifecycleQueue = lifecycle.BuildQueue(snapshot.LifecycleGaps)
 	}
 	actionPaths := []risk.ActionPath(nil)
 	var controlPathGraph *aggattack.ControlPathGraph
@@ -95,8 +102,11 @@ func refreshDerivedMutationSnapshot(snapshot *state.Snapshot) error {
 	} else if snapshot.Inventory != nil || snapshot.ControlBacklog != nil {
 		backlog := controlbacklog.Build(controlbacklog.Input{
 			Mode:             snapshot.ScanMode,
+			GeneratedAt:      mutationGeneratedAt(snapshot),
 			Findings:         snapshot.Findings,
 			Inventory:        snapshot.Inventory,
+			Identities:       snapshot.Identities,
+			LifecycleGaps:    snapshot.LifecycleGaps,
 			ActionPaths:      actionPaths,
 			ControlPathGraph: controlPathGraph,
 		})
@@ -219,15 +229,7 @@ func applyInventoryMutationOverrides(snapshot *state.Snapshot, record manifest.I
 	if strings.TrimSpace(action) != "exclude" {
 		return
 	}
-	items := snapshot.ControlBacklog.Items[:0]
-	for _, item := range snapshot.ControlBacklog.Items {
-		if backlogItemMatchesRecord(item.ID, item.Repo, item.Path, requestedID, record) {
-			continue
-		}
-		items = append(items, item)
-	}
-	snapshot.ControlBacklog.Items = items
-	snapshot.ControlBacklog.Summary = summarizeBacklogItems(items)
+	snapshot.ControlBacklog.Summary = summarizeBacklogItems(snapshot.ControlBacklog.Items)
 }
 
 func backlogApprovalStatus(record manifest.IdentityRecord) string {
@@ -271,4 +273,18 @@ func backlogSecurityVisibility(record manifest.IdentityRecord) string {
 	default:
 		return agginventory.SecurityVisibilityNeedsReview
 	}
+}
+
+func mutationGeneratedAt(snapshot *state.Snapshot) time.Time {
+	if snapshot == nil || len(snapshot.Transitions) == 0 {
+		return time.Now().UTC().Truncate(time.Second)
+	}
+	latest := strings.TrimSpace(snapshot.Transitions[len(snapshot.Transitions)-1].Timestamp)
+	if latest == "" {
+		return time.Now().UTC().Truncate(time.Second)
+	}
+	if parsed, err := time.Parse(time.RFC3339, latest); err == nil {
+		return parsed.UTC().Truncate(time.Second)
+	}
+	return time.Now().UTC().Truncate(time.Second)
 }

--- a/core/cli/state_mutation.go
+++ b/core/cli/state_mutation.go
@@ -229,6 +229,31 @@ func applyInventoryMutationOverrides(snapshot *state.Snapshot, record manifest.I
 	if strings.TrimSpace(action) != "exclude" {
 		return
 	}
+	items := snapshot.ControlBacklog.Items[:0]
+	for _, item := range snapshot.ControlBacklog.Items {
+		updated := item
+		if backlogItemMatchesRecord(item.ID, item.Repo, item.Path, requestedID, record) {
+			updated.ApprovalStatus = backlogApprovalStatus(record)
+			updated.SecurityVisibility = agginventory.GovernanceSecurityVisibilityStatus(backlogSecurityVisibility(record), strings.TrimSpace(record.ApprovalState), strings.TrimSpace(record.Status))
+			updated.Queue = controlbacklog.QueueInventoryHygiene
+			updated.FindingVisibility = controlbacklog.FindingVisibilityAppendix
+			updated.RecommendedAction = controlbacklog.ActionSuppress
+			updated.GovernanceDisposition = &controlbacklog.GovernanceDisposition{
+				Kind:               controlbacklog.GovernanceKindSuppression,
+				Status:             controlbacklog.GovernanceStatusActive,
+				Reason:             firstNonEmptySnapshotValue(strings.TrimSpace(record.Approval.ExclusionReason), strings.TrimSpace(record.Approval.DecisionReason)),
+				Scope:              firstNonEmptySnapshotValue(strings.TrimSpace(record.Approval.Scope), "control_path"),
+				Issuer:             firstNonEmptySnapshotValue(strings.TrimSpace(record.Approval.Approver), strings.TrimSpace(record.Approval.Owner)),
+				ExpiresAt:          strings.TrimSpace(record.Approval.Expires),
+				EvidenceState:      firstNonEmptySnapshotValue(strings.TrimSpace(updated.ApprovalEvidenceState), "unknown"),
+				VisibilityBehavior: controlbacklog.FindingVisibilityAppendix,
+				RescanBehavior:     "retain_appendix_until_expiry",
+				EvidenceRefs:       compactSnapshotStrings(strings.TrimSpace(record.Approval.ControlID), strings.TrimSpace(record.Approval.EvidenceURL)),
+			}
+		}
+		items = append(items, updated)
+	}
+	snapshot.ControlBacklog.Items = items
 	snapshot.ControlBacklog.Summary = summarizeBacklogItems(snapshot.ControlBacklog.Items)
 }
 
@@ -287,4 +312,30 @@ func mutationGeneratedAt(snapshot *state.Snapshot) time.Time {
 		return parsed.UTC().Truncate(time.Second)
 	}
 	return time.Now().UTC().Truncate(time.Second)
+}
+
+func firstNonEmptySnapshotValue(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func compactSnapshotStrings(values ...string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
 }

--- a/core/cli/state_mutation_test.go
+++ b/core/cli/state_mutation_test.go
@@ -325,7 +325,7 @@ func TestRegressBaselineInitializedAfterApprovalUsesUpdatedSavedState(t *testing
 	t.Fatalf("expected baseline tool for %s", agentID)
 }
 
-func TestInventoryExcludeRemovesControlBacklogWithoutRescan(t *testing.T) {
+func TestInventoryExcludeMovesControlBacklogItemToAppendixWithoutRescan(t *testing.T) {
 	t.Parallel()
 
 	tmp := t.TempDir()
@@ -349,6 +349,8 @@ func TestInventoryExcludeRemovesControlBacklogWithoutRescan(t *testing.T) {
 	var excludeErr bytes.Buffer
 	if code := Run([]string{
 		"inventory", "exclude", agentID,
+		"--owner", "platform-security",
+		"--expires", "30d",
 		"--reason", "retired_control_path",
 		"--state", statePath,
 		"--json",
@@ -357,8 +359,19 @@ func TestInventoryExcludeRemovesControlBacklogWithoutRescan(t *testing.T) {
 	}
 
 	after := runReportJSON(t, statePath)
-	if _, ok := reportBacklogItem(after, recordBefore.Repo, recordBefore.Location); ok {
-		t.Fatalf("expected excluded control path to be removed from report backlog without rescanning")
+	item, ok := reportBacklogItem(after, recordBefore.Repo, recordBefore.Location)
+	if !ok {
+		t.Fatalf("expected suppressed control path to remain auditable in report backlog")
+	}
+	if item["finding_visibility"] != "appendix" {
+		t.Fatalf("expected suppressed control path to move to appendix visibility, got %+v", item)
+	}
+	disposition, ok := item["governance_disposition"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected governance disposition on suppressed item, got %+v", item)
+	}
+	if disposition["kind"] != "suppression" {
+		t.Fatalf("expected suppression governance disposition, got %+v", disposition)
 	}
 }
 

--- a/core/cli/state_mutation_test.go
+++ b/core/cli/state_mutation_test.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/Clyra-AI/wrkr/core/aggregate/controlbacklog"
 	"github.com/Clyra-AI/wrkr/core/identity"
 	"github.com/Clyra-AI/wrkr/core/lifecycle"
 	"github.com/Clyra-AI/wrkr/core/manifest"
@@ -283,6 +284,50 @@ func TestReportReflectsInventoryApproveWithoutRescan(t *testing.T) {
 	}
 	if afterItem["security_visibility"] != "known_approved" {
 		t.Fatalf("expected report backlog item security_visibility=known_approved after approval, got %v", afterItem)
+	}
+}
+
+func TestApplyInventoryMutationOverridesMovesExcludedBacklogItemToAppendix(t *testing.T) {
+	t.Parallel()
+
+	snapshot := state.Snapshot{
+		ControlBacklog: &controlbacklog.Backlog{
+			Items: []controlbacklog.Item{{
+				ID:                "cb-1",
+				Repo:              "acme/repo",
+				Path:              "AGENTS.md",
+				Queue:             controlbacklog.QueueReviewQueue,
+				FindingVisibility: controlbacklog.FindingVisibilityPrimary,
+				RecommendedAction: controlbacklog.ActionAttachEvidence,
+			}},
+		},
+	}
+	record := manifest.IdentityRecord{
+		AgentID:       "wrkr:codex-app:acme",
+		Repo:          "acme/repo",
+		Location:      "AGENTS.md",
+		Status:        identity.StateRevoked,
+		ApprovalState: "excluded",
+		Approval: manifest.Approval{
+			Owner:           "platform-security",
+			Approver:        "platform-security",
+			Scope:           "control_path",
+			Expires:         "2026-06-30T00:00:00Z",
+			ExclusionReason: "retired_control_path",
+		},
+	}
+
+	applyInventoryMutationOverrides(&snapshot, record, "cb-1", "exclude")
+
+	item := snapshot.ControlBacklog.Items[0]
+	if item.Queue != controlbacklog.QueueInventoryHygiene || item.FindingVisibility != controlbacklog.FindingVisibilityAppendix {
+		t.Fatalf("expected excluded item to move to appendix visibility, got %+v", item)
+	}
+	if item.RecommendedAction != controlbacklog.ActionSuppress {
+		t.Fatalf("expected suppress action for excluded item, got %+v", item)
+	}
+	if item.GovernanceDisposition == nil || item.GovernanceDisposition.Kind != controlbacklog.GovernanceKindSuppression {
+		t.Fatalf("expected suppression governance disposition, got %+v", item.GovernanceDisposition)
 	}
 }
 

--- a/core/governancequeue/queue.go
+++ b/core/governancequeue/queue.go
@@ -1,0 +1,25 @@
+package governancequeue
+
+const (
+	CredentialStatusPresent = "credential_access_present"
+	CredentialStatusNone    = "no_credential_access"
+)
+
+type Item struct {
+	QueueID            string   `json:"queue_id" yaml:"queue_id"`
+	GapID              string   `json:"gap_id" yaml:"gap_id"`
+	AgentID            string   `json:"agent_id,omitempty" yaml:"agent_id,omitempty"`
+	Repo               string   `json:"repo,omitempty" yaml:"repo,omitempty"`
+	Path               string   `json:"path,omitempty" yaml:"path,omitempty"`
+	ReasonCode         string   `json:"reason_code" yaml:"reason_code"`
+	Severity           string   `json:"severity" yaml:"severity"`
+	Owner              string   `json:"owner,omitempty" yaml:"owner,omitempty"`
+	OwnerEvidenceState string   `json:"owner_evidence_state,omitempty" yaml:"owner_evidence_state,omitempty"`
+	CredentialStatus   string   `json:"credential_status,omitempty" yaml:"credential_status,omitempty"`
+	LifecycleStatus    string   `json:"lifecycle_status,omitempty" yaml:"lifecycle_status,omitempty"`
+	RecommendedAction  string   `json:"recommended_action" yaml:"recommended_action"`
+	SLA                string   `json:"sla" yaml:"sla"`
+	ClosureCriteria    string   `json:"closure_criteria" yaml:"closure_criteria"`
+	EvidenceRefs       []string `json:"evidence_refs,omitempty" yaml:"evidence_refs,omitempty"`
+	SourceConflicts    []string `json:"source_conflicts,omitempty" yaml:"source_conflicts,omitempty"`
+}

--- a/core/governancequeue/queue.go
+++ b/core/governancequeue/queue.go
@@ -1,8 +1,8 @@
 package governancequeue
 
 const (
-	CredentialStatusPresent = "credential_access_present"
-	CredentialStatusNone    = "no_credential_access"
+	CredentialStatusPresent = "credential_access_present" // #nosec G101 -- deterministic queue status label, not credential material.
+	CredentialStatusNone    = "no_credential_access"      // #nosec G101 -- deterministic queue status label, not credential material.
 )
 
 type Item struct {

--- a/core/lifecycle/lifecycle.go
+++ b/core/lifecycle/lifecycle.go
@@ -262,18 +262,29 @@ func ApplyInventoryMutation(m manifest.Manifest, mutation InventoryMutation) (ma
 		diff["control_id"] = strings.TrimSpace(mutation.ControlID)
 		diff["evidence_url"] = strings.TrimSpace(mutation.EvidenceURL)
 	case "accept_risk":
+		if strings.TrimSpace(mutation.Owner) == "" {
+			return manifest.Manifest{}, Transition{}, fmt.Errorf("--owner is required")
+		}
+		if strings.TrimSpace(mutation.Reason) == "" {
+			return manifest.Manifest{}, Transition{}, fmt.Errorf("--reason is required")
+		}
 		if mutation.ExpiresAt.IsZero() {
 			return manifest.Manifest{}, Transition{}, fmt.Errorf("--expires is required")
 		}
 		record.Status = identity.StateActive
 		record.ApprovalState = "accepted_risk"
 		record.Approval.AcceptedRisk = true
+		record.Approval.Approver = strings.TrimSpace(mutation.Owner)
+		record.Approval.Owner = strings.TrimSpace(mutation.Owner)
+		record.Approval.Scope = fallback(record.Approval.Scope, "control_path")
 		record.Approval.Approved = now.Format(time.RFC3339)
 		record.Approval.Expires = mutation.ExpiresAt.UTC().Truncate(time.Second).Format(time.RFC3339)
 		record.Approval.LastReviewed = now.Format(time.RFC3339)
+		record.Approval.ReviewCadence = fallback(strings.TrimSpace(mutation.ReviewCadence), "30d")
 		record.Approval.RenewalState = renewalState(mutation.ExpiresAt, now)
 		record.Approval.DecisionReason = strings.TrimSpace(mutation.Reason)
 		record.Approval.ExclusionReason = ""
+		diff["owner"] = strings.TrimSpace(mutation.Owner)
 		diff["expires"] = record.Approval.Expires
 		diff["accepted_risk"] = true
 		if strings.TrimSpace(mutation.Reason) != "" {
@@ -292,16 +303,29 @@ func ApplyInventoryMutation(m manifest.Manifest, mutation InventoryMutation) (ma
 		record.Approval.RenewalState = "not_applicable"
 		diff["reason"] = strings.TrimSpace(mutation.Reason)
 	case "exclude":
+		if strings.TrimSpace(mutation.Owner) == "" {
+			return manifest.Manifest{}, Transition{}, fmt.Errorf("--owner is required")
+		}
 		if strings.TrimSpace(mutation.Reason) == "" {
 			return manifest.Manifest{}, Transition{}, fmt.Errorf("--reason is required")
+		}
+		if mutation.ExpiresAt.IsZero() {
+			return manifest.Manifest{}, Transition{}, fmt.Errorf("--expires is required")
 		}
 		record.Status = identity.StateRevoked
 		record.ApprovalState = "excluded"
 		record.Approval.AcceptedRisk = false
-		record.Approval.Expires = ""
+		record.Approval.Approver = strings.TrimSpace(mutation.Owner)
+		record.Approval.Owner = strings.TrimSpace(mutation.Owner)
+		record.Approval.Scope = fallback(record.Approval.Scope, "control_path")
+		record.Approval.Expires = mutation.ExpiresAt.UTC().Truncate(time.Second).Format(time.RFC3339)
 		record.Approval.ExclusionReason = strings.TrimSpace(mutation.Reason)
+		record.Approval.DecisionReason = strings.TrimSpace(mutation.Reason)
 		record.Approval.LastReviewed = now.Format(time.RFC3339)
-		record.Approval.RenewalState = "not_applicable"
+		record.Approval.ReviewCadence = fallback(strings.TrimSpace(mutation.ReviewCadence), "30d")
+		record.Approval.RenewalState = renewalState(mutation.ExpiresAt, now)
+		diff["owner"] = strings.TrimSpace(mutation.Owner)
+		diff["expires"] = record.Approval.Expires
 		diff["reason"] = strings.TrimSpace(mutation.Reason)
 	default:
 		return manifest.Manifest{}, Transition{}, fmt.Errorf("unsupported inventory action %q", action)

--- a/core/lifecycle/queue_projection.go
+++ b/core/lifecycle/queue_projection.go
@@ -1,0 +1,181 @@
+package lifecycle
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/Clyra-AI/wrkr/core/governancequeue"
+)
+
+func BuildQueue(gaps []Gap) []governancequeue.Item {
+	if len(gaps) == 0 {
+		return nil
+	}
+	items := make([]governancequeue.Item, 0, len(gaps))
+	for _, gap := range gaps {
+		items = append(items, QueueItemFromGap(gap))
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if queueSeverityRank(items[i].Severity) != queueSeverityRank(items[j].Severity) {
+			return queueSeverityRank(items[i].Severity) < queueSeverityRank(items[j].Severity)
+		}
+		if queueCredentialRank(items[i].CredentialStatus) != queueCredentialRank(items[j].CredentialStatus) {
+			return queueCredentialRank(items[i].CredentialStatus) < queueCredentialRank(items[j].CredentialStatus)
+		}
+		if queueOwnerEvidenceRank(items[i].OwnerEvidenceState) != queueOwnerEvidenceRank(items[j].OwnerEvidenceState) {
+			return queueOwnerEvidenceRank(items[i].OwnerEvidenceState) < queueOwnerEvidenceRank(items[j].OwnerEvidenceState)
+		}
+		if items[i].Repo != items[j].Repo {
+			return items[i].Repo < items[j].Repo
+		}
+		if items[i].Path != items[j].Path {
+			return items[i].Path < items[j].Path
+		}
+		return items[i].QueueID < items[j].QueueID
+	})
+	return items
+}
+
+func QueueItemFromGap(gap Gap) governancequeue.Item {
+	item := governancequeue.Item{
+		QueueID:            "lq-" + strings.TrimPrefix(strings.TrimSpace(gap.GapID), "gap-"),
+		GapID:              strings.TrimSpace(gap.GapID),
+		AgentID:            strings.TrimSpace(gap.AgentID),
+		Repo:               strings.TrimSpace(gap.Repo),
+		Path:               strings.TrimSpace(gap.Location),
+		ReasonCode:         strings.TrimSpace(gap.ReasonCode),
+		Severity:           strings.TrimSpace(gap.Severity),
+		Owner:              strings.TrimSpace(gap.Owner),
+		OwnerEvidenceState: queueOwnerEvidenceStateFromGap(gap),
+		CredentialStatus:   queueCredentialStatusFromGap(gap),
+		LifecycleStatus:    strings.TrimSpace(gap.LifecycleState),
+		RecommendedAction:  queueRecommendedAction(gap),
+		SLA:                queueSLA(gap),
+		ClosureCriteria:    queueClosure(gap),
+		EvidenceRefs:       queueCleanStrings(gap.EvidenceBasis),
+		SourceConflicts:    queueSourceConflicts(gap),
+	}
+	if item.QueueID == "lq-" {
+		item.QueueID = "lq-" + strings.TrimSpace(gap.AgentID) + "-" + strings.TrimSpace(gap.ReasonCode)
+	}
+	return item
+}
+
+func queueOwnerEvidenceStateFromGap(gap Gap) string {
+	switch strings.TrimSpace(gap.OwnershipStatus) {
+	case "explicit":
+		return "verified"
+	case "inferred":
+		return "inferred"
+	default:
+		return "unknown"
+	}
+}
+
+func queueCredentialStatusFromGap(gap Gap) string {
+	if gap.CredentialAccess {
+		return governancequeue.CredentialStatusPresent
+	}
+	return governancequeue.CredentialStatusNone
+}
+
+func queueRecommendedAction(gap Gap) string {
+	switch strings.TrimSpace(gap.ReasonCode) {
+	case GapInactiveCredentialed, GapRevokedStillPresent:
+		return "remediate"
+	case GapOwnerlessExposure, GapOwnerUnresolved:
+		return "attach_evidence"
+	case GapOwnerInferred, GapApprovalExpired, GapMissingApproval:
+		return "approve"
+	default:
+		return "inventory_review"
+	}
+}
+
+func queueSLA(gap Gap) string {
+	switch strings.TrimSpace(gap.Severity) {
+	case "high":
+		return "7d"
+	case "medium":
+		return "14d"
+	default:
+		return "30d"
+	}
+}
+
+func queueClosure(gap Gap) string {
+	switch strings.TrimSpace(gap.ReasonCode) {
+	case GapInactiveCredentialed:
+		return "Remove standing credential access or return the path to an active approved lifecycle state."
+	case GapRevokedStillPresent:
+		return "Remove the revoked path from active execution and confirm it no longer appears in scan output."
+	case GapOwnerlessExposure, GapOwnerUnresolved:
+		return "Assign an explicit owner and attach lifecycle review evidence for the active path."
+	case GapOwnerInferred:
+		return "Confirm the inferred owner with explicit review evidence."
+	case GapApprovalExpired, GapMissingApproval:
+		return "Attach fresh approval evidence with owner, expiry, and review scope."
+	default:
+		return "Record lifecycle review evidence and rescan."
+	}
+}
+
+func queueSourceConflicts(gap Gap) []string {
+	switch strings.TrimSpace(gap.OwnershipStatus) {
+	case "unresolved":
+		return []string{"owner_resolution:unresolved"}
+	default:
+		return nil
+	}
+}
+
+func queueCleanStrings(values []string) []string {
+	set := map[string]struct{}{}
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		set[trimmed] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func queueSeverityRank(value string) int {
+	switch strings.TrimSpace(value) {
+	case "high":
+		return 0
+	case "medium":
+		return 1
+	default:
+		return 2
+	}
+}
+
+func queueCredentialRank(value string) int {
+	switch strings.TrimSpace(value) {
+	case governancequeue.CredentialStatusPresent:
+		return 0
+	default:
+		return 1
+	}
+}
+
+func queueOwnerEvidenceRank(value string) int {
+	switch strings.TrimSpace(value) {
+	case "unknown":
+		return 0
+	case "inferred":
+		return 1
+	default:
+		return 2
+	}
+}

--- a/core/report/agent_action_bom.go
+++ b/core/report/agent_action_bom.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Clyra-AI/wrkr/core/aggregate/scanquality"
 	"github.com/Clyra-AI/wrkr/core/attribution"
 	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
+	"github.com/Clyra-AI/wrkr/core/governancequeue"
 	"github.com/Clyra-AI/wrkr/core/ingest"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/risk"
@@ -43,6 +44,8 @@ type AgentActionBOMSummary struct {
 	StandingPrivilegeItems       int                                 `json:"standing_privilege_items"`
 	StaticCredentialItems        int                                 `json:"static_credential_items"`
 	ProductionTargetItems        int                                 `json:"production_target_items"`
+	AcceptedRiskItems            int                                 `json:"accepted_risk_items,omitempty"`
+	LifecycleQueueItems          int                                 `json:"lifecycle_queue_items,omitempty"`
 	ApprovalEvidenceUnknownItems int                                 `json:"approval_evidence_unknown_items,omitempty"`
 	ControlEvidenceUnknownItems  int                                 `json:"control_evidence_unknown_items,omitempty"`
 	OwnerEvidenceUnknownItems    int                                 `json:"owner_evidence_unknown_items,omitempty"`
@@ -150,6 +153,8 @@ type AgentActionBOMItem struct {
 	Queue                        string                                 `json:"queue,omitempty"`
 	FindingVisibility            string                                 `json:"finding_visibility,omitempty"`
 	Remediation                  string                                 `json:"remediation,omitempty"`
+	GovernanceDisposition        *controlbacklog.GovernanceDisposition  `json:"governance_disposition,omitempty"`
+	LifecycleQueue               *governancequeue.Item                  `json:"lifecycle_queue,omitempty"`
 	AttackPathRefs               []string                               `json:"attack_path_refs,omitempty"`
 	SourceFindingKeys            []string                               `json:"source_finding_keys,omitempty"`
 	ExclusionReason              string                                 `json:"exclusion_reason,omitempty"`
@@ -311,6 +316,8 @@ func buildAgentActionBOM(summary Summary, findings []model.Finding) *AgentAction
 			Queue:                        firstNonEmptyValue(strings.TrimSpace(backlogItem.Queue), queueForActionPath(path)),
 			FindingVisibility:            firstNonEmptyValue(strings.TrimSpace(backlogItem.FindingVisibility), visibilityForQueue(firstNonEmptyValue(strings.TrimSpace(backlogItem.Queue), queueForActionPath(path)))),
 			Remediation:                  firstNonEmptyValue(strings.TrimSpace(backlogItem.Remediation), risk.RemediationForActionPath(path)),
+			GovernanceDisposition:        cloneGovernanceDisposition(backlogItem.GovernanceDisposition),
+			LifecycleQueue:               cloneLifecycleQueue(backlogItem.LifecycleQueue),
 			AttackPathRefs:               append([]string(nil), path.AttackPathRefs...),
 			SourceFindingKeys:            append([]string(nil), path.SourceFindingKeys...),
 			GraphRefs:                    itemGraphRefs,
@@ -399,7 +406,28 @@ func backlogItemsByPath(backlog *controlbacklog.Backlog) map[string]controlbackl
 		if strings.TrimSpace(item.LinkedActionPathID) == "" {
 			continue
 		}
-		out[strings.TrimSpace(item.LinkedActionPathID)] = item
+		key := strings.TrimSpace(item.LinkedActionPathID)
+		current, ok := out[key]
+		if !ok {
+			out[key] = item
+			continue
+		}
+		if current.GovernanceDisposition == nil {
+			current.GovernanceDisposition = cloneGovernanceDisposition(item.GovernanceDisposition)
+		}
+		if current.LifecycleQueue == nil {
+			current.LifecycleQueue = cloneLifecycleQueue(item.LifecycleQueue)
+		}
+		if strings.TrimSpace(current.Remediation) == "" {
+			current.Remediation = item.Remediation
+		}
+		if strings.TrimSpace(current.Queue) == "" {
+			current.Queue = item.Queue
+		}
+		if strings.TrimSpace(current.FindingVisibility) == "" {
+			current.FindingVisibility = item.FindingVisibility
+		}
+		out[key] = current
 	}
 	return out
 }
@@ -597,6 +625,12 @@ func summarizeAgentActionBOMItems(items []AgentActionBOMItem, paths []risk.Actio
 		if item.ProductionWrite || len(item.MatchedProductionTargets) > 0 {
 			counts.ProductionTargetItems++
 		}
+		if item.GovernanceDisposition != nil && item.GovernanceDisposition.Kind == controlbacklog.GovernanceKindAcceptedRisk && item.GovernanceDisposition.Status == controlbacklog.GovernanceStatusActive {
+			counts.AcceptedRiskItems++
+		}
+		if item.LifecycleQueue != nil {
+			counts.LifecycleQueueItems++
+		}
 		if item.ApprovalEvidenceState == risk.EvidenceStateUnknown {
 			counts.ApprovalEvidenceUnknownItems++
 			counts.MissingApprovalItems++
@@ -666,6 +700,25 @@ func evaluateBOMEmptyState(projection risk.ActionPathSummary, counts AgentAction
 	default:
 		return risk.EmptyStateEligible, uniqueSortedStrings(reasons)
 	}
+}
+
+func cloneGovernanceDisposition(in *controlbacklog.GovernanceDisposition) *controlbacklog.GovernanceDisposition {
+	if in == nil {
+		return nil
+	}
+	copyItem := *in
+	copyItem.EvidenceRefs = append([]string(nil), in.EvidenceRefs...)
+	return &copyItem
+}
+
+func cloneLifecycleQueue(in *governancequeue.Item) *governancequeue.Item {
+	if in == nil {
+		return nil
+	}
+	copyItem := *in
+	copyItem.EvidenceRefs = append([]string(nil), in.EvidenceRefs...)
+	copyItem.SourceConflicts = append([]string(nil), in.SourceConflicts...)
+	return &copyItem
 }
 
 func cloneShareProfileMetadata(in *ShareProfileMetadata) *ShareProfileMetadata {

--- a/core/report/build.go
+++ b/core/report/build.go
@@ -1355,6 +1355,8 @@ func mergeBacklogGovernance(base, overlay *controlbacklog.Backlog) *controlbackl
 	copyBacklog.Items = append([]controlbacklog.Item(nil), base.Items...)
 	overlayByID := map[string]controlbacklog.Item{}
 	overlayByRepoPath := map[string]controlbacklog.Item{}
+	seenOverlayIDs := map[string]struct{}{}
+	seenOverlayRepoPaths := map[string]struct{}{}
 	for _, item := range overlay.Items {
 		if id := strings.TrimSpace(item.ID); id != "" {
 			overlayByID[id] = item
@@ -1372,6 +1374,12 @@ func mergeBacklogGovernance(base, overlay *controlbacklog.Backlog) *controlbackl
 		if !ok {
 			continue
 		}
+		if id := strings.TrimSpace(overlayItem.ID); id != "" {
+			seenOverlayIDs[id] = struct{}{}
+		}
+		if key := strings.TrimSpace(overlayItem.Repo) + "|" + strings.TrimSpace(overlayItem.Path); key != "|" {
+			seenOverlayRepoPaths[key] = struct{}{}
+		}
 		current.GovernanceDisposition = overlayItem.GovernanceDisposition
 		current.LifecycleQueue = overlayItem.LifecycleQueue
 		if overlayItem.GovernanceDisposition != nil || overlayItem.LifecycleQueue != nil {
@@ -1382,6 +1390,19 @@ func mergeBacklogGovernance(base, overlay *controlbacklog.Backlog) *controlbackl
 			current.EvidenceGaps = uniqueStrings(append(append([]string(nil), current.EvidenceGaps...), overlayItem.EvidenceGaps...))
 		}
 		copyBacklog.Items[idx] = current
+	}
+	for _, item := range overlay.Items {
+		if id := strings.TrimSpace(item.ID); id != "" {
+			if _, ok := seenOverlayIDs[id]; ok {
+				continue
+			}
+		}
+		if key := strings.TrimSpace(item.Repo) + "|" + strings.TrimSpace(item.Path); key != "|" {
+			if _, ok := seenOverlayRepoPaths[key]; ok {
+				continue
+			}
+		}
+		copyBacklog.Items = append(copyBacklog.Items, item)
 	}
 	copyBacklog.Summary = controlbacklog.SummarizeItems(copyBacklog.Items)
 	return &copyBacklog

--- a/core/report/build.go
+++ b/core/report/build.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Clyra-AI/wrkr/core/aggregate/scanquality"
 	"github.com/Clyra-AI/wrkr/core/compliance"
 	"github.com/Clyra-AI/wrkr/core/detect"
+	"github.com/Clyra-AI/wrkr/core/governancequeue"
 	"github.com/Clyra-AI/wrkr/core/identity"
 	"github.com/Clyra-AI/wrkr/core/ingest"
 	"github.com/Clyra-AI/wrkr/core/lifecycle"
@@ -110,18 +111,20 @@ func BuildSummary(in BuildInput) (Summary, error) {
 	riskReport.ActionPathToControlFirst = decorateControlFirstForReport(riskReport.ActionPaths, scanQualityCoverageReduced(scanQuality))
 	activation := BuildActivation(in.Snapshot.Target.Mode, riskReport.Ranked, in.Snapshot.Inventory, riskReport.ActionPaths, top)
 	exposureGroups := risk.BuildExposureGroups(riskReport.ActionPaths)
+	controlBacklogBuilt := controlbacklog.Build(controlbacklog.Input{
+		Mode:             in.Snapshot.Target.Mode,
+		GeneratedAt:      now,
+		Findings:         in.Snapshot.Findings,
+		Inventory:        in.Snapshot.Inventory,
+		Identities:       in.Snapshot.Identities,
+		LifecycleGaps:    in.Snapshot.LifecycleGaps,
+		ActionPaths:      riskReport.ActionPaths,
+		ControlPathGraph: riskReport.ControlPathGraph,
+	})
 	var controlBacklog *controlbacklog.Backlog
 	if in.Snapshot.ControlBacklog != nil {
-		controlBacklog = decorateControlBacklogFromActionPaths(in.Snapshot.ControlBacklog, riskReport.ActionPaths)
+		controlBacklog = mergeBacklogGovernance(decorateControlBacklogFromActionPaths(in.Snapshot.ControlBacklog, riskReport.ActionPaths), &controlBacklogBuilt)
 	} else {
-		controlBacklogBuilt := controlbacklog.Build(controlbacklog.Input{
-			Mode:             in.Snapshot.Target.Mode,
-			Findings:         in.Snapshot.Findings,
-			Inventory:        in.Snapshot.Inventory,
-			LifecycleGaps:    in.Snapshot.LifecycleGaps,
-			ActionPaths:      riskReport.ActionPaths,
-			ControlPathGraph: riskReport.ControlPathGraph,
-		})
 		controlBacklog = &controlBacklogBuilt
 	}
 	riskItems := buildRiskItems(topFindings, riskReport.ActionPaths)
@@ -649,6 +652,7 @@ func buildLifecycleSummary(
 		DeprecatedCount:    deprecated,
 		PendingActionCount: underReview + revoked + deprecated + len(gaps),
 		Gaps:               append([]lifecycle.Gap(nil), gaps...),
+		Queue:              lifecycle.BuildQueue(gaps),
 		RecentTransitions:  normalizedTransitions,
 	}
 }
@@ -1340,6 +1344,49 @@ func decorateControlBacklogFromActionPaths(backlog *controlbacklog.Backlog, path
 	return &copyBacklog
 }
 
+func mergeBacklogGovernance(base, overlay *controlbacklog.Backlog) *controlbacklog.Backlog {
+	if base == nil {
+		return overlay
+	}
+	if overlay == nil {
+		return base
+	}
+	copyBacklog := *base
+	copyBacklog.Items = append([]controlbacklog.Item(nil), base.Items...)
+	overlayByID := map[string]controlbacklog.Item{}
+	overlayByRepoPath := map[string]controlbacklog.Item{}
+	for _, item := range overlay.Items {
+		if id := strings.TrimSpace(item.ID); id != "" {
+			overlayByID[id] = item
+		}
+		if key := strings.TrimSpace(item.Repo) + "|" + strings.TrimSpace(item.Path); key != "|" {
+			overlayByRepoPath[key] = item
+		}
+	}
+	for idx := range copyBacklog.Items {
+		current := copyBacklog.Items[idx]
+		overlayItem, ok := overlayByID[strings.TrimSpace(current.ID)]
+		if !ok {
+			overlayItem, ok = overlayByRepoPath[strings.TrimSpace(current.Repo)+"|"+strings.TrimSpace(current.Path)]
+		}
+		if !ok {
+			continue
+		}
+		current.GovernanceDisposition = overlayItem.GovernanceDisposition
+		current.LifecycleQueue = overlayItem.LifecycleQueue
+		if overlayItem.GovernanceDisposition != nil || overlayItem.LifecycleQueue != nil {
+			current.Queue = firstNonEmptyValue(strings.TrimSpace(overlayItem.Queue), strings.TrimSpace(current.Queue))
+			current.FindingVisibility = firstNonEmptyValue(strings.TrimSpace(overlayItem.FindingVisibility), strings.TrimSpace(current.FindingVisibility))
+			current.SecurityVisibility = firstNonEmptyValue(strings.TrimSpace(overlayItem.SecurityVisibility), strings.TrimSpace(current.SecurityVisibility))
+			current.Remediation = firstNonEmptyValue(strings.TrimSpace(overlayItem.Remediation), strings.TrimSpace(current.Remediation))
+			current.EvidenceGaps = uniqueStrings(append(append([]string(nil), current.EvidenceGaps...), overlayItem.EvidenceGaps...))
+		}
+		copyBacklog.Items[idx] = current
+	}
+	copyBacklog.Summary = controlbacklog.SummarizeItems(copyBacklog.Items)
+	return &copyBacklog
+}
+
 func actionPathSeverity(path risk.ActionPath) string {
 	path = risk.ProjectActionPath(path)
 	switch strings.TrimSpace(path.RiskTier) {
@@ -1486,6 +1533,14 @@ func sanitizeLifecycleSummaryPublic(in LifecycleSummary) LifecycleSummary {
 		copySummary.Gaps[idx].Repo = redactValue("repo", copySummary.Gaps[idx].Repo, 6)
 		copySummary.Gaps[idx].Location = redactValue("loc", copySummary.Gaps[idx].Location, 8)
 		copySummary.Gaps[idx].Owner = redactValue("owner", copySummary.Gaps[idx].Owner, 8)
+	}
+	for idx := range copySummary.Queue {
+		copySummary.Queue[idx].AgentID = redactValue("agent", copySummary.Queue[idx].AgentID, 8)
+		copySummary.Queue[idx].Repo = redactValue("repo", copySummary.Queue[idx].Repo, 6)
+		copySummary.Queue[idx].Path = redactValue("loc", copySummary.Queue[idx].Path, 8)
+		copySummary.Queue[idx].Owner = redactValue("owner", copySummary.Queue[idx].Owner, 8)
+		copySummary.Queue[idx].EvidenceRefs = redactStringSlice(copySummary.Queue[idx].EvidenceRefs, "evidence")
+		copySummary.Queue[idx].SourceConflicts = redactStringSlice(copySummary.Queue[idx].SourceConflicts, "owner")
 	}
 	return copySummary
 }
@@ -1744,6 +1799,8 @@ func sanitizeControlBacklogPublic(in *controlbacklog.Backlog) *controlbacklog.Ba
 		copyBacklog.Items[idx].LinkedControlPathEdgeIDs = redactStringSlice(copyBacklog.Items[idx].LinkedControlPathEdgeIDs, "edge")
 		copyBacklog.Items[idx].OwnershipEvidence = redactStringSlice(copyBacklog.Items[idx].OwnershipEvidence, "evidence")
 		copyBacklog.Items[idx].OwnershipConflicts = redactStringSlice(copyBacklog.Items[idx].OwnershipConflicts, "owner")
+		copyBacklog.Items[idx].GovernanceDisposition = sanitizeGovernanceDispositionPublic(copyBacklog.Items[idx].GovernanceDisposition)
+		copyBacklog.Items[idx].LifecycleQueue = sanitizeLifecycleQueuePublic(copyBacklog.Items[idx].LifecycleQueue)
 		if copyBacklog.Items[idx].CredentialProvenance != nil {
 			copyBacklog.Items[idx].CredentialProvenance = agginventory.CloneCredentialProvenance(copyBacklog.Items[idx].CredentialProvenance)
 			copyBacklog.Items[idx].CredentialProvenance.Subject = redactValue("credential", copyBacklog.Items[idx].CredentialProvenance.Subject, 8)
@@ -1787,6 +1844,8 @@ func sanitizeAgentActionBOM(in *AgentActionBOM, profile ShareProfile) *AgentActi
 		copyBOM.Items[idx].RuntimeEvidenceRefs = redactStringSlice(copyBOM.Items[idx].RuntimeEvidenceRefs, "runtime")
 		copyBOM.Items[idx].PolicyRefs = redactStringSlice(copyBOM.Items[idx].PolicyRefs, "policy")
 		copyBOM.Items[idx].PolicyEvidenceRefs = redactStringSlice(copyBOM.Items[idx].PolicyEvidenceRefs, "policy")
+		copyBOM.Items[idx].GovernanceDisposition = sanitizeGovernanceDispositionPublic(copyBOM.Items[idx].GovernanceDisposition)
+		copyBOM.Items[idx].LifecycleQueue = sanitizeLifecycleQueuePublic(copyBOM.Items[idx].LifecycleQueue)
 		copyBOM.Items[idx].AttackPathRefs = redactStringSlice(copyBOM.Items[idx].AttackPathRefs, "attack")
 		copyBOM.Items[idx].SourceFindingKeys = redactStringSlice(copyBOM.Items[idx].SourceFindingKeys, "finding")
 		copyBOM.Items[idx].EvidenceRefs = redactStringSlice(copyBOM.Items[idx].EvidenceRefs, "evidence")
@@ -1823,6 +1882,30 @@ func sanitizeAgentActionBOM(in *AgentActionBOM, profile ShareProfile) *AgentActi
 		}
 	}
 	return &copyBOM
+}
+
+func sanitizeGovernanceDispositionPublic(in *controlbacklog.GovernanceDisposition) *controlbacklog.GovernanceDisposition {
+	if in == nil {
+		return nil
+	}
+	copyItem := *in
+	copyItem.Issuer = redactValue("owner", copyItem.Issuer, 8)
+	copyItem.EvidenceRefs = redactStringSlice(copyItem.EvidenceRefs, "evidence")
+	return &copyItem
+}
+
+func sanitizeLifecycleQueuePublic(in *governancequeue.Item) *governancequeue.Item {
+	if in == nil {
+		return nil
+	}
+	copyItem := *in
+	copyItem.AgentID = redactValue("agent", copyItem.AgentID, 8)
+	copyItem.Repo = redactValue("repo", copyItem.Repo, 6)
+	copyItem.Path = redactValue("loc", copyItem.Path, 8)
+	copyItem.Owner = redactValue("owner", copyItem.Owner, 8)
+	copyItem.EvidenceRefs = redactStringSlice(copyItem.EvidenceRefs, "evidence")
+	copyItem.SourceConflicts = redactStringSlice(copyItem.SourceConflicts, "owner")
+	return &copyItem
 }
 
 func sanitizeReachabilityPublic(in []AgentActionBOMReachability) []AgentActionBOMReachability {

--- a/core/report/redaction_summary.go
+++ b/core/report/redaction_summary.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Clyra-AI/wrkr/core/aggregate/controlbacklog"
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/aggregate/scanquality"
+	"github.com/Clyra-AI/wrkr/core/governancequeue"
 	"github.com/Clyra-AI/wrkr/core/lifecycle"
 	"github.com/Clyra-AI/wrkr/core/risk"
 )
@@ -26,10 +27,19 @@ func sanitizeLifecycleSummaryWithConfig(in LifecycleSummary, config RedactionCon
 	copySummary := in
 	copySummary.RecentTransitions = append([]LifecycleTransition(nil), in.RecentTransitions...)
 	copySummary.Gaps = append([]lifecycle.Gap(nil), in.Gaps...)
+	copySummary.Queue = append([]governancequeue.Item(nil), in.Queue...)
 	for idx := range copySummary.Gaps {
 		copySummary.Gaps[idx].Repo = maybeRedactRepo(copySummary.Gaps[idx].Repo, config)
 		copySummary.Gaps[idx].Location = maybeRedactLocationLike(copySummary.Gaps[idx].Location, config)
 		copySummary.Gaps[idx].Owner = maybeRedactOwner(copySummary.Gaps[idx].Owner, config)
+	}
+	for idx := range copySummary.Queue {
+		copySummary.Queue[idx].AgentID = maybeRedactPathID(copySummary.Queue[idx].AgentID, config)
+		copySummary.Queue[idx].Repo = maybeRedactRepo(copySummary.Queue[idx].Repo, config)
+		copySummary.Queue[idx].Path = maybeRedactLocationLike(copySummary.Queue[idx].Path, config)
+		copySummary.Queue[idx].Owner = maybeRedactOwner(copySummary.Queue[idx].Owner, config)
+		copySummary.Queue[idx].EvidenceRefs = maybeRedactStringSlice(copySummary.Queue[idx].EvidenceRefs, "evidence", config.Has(RedactionProofRefs))
+		copySummary.Queue[idx].SourceConflicts = maybeRedactStringSlice(copySummary.Queue[idx].SourceConflicts, "owner", config.Has(RedactionOwners))
 	}
 	return copySummary
 }
@@ -278,6 +288,8 @@ func sanitizeControlBacklogWithConfig(in *controlbacklog.Backlog, config Redacti
 		copyBacklog.Items[idx].LinkedControlPathEdgeIDs = maybeRedactStringSlice(copyBacklog.Items[idx].LinkedControlPathEdgeIDs, "edge", config.Has(RedactionGraphRefs))
 		copyBacklog.Items[idx].OwnershipEvidence = cloneStrings(copyBacklog.Items[idx].OwnershipEvidence)
 		copyBacklog.Items[idx].OwnershipConflicts = maybeRedactStringSlice(copyBacklog.Items[idx].OwnershipConflicts, "owner", config.Has(RedactionOwners))
+		copyBacklog.Items[idx].GovernanceDisposition = sanitizeGovernanceDispositionWithConfig(copyBacklog.Items[idx].GovernanceDisposition, config)
+		copyBacklog.Items[idx].LifecycleQueue = sanitizeLifecycleQueueWithConfig(copyBacklog.Items[idx].LifecycleQueue, config)
 		if copyBacklog.Items[idx].CredentialProvenance != nil {
 			copyBacklog.Items[idx].CredentialProvenance = agginventory.CloneCredentialProvenance(copyBacklog.Items[idx].CredentialProvenance)
 			copyBacklog.Items[idx].CredentialProvenance.Subject = maybeRedactCredentialSubject(copyBacklog.Items[idx].CredentialProvenance.Subject, config)
@@ -315,6 +327,8 @@ func sanitizeAgentActionBOMWithConfig(in *AgentActionBOM, profile ShareProfile, 
 		copyBOM.Items[idx].RuntimeEvidenceRefs = cloneStrings(copyBOM.Items[idx].RuntimeEvidenceRefs)
 		copyBOM.Items[idx].PolicyRefs = cloneStrings(copyBOM.Items[idx].PolicyRefs)
 		copyBOM.Items[idx].PolicyEvidenceRefs = cloneStrings(copyBOM.Items[idx].PolicyEvidenceRefs)
+		copyBOM.Items[idx].GovernanceDisposition = sanitizeGovernanceDispositionWithConfig(copyBOM.Items[idx].GovernanceDisposition, config)
+		copyBOM.Items[idx].LifecycleQueue = sanitizeLifecycleQueueWithConfig(copyBOM.Items[idx].LifecycleQueue, config)
 		copyBOM.Items[idx].AttackPathRefs = maybeRedactStringSlice(copyBOM.Items[idx].AttackPathRefs, "attack", config.Has(RedactionGraphRefs))
 		copyBOM.Items[idx].SourceFindingKeys = maybeRedactStringSlice(copyBOM.Items[idx].SourceFindingKeys, "finding", shouldRedactFindingKeys(config))
 		copyBOM.Items[idx].EvidenceRefs = maybeRedactStringSlice(copyBOM.Items[idx].EvidenceRefs, "evidence", config.Has(RedactionProofRefs))
@@ -348,6 +362,30 @@ func sanitizeAgentActionBOMWithConfig(in *AgentActionBOM, profile ShareProfile, 
 		}
 	}
 	return &copyBOM
+}
+
+func sanitizeGovernanceDispositionWithConfig(in *controlbacklog.GovernanceDisposition, config RedactionConfig) *controlbacklog.GovernanceDisposition {
+	if in == nil {
+		return nil
+	}
+	copyItem := *in
+	copyItem.Issuer = maybeRedactOwner(copyItem.Issuer, config)
+	copyItem.EvidenceRefs = maybeRedactStringSlice(copyItem.EvidenceRefs, "evidence", config.Has(RedactionProofRefs))
+	return &copyItem
+}
+
+func sanitizeLifecycleQueueWithConfig(in *governancequeue.Item, config RedactionConfig) *governancequeue.Item {
+	if in == nil {
+		return nil
+	}
+	copyItem := *in
+	copyItem.AgentID = maybeRedactPathID(copyItem.AgentID, config)
+	copyItem.Repo = maybeRedactRepo(copyItem.Repo, config)
+	copyItem.Path = maybeRedactLocationLike(copyItem.Path, config)
+	copyItem.Owner = maybeRedactOwner(copyItem.Owner, config)
+	copyItem.EvidenceRefs = maybeRedactStringSlice(copyItem.EvidenceRefs, "evidence", config.Has(RedactionProofRefs))
+	copyItem.SourceConflicts = maybeRedactStringSlice(copyItem.SourceConflicts, "owner", config.Has(RedactionOwners))
+	return &copyItem
 }
 
 func sanitizeReachabilityWithConfig(in []AgentActionBOMReachability, config RedactionConfig) []AgentActionBOMReachability {

--- a/core/report/render_markdown.go
+++ b/core/report/render_markdown.go
@@ -128,6 +128,23 @@ func RenderMarkdown(summary Summary) string {
 				if len(item.Contradictions) > 0 {
 					builder.WriteString(fmt.Sprintf("  contradictions=%s\n", markdownContradictions(item.Contradictions)))
 				}
+				if item.GovernanceDisposition != nil {
+					builder.WriteString(fmt.Sprintf("  governance=%s status=%s scope=%s expires=%s reason=%s\n",
+						item.GovernanceDisposition.Kind,
+						item.GovernanceDisposition.Status,
+						item.GovernanceDisposition.Scope,
+						item.GovernanceDisposition.ExpiresAt,
+						item.GovernanceDisposition.Reason,
+					))
+				}
+				if item.LifecycleQueue != nil {
+					builder.WriteString(fmt.Sprintf("  lifecycle_queue=%s severity=%s credential_status=%s closure=%s\n",
+						item.LifecycleQueue.ReasonCode,
+						item.LifecycleQueue.Severity,
+						item.LifecycleQueue.CredentialStatus,
+						item.LifecycleQueue.ClosureCriteria,
+					))
+				}
 			}
 			builder.WriteString("\n")
 		}
@@ -258,6 +275,23 @@ func RenderMarkdown(summary Summary) string {
 			if len(item.Contradictions) > 0 {
 				builder.WriteString(fmt.Sprintf("  contradictions=%s\n", markdownContradictions(item.Contradictions)))
 			}
+			if item.GovernanceDisposition != nil {
+				builder.WriteString(fmt.Sprintf("  governance=%s status=%s scope=%s expires=%s reason=%s\n",
+					item.GovernanceDisposition.Kind,
+					item.GovernanceDisposition.Status,
+					item.GovernanceDisposition.Scope,
+					item.GovernanceDisposition.ExpiresAt,
+					item.GovernanceDisposition.Reason,
+				))
+			}
+			if item.LifecycleQueue != nil {
+				builder.WriteString(fmt.Sprintf("  lifecycle_queue=%s severity=%s credential_status=%s closure=%s\n",
+					item.LifecycleQueue.ReasonCode,
+					item.LifecycleQueue.Severity,
+					item.LifecycleQueue.CredentialStatus,
+					item.LifecycleQueue.ClosureCriteria,
+				))
+			}
 			if item.GaitCoverage != nil {
 				builder.WriteString(fmt.Sprintf("  gait=policy:%s approval:%s jit:%s freeze:%s kill:%s outcome:%s proof:%s\n",
 					item.GaitCoverage.PolicyDecision.Status,
@@ -295,6 +329,23 @@ func RenderMarkdown(summary Summary) string {
 				item.ClosureCriteria,
 				item.Remediation,
 			))
+			if item.GovernanceDisposition != nil {
+				builder.WriteString(fmt.Sprintf("  governance=%s status=%s scope=%s expires=%s reason=%s\n",
+					item.GovernanceDisposition.Kind,
+					item.GovernanceDisposition.Status,
+					item.GovernanceDisposition.Scope,
+					item.GovernanceDisposition.ExpiresAt,
+					item.GovernanceDisposition.Reason,
+				))
+			}
+			if item.LifecycleQueue != nil {
+				builder.WriteString(fmt.Sprintf("  lifecycle_queue=%s severity=%s credential_status=%s closure=%s\n",
+					item.LifecycleQueue.ReasonCode,
+					item.LifecycleQueue.Severity,
+					item.LifecycleQueue.CredentialStatus,
+					item.LifecycleQueue.ClosureCriteria,
+				))
+			}
 		}
 		builder.WriteString("\n")
 	}

--- a/core/report/report_test.go
+++ b/core/report/report_test.go
@@ -2146,6 +2146,42 @@ func TestBuildSummaryDecoratesBacklogWithProjectedPosture(t *testing.T) {
 	}
 }
 
+func TestMergeBacklogGovernanceAppendsOverlayOnlyItems(t *testing.T) {
+	t.Parallel()
+
+	base := &controlbacklog.Backlog{
+		Items: []controlbacklog.Item{{
+			ID:   "cb-base",
+			Repo: "acme/repo",
+			Path: "AGENTS.md",
+		}},
+	}
+	overlay := &controlbacklog.Backlog{
+		Items: []controlbacklog.Item{{
+			ID:                "cb-overlay",
+			Repo:              "acme/repo",
+			Path:              ".github/workflows/release.yml",
+			Queue:             controlbacklog.QueueAcceptedRisk,
+			FindingVisibility: controlbacklog.FindingVisibilityAppendix,
+			GovernanceDisposition: &controlbacklog.GovernanceDisposition{
+				Kind:   controlbacklog.GovernanceKindAcceptedRisk,
+				Status: controlbacklog.GovernanceStatusActive,
+				Reason: "time_bounded_exception",
+				Scope:  "control_path",
+			},
+		}},
+	}
+
+	merged := mergeBacklogGovernance(base, overlay)
+	if merged == nil || len(merged.Items) != 2 {
+		t.Fatalf("expected overlay-only backlog item to be appended, got %+v", merged)
+	}
+	last := merged.Items[1]
+	if last.ID != "cb-overlay" || last.GovernanceDisposition == nil || last.GovernanceDisposition.Kind != controlbacklog.GovernanceKindAcceptedRisk {
+		t.Fatalf("expected appended overlay item with governance metadata, got %+v", last)
+	}
+}
+
 func TestControlStateConsistencyBuildSummaryNormalizesCriticalControlStateAcrossSurfaces(t *testing.T) {
 	t.Parallel()
 

--- a/core/report/report_test.go
+++ b/core/report/report_test.go
@@ -14,6 +14,7 @@ import (
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/aggregate/scanquality"
 	"github.com/Clyra-AI/wrkr/core/attribution"
+	"github.com/Clyra-AI/wrkr/core/governancequeue"
 	"github.com/Clyra-AI/wrkr/core/ingest"
 	"github.com/Clyra-AI/wrkr/core/lifecycle"
 	"github.com/Clyra-AI/wrkr/core/manifest"
@@ -779,6 +780,69 @@ func TestBuildAgentActionBOMDerivesStableItemsFromSummary(t *testing.T) {
 	}
 	if first.Items[0].RuntimeEvidenceStatus != ingest.CorrelationStatusMatched || first.Items[0].RuntimeEvidenceAbsenceStatus != "" {
 		t.Fatalf("expected synthetic summary input to preserve raw matched runtime status without derived absence framing, got %+v", first.Items[0])
+	}
+}
+
+func TestBuildAgentActionBOMCarriesGovernanceDispositionAndLifecycleQueue(t *testing.T) {
+	t.Parallel()
+
+	summary := Summary{
+		GeneratedAt: "2026-05-26T12:00:00Z",
+		ActionPaths: []risk.ActionPath{{
+			PathID:                "apc-governed",
+			AgentID:               "wrkr:codex-app:acme",
+			Org:                   "acme",
+			Repo:                  "app",
+			ToolType:              "codex",
+			Location:              "AGENTS.md",
+			ApprovalGap:           true,
+			ApprovalEvidenceState: risk.EvidenceStateUnknown,
+			RecommendedAction:     "approve",
+		}},
+		ControlBacklog: &controlbacklog.Backlog{
+			Items: []controlbacklog.Item{{
+				LinkedActionPathID: "apc-governed",
+				Queue:              controlbacklog.QueueAcceptedRisk,
+				FindingVisibility:  controlbacklog.FindingVisibilityAppendix,
+				Remediation:        "Monitor the accepted-risk exception until it expires.",
+				GovernanceDisposition: &controlbacklog.GovernanceDisposition{
+					Kind:               controlbacklog.GovernanceKindAcceptedRisk,
+					Status:             controlbacklog.GovernanceStatusActive,
+					Reason:             "time_bounded_exception",
+					Scope:              "control_path",
+					ExpiresAt:          "2026-05-28T12:00:00Z",
+					EvidenceState:      risk.EvidenceStateUnknown,
+					VisibilityBehavior: controlbacklog.QueueAcceptedRisk,
+					RescanBehavior:     "repromote_on_expiry",
+				},
+				LifecycleQueue: &governancequeue.Item{
+					QueueID:           "lq-governed",
+					GapID:             "gap-governed",
+					AgentID:           "wrkr:codex-app:acme",
+					ReasonCode:        lifecycle.GapApprovalExpired,
+					Severity:          "high",
+					CredentialStatus:  governancequeue.CredentialStatusPresent,
+					RecommendedAction: "approve",
+					SLA:               "7d",
+					ClosureCriteria:   "Attach fresh approval evidence with owner, expiry, and review scope.",
+				},
+			}},
+		},
+	}
+
+	bom := BuildAgentActionBOM(summary)
+	if bom == nil || len(bom.Items) != 1 {
+		t.Fatalf("expected one BOM item, got %+v", bom)
+	}
+	item := bom.Items[0]
+	if item.GovernanceDisposition == nil || item.GovernanceDisposition.Kind != controlbacklog.GovernanceKindAcceptedRisk {
+		t.Fatalf("expected accepted-risk governance disposition on BOM item, got %+v", item)
+	}
+	if item.LifecycleQueue == nil || item.LifecycleQueue.ReasonCode != lifecycle.GapApprovalExpired {
+		t.Fatalf("expected lifecycle queue metadata on BOM item, got %+v", item)
+	}
+	if bom.Summary.AcceptedRiskItems != 1 || bom.Summary.LifecycleQueueItems != 1 {
+		t.Fatalf("expected BOM summary counts for accepted risk and lifecycle queue, got %+v", bom.Summary)
 	}
 }
 

--- a/core/report/types.go
+++ b/core/report/types.go
@@ -8,6 +8,7 @@ import (
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/aggregate/scanquality"
 	"github.com/Clyra-AI/wrkr/core/compliance"
+	"github.com/Clyra-AI/wrkr/core/governancequeue"
 	"github.com/Clyra-AI/wrkr/core/ingest"
 	"github.com/Clyra-AI/wrkr/core/lifecycle"
 	"github.com/Clyra-AI/wrkr/core/manifest"
@@ -245,13 +246,14 @@ type DeltaMetric struct {
 }
 
 type LifecycleSummary struct {
-	IdentityCount      int                   `json:"identity_count"`
-	UnderReviewCount   int                   `json:"under_review_count"`
-	RevokedCount       int                   `json:"revoked_count"`
-	DeprecatedCount    int                   `json:"deprecated_count"`
-	PendingActionCount int                   `json:"pending_action_count"`
-	Gaps               []lifecycle.Gap       `json:"gaps,omitempty"`
-	RecentTransitions  []LifecycleTransition `json:"recent_transitions"`
+	IdentityCount      int                    `json:"identity_count"`
+	UnderReviewCount   int                    `json:"under_review_count"`
+	RevokedCount       int                    `json:"revoked_count"`
+	DeprecatedCount    int                    `json:"deprecated_count"`
+	PendingActionCount int                    `json:"pending_action_count"`
+	Gaps               []lifecycle.Gap        `json:"gaps,omitempty"`
+	Queue              []governancequeue.Item `json:"queue,omitempty"`
+	RecentTransitions  []LifecycleTransition  `json:"recent_transitions"`
 }
 
 type LifecycleTransition struct {

--- a/scenarios/wrkr/agent-action-bom-demo/expected/after-evidence-report.json
+++ b/scenarios/wrkr/agent-action-bom-demo/expected/after-evidence-report.json
@@ -136,6 +136,7 @@
     "likely_action_path_items": 3,
     "semantic_review_candidate_items": 1,
     "context_only_items": 1,
+    "lifecycle_queue_items": 6,
     "empty_state_status": "not_eligible",
     "empty_state_reasons": [
       "approval_evidence_unknown_paths_present",

--- a/scenarios/wrkr/agent-action-bom-demo/expected/after-report.json
+++ b/scenarios/wrkr/agent-action-bom-demo/expected/after-report.json
@@ -20,6 +20,7 @@
     "likely_action_path_items": 3,
     "semantic_review_candidate_items": 1,
     "context_only_items": 1,
+    "lifecycle_queue_items": 6,
     "empty_state_status": "not_eligible",
     "empty_state_reasons": [
       "approval_evidence_unknown_paths_present",

--- a/scenarios/wrkr/agent-action-bom-demo/expected/before-report.json
+++ b/scenarios/wrkr/agent-action-bom-demo/expected/before-report.json
@@ -17,6 +17,7 @@
     "likely_action_path_items": 2,
     "semantic_review_candidate_items": 1,
     "context_only_items": 1,
+    "lifecycle_queue_items": 5,
     "empty_state_status": "not_eligible",
     "empty_state_reasons": [
       "approval_evidence_unknown_paths_present",

--- a/schemas/v1/agent-action-bom.schema.json
+++ b/schemas/v1/agent-action-bom.schema.json
@@ -41,6 +41,8 @@
         "standing_privilege_items": {"type": "integer"},
         "static_credential_items": {"type": "integer"},
         "production_target_items": {"type": "integer"},
+        "accepted_risk_items": {"type": "integer"},
+        "lifecycle_queue_items": {"type": "integer"},
         "approval_evidence_unknown_items": {"type": "integer"},
         "control_evidence_unknown_items": {"type": "integer"},
         "owner_evidence_unknown_items": {"type": "integer"},
@@ -90,6 +92,8 @@
         "ownership_state": {"type": "string"},
         "evidence_decisions": {"type": "array", "items": {"$ref": "#/$defs/evidenceDecision"}},
         "contradictions": {"type": "array", "items": {"$ref": "#/$defs/contradiction"}},
+        "governance_disposition": {"$ref": "#/$defs/governanceDisposition"},
+        "lifecycle_queue": {"$ref": "#/$defs/lifecycleQueue"},
         "control_resolution_state": {"type": "string", "enum": ["detected_control", "declared_control", "external_control_reference", "no_visible_control", "not_applicable", "contradictory_control"]},
         "control_resolution_reasons": {"type": "array", "items": {"type": "string"}},
         "control_evidence_refs": {"type": "array", "items": {"type": "string"}},
@@ -155,7 +159,7 @@
         "control_priority": {"type": "string"},
         "risk_tier": {"type": "string", "enum": ["critical", "high", "medium", "low"]},
         "recommended_next_action": {"type": "string"},
-        "queue": {"type": "string", "enum": ["control_first", "review_queue", "inventory_hygiene", "debug_only"]},
+        "queue": {"type": "string", "enum": ["control_first", "review_queue", "accepted_risk_queue", "inventory_hygiene", "debug_only"]},
         "finding_visibility": {"type": "string", "enum": ["primary", "appendix", "debug"]},
         "remediation": {"type": "string"},
         "attack_path_refs": {"type": "array", "items": {"type": "string"}},
@@ -245,6 +249,46 @@
         "evidence_refs": {"type": "array", "items": {"type": "string"}},
         "impacted_target_class": {"type": "string"},
         "recommended_action": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "governanceDisposition": {
+      "type": "object",
+      "required": ["kind", "status", "reason", "scope"],
+      "properties": {
+        "kind": {"type": "string", "enum": ["accepted_risk", "suppression"]},
+        "status": {"type": "string", "enum": ["active", "expired", "invalid"]},
+        "reason": {"type": "string"},
+        "scope": {"type": "string"},
+        "issuer": {"type": "string"},
+        "expires_at": {"type": "string"},
+        "evidence_state": {"type": "string", "enum": ["verified", "declared", "inferred", "unknown", "contradictory"]},
+        "visibility_behavior": {"type": "string"},
+        "rescan_behavior": {"type": "string"},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "lifecycleQueue": {
+      "type": "object",
+      "required": ["queue_id", "gap_id", "reason_code", "severity", "recommended_action", "sla", "closure_criteria"],
+      "properties": {
+        "queue_id": {"type": "string"},
+        "gap_id": {"type": "string"},
+        "agent_id": {"type": "string"},
+        "repo": {"type": "string"},
+        "path": {"type": "string"},
+        "reason_code": {"type": "string"},
+        "severity": {"type": "string"},
+        "owner": {"type": "string"},
+        "owner_evidence_state": {"type": "string", "enum": ["verified", "inferred", "unknown"]},
+        "credential_status": {"type": "string", "enum": ["credential_access_present", "no_credential_access"]},
+        "lifecycle_status": {"type": "string"},
+        "recommended_action": {"type": "string"},
+        "sla": {"type": "string"},
+        "closure_criteria": {"type": "string"},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "source_conflicts": {"type": "array", "items": {"type": "string"}}
       },
       "additionalProperties": false
     },

--- a/schemas/v1/report/report-summary.schema.json
+++ b/schemas/v1/report/report-summary.schema.json
@@ -872,6 +872,7 @@
         "deprecated_count": {"type": "integer"},
         "pending_action_count": {"type": "integer"},
         "gaps": {"type": "array", "items": {"$ref": "#/$defs/lifecycleGap"}},
+        "queue": {"type": "array", "items": {"$ref": "#/$defs/lifecycleQueue"}},
         "recent_transitions": {
           "type": "array",
           "items": {"$ref": "#/$defs/lifecycleTransition"}
@@ -912,6 +913,29 @@
         "trigger": {"type": "string"},
         "timestamp": {"type": "string"}
       }
+    },
+    "lifecycleQueue": {
+      "type": "object",
+      "required": ["queue_id", "gap_id", "reason_code", "severity", "recommended_action", "sla", "closure_criteria"],
+      "properties": {
+        "queue_id": {"type": "string"},
+        "gap_id": {"type": "string"},
+        "agent_id": {"type": "string"},
+        "repo": {"type": "string"},
+        "path": {"type": "string"},
+        "reason_code": {"type": "string"},
+        "severity": {"type": "string"},
+        "owner": {"type": "string"},
+        "owner_evidence_state": {"type": "string", "enum": ["verified", "inferred", "unknown"]},
+        "credential_status": {"type": "string", "enum": ["credential_access_present", "no_credential_access"]},
+        "lifecycle_status": {"type": "string"},
+        "recommended_action": {"type": "string"},
+        "sla": {"type": "string"},
+        "closure_criteria": {"type": "string"},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "source_conflicts": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
     },
     "regress": {
       "type": "object",


### PR DESCRIPTION
## Problem
- Wave 3 of `product/plans/adhoc/PLAN_ADHOC_2026-05-25_173030_evidence-ingest-closure-control-context.md` requires governance-grade accepted-risk/suppression handling and a normalized lifecycle/ownership control queue.
- Before this change, excluded items disappeared from the backlog, accepted-risk records were not projected as durable governance state, and lifecycle queue semantics were not carried consistently through inventory, backlog, report, and Agent Action BOM surfaces.

## Changes
- add governance disposition projection for accepted-risk and suppression records, including expiry-driven re-promotion and appendix visibility retention
- require governance fields for accepted-risk/suppression mutations and preserve them through lifecycle/state refresh flows
- add a normalized lifecycle queue model and project it through backlog, inventory, report summary, markdown, and Agent Action BOM outputs
- extend v1 report/BOM schemas and scenario fixtures for the new additive queue and governance fields

## Validation
- `go test ./core/aggregate/controlbacklog ./core/aggregate/inventory ./core/cli ./core/evidence ./core/owners ./core/report ./core/risk -count=1`
- `make test-contracts`
- `make test-hardening`
- `make test-scenarios`
- `make prepush-full`
- `make codeql`
- `git diff --check`

## Risks
- report/backlog projections now merge stored backlog rows with regenerated governance overlays, so any downstream consumer that depended on suppressed items disappearing will now see appendix-visible records instead
- lifecycle queue counts are additive public fields and may require downstream consumers to tolerate new summary keys
