### PR TITLE
feat: add closure guidance and evidence completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - [semver:minor] Added contradiction detection for customer declarations, production targets, credentials, workflows, deployment constraints, and policy evidence.
 - [semver:minor] Added accepted-risk and suppression governance with expiry, ownership, scope, evidence state, rescan behavior, and appendix visibility.
 - [semver:minor] Added lifecycle and ownership control queues for ownerless, inferred-owner, stale-lifecycle, and credential-bearing governance gaps.
+- [semver:minor] Added path-specific closure evidence guidance across control backlog, Agent Action BOM, markdown reports, and exports.
+- [semver:minor] Added per-path evidence completeness scoring for discovery, authority, blast radius, control, runtime evidence, and proof sufficiency.
 
 ### Changed
 

--- a/core/aggregate/controlbacklog/controlbacklog.go
+++ b/core/aggregate/controlbacklog/controlbacklog.go
@@ -158,6 +158,8 @@ type Item struct {
 	ConfidenceRaise            []string                                `json:"confidence_raise,omitempty"`
 	SLA                        string                                  `json:"sla"`
 	ClosureCriteria            string                                  `json:"closure_criteria"`
+	ClosureRequirements        []risk.ClosureRequirement               `json:"closure_requirements,omitempty"`
+	EvidenceCompleteness       *risk.EvidenceCompleteness              `json:"evidence_completeness,omitempty"`
 	GovernanceDisposition      *GovernanceDisposition                  `json:"governance_disposition,omitempty"`
 	LifecycleQueue             *governancequeue.Item                   `json:"lifecycle_queue,omitempty"`
 	SecretSignalTypes          []string                                `json:"secret_signal_types,omitempty"`
@@ -422,6 +424,8 @@ func (b *builder) addActionPath(path risk.ActionPath) {
 		PolicyEvidenceRefs:         append([]string(nil), path.PolicyEvidenceRefs...),
 		PolicyConfidence:           strings.TrimSpace(path.PolicyConfidence),
 		TrustDepth:                 agginventory.CloneTrustDepth(path.TrustDepth),
+		ClosureRequirements:        risk.CloneClosureRequirements(path.ClosureRequirements),
+		EvidenceCompleteness:       risk.CloneEvidenceCompleteness(path.EvidenceCompleteness),
 	}
 	item.LinkedFindingIDs = b.linkedFindingIDs(path.Org, path.Repo, path.Location)
 	item.SecretSignalTypes = secretSignalTypesForActionPath(path)
@@ -441,7 +445,7 @@ func (b *builder) addActionPath(path risk.ActionPath) {
 	item.Capability = capabilitySummary(item.Capabilities)
 	item.Confidence, item.EvidenceGaps, item.ConfidenceRaise = qualityForItem(item)
 	item.SLA = slaForAction(item.RecommendedAction)
-	item.ClosureCriteria = closureCriteriaForAction(item.RecommendedAction)
+	item.ClosureCriteria = risk.ClosureCriteriaText(item.ClosureRequirements, closureCriteriaForAction(item.RecommendedAction))
 	item.SecurityTestRecipes = buildSecurityTestRecipes(item)
 	b.merge(item)
 }
@@ -589,7 +593,14 @@ func (b *builder) merge(item Item) {
 	if strings.TrimSpace(current.Remediation) == "" {
 		current.Remediation = item.Remediation
 	}
+	if len(current.ClosureRequirements) == 0 {
+		current.ClosureRequirements = risk.CloneClosureRequirements(item.ClosureRequirements)
+	}
+	if current.EvidenceCompleteness == nil {
+		current.EvidenceCompleteness = risk.CloneEvidenceCompleteness(item.EvidenceCompleteness)
+	}
 	current.GovernanceControls = mergeGovernanceControls(current.GovernanceControls, item.GovernanceControls)
+	current.ClosureCriteria = risk.ClosureCriteriaText(current.ClosureRequirements, current.ClosureCriteria)
 	b.itemsByKey[key] = normalizeItem(current)
 }
 
@@ -1546,7 +1557,9 @@ func normalizeItem(item Item) Item {
 	}
 	item.Remediation = fallback(item.Remediation, remediationForBacklogAction(item.RecommendedAction))
 	item.SLA = fallback(item.SLA, slaForAction(item.RecommendedAction))
-	item.ClosureCriteria = fallback(item.ClosureCriteria, closureCriteriaForAction(item.RecommendedAction))
+	item.ClosureRequirements = risk.CloneClosureRequirements(item.ClosureRequirements)
+	item.EvidenceCompleteness = risk.CloneEvidenceCompleteness(item.EvidenceCompleteness)
+	item.ClosureCriteria = risk.ClosureCriteriaText(item.ClosureRequirements, fallback(item.ClosureCriteria, closureCriteriaForAction(item.RecommendedAction)))
 	item.EvidenceGaps = mergeStrings(item.EvidenceGaps, nil)
 	item.ConfidenceRaise = mergeStrings(item.ConfidenceRaise, nil)
 	item.ConfidenceLane = firstNonEmptyConfidenceLane(item.ConfidenceLane, "")

--- a/core/aggregate/controlbacklog/controlbacklog_test.go
+++ b/core/aggregate/controlbacklog/controlbacklog_test.go
@@ -429,6 +429,43 @@ func TestBacklogClosureDoesNotSayOwnerMissing(t *testing.T) {
 	}
 }
 
+func TestBacklogCarriesClosureRequirementsAndCompleteness(t *testing.T) {
+	t.Parallel()
+
+	paths := risk.DecorateEvidenceContext([]risk.ActionPath{{
+		PathID:                 "apc-closure-completeness",
+		Org:                    "acme",
+		Repo:                   "app",
+		ToolType:               "compiled_action",
+		Location:               ".github/workflows/release.yml",
+		WriteCapable:           true,
+		DeployWrite:            true,
+		ApprovalGap:            true,
+		ApprovalGapReasons:     []string{"approval_source_missing"},
+		OwnerEvidenceState:     risk.EvidenceStateUnknown,
+		ControlResolutionState: risk.ControlResolutionStateNoVisibleControl,
+		PolicyCoverageStatus:   risk.PolicyCoverageStatusNone,
+		ControlPriority:        risk.ControlPriorityControlFirst,
+		ConfidenceLane:         risk.ConfidenceLaneConfirmedActionPath,
+		ActionPathType:         risk.ActionPathTypeCICDWorkflow,
+	}}, nil)
+
+	backlog := Build(Input{ActionPaths: paths})
+	if len(backlog.Items) != 1 {
+		t.Fatalf("expected one backlog item, got %+v", backlog.Items)
+	}
+	item := backlog.Items[0]
+	if len(item.ClosureRequirements) == 0 {
+		t.Fatalf("expected closure requirements on backlog item, got %+v", item)
+	}
+	if item.EvidenceCompleteness == nil {
+		t.Fatalf("expected completeness on backlog item, got %+v", item)
+	}
+	if strings.TrimSpace(item.ClosureCriteria) != strings.TrimSpace(item.ClosureRequirements[0].Guidance) {
+		t.Fatalf("expected closure criteria to use first requirement guidance, got closure=%q requirements=%+v", item.ClosureCriteria, item.ClosureRequirements)
+	}
+}
+
 func TestCriticalReviewBurdenRoutesToControlFirstQueue(t *testing.T) {
 	t.Parallel()
 

--- a/core/aggregate/scanquality/scanquality.go
+++ b/core/aggregate/scanquality/scanquality.go
@@ -46,6 +46,13 @@ type CompactCoverageSummary struct {
 	ImpactStatement              string `json:"impact_statement,omitempty"`
 }
 
+type CompletenessSignals struct {
+	ReducedCoverage     bool     `json:"reduced_coverage,omitempty"`
+	ReducedDetectors    []string `json:"reduced_detectors,omitempty"`
+	UnsupportedSurfaces []string `json:"unsupported_surfaces,omitempty"`
+	Reasons             []string `json:"reasons,omitempty"`
+}
+
 type AbsenceClaim struct {
 	Org     string   `json:"org,omitempty"`
 	Repo    string   `json:"repo,omitempty"`
@@ -179,6 +186,69 @@ func CoverageConfidence(report *Report) string {
 	return BuildCompactCoverageSummary(report).CoverageConfidence
 }
 
+func CompletenessSignalsForRepo(report *Report, org string, repo string) CompletenessSignals {
+	signals := CompletenessSignals{}
+	if report == nil {
+		return signals
+	}
+	org = strings.TrimSpace(org)
+	repo = strings.TrimSpace(repo)
+	reducedDetectors := map[string]struct{}{}
+	unsupportedSurfaces := map[string]struct{}{}
+	reasons := map[string]struct{}{}
+	for _, detector := range report.Detectors {
+		if org != "" && strings.TrimSpace(detector.Org) != "" && strings.TrimSpace(detector.Org) != org {
+			continue
+		}
+		if repo != "" && strings.TrimSpace(detector.Repo) != "" && strings.TrimSpace(detector.Repo) != repo {
+			continue
+		}
+		switch strings.TrimSpace(detector.Status) {
+		case "partial", "reduced", "blocked":
+			signals.ReducedCoverage = true
+			if name := strings.TrimSpace(detector.Detector); name != "" {
+				reducedDetectors[name] = struct{}{}
+				reasons["detector:"+name+":"+strings.TrimSpace(detector.Status)] = struct{}{}
+			}
+			for _, reason := range detector.CoverageReasons {
+				if trimmed := strings.TrimSpace(reason); trimmed != "" {
+					reasons["coverage_reason:"+trimmed] = struct{}{}
+				}
+			}
+		}
+	}
+	for _, issue := range report.ParseErrors {
+		if org != "" && strings.TrimSpace(issue.Org) != "" && strings.TrimSpace(issue.Org) != org {
+			continue
+		}
+		if repo != "" && strings.TrimSpace(issue.Repo) != "" && strings.TrimSpace(issue.Repo) != repo {
+			continue
+		}
+		signals.ReducedCoverage = true
+		reasons["parse_issue:"+strings.TrimSpace(issue.Kind)] = struct{}{}
+	}
+	for _, claim := range report.AbsenceClaims {
+		if org != "" && strings.TrimSpace(claim.Org) != "" && strings.TrimSpace(claim.Org) != org {
+			continue
+		}
+		if repo != "" && strings.TrimSpace(claim.Repo) != "" && strings.TrimSpace(claim.Repo) != repo {
+			continue
+		}
+		switch strings.TrimSpace(claim.Status) {
+		case AbsenceStatusUnsupportedSurface, AbsenceStatusCandidateParseFailed, AbsenceStatusNotScanned:
+			signals.ReducedCoverage = true
+			if surface := strings.TrimSpace(claim.Surface); surface != "" {
+				unsupportedSurfaces[surface] = struct{}{}
+				reasons["absence_claim:"+surface+":"+strings.TrimSpace(claim.Status)] = struct{}{}
+			}
+		}
+	}
+	signals.ReducedDetectors = mapKeysSorted(reducedDetectors)
+	signals.UnsupportedSurfaces = mapKeysSorted(unsupportedSurfaces)
+	signals.Reasons = mapKeysSorted(reasons)
+	return signals
+}
+
 func cloneCompactCoverageSummary(in *CompactCoverageSummary) CompactCoverageSummary {
 	if in == nil {
 		return CompactCoverageSummary{
@@ -202,6 +272,20 @@ func compactCoverageImpactStatement(report *Report, coverageConfidence string, b
 	default:
 		return "Coverage for scanned inputs was complete enough to support scoped negative claims."
 	}
+}
+
+func mapKeysSorted(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for value := range values {
+		if strings.TrimSpace(value) != "" {
+			out = append(out, strings.TrimSpace(value))
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 func AbsenceClaimForSurface(report *Report, org string, repo string, surface string) *AbsenceClaim {

--- a/core/aggregate/scanquality/scanquality_test.go
+++ b/core/aggregate/scanquality/scanquality_test.go
@@ -139,6 +139,41 @@ func TestCoverageSummaryCountsReducedSignals(t *testing.T) {
 	}
 }
 
+func TestCompletenessSignalsForRepoCollectsReducedCoverageAndUnsupportedSurfaces(t *testing.T) {
+	t.Parallel()
+
+	signals := CompletenessSignalsForRepo(&Report{
+		Detectors: []DetectorHealth{{
+			Org:             "acme",
+			Repo:            "payments",
+			Detector:        "mcp",
+			Status:          "reduced",
+			CoverageReasons: []string{"generated_suppression"},
+		}},
+		ParseErrors: []ParseIssue{{
+			Org:  "acme",
+			Repo: "payments",
+			Kind: "parse_error",
+		}},
+		AbsenceClaims: []AbsenceClaim{{
+			Org:     "acme",
+			Repo:    "payments",
+			Surface: SurfaceMCPServer,
+			Status:  AbsenceStatusUnsupportedSurface,
+		}},
+	}, "acme", "payments")
+
+	if !signals.ReducedCoverage {
+		t.Fatalf("expected reduced coverage signals, got %+v", signals)
+	}
+	if len(signals.ReducedDetectors) != 1 || signals.ReducedDetectors[0] != "mcp" {
+		t.Fatalf("expected reduced detector signal, got %+v", signals)
+	}
+	if len(signals.UnsupportedSurfaces) != 1 || signals.UnsupportedSurfaces[0] != SurfaceMCPServer {
+		t.Fatalf("expected unsupported surface signal, got %+v", signals)
+	}
+}
+
 func TestScanQualitySkipsGeneratedDependencyDirectoriesInGovernanceMode(t *testing.T) {
 	t.Parallel()
 

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -537,6 +537,8 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		Findings:       findings,
 		DetectorErrors: detectorErrors,
 	})
+	riskReport.ActionPaths = risk.DecorateEvidenceContext(riskReport.ActionPaths, &scanQuality)
+	riskReport.ActionPathToControlFirst = risk.BuildActionPathChoice(riskReport.ActionPaths)
 	lifecycleGaps := lifecycle.DetectGaps(lifecycle.GapInput{
 		Identities:  nextManifest.Identities,
 		Inventory:   &inventoryOut,

--- a/core/evidence/evidence.go
+++ b/core/evidence/evidence.go
@@ -459,9 +459,10 @@ func defaultCoverageNote() CoverageNote {
 	return CoverageNote{
 		Basis:            "evidenced_controls_only",
 		LowCoverageMeans: "evidence_gap",
-		Message:          "framework_coverage reflects only controls evidenced in the current scanned state; low or zero first-run coverage indicates evidence gaps rather than unsupported framework parsing.",
+		Message:          "framework_coverage reflects only controls evidenced in the current scanned state; low or zero first-run coverage indicates evidence gaps rather than unsupported framework parsing or low-risk posture.",
 		RecommendedActions: []string{
 			"Run wrkr report --top 5 --json to prioritize missing controls and approvals.",
+			"Review Agent Action BOM evidence completeness before treating low-evidence paths as safe.",
 			"Remediate the highest-priority gaps and rerun wrkr scan, wrkr evidence, and wrkr report with the same deterministic inputs.",
 		},
 	}

--- a/core/report/agent_action_bom.go
+++ b/core/report/agent_action_bom.go
@@ -65,6 +65,7 @@ type AgentActionBOMSummary struct {
 	SourcePrivacy                *sourceprivacy.Contract             `json:"source_privacy,omitempty"`
 	OperationalExposure          *scorecore.AxisSummary              `json:"operational_exposure,omitempty"`
 	GovernanceReadiness          *scorecore.AxisSummary              `json:"governance_readiness,omitempty"`
+	EvidenceCompleteness         *risk.EvidenceCompletenessSummary   `json:"evidence_completeness,omitempty"`
 	ScanCoverage                 *scanquality.CompactCoverageSummary `json:"scan_coverage,omitempty"`
 	CoverageConfidence           string                              `json:"coverage_confidence,omitempty"`
 }
@@ -153,6 +154,8 @@ type AgentActionBOMItem struct {
 	Queue                        string                                 `json:"queue,omitempty"`
 	FindingVisibility            string                                 `json:"finding_visibility,omitempty"`
 	Remediation                  string                                 `json:"remediation,omitempty"`
+	ClosureRequirements          []risk.ClosureRequirement              `json:"closure_requirements,omitempty"`
+	EvidenceCompleteness         *risk.EvidenceCompleteness             `json:"evidence_completeness,omitempty"`
 	GovernanceDisposition        *controlbacklog.GovernanceDisposition  `json:"governance_disposition,omitempty"`
 	LifecycleQueue               *governancequeue.Item                  `json:"lifecycle_queue,omitempty"`
 	AttackPathRefs               []string                               `json:"attack_path_refs,omitempty"`
@@ -316,6 +319,8 @@ func buildAgentActionBOM(summary Summary, findings []model.Finding) *AgentAction
 			Queue:                        firstNonEmptyValue(strings.TrimSpace(backlogItem.Queue), queueForActionPath(path)),
 			FindingVisibility:            firstNonEmptyValue(strings.TrimSpace(backlogItem.FindingVisibility), visibilityForQueue(firstNonEmptyValue(strings.TrimSpace(backlogItem.Queue), queueForActionPath(path)))),
 			Remediation:                  firstNonEmptyValue(strings.TrimSpace(backlogItem.Remediation), risk.RemediationForActionPath(path)),
+			ClosureRequirements:          firstNonEmptyClosureRequirementsForBOM(path.ClosureRequirements, backlogItem.ClosureRequirements),
+			EvidenceCompleteness:         firstNonNilEvidenceCompletenessForBOM(path.EvidenceCompleteness, backlogItem.EvidenceCompleteness),
 			GovernanceDisposition:        cloneGovernanceDisposition(backlogItem.GovernanceDisposition),
 			LifecycleQueue:               cloneLifecycleQueue(backlogItem.LifecycleQueue),
 			AttackPathRefs:               append([]string(nil), path.AttackPathRefs...),
@@ -364,6 +369,7 @@ func buildAgentActionBOM(summary Summary, findings []model.Finding) *AgentAction
 	counts.SourcePrivacy = normalizedSourcePrivacy(summary.SourcePrivacy)
 	counts.OperationalExposure = cloneAxisSummary(summary.OperationalExposure)
 	counts.GovernanceReadiness = cloneAxisSummary(summary.GovernanceReadiness)
+	counts.EvidenceCompleteness = risk.CloneEvidenceCompletenessSummary(summary.EvidenceCompleteness)
 	scanCoverage := scanquality.BuildCompactCoverageSummary(summary.ScanQuality)
 	counts.ScanCoverage = &scanCoverage
 	counts.CoverageConfidence = scanCoverage.CoverageConfidence
@@ -426,6 +432,15 @@ func backlogItemsByPath(backlog *controlbacklog.Backlog) map[string]controlbackl
 		}
 		if strings.TrimSpace(current.FindingVisibility) == "" {
 			current.FindingVisibility = item.FindingVisibility
+		}
+		if len(current.ClosureRequirements) == 0 {
+			current.ClosureRequirements = risk.CloneClosureRequirements(item.ClosureRequirements)
+		}
+		if current.EvidenceCompleteness == nil {
+			current.EvidenceCompleteness = risk.CloneEvidenceCompleteness(item.EvidenceCompleteness)
+		}
+		if strings.TrimSpace(current.ClosureCriteria) == "" {
+			current.ClosureCriteria = item.ClosureCriteria
 		}
 		out[key] = current
 	}
@@ -745,6 +760,20 @@ func cloneAxisSummary(in *scorecore.AxisSummary) *scorecore.AxisSummary {
 	out := *in
 	out.Rationale = append([]string(nil), in.Rationale...)
 	return &out
+}
+
+func firstNonEmptyClosureRequirementsForBOM(pathRequirements []risk.ClosureRequirement, backlogRequirements []risk.ClosureRequirement) []risk.ClosureRequirement {
+	if len(pathRequirements) > 0 {
+		return risk.CloneClosureRequirements(pathRequirements)
+	}
+	return risk.CloneClosureRequirements(backlogRequirements)
+}
+
+func firstNonNilEvidenceCompletenessForBOM(pathCompleteness *risk.EvidenceCompleteness, backlogCompleteness *risk.EvidenceCompleteness) *risk.EvidenceCompleteness {
+	if pathCompleteness != nil {
+		return risk.CloneEvidenceCompleteness(pathCompleteness)
+	}
+	return risk.CloneEvidenceCompleteness(backlogCompleteness)
 }
 
 func decorateLineageForBOM(in *risk.ActionLineage, item AgentActionBOMItem) *risk.ActionLineage {

--- a/core/report/build.go
+++ b/core/report/build.go
@@ -108,6 +108,7 @@ func BuildSummary(in BuildInput) (Summary, error) {
 	sourcePrivacy := normalizedSourcePrivacy(in.Snapshot.SourcePrivacy)
 	runtimeEvidence := buildRuntimeEvidenceSummary(in.StatePath, in.Snapshot)
 	riskReport.ActionPaths = decorateActionPathsForReport(riskReport.ActionPaths, runtimeEvidence)
+	riskReport.ActionPaths = risk.DecorateEvidenceContext(riskReport.ActionPaths, scanQuality)
 	riskReport.ActionPathToControlFirst = decorateControlFirstForReport(riskReport.ActionPaths, scanQualityCoverageReduced(scanQuality))
 	activation := BuildActivation(in.Snapshot.Target.Mode, riskReport.Ranked, in.Snapshot.Inventory, riskReport.ActionPaths, top)
 	exposureGroups := risk.BuildExposureGroups(riskReport.ActionPaths)
@@ -139,6 +140,7 @@ func BuildSummary(in BuildInput) (Summary, error) {
 	shareProfileMetadata := BuildShareProfileMetadata(redactionConfig)
 	operationalExposure := scorecore.SummarizeOperationalExposure(riskReport.ActionPaths)
 	governanceReadiness := scorecore.SummarizeGovernanceReadiness(riskReport.ActionPaths, missingProofPathCount(controlProofStatus), scanQualityCoverageReduced(scanQuality))
+	evidenceCompleteness := risk.BuildEvidenceCompletenessSummary(riskReport.ActionPaths)
 
 	if shareProfileRequiresRedaction(shareProfile) {
 		proofRef = sanitizeProofReferencePublic(proofRef)
@@ -206,6 +208,7 @@ func BuildSummary(in BuildInput) (Summary, error) {
 		ScanScope:                scanScope,
 		OperationalExposure:      &operationalExposure,
 		GovernanceReadiness:      &governanceReadiness,
+		EvidenceCompleteness:     evidenceCompleteness,
 		AssessmentSummary:        assessmentSummary,
 		Methodology:              methodology,
 		TopRisks:                 riskItems,
@@ -1331,6 +1334,9 @@ func decorateControlBacklogFromActionPaths(backlog *controlbacklog.Backlog, path
 		copyBacklog.Items[idx].PolicyMissingReasons = uniqueStrings(append(append([]string(nil), item.PolicyMissingReasons...), path.PolicyMissingReasons...))
 		copyBacklog.Items[idx].PolicyEvidenceRefs = uniqueStrings(append(append([]string(nil), item.PolicyEvidenceRefs...), path.PolicyEvidenceRefs...))
 		copyBacklog.Items[idx].PolicyConfidence = firstNonEmptyValue(strings.TrimSpace(path.PolicyConfidence), strings.TrimSpace(item.PolicyConfidence))
+		copyBacklog.Items[idx].ClosureRequirements = risk.CloneClosureRequirements(path.ClosureRequirements)
+		copyBacklog.Items[idx].EvidenceCompleteness = risk.CloneEvidenceCompleteness(path.EvidenceCompleteness)
+		copyBacklog.Items[idx].ClosureCriteria = risk.ClosureCriteriaText(copyBacklog.Items[idx].ClosureRequirements, strings.TrimSpace(item.ClosureCriteria))
 		copyBacklog.Items[idx].Queue = queueForActionPath(path)
 		copyBacklog.Items[idx].FindingVisibility = visibilityForQueue(copyBacklog.Items[idx].Queue)
 		copyBacklog.Items[idx].Remediation = risk.RemediationForActionPath(path)
@@ -1624,6 +1630,8 @@ func sanitizeActionPathsPublic(in []risk.ActionPath) []risk.ActionPath {
 		}
 		copyItem.MutableEndpointSemantics = sanitizeMutableEndpointSemanticsPublic(copyItem.MutableEndpointSemantics)
 		copyItem.Credentials = redactCredentialsPublic(copyItem.Credentials)
+		copyItem.ClosureRequirements = sanitizeClosureRequirementsPublic(copyItem.ClosureRequirements)
+		copyItem.EvidenceCompleteness = risk.CloneEvidenceCompleteness(copyItem.EvidenceCompleteness)
 		copyItem.ActionLineage = sanitizeActionLineagePublic(copyItem.ActionLineage)
 		if copyItem.IntroducedBy != nil {
 			introduced := *copyItem.IntroducedBy
@@ -1820,6 +1828,8 @@ func sanitizeControlBacklogPublic(in *controlbacklog.Backlog) *controlbacklog.Ba
 		copyBacklog.Items[idx].LinkedControlPathEdgeIDs = redactStringSlice(copyBacklog.Items[idx].LinkedControlPathEdgeIDs, "edge")
 		copyBacklog.Items[idx].OwnershipEvidence = redactStringSlice(copyBacklog.Items[idx].OwnershipEvidence, "evidence")
 		copyBacklog.Items[idx].OwnershipConflicts = redactStringSlice(copyBacklog.Items[idx].OwnershipConflicts, "owner")
+		copyBacklog.Items[idx].ClosureRequirements = sanitizeClosureRequirementsPublic(copyBacklog.Items[idx].ClosureRequirements)
+		copyBacklog.Items[idx].EvidenceCompleteness = risk.CloneEvidenceCompleteness(copyBacklog.Items[idx].EvidenceCompleteness)
 		copyBacklog.Items[idx].GovernanceDisposition = sanitizeGovernanceDispositionPublic(copyBacklog.Items[idx].GovernanceDisposition)
 		copyBacklog.Items[idx].LifecycleQueue = sanitizeLifecycleQueuePublic(copyBacklog.Items[idx].LifecycleQueue)
 		if copyBacklog.Items[idx].CredentialProvenance != nil {
@@ -1843,6 +1853,7 @@ func sanitizeAgentActionBOM(in *AgentActionBOM, profile ShareProfile) *AgentActi
 	copyBOM := *in
 	copyBOM.ShareProfile = string(profile)
 	copyBOM.ShareProfileMetadata = cloneShareProfileMetadata(in.ShareProfileMetadata)
+	copyBOM.Summary.EvidenceCompleteness = risk.CloneEvidenceCompletenessSummary(in.Summary.EvidenceCompleteness)
 	copyBOM.ScanQuality = sanitizeScanQualityPublic(in.ScanQuality)
 	copyBOM.EvidenceRefs = redactStringSlice(in.EvidenceRefs, "evidence")
 	copyBOM.ProofRefs = redactStringSlice(in.ProofRefs, "proof")
@@ -1865,6 +1876,8 @@ func sanitizeAgentActionBOM(in *AgentActionBOM, profile ShareProfile) *AgentActi
 		copyBOM.Items[idx].RuntimeEvidenceRefs = redactStringSlice(copyBOM.Items[idx].RuntimeEvidenceRefs, "runtime")
 		copyBOM.Items[idx].PolicyRefs = redactStringSlice(copyBOM.Items[idx].PolicyRefs, "policy")
 		copyBOM.Items[idx].PolicyEvidenceRefs = redactStringSlice(copyBOM.Items[idx].PolicyEvidenceRefs, "policy")
+		copyBOM.Items[idx].ClosureRequirements = sanitizeClosureRequirementsPublic(copyBOM.Items[idx].ClosureRequirements)
+		copyBOM.Items[idx].EvidenceCompleteness = risk.CloneEvidenceCompleteness(copyBOM.Items[idx].EvidenceCompleteness)
 		copyBOM.Items[idx].GovernanceDisposition = sanitizeGovernanceDispositionPublic(copyBOM.Items[idx].GovernanceDisposition)
 		copyBOM.Items[idx].LifecycleQueue = sanitizeLifecycleQueuePublic(copyBOM.Items[idx].LifecycleQueue)
 		copyBOM.Items[idx].AttackPathRefs = redactStringSlice(copyBOM.Items[idx].AttackPathRefs, "attack")
@@ -1952,6 +1965,17 @@ func sanitizeReachabilityPublic(in []AgentActionBOMReachability) []AgentActionBO
 			copyItem.Name = redactValue("reach", copyItem.Name, 8)
 		}
 		out = append(out, copyItem)
+	}
+	return out
+}
+
+func sanitizeClosureRequirementsPublic(in []risk.ClosureRequirement) []risk.ClosureRequirement {
+	if len(in) == 0 {
+		return nil
+	}
+	out := risk.CloneClosureRequirements(in)
+	for idx := range out {
+		out[idx].ClosureRefs = redactStringSlice(out[idx].ClosureRefs, "evidence")
 	}
 	return out
 }

--- a/core/report/redaction_summary.go
+++ b/core/report/redaction_summary.go
@@ -99,6 +99,8 @@ func sanitizeActionPathsWithConfig(in []risk.ActionPath, config RedactionConfig)
 		}
 		copyItem.MutableEndpointSemantics = sanitizeMutableEndpointSemanticsWithConfig(copyItem.MutableEndpointSemantics, config)
 		copyItem.Credentials = redactCredentialsWithConfig(copyItem.Credentials, config)
+		copyItem.ClosureRequirements = sanitizeClosureRequirementsWithConfig(copyItem.ClosureRequirements, config)
+		copyItem.EvidenceCompleteness = risk.CloneEvidenceCompleteness(copyItem.EvidenceCompleteness)
 		copyItem.ActionLineage = sanitizeActionLineageWithConfig(copyItem.ActionLineage, config)
 		if copyItem.IntroducedBy != nil {
 			introduced := *copyItem.IntroducedBy
@@ -288,6 +290,8 @@ func sanitizeControlBacklogWithConfig(in *controlbacklog.Backlog, config Redacti
 		copyBacklog.Items[idx].LinkedControlPathEdgeIDs = maybeRedactStringSlice(copyBacklog.Items[idx].LinkedControlPathEdgeIDs, "edge", config.Has(RedactionGraphRefs))
 		copyBacklog.Items[idx].OwnershipEvidence = cloneStrings(copyBacklog.Items[idx].OwnershipEvidence)
 		copyBacklog.Items[idx].OwnershipConflicts = maybeRedactStringSlice(copyBacklog.Items[idx].OwnershipConflicts, "owner", config.Has(RedactionOwners))
+		copyBacklog.Items[idx].ClosureRequirements = sanitizeClosureRequirementsWithConfig(copyBacklog.Items[idx].ClosureRequirements, config)
+		copyBacklog.Items[idx].EvidenceCompleteness = risk.CloneEvidenceCompleteness(copyBacklog.Items[idx].EvidenceCompleteness)
 		copyBacklog.Items[idx].GovernanceDisposition = sanitizeGovernanceDispositionWithConfig(copyBacklog.Items[idx].GovernanceDisposition, config)
 		copyBacklog.Items[idx].LifecycleQueue = sanitizeLifecycleQueueWithConfig(copyBacklog.Items[idx].LifecycleQueue, config)
 		if copyBacklog.Items[idx].CredentialProvenance != nil {
@@ -311,6 +315,7 @@ func sanitizeAgentActionBOMWithConfig(in *AgentActionBOM, profile ShareProfile, 
 	copyBOM := *in
 	copyBOM.ShareProfile = string(profile)
 	copyBOM.ShareProfileMetadata = cloneShareProfileMetadata(in.ShareProfileMetadata)
+	copyBOM.Summary.EvidenceCompleteness = risk.CloneEvidenceCompletenessSummary(in.Summary.EvidenceCompleteness)
 	copyBOM.ScanQuality = sanitizeScanQualityWithConfig(in.ScanQuality, config)
 	copyBOM.EvidenceRefs = maybeRedactStringSlice(in.EvidenceRefs, "evidence", config.Has(RedactionProofRefs))
 	copyBOM.ProofRefs = maybeRedactStringSlice(in.ProofRefs, "proof", config.Has(RedactionProofRefs))
@@ -327,6 +332,8 @@ func sanitizeAgentActionBOMWithConfig(in *AgentActionBOM, profile ShareProfile, 
 		copyBOM.Items[idx].RuntimeEvidenceRefs = cloneStrings(copyBOM.Items[idx].RuntimeEvidenceRefs)
 		copyBOM.Items[idx].PolicyRefs = cloneStrings(copyBOM.Items[idx].PolicyRefs)
 		copyBOM.Items[idx].PolicyEvidenceRefs = cloneStrings(copyBOM.Items[idx].PolicyEvidenceRefs)
+		copyBOM.Items[idx].ClosureRequirements = sanitizeClosureRequirementsWithConfig(copyBOM.Items[idx].ClosureRequirements, config)
+		copyBOM.Items[idx].EvidenceCompleteness = risk.CloneEvidenceCompleteness(copyBOM.Items[idx].EvidenceCompleteness)
 		copyBOM.Items[idx].GovernanceDisposition = sanitizeGovernanceDispositionWithConfig(copyBOM.Items[idx].GovernanceDisposition, config)
 		copyBOM.Items[idx].LifecycleQueue = sanitizeLifecycleQueueWithConfig(copyBOM.Items[idx].LifecycleQueue, config)
 		copyBOM.Items[idx].AttackPathRefs = maybeRedactStringSlice(copyBOM.Items[idx].AttackPathRefs, "attack", config.Has(RedactionGraphRefs))
@@ -403,6 +410,17 @@ func sanitizeReachabilityWithConfig(in []AgentActionBOMReachability, config Reda
 			}
 		}
 		out = append(out, copyItem)
+	}
+	return out
+}
+
+func sanitizeClosureRequirementsWithConfig(in []risk.ClosureRequirement, config RedactionConfig) []risk.ClosureRequirement {
+	if len(in) == 0 {
+		return nil
+	}
+	out := risk.CloneClosureRequirements(in)
+	for idx := range out {
+		out[idx].ClosureRefs = maybeRedactStringSlice(out[idx].ClosureRefs, "evidence", config.Has(RedactionProofRefs) || config.Has(RedactionGraphRefs) || config.Has(RedactionProviders))
 	}
 	return out
 }

--- a/core/report/render_markdown.go
+++ b/core/report/render_markdown.go
@@ -55,6 +55,14 @@ func RenderMarkdown(summary Summary) string {
 				summary.GovernanceReadiness.PathCount,
 			))
 		}
+		if summary.EvidenceCompleteness != nil {
+			builder.WriteString(fmt.Sprintf("- Evidence completeness: average=%d label=%s low_evidence_paths=%d reduced_coverage_paths=%d\n",
+				summary.EvidenceCompleteness.AverageTotalScore,
+				risk.BuyerEvidenceCompletenessSummaryLabel(summary.EvidenceCompleteness),
+				summary.EvidenceCompleteness.LowEvidencePathCount,
+				summary.EvidenceCompleteness.ReducedCoveragePathCount,
+			))
+		}
 		builder.WriteString(fmt.Sprintf("- Coverage confidence: %s\n", summary.AgentActionBOM.Summary.CoverageConfidence))
 		if summary.AgentActionBOM.Summary.ScanCoverage != nil {
 			builder.WriteString(fmt.Sprintf("- Scan coverage: reduced_detectors=%d parse_failures=%d suppressed_generated_files=%d blocked_detectors=%d unsupported_declarations=%d impact=%s\n",
@@ -103,7 +111,7 @@ func RenderMarkdown(summary Summary) string {
 			}
 			for idx := 0; idx < limit; idx++ {
 				item := summary.AgentActionBOM.Items[idx]
-				builder.WriteString(fmt.Sprintf("- %s repo=%s location=%s lane=%s type=%s state=%s zone=%s target=%s review=%s priority=%s tier=%s control=%s approval=%s owner=%s proof=%s runtime=%s confidence=%s evidence=%s queue=%s remediation=%s\n",
+				builder.WriteString(fmt.Sprintf("- %s repo=%s location=%s lane=%s type=%s state=%s zone=%s target=%s review=%s priority=%s tier=%s control=%s approval=%s owner=%s proof=%s runtime=%s confidence=%s evidence=%s completeness=%s(%d) queue=%s remediation=%s\n",
 					markdownActionPathLabel(item.ConfidenceLane, item.ActionPathType),
 					item.Repo,
 					item.Location,
@@ -122,9 +130,14 @@ func RenderMarkdown(summary Summary) string {
 					markdownBOMRuntimeEvidenceLabel(item),
 					item.Confidence,
 					item.EvidenceStrength,
+					risk.BuyerEvidenceCompletenessLabel(item.EvidenceCompleteness),
+					markdownCompletenessScore(item.EvidenceCompleteness),
 					item.Queue,
 					item.Remediation,
 				))
+				if len(item.ClosureRequirements) > 0 {
+					builder.WriteString(fmt.Sprintf("  closure_requirements=%s\n", markdownClosureRequirements(item.ClosureRequirements)))
+				}
 				if len(item.Contradictions) > 0 {
 					builder.WriteString(fmt.Sprintf("  contradictions=%s\n", markdownContradictions(item.Contradictions)))
 				}
@@ -249,7 +262,7 @@ func RenderMarkdown(summary Summary) string {
 		}
 		for idx := 0; idx < limit; idx++ {
 			item := summary.AgentActionBOM.Items[idx]
-			builder.WriteString(fmt.Sprintf("- %s repo=%s location=%s owner=%s lane=%s type=%s state=%s zone=%s target=%s review=%s queue=%s priority=%s tier=%s control=%s approval=%s proof=%s runtime=%s confidence=%s evidence=%s policy=%s remediation=%s\n",
+			builder.WriteString(fmt.Sprintf("- %s repo=%s location=%s owner=%s lane=%s type=%s state=%s zone=%s target=%s review=%s queue=%s priority=%s tier=%s control=%s approval=%s proof=%s runtime=%s confidence=%s evidence=%s completeness=%s(%d) policy=%s remediation=%s\n",
 				markdownActionPathLabel(item.ConfidenceLane, item.ActionPathType),
 				item.Repo,
 				item.Location,
@@ -269,9 +282,14 @@ func RenderMarkdown(summary Summary) string {
 				markdownBOMRuntimeEvidenceLabel(item),
 				item.Confidence,
 				item.EvidenceStrength,
+				risk.BuyerEvidenceCompletenessLabel(item.EvidenceCompleteness),
+				markdownCompletenessScore(item.EvidenceCompleteness),
 				item.PolicyStatus,
 				item.Remediation,
 			))
+			if len(item.ClosureRequirements) > 0 {
+				builder.WriteString(fmt.Sprintf("  closure_requirements=%s\n", markdownClosureRequirements(item.ClosureRequirements)))
+			}
 			if len(item.Contradictions) > 0 {
 				builder.WriteString(fmt.Sprintf("  contradictions=%s\n", markdownContradictions(item.Contradictions)))
 			}
@@ -329,6 +347,15 @@ func RenderMarkdown(summary Summary) string {
 				item.ClosureCriteria,
 				item.Remediation,
 			))
+			if item.EvidenceCompleteness != nil {
+				builder.WriteString(fmt.Sprintf("  completeness=%s(%d)\n",
+					risk.BuyerEvidenceCompletenessLabel(item.EvidenceCompleteness),
+					markdownCompletenessScore(item.EvidenceCompleteness),
+				))
+			}
+			if len(item.ClosureRequirements) > 0 {
+				builder.WriteString(fmt.Sprintf("  closure_requirements=%s\n", markdownClosureRequirements(item.ClosureRequirements)))
+			}
 			if item.GovernanceDisposition != nil {
 				builder.WriteString(fmt.Sprintf("  governance=%s status=%s scope=%s expires=%s reason=%s\n",
 					item.GovernanceDisposition.Kind,
@@ -400,6 +427,33 @@ func markdownContradictions(items []evidencepolicy.Contradiction) string {
 		return "none"
 	}
 	return strings.Join(parts, " | ")
+}
+
+func markdownClosureRequirements(items []risk.ClosureRequirement) string {
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		label := strings.TrimSpace(item.ID)
+		if guidance := strings.TrimSpace(item.Guidance); guidance != "" {
+			if label != "" {
+				label += ":"
+			}
+			label += guidance
+		}
+		if label != "" {
+			parts = append(parts, label)
+		}
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, " | ")
+}
+
+func markdownCompletenessScore(completeness *risk.EvidenceCompleteness) int {
+	if completeness == nil {
+		return 0
+	}
+	return completeness.TotalScore
 }
 
 func renderTriggerClassSuffix(triggerClass string) string {

--- a/core/report/report_test.go
+++ b/core/report/report_test.go
@@ -1674,6 +1674,101 @@ func TestMarkdownApprovalUnknownUsesEvidenceNotFound(t *testing.T) {
 	}
 }
 
+func TestClosureGuidanceMarkdownMatchesJSON(t *testing.T) {
+	t.Parallel()
+
+	paths := risk.DecorateEvidenceContext([]risk.ActionPath{{
+		PathID:                 "apc-closure-markdown",
+		Org:                    "acme",
+		Repo:                   "acme/release",
+		ToolType:               "compiled_action",
+		Location:               ".github/workflows/release.yml",
+		WriteCapable:           true,
+		DeployWrite:            true,
+		ApprovalGap:            true,
+		ApprovalGapReasons:     []string{"approval_source_missing"},
+		OwnerEvidenceState:     risk.EvidenceStateUnknown,
+		ControlResolutionState: risk.ControlResolutionStateNoVisibleControl,
+		PolicyCoverageStatus:   risk.PolicyCoverageStatusNone,
+		ControlPriority:        risk.ControlPriorityControlFirst,
+		ConfidenceLane:         risk.ConfidenceLaneConfirmedActionPath,
+		ActionPathType:         risk.ActionPathTypeCICDWorkflow,
+	}}, nil)
+	backlog := controlbacklog.Build(controlbacklog.Input{ActionPaths: paths})
+	summary := Summary{
+		GeneratedAt:          "2026-05-26T12:00:00Z",
+		Template:             string(TemplateAgentActionBOM),
+		ShareProfile:         string(ShareProfileInternal),
+		ActionPaths:          paths,
+		ControlBacklog:       &backlog,
+		EvidenceCompleteness: risk.BuildEvidenceCompletenessSummary(paths),
+	}
+	summary.AgentActionBOM = BuildAgentActionBOM(summary)
+
+	if summary.AgentActionBOM == nil || len(summary.AgentActionBOM.Items) != 1 || len(summary.AgentActionBOM.Items[0].ClosureRequirements) == 0 {
+		t.Fatalf("expected closure requirements on BOM item, got %+v", summary.AgentActionBOM)
+	}
+	requirement := summary.AgentActionBOM.Items[0].ClosureRequirements[0]
+	markdown := RenderMarkdown(summary)
+	if !strings.Contains(markdown, requirement.ID) || !strings.Contains(markdown, requirement.Guidance) {
+		t.Fatalf("expected markdown closure guidance to match JSON contract, got:\n%s", markdown)
+	}
+	payload, err := RenderEvidenceBundleJSON(summary)
+	if err != nil {
+		t.Fatalf("render evidence bundle: %v", err)
+	}
+	if !strings.Contains(string(payload), "\"closure_requirements\"") {
+		t.Fatalf("expected evidence bundle JSON to include closure requirements, got %s", string(payload))
+	}
+}
+
+func TestMarkdownUsesBuyerSafeCompletenessLabels(t *testing.T) {
+	t.Parallel()
+
+	paths := risk.DecorateEvidenceContext([]risk.ActionPath{{
+		PathID:               "apc-completeness-label",
+		Org:                  "acme",
+		Repo:                 "acme/release",
+		ToolType:             "mcp",
+		Location:             ".cursor/mcp.json",
+		WriteCapable:         true,
+		CredentialAccess:     true,
+		ProductionWrite:      true,
+		ApprovalGap:          true,
+		OwnerEvidenceState:   risk.EvidenceStateUnknown,
+		PolicyCoverageStatus: risk.PolicyCoverageStatusNone,
+		ControlPriority:      risk.ControlPriorityControlFirst,
+		RiskTier:             risk.RiskTierHigh,
+		ConfidenceLane:       risk.ConfidenceLaneConfirmedActionPath,
+		ActionPathType:       risk.ActionPathTypeAgentFramework,
+	}}, &scanquality.Report{
+		Detectors: []scanquality.DetectorHealth{{
+			Org:      "acme",
+			Repo:     "acme/release",
+			Detector: "mcp",
+			Status:   "reduced",
+		}},
+	})
+	backlog := controlbacklog.Build(controlbacklog.Input{ActionPaths: paths})
+	summary := Summary{
+		GeneratedAt:          "2026-05-26T12:00:00Z",
+		Template:             string(TemplateAgentActionBOM),
+		ShareProfile:         string(ShareProfileInternal),
+		ActionPaths:          paths,
+		ControlBacklog:       &backlog,
+		EvidenceCompleteness: risk.BuildEvidenceCompletenessSummary(paths),
+	}
+	summary.AgentActionBOM = BuildAgentActionBOM(summary)
+
+	markdown := RenderMarkdown(summary)
+	if !strings.Contains(markdown, "insufficient evidence coverage") {
+		t.Fatalf("expected buyer-safe completeness wording, got:\n%s", markdown)
+	}
+	if strings.Contains(strings.ToLower(markdown), "low risk because evidence is low") {
+		t.Fatalf("expected completeness wording to stay separate from risk, got:\n%s", markdown)
+	}
+}
+
 func TestReportQABlocksUnsupportedApprovalMissing(t *testing.T) {
 	t.Parallel()
 

--- a/core/report/types.go
+++ b/core/report/types.go
@@ -84,6 +84,7 @@ type Summary struct {
 	ScanScope                *ScanScopeSummary                      `json:"scan_scope,omitempty"`
 	OperationalExposure      *scorecore.AxisSummary                 `json:"operational_exposure,omitempty"`
 	GovernanceReadiness      *scorecore.AxisSummary                 `json:"governance_readiness,omitempty"`
+	EvidenceCompleteness     *risk.EvidenceCompletenessSummary      `json:"evidence_completeness,omitempty"`
 	AssessmentSummary        *AssessmentSummary                     `json:"assessment_summary,omitempty"`
 	Methodology              Methodology                            `json:"methodology"`
 	TopRisks                 []RiskItem                             `json:"top_risks"`

--- a/core/risk/action_paths.go
+++ b/core/risk/action_paths.go
@@ -149,6 +149,8 @@ type ActionPath struct {
 	SourceFindingKeys          []string                                `json:"source_finding_keys,omitempty"`
 	MatchedProductionTargets   []string                                `json:"matched_production_targets,omitempty"`
 	GovernanceControls         []agginventory.GovernanceControlMapping `json:"governance_controls,omitempty"`
+	ClosureRequirements        []ClosureRequirement                    `json:"closure_requirements,omitempty"`
+	EvidenceCompleteness       *EvidenceCompleteness                   `json:"evidence_completeness,omitempty"`
 	ActionLineage              *ActionLineage                          `json:"action_lineage,omitempty"`
 }
 
@@ -457,6 +459,8 @@ func mergeActionPath(current, incoming ActionPath) ActionPath {
 	merged.GaitCoverage = MergeGaitCoverage(current.GaitCoverage, incoming.GaitCoverage)
 	merged.IntroducedBy = attribution.Merge(current.IntroducedBy, incoming.IntroducedBy)
 	merged.GovernanceControls = mergeGovernanceControls(current.GovernanceControls, incoming.GovernanceControls)
+	merged.ClosureRequirements = CloneClosureRequirements(firstNonEmptyClosureRequirements(current.ClosureRequirements, incoming.ClosureRequirements))
+	merged.EvidenceCompleteness = firstNonNilEvidenceCompleteness(current.EvidenceCompleteness, incoming.EvidenceCompleteness)
 	merged.AttackPathRefs = dedupeSortedStrings(append(append([]string(nil), current.AttackPathRefs...), incoming.AttackPathRefs...))
 	merged.SourceFindingKeys = dedupeSortedStrings(append(append([]string(nil), current.SourceFindingKeys...), incoming.SourceFindingKeys...))
 	merged.ActionLineage = CloneActionLineage(firstNonNilLineage(current.ActionLineage, incoming.ActionLineage))
@@ -797,6 +801,24 @@ func firstNonNilLineage(values ...*ActionLineage) *ActionLineage {
 	for _, value := range values {
 		if value != nil {
 			return value
+		}
+	}
+	return nil
+}
+
+func firstNonEmptyClosureRequirements(values ...[]ClosureRequirement) []ClosureRequirement {
+	for _, value := range values {
+		if len(value) > 0 {
+			return value
+		}
+	}
+	return nil
+}
+
+func firstNonNilEvidenceCompleteness(values ...*EvidenceCompleteness) *EvidenceCompleteness {
+	for _, value := range values {
+		if value != nil {
+			return CloneEvidenceCompleteness(value)
 		}
 	}
 	return nil

--- a/core/risk/evidence_context.go
+++ b/core/risk/evidence_context.go
@@ -127,7 +127,7 @@ func BuildEvidenceCompletenessSummary(paths []ActionPath) *EvidenceCompletenessS
 		if path.EvidenceCompleteness.Label == EvidenceCompletenessInsufficient {
 			lowEvidence++
 		}
-		if len(path.EvidenceCompleteness.UnsupportedSurfaces) > 0 {
+		if evidenceCompletenessHasReducedCoverage(path.EvidenceCompleteness) {
 			reducedCoverage++
 		}
 		reasons = append(reasons, path.EvidenceCompleteness.Reasons...)
@@ -1015,6 +1015,26 @@ func evidenceCompletenessLabel(score int) string {
 	default:
 		return EvidenceCompletenessInsufficient
 	}
+}
+
+func evidenceCompletenessHasReducedCoverage(completeness *EvidenceCompleteness) bool {
+	if completeness == nil {
+		return false
+	}
+	if len(completeness.UnsupportedSurfaces) > 0 {
+		return true
+	}
+	for _, reason := range completeness.Reasons {
+		trimmed := strings.TrimSpace(reason)
+		if trimmed == "scan_quality:reduced" ||
+			strings.HasPrefix(trimmed, "detector:") ||
+			strings.HasPrefix(trimmed, "coverage_reason:") ||
+			strings.HasPrefix(trimmed, "parse_issue:") ||
+			strings.HasPrefix(trimmed, "absence_claim:") {
+			return true
+		}
+	}
+	return false
 }
 
 func clampScore(value int) int {

--- a/core/risk/evidence_context.go
+++ b/core/risk/evidence_context.go
@@ -25,7 +25,7 @@ const (
 	ClosureRequirementExpandScanCoverage        = "expand_scan_coverage"
 	ClosureRequirementProvideProviderExport     = "provide_provider_export"
 	ClosureRequirementProveDeploymentConstraint = "prove_deployment_constraint"
-	ClosureRequirementProveJITCredential        = "prove_jit_credential"
+	ClosureRequirementProveJITCredential        = "prove_jit_credential" // #nosec G101 -- deterministic requirement label, not credential material.
 	ClosureRequirementRefreshExpiredEvidence    = "refresh_expired_evidence"
 	ClosureRequirementResolveContradiction      = "resolve_contradiction"
 	ClosureRequirementAcceptInternalTooling     = "accept_declared_internal_tooling"
@@ -72,10 +72,10 @@ type EvidenceCompletenessAxisScore struct {
 }
 
 type EvidenceCompleteness struct {
-	TotalScore            int                            `json:"total_score"`
-	Label                 string                         `json:"label"`
-	AxisScores            []EvidenceCompletenessAxisScore `json:"axis_scores"`
-	EvidenceGaps          []string                       `json:"evidence_gaps,omitempty"`
+	TotalScore             int                             `json:"total_score"`
+	Label                  string                          `json:"label"`
+	AxisScores             []EvidenceCompletenessAxisScore `json:"axis_scores"`
+	EvidenceGaps           []string                        `json:"evidence_gaps,omitempty"`
 	UnsupportedSurfaces    []string                        `json:"unsupported_surfaces,omitempty"`
 	FreshnessPenalties     []string                        `json:"freshness_penalties,omitempty"`
 	ContradictionPenalties []string                        `json:"contradiction_penalties,omitempty"`
@@ -83,13 +83,13 @@ type EvidenceCompleteness struct {
 }
 
 type EvidenceCompletenessSummary struct {
-	PathCount               int                            `json:"path_count"`
-	AverageTotalScore       int                            `json:"average_total_score"`
-	Label                   string                         `json:"label"`
-	LowEvidencePathCount    int                            `json:"low_evidence_path_count,omitempty"`
-	ReducedCoveragePathCount int                            `json:"reduced_coverage_path_count,omitempty"`
+	PathCount                int                             `json:"path_count"`
+	AverageTotalScore        int                             `json:"average_total_score"`
+	Label                    string                          `json:"label"`
+	LowEvidencePathCount     int                             `json:"low_evidence_path_count,omitempty"`
+	ReducedCoveragePathCount int                             `json:"reduced_coverage_path_count,omitempty"`
 	AxisScores               []EvidenceCompletenessAxisScore `json:"axis_scores,omitempty"`
-	Reasons                  []string                       `json:"reasons,omitempty"`
+	Reasons                  []string                        `json:"reasons,omitempty"`
 }
 
 func DecorateEvidenceContext(paths []ActionPath, report *scanquality.Report) []ActionPath {
@@ -417,9 +417,9 @@ func approvalClosureRequirement(path ActionPath) (ClosureRequirement, bool) {
 			Examples: []string{
 				"Attach a ticket or provider export that records the same approval decision.",
 			},
-			ClosureRefs:             append([]string(nil), path.ControlEvidenceRefs...),
-			ReasonCodes:             []string{"approval_evidence:declared"},
-			Guidance:                "Provide exported approval evidence for this path if you need it to move from declared approval toward verified approval.",
+			ClosureRefs: append([]string(nil), path.ControlEvidenceRefs...),
+			ReasonCodes: []string{"approval_evidence:declared"},
+			Guidance:    "Provide exported approval evidence for this path if you need it to move from declared approval toward verified approval.",
 		}, true
 	default:
 		return ClosureRequirement{}, false
@@ -563,9 +563,9 @@ func scanCoverageClosureRequirement(path ActionPath, signals scanquality.Complet
 			"Fix reduced detector coverage or parse failures, then rerun the same scan inputs.",
 			"Attach exported control evidence if this surface stays parser-limited.",
 		},
-		ClosureRefs:             append([]string(nil), signals.UnsupportedSurfaces...),
-		ReasonCodes:             append([]string{"scan_quality:reduced"}, signals.Reasons...),
-		Guidance:                "Restore complete scan coverage for this repository or attach stronger exported evidence before treating low-completeness conclusions as fully supported.",
+		ClosureRefs: append([]string(nil), signals.UnsupportedSurfaces...),
+		ReasonCodes: append([]string{"scan_quality:reduced"}, signals.Reasons...),
+		Guidance:    "Restore complete scan coverage for this repository or attach stronger exported evidence before treating low-completeness conclusions as fully supported.",
 	}, true
 }
 

--- a/core/risk/evidence_context.go
+++ b/core/risk/evidence_context.go
@@ -966,10 +966,12 @@ func freshnessExamples(field string) []string {
 }
 
 func pathNeedsDeploymentConstraintEvidence(path ActionPath) bool {
-	if !(path.DeployWrite || path.ProductionWrite || len(path.MatchedProductionTargets) > 0 || strings.TrimSpace(path.WorkflowTriggerClass) == "deploy_pipeline") {
-		return false
-	}
-	return len(path.ConstraintEvidenceClasses) == 0 && len(path.ConstraintEvidenceRefs) == 0
+	return (path.DeployWrite ||
+		path.ProductionWrite ||
+		len(path.MatchedProductionTargets) > 0 ||
+		strings.TrimSpace(path.WorkflowTriggerClass) == "deploy_pipeline") &&
+		len(path.ConstraintEvidenceClasses) == 0 &&
+		len(path.ConstraintEvidenceRefs) == 0
 }
 
 func likelyJITCredential(path ActionPath) bool {

--- a/core/risk/evidence_context.go
+++ b/core/risk/evidence_context.go
@@ -1,0 +1,1046 @@
+package risk
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/Clyra-AI/wrkr/core/aggregate/scanquality"
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
+)
+
+const (
+	ClosureSeverityCritical = "critical"
+	ClosureSeverityHigh     = "high"
+	ClosureSeverityMedium   = "medium"
+	ClosureSeverityLow      = "low"
+
+	ClosureRequirementAssignOwner               = "assign_owner"
+	ClosureRequirementAttachApproval            = "attach_approval"
+	ClosureRequirementAttachPolicyReference     = "attach_policy_reference"
+	ClosureRequirementAttachProof               = "attach_proof"
+	ClosureRequirementCollectRuntimeEvidence    = "collect_runtime_evidence"
+	ClosureRequirementExpandScanCoverage        = "expand_scan_coverage"
+	ClosureRequirementProvideProviderExport     = "provide_provider_export"
+	ClosureRequirementProveDeploymentConstraint = "prove_deployment_constraint"
+	ClosureRequirementProveJITCredential        = "prove_jit_credential"
+	ClosureRequirementRefreshExpiredEvidence    = "refresh_expired_evidence"
+	ClosureRequirementResolveContradiction      = "resolve_contradiction"
+	ClosureRequirementAcceptInternalTooling     = "accept_declared_internal_tooling"
+
+	CompletenessAxisDiscovery = "discovery"
+	CompletenessAxisAuthority = "authority"
+	CompletenessAxisBlast     = "blast_radius"
+	CompletenessAxisControl   = "control"
+	CompletenessAxisRuntime   = "runtime_evidence"
+	CompletenessAxisProof     = "proof"
+
+	EvidenceCompletenessStrong       = "strong_evidence"
+	EvidenceCompletenessPartial      = "partial_evidence"
+	EvidenceCompletenessInsufficient = "insufficient_evidence"
+)
+
+var completenessAxisOrder = []string{
+	CompletenessAxisDiscovery,
+	CompletenessAxisAuthority,
+	CompletenessAxisBlast,
+	CompletenessAxisControl,
+	CompletenessAxisRuntime,
+	CompletenessAxisProof,
+}
+
+type ClosureRequirement struct {
+	ID                      string   `json:"id"`
+	Severity                string   `json:"severity"`
+	RequirementType         string   `json:"requirement_type"`
+	CurrentEvidenceState    string   `json:"current_evidence_state,omitempty"`
+	RequiredEvidence        string   `json:"required_evidence"`
+	AcceptableSourceClasses []string `json:"acceptable_source_classes,omitempty"`
+	FreshnessRequirement    string   `json:"freshness_requirement,omitempty"`
+	Examples                []string `json:"examples,omitempty"`
+	ClosureRefs             []string `json:"closure_refs,omitempty"`
+	ReasonCodes             []string `json:"reason_codes,omitempty"`
+	Guidance                string   `json:"guidance"`
+}
+
+type EvidenceCompletenessAxisScore struct {
+	Axis    string   `json:"axis"`
+	Score   int      `json:"score"`
+	Reasons []string `json:"reasons,omitempty"`
+}
+
+type EvidenceCompleteness struct {
+	TotalScore            int                            `json:"total_score"`
+	Label                 string                         `json:"label"`
+	AxisScores            []EvidenceCompletenessAxisScore `json:"axis_scores"`
+	EvidenceGaps          []string                       `json:"evidence_gaps,omitempty"`
+	UnsupportedSurfaces    []string                        `json:"unsupported_surfaces,omitempty"`
+	FreshnessPenalties     []string                        `json:"freshness_penalties,omitempty"`
+	ContradictionPenalties []string                        `json:"contradiction_penalties,omitempty"`
+	Reasons                []string                        `json:"reasons,omitempty"`
+}
+
+type EvidenceCompletenessSummary struct {
+	PathCount               int                            `json:"path_count"`
+	AverageTotalScore       int                            `json:"average_total_score"`
+	Label                   string                         `json:"label"`
+	LowEvidencePathCount    int                            `json:"low_evidence_path_count,omitempty"`
+	ReducedCoveragePathCount int                            `json:"reduced_coverage_path_count,omitempty"`
+	AxisScores               []EvidenceCompletenessAxisScore `json:"axis_scores,omitempty"`
+	Reasons                  []string                       `json:"reasons,omitempty"`
+}
+
+func DecorateEvidenceContext(paths []ActionPath, report *scanquality.Report) []ActionPath {
+	if len(paths) == 0 {
+		return nil
+	}
+	out := make([]ActionPath, 0, len(paths))
+	for _, raw := range paths {
+		path := ProjectActionPath(raw)
+		signals := scanquality.CompletenessSignalsForRepo(report, path.Org, path.Repo)
+		completeness := buildEvidenceCompleteness(path, signals)
+		path.EvidenceCompleteness = completeness
+		path.ClosureRequirements = buildClosureRequirements(path, signals, completeness)
+		out = append(out, path)
+	}
+	return out
+}
+
+func BuildEvidenceCompletenessSummary(paths []ActionPath) *EvidenceCompletenessSummary {
+	if len(paths) == 0 {
+		return nil
+	}
+	axisTotals := map[string]int{}
+	axisReasons := map[string][]string{}
+	total := 0
+	lowEvidence := 0
+	reducedCoverage := 0
+	reasons := []string{}
+	for _, raw := range paths {
+		path := raw
+		if path.EvidenceCompleteness == nil {
+			path.EvidenceCompleteness = buildEvidenceCompleteness(path, scanquality.CompletenessSignals{})
+		}
+		total += path.EvidenceCompleteness.TotalScore
+		if path.EvidenceCompleteness.Label == EvidenceCompletenessInsufficient {
+			lowEvidence++
+		}
+		if len(path.EvidenceCompleteness.UnsupportedSurfaces) > 0 {
+			reducedCoverage++
+		}
+		reasons = append(reasons, path.EvidenceCompleteness.Reasons...)
+		for _, axis := range path.EvidenceCompleteness.AxisScores {
+			axisTotals[axis.Axis] += axis.Score
+			axisReasons[axis.Axis] = append(axisReasons[axis.Axis], axis.Reasons...)
+		}
+	}
+	summary := &EvidenceCompletenessSummary{
+		PathCount:                len(paths),
+		AverageTotalScore:        int(math.Round(float64(total) / float64(len(paths)))),
+		LowEvidencePathCount:     lowEvidence,
+		ReducedCoveragePathCount: reducedCoverage,
+		Reasons:                  dedupeSortedStrings(reasons),
+	}
+	summary.Label = evidenceCompletenessLabel(summary.AverageTotalScore)
+	summary.AxisScores = make([]EvidenceCompletenessAxisScore, 0, len(completenessAxisOrder))
+	for _, axis := range completenessAxisOrder {
+		score := 0
+		if len(paths) > 0 {
+			score = int(math.Round(float64(axisTotals[axis]) / float64(len(paths))))
+		}
+		summary.AxisScores = append(summary.AxisScores, EvidenceCompletenessAxisScore{
+			Axis:    axis,
+			Score:   score,
+			Reasons: dedupeSortedStrings(axisReasons[axis]),
+		})
+	}
+	return summary
+}
+
+func CloneClosureRequirements(in []ClosureRequirement) []ClosureRequirement {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]ClosureRequirement, 0, len(in))
+	for _, item := range in {
+		copyItem := item
+		copyItem.AcceptableSourceClasses = append([]string(nil), item.AcceptableSourceClasses...)
+		copyItem.Examples = append([]string(nil), item.Examples...)
+		copyItem.ClosureRefs = append([]string(nil), item.ClosureRefs...)
+		copyItem.ReasonCodes = append([]string(nil), item.ReasonCodes...)
+		out = append(out, copyItem)
+	}
+	return out
+}
+
+func CloneEvidenceCompleteness(in *EvidenceCompleteness) *EvidenceCompleteness {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	out.AxisScores = cloneEvidenceCompletenessAxisScores(in.AxisScores)
+	out.EvidenceGaps = append([]string(nil), in.EvidenceGaps...)
+	out.UnsupportedSurfaces = append([]string(nil), in.UnsupportedSurfaces...)
+	out.FreshnessPenalties = append([]string(nil), in.FreshnessPenalties...)
+	out.ContradictionPenalties = append([]string(nil), in.ContradictionPenalties...)
+	out.Reasons = append([]string(nil), in.Reasons...)
+	return &out
+}
+
+func CloneEvidenceCompletenessSummary(in *EvidenceCompletenessSummary) *EvidenceCompletenessSummary {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	out.AxisScores = cloneEvidenceCompletenessAxisScores(in.AxisScores)
+	out.Reasons = append([]string(nil), in.Reasons...)
+	return &out
+}
+
+func cloneEvidenceCompletenessAxisScores(in []EvidenceCompletenessAxisScore) []EvidenceCompletenessAxisScore {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]EvidenceCompletenessAxisScore, 0, len(in))
+	for _, item := range in {
+		copyItem := item
+		copyItem.Reasons = append([]string(nil), item.Reasons...)
+		out = append(out, copyItem)
+	}
+	return out
+}
+
+func ClosureCriteriaText(requirements []ClosureRequirement, fallback string) string {
+	if len(requirements) == 0 {
+		return strings.TrimSpace(fallback)
+	}
+	return strings.TrimSpace(requirements[0].Guidance)
+}
+
+func buildClosureRequirements(path ActionPath, signals scanquality.CompletenessSignals, completeness *EvidenceCompleteness) []ClosureRequirement {
+	requirements := []ClosureRequirement{}
+	add := func(item ClosureRequirement) {
+		if strings.TrimSpace(item.ID) == "" || strings.TrimSpace(item.Guidance) == "" {
+			return
+		}
+		item.AcceptableSourceClasses = dedupeSortedStrings(item.AcceptableSourceClasses)
+		item.Examples = dedupeSortedStrings(item.Examples)
+		item.ClosureRefs = dedupeSortedStrings(item.ClosureRefs)
+		item.ReasonCodes = dedupeSortedStrings(item.ReasonCodes)
+		requirements = append(requirements, item)
+	}
+
+	if contradictionRequirement, ok := contradictionClosureRequirement(path); ok {
+		add(contradictionRequirement)
+	}
+	for _, freshness := range freshnessClosureRequirements(path) {
+		add(freshness)
+	}
+	if ownerRequirement, ok := ownerClosureRequirement(path); ok {
+		add(ownerRequirement)
+	}
+	if approvalRequirement, ok := approvalClosureRequirement(path); ok {
+		add(approvalRequirement)
+	}
+	if proofRequirement, ok := proofClosureRequirement(path); ok {
+		add(proofRequirement)
+	}
+	if runtimeRequirement, ok := runtimeClosureRequirement(path); ok {
+		add(runtimeRequirement)
+	}
+	if deployRequirement, ok := deploymentConstraintClosureRequirement(path); ok {
+		add(deployRequirement)
+	}
+	if internalRequirement, ok := internalToolingClosureRequirement(path); ok {
+		add(internalRequirement)
+	}
+	if scanRequirement, ok := scanCoverageClosureRequirement(path, signals, completeness); ok {
+		add(scanRequirement)
+	}
+
+	sort.Slice(requirements, func(i, j int) bool {
+		if closureSeverityPriority(requirements[i].Severity) != closureSeverityPriority(requirements[j].Severity) {
+			return closureSeverityPriority(requirements[i].Severity) < closureSeverityPriority(requirements[j].Severity)
+		}
+		if requirements[i].RequirementType != requirements[j].RequirementType {
+			return requirements[i].RequirementType < requirements[j].RequirementType
+		}
+		if normalizeEvidenceState(requirements[i].CurrentEvidenceState) != normalizeEvidenceState(requirements[j].CurrentEvidenceState) {
+			return normalizeEvidenceState(requirements[i].CurrentEvidenceState) < normalizeEvidenceState(requirements[j].CurrentEvidenceState)
+		}
+		return requirements[i].ID < requirements[j].ID
+	})
+	if len(requirements) == 0 {
+		return nil
+	}
+	return requirements
+}
+
+func contradictionClosureRequirement(path ActionPath) (ClosureRequirement, bool) {
+	if len(path.Contradictions) == 0 &&
+		normalizeControlResolutionState(path.ControlResolutionState) != ControlResolutionStateContradictoryControl &&
+		normalizeEvidenceState(path.TargetEvidenceState) != EvidenceStateContradictory &&
+		normalizeEvidenceState(path.OwnerEvidenceState) != EvidenceStateContradictory &&
+		normalizeEvidenceState(path.ApprovalEvidenceState) != EvidenceStateContradictory &&
+		normalizeEvidenceState(path.ProofEvidenceState) != EvidenceStateContradictory &&
+		normalizeEvidenceState(path.RuntimeEvidenceState) != EvidenceStateContradictory {
+		return ClosureRequirement{}, false
+	}
+	reasonCodes := contradictionReasonCodes(path.Contradictions)
+	if len(reasonCodes) == 0 {
+		reasonCodes = []string{"control_evidence:contradictory"}
+	}
+	refs := contradictionEvidenceRefs(path.Contradictions)
+	refs = dedupeSortedStrings(append(refs, path.ControlEvidenceRefs...))
+	return ClosureRequirement{
+		ID:                      closureRequirementID(path.PathID, ClosureRequirementResolveContradiction, EvidenceStateContradictory),
+		Severity:                ClosureSeverityCritical,
+		RequirementType:         ClosureRequirementResolveContradiction,
+		CurrentEvidenceState:    EvidenceStateContradictory,
+		RequiredEvidence:        "One authoritative owner/control decision with matching target, credential, and approval evidence for this exact path.",
+		AcceptableSourceClasses: []string{evidencepolicy.SourceTypeProviderExport, evidencepolicy.SourceTypeSignedDeclaration, evidencepolicy.SourceTypeRepoPolicy, evidencepolicy.SourceTypeTicketExport},
+		FreshnessRequirement:    "fresh authoritative evidence required",
+		Examples: []string{
+			"Replace conflicting non-production declarations with one current signed declaration.",
+			"Attach one owner-approved control export that matches the production-bearing path state.",
+		},
+		ClosureRefs: refs,
+		ReasonCodes: reasonCodes,
+		Guidance:    "Resolve the contradictory evidence for this path and attach one authoritative owner/control decision before treating it as governed.",
+	}, true
+}
+
+func freshnessClosureRequirements(path ActionPath) []ClosureRequirement {
+	out := []ClosureRequirement{}
+	for _, issue := range freshnessIssuesForPath(path) {
+		required := "Fresh evidence for this path with observed_at and valid_until or max_age metadata."
+		guidance := "Refresh the stale evidence for this path and rescan before treating it as verified."
+		severity := ClosureSeverityMedium
+		if strings.Contains(issue.reason, "expired") {
+			required = "Fresh replacement evidence for this path with a new validity window."
+			guidance = "Refresh the expired evidence for this path and rescan before treating it as verified."
+			severity = ClosureSeverityHigh
+		}
+		out = append(out, ClosureRequirement{
+			ID:                      closureRequirementID(path.PathID, ClosureRequirementRefreshExpiredEvidence, issue.field),
+			Severity:                severity,
+			RequirementType:         ClosureRequirementRefreshExpiredEvidence,
+			CurrentEvidenceState:    issue.state,
+			RequiredEvidence:        required,
+			AcceptableSourceClasses: freshnessSourceClasses(issue.field),
+			FreshnessRequirement:    "fresh evidence with current validity metadata",
+			Examples:                freshnessExamples(issue.field),
+			ClosureRefs:             append([]string(nil), issue.refs...),
+			ReasonCodes:             []string{issue.reason},
+			Guidance:                strings.ReplaceAll(guidance, "the stale evidence", strings.TrimSpace(issue.label)+" evidence"),
+		})
+	}
+	return out
+}
+
+func ownerClosureRequirement(path ActionPath) (ClosureRequirement, bool) {
+	switch normalizeEvidenceState(path.OwnerEvidenceState) {
+	case EvidenceStateUnknown, EvidenceStateInferred:
+		return ClosureRequirement{
+			ID:                      closureRequirementID(path.PathID, ClosureRequirementAssignOwner, path.OwnerEvidenceState),
+			Severity:                ownerClosureSeverity(path),
+			RequirementType:         ClosureRequirementAssignOwner,
+			CurrentEvidenceState:    normalizeEvidenceState(path.OwnerEvidenceState),
+			RequiredEvidence:        "Explicit owner evidence for this path with a linked team, service, or approver record.",
+			AcceptableSourceClasses: []string{evidencepolicy.SourceTypeProviderExport, evidencepolicy.SourceTypeCustomerOwnerMap, evidencepolicy.SourceTypeSignedDeclaration, evidencepolicy.SourceTypeAppCatalog, evidencepolicy.SourceTypeCodeowners},
+			FreshnessRequirement:    "owner evidence should be current and reviewable",
+			Examples: []string{
+				"Attach a provider-exported team ownership record for the workflow or service.",
+				"Declare one owner in wrkr-control-declarations.yaml with expiry and evidence refs.",
+			},
+			ClosureRefs: append([]string(nil), path.OwnershipEvidence...),
+			ReasonCodes: []string{"owner_evidence:" + normalizeEvidenceState(path.OwnerEvidenceState)},
+			Guidance:    "Assign explicit owner evidence for this path and attach a linked owner record before approving or expanding it.",
+		}, true
+	case EvidenceStateDeclared:
+		if path.ControlPriority != ControlPriorityControlFirst {
+			return ClosureRequirement{}, false
+		}
+		return ClosureRequirement{
+			ID:                      closureRequirementID(path.PathID, ClosureRequirementProvideProviderExport, evidencepolicy.FieldOwner),
+			Severity:                ClosureSeverityMedium,
+			RequirementType:         ClosureRequirementProvideProviderExport,
+			CurrentEvidenceState:    normalizeEvidenceState(path.OwnerEvidenceState),
+			RequiredEvidence:        "Provider-exported or catalog-backed owner evidence for this control path.",
+			AcceptableSourceClasses: []string{evidencepolicy.SourceTypeProviderExport, evidencepolicy.SourceTypeGitHubTeamExport, evidencepolicy.SourceTypeAppCatalog},
+			FreshnessRequirement:    "fresh authoritative export preferred over declarations",
+			Examples: []string{
+				"Attach a GitHub team export or app catalog record that resolves to one owner.",
+			},
+			ClosureRefs: append([]string(nil), path.OwnershipEvidence...),
+			ReasonCodes: []string{"owner_evidence:declared"},
+			Guidance:    "Provide provider-exported owner evidence for this path if you need it to move from declared ownership toward verified ownership.",
+		}, true
+	default:
+		return ClosureRequirement{}, false
+	}
+}
+
+func approvalClosureRequirement(path ActionPath) (ClosureRequirement, bool) {
+	switch normalizeEvidenceState(path.ApprovalEvidenceState) {
+	case EvidenceStateUnknown, EvidenceStateInferred:
+		return ClosureRequirement{
+			ID:                      closureRequirementID(path.PathID, ClosureRequirementAttachApproval, path.ApprovalEvidenceState),
+			Severity:                approvalClosureSeverity(path),
+			RequirementType:         ClosureRequirementAttachApproval,
+			CurrentEvidenceState:    normalizeEvidenceState(path.ApprovalEvidenceState),
+			RequiredEvidence:        "Path-scoped approval evidence with owner, scope, expiry, and linked proof or ticket refs.",
+			AcceptableSourceClasses: []string{evidencepolicy.SourceTypeProviderExport, evidencepolicy.SourceTypeTicketExport, evidencepolicy.SourceTypeSignedDeclaration, evidencepolicy.SourceTypeRepoPolicy},
+			FreshnessRequirement:    "approval evidence must be current and time-bounded",
+			Examples: []string{
+				"Attach an approval ticket export with approver, scope, and expiry.",
+				"Record a signed declaration with owner approval and a valid_until timestamp.",
+			},
+			ClosureRefs: append([]string(nil), path.ControlEvidenceRefs...),
+			ReasonCodes: dedupeSortedStrings(append([]string{"approval_evidence:" + normalizeEvidenceState(path.ApprovalEvidenceState)}, path.ApprovalGapReasons...)),
+			Guidance:    "Attach approval evidence for this exact path with scope and expiry before treating it as governed.",
+		}, true
+	case EvidenceStateDeclared:
+		if path.ControlPriority != ControlPriorityControlFirst {
+			return ClosureRequirement{}, false
+		}
+		return ClosureRequirement{
+			ID:                      closureRequirementID(path.PathID, ClosureRequirementProvideProviderExport, evidencepolicy.FieldApproval),
+			Severity:                ClosureSeverityMedium,
+			RequirementType:         ClosureRequirementProvideProviderExport,
+			CurrentEvidenceState:    normalizeEvidenceState(path.ApprovalEvidenceState),
+			RequiredEvidence:        "Authoritative exported approval evidence for this control path.",
+			AcceptableSourceClasses: []string{evidencepolicy.SourceTypeProviderExport, evidencepolicy.SourceTypeTicketExport},
+			FreshnessRequirement:    "fresh exported approval evidence preferred over declarations",
+			Examples: []string{
+				"Attach a ticket or provider export that records the same approval decision.",
+			},
+			ClosureRefs:             append([]string(nil), path.ControlEvidenceRefs...),
+			ReasonCodes:             []string{"approval_evidence:declared"},
+			Guidance:                "Provide exported approval evidence for this path if you need it to move from declared approval toward verified approval.",
+		}, true
+	default:
+		return ClosureRequirement{}, false
+	}
+}
+
+func proofClosureRequirement(path ActionPath) (ClosureRequirement, bool) {
+	switch {
+	case strings.TrimSpace(path.PolicyCoverageStatus) == PolicyCoverageStatusNone || len(path.PolicyMissingReasons) > 0:
+		return ClosureRequirement{
+			ID:                      closureRequirementID(path.PathID, ClosureRequirementAttachPolicyReference, path.PolicyCoverageStatus),
+			Severity:                proofClosureSeverity(path),
+			RequirementType:         ClosureRequirementAttachPolicyReference,
+			CurrentEvidenceState:    normalizeEvidenceState(path.ProofEvidenceState),
+			RequiredEvidence:        "Path-specific policy or proof reference that names the control bound to this path.",
+			AcceptableSourceClasses: []string{evidencepolicy.SourceTypeProviderExport, evidencepolicy.SourceTypeRepoPolicy, evidencepolicy.SourceTypePolicyConfig, evidencepolicy.SourceTypeSignedDeclaration},
+			FreshnessRequirement:    "policy and proof references should match the current path scope",
+			Examples: []string{
+				"Attach a policy export or repo policy reference for this workflow or agent config.",
+				"Link a proof record that names the exact control path.",
+			},
+			ClosureRefs: append([]string(nil), path.PolicyEvidenceRefs...),
+			ReasonCodes: dedupeSortedStrings(append([]string{"proof_evidence:none"}, path.PolicyMissingReasons...)),
+			Guidance:    "Attach a path-specific policy or proof reference for this exact path and rescan so proof is no longer inferred or absent.",
+		}, true
+	case normalizeEvidenceState(path.ProofEvidenceState) == EvidenceStateUnknown || normalizeEvidenceState(path.ProofEvidenceState) == EvidenceStateInferred:
+		return ClosureRequirement{
+			ID:                      closureRequirementID(path.PathID, ClosureRequirementAttachProof, path.ProofEvidenceState),
+			Severity:                proofClosureSeverity(path),
+			RequirementType:         ClosureRequirementAttachProof,
+			CurrentEvidenceState:    normalizeEvidenceState(path.ProofEvidenceState),
+			RequiredEvidence:        "Path-specific proof record or export that verifies the current control claim.",
+			AcceptableSourceClasses: []string{evidencepolicy.SourceTypeProviderExport, evidencepolicy.SourceTypeRuntime, evidencepolicy.SourceTypeRepoPolicy},
+			FreshnessRequirement:    "proof should verify the current policy and runtime posture",
+			Examples: []string{
+				"Attach a proof record that references the same control_id and path_id.",
+				"Provide a provider export that confirms the runtime control claim.",
+			},
+			ClosureRefs: append([]string(nil), path.PolicyEvidenceRefs...),
+			ReasonCodes: []string{"proof_evidence:" + normalizeEvidenceState(path.ProofEvidenceState)},
+			Guidance:    "Attach path-specific proof for the current control claim before treating this path as fully verified.",
+		}, true
+	default:
+		return ClosureRequirement{}, false
+	}
+}
+
+func runtimeClosureRequirement(path ActionPath) (ClosureRequirement, bool) {
+	absence := RuntimeEvidenceAbsenceStatus(path)
+	requirementType := ClosureRequirementCollectRuntimeEvidence
+	required := "Runtime control evidence for this path with correlation back to the current path_id."
+	guidance := "Collect runtime evidence for this path and correlate it back to the saved path before treating runtime claims as verified."
+	examples := []string{
+		"Attach a runtime evidence bundle with policy, approval, or action outcome records for this path.",
+	}
+	if likelyJITCredential(path) {
+		requirementType = ClosureRequirementProveJITCredential
+		required = "JIT credential evidence for this path that proves the credential is brokered or short-lived."
+		guidance = "Provide JIT credential evidence for this path and correlate it back to the saved path before treating standing-access risk as reduced."
+		examples = append(examples, "Attach a runtime record that proves the credential was issued just in time for this path.")
+	}
+	switch absence {
+	case RuntimeEvidenceAbsenceMissingRequired, RuntimeEvidenceAbsenceMissingForClaim, RuntimeEvidenceAbsenceNotCollected:
+		return ClosureRequirement{
+			ID:                      closureRequirementID(path.PathID, requirementType, absence),
+			Severity:                runtimeClosureSeverity(path, absence),
+			RequirementType:         requirementType,
+			CurrentEvidenceState:    normalizeEvidenceState(path.RuntimeEvidenceState),
+			RequiredEvidence:        required,
+			AcceptableSourceClasses: []string{evidencepolicy.SourceTypeRuntime, evidencepolicy.SourceTypeProviderExport},
+			FreshnessRequirement:    "runtime evidence should match the current execution window",
+			Examples:                examples,
+			ClosureRefs:             append([]string(nil), path.ControlEvidenceRefs...),
+			ReasonCodes:             []string{"runtime_absence_status:" + absence},
+			Guidance:                guidance,
+		}, true
+	default:
+		return ClosureRequirement{}, false
+	}
+}
+
+func deploymentConstraintClosureRequirement(path ActionPath) (ClosureRequirement, bool) {
+	if !pathNeedsDeploymentConstraintEvidence(path) {
+		return ClosureRequirement{}, false
+	}
+	return ClosureRequirement{
+		ID:                      closureRequirementID(path.PathID, ClosureRequirementProveDeploymentConstraint, path.TargetClass),
+		Severity:                ClosureSeverityHigh,
+		RequirementType:         ClosureRequirementProveDeploymentConstraint,
+		CurrentEvidenceState:    normalizeEvidenceState(path.ProofEvidenceState),
+		RequiredEvidence:        "Deterministic deployment or branch-protection constraint evidence for this path.",
+		AcceptableSourceClasses: []string{evidencepolicy.SourceTypeProviderExport, evidencepolicy.SourceTypeRepoPolicy, evidencepolicy.SourceTypeSignedDeclaration},
+		FreshnessRequirement:    "constraint evidence should match the active branch, environment, and approval gates",
+		Examples: []string{
+			"Attach a protected-environment or required-check export for the deploy path.",
+			"Attach repo-local policy that names the deployment gate, freeze window, or kill switch for this path.",
+		},
+		ClosureRefs: dedupeSortedStrings(append(append([]string(nil), path.ConstraintEvidenceRefs...), path.PolicyEvidenceRefs...)),
+		ReasonCodes: []string{"constraint_evidence:missing"},
+		Guidance:    "Prove the deployment or branch-protection constraint for this path before treating delivery controls as verified.",
+	}, true
+}
+
+func internalToolingClosureRequirement(path ActionPath) (ClosureRequirement, bool) {
+	if strings.TrimSpace(path.TargetClass) != TargetClassInternalTooling {
+		return ClosureRequirement{}, false
+	}
+	if len(path.Contradictions) > 0 || path.ControlPriority == ControlPriorityControlFirst {
+		return ClosureRequirement{}, false
+	}
+	return ClosureRequirement{
+		ID:                      closureRequirementID(path.PathID, ClosureRequirementAcceptInternalTooling, path.TargetClass),
+		Severity:                ClosureSeverityLow,
+		RequirementType:         ClosureRequirementAcceptInternalTooling,
+		CurrentEvidenceState:    normalizeEvidenceState(path.TargetEvidenceState),
+		RequiredEvidence:        "A declared internal-tooling acceptance with owner, scope, and expiry.",
+		AcceptableSourceClasses: []string{evidencepolicy.SourceTypeSignedDeclaration, evidencepolicy.SourceTypeRepoPolicy},
+		FreshnessRequirement:    "acceptance should be explicit and time-bounded",
+		Examples: []string{
+			"Record the path in wrkr-control-declarations.yaml as approved internal tooling with expiry.",
+		},
+		ClosureRefs: append([]string(nil), path.TargetClassEvidenceRefs...),
+		ReasonCodes: []string{"target_class:internal_tooling"},
+		Guidance:    "If this path is intentionally internal-only tooling, declare that acceptance with owner and expiry so Wrkr can keep it visible without over-escalating it.",
+	}, true
+}
+
+func scanCoverageClosureRequirement(path ActionPath, signals scanquality.CompletenessSignals, completeness *EvidenceCompleteness) (ClosureRequirement, bool) {
+	if !signals.ReducedCoverage {
+		return ClosureRequirement{}, false
+	}
+	return ClosureRequirement{
+		ID:                      closureRequirementID(path.PathID, ClosureRequirementExpandScanCoverage, path.ConfidenceLane),
+		Severity:                ClosureSeverityMedium,
+		RequirementType:         ClosureRequirementExpandScanCoverage,
+		CurrentEvidenceState:    EvidenceStateUnknown,
+		RequiredEvidence:        "Complete parser and detector coverage for the repository that contains this path.",
+		AcceptableSourceClasses: []string{evidencepolicy.SourceTypeRepoPolicy, evidencepolicy.SourceTypeProviderExport},
+		FreshnessRequirement:    "rerun with current parser coverage after fixing reduced or blocked inputs",
+		Examples: []string{
+			"Fix reduced detector coverage or parse failures, then rerun the same scan inputs.",
+			"Attach exported control evidence if this surface stays parser-limited.",
+		},
+		ClosureRefs:             append([]string(nil), signals.UnsupportedSurfaces...),
+		ReasonCodes:             append([]string{"scan_quality:reduced"}, signals.Reasons...),
+		Guidance:                "Restore complete scan coverage for this repository or attach stronger exported evidence before treating low-completeness conclusions as fully supported.",
+	}, true
+}
+
+type freshnessIssue struct {
+	field  string
+	label  string
+	reason string
+	state  string
+	refs   []string
+}
+
+func freshnessIssuesForPath(path ActionPath) []freshnessIssue {
+	issues := []freshnessIssue{}
+	appendDecisionIssue := func(field, label, state string) {
+		decision, ok := evidenceDecisionForField(path, field)
+		if !ok {
+			return
+		}
+		switch strings.TrimSpace(decision.SelectedFreshnessState) {
+		case evidencepolicy.FreshnessStateExpired:
+			issues = append(issues, freshnessIssue{
+				field:  field,
+				label:  label,
+				reason: field + ":expired",
+				state:  state,
+				refs:   decisionEvidenceRefs(decision),
+			})
+		case evidencepolicy.FreshnessStateStale:
+			issues = append(issues, freshnessIssue{
+				field:  field,
+				label:  label,
+				reason: field + ":stale",
+				state:  state,
+				refs:   decisionEvidenceRefs(decision),
+			})
+		}
+	}
+	appendDecisionIssue(evidencepolicy.FieldOwner, "owner", normalizeEvidenceState(path.OwnerEvidenceState))
+	appendDecisionIssue(evidencepolicy.FieldApproval, "approval", normalizeEvidenceState(path.ApprovalEvidenceState))
+	if strings.TrimSpace(path.PolicyCoverageStatus) == PolicyCoverageStatusStale {
+		issues = append(issues, freshnessIssue{
+			field:  "policy",
+			label:  "policy",
+			reason: "policy:stale",
+			state:  normalizeEvidenceState(path.ProofEvidenceState),
+			refs:   append([]string(nil), path.PolicyEvidenceRefs...),
+		})
+	}
+	if path.GaitCoverage != nil && GaitCoverageHasStatus(path.GaitCoverage, GaitStatusStale) {
+		issues = append(issues, freshnessIssue{
+			field:  "runtime",
+			label:  "runtime",
+			reason: "runtime:stale",
+			state:  normalizeEvidenceState(path.RuntimeEvidenceState),
+			refs:   append([]string(nil), path.ControlEvidenceRefs...),
+		})
+	}
+	sort.Slice(issues, func(i, j int) bool {
+		if issues[i].field != issues[j].field {
+			return issues[i].field < issues[j].field
+		}
+		return issues[i].reason < issues[j].reason
+	})
+	return issues
+}
+
+func buildEvidenceCompleteness(path ActionPath, signals scanquality.CompletenessSignals) *EvidenceCompleteness {
+	axisScores := []EvidenceCompletenessAxisScore{
+		discoveryCompletenessAxis(path, signals),
+		authorityCompletenessAxis(path),
+		blastCompletenessAxis(path),
+		controlCompletenessAxis(path),
+		runtimeCompletenessAxis(path),
+		proofCompletenessAxis(path),
+	}
+	total := 0
+	reasons := []string{}
+	for _, axis := range axisScores {
+		total += axis.Score
+		reasons = append(reasons, axis.Reasons...)
+	}
+	gaps := evidenceGapsForCompleteness(path)
+	freshnessPenalties := freshnessPenaltyReasons(path)
+	contradictionPenalties := contradictionPenaltyReasons(path)
+	reasons = append(reasons, gaps...)
+	reasons = append(reasons, freshnessPenalties...)
+	reasons = append(reasons, contradictionPenalties...)
+	reasons = append(reasons, signals.Reasons...)
+	score := int(math.Round(float64(total) / float64(len(axisScores))))
+	if score < 0 {
+		score = 0
+	}
+	if score > 100 {
+		score = 100
+	}
+	return &EvidenceCompleteness{
+		TotalScore:             score,
+		Label:                  evidenceCompletenessLabel(score),
+		AxisScores:             axisScores,
+		EvidenceGaps:           gaps,
+		UnsupportedSurfaces:    dedupeSortedStrings(signals.UnsupportedSurfaces),
+		FreshnessPenalties:     freshnessPenalties,
+		ContradictionPenalties: contradictionPenalties,
+		Reasons:                dedupeSortedStrings(reasons),
+	}
+}
+
+func discoveryCompletenessAxis(path ActionPath, signals scanquality.CompletenessSignals) EvidenceCompletenessAxisScore {
+	score := 60
+	reasons := []string{"confidence_lane:" + firstNonEmptyString(path.ConfidenceLane, ConfidenceLaneContextOnly)}
+	switch strings.TrimSpace(path.ConfidenceLane) {
+	case ConfidenceLaneConfirmedActionPath:
+		score = 100
+	case ConfidenceLaneLikelyActionPath:
+		score = 85
+	case ConfidenceLaneSemanticReviewCandidate:
+		score = 70
+	case ConfidenceLaneContextOnly:
+		score = 55
+	}
+	switch strings.TrimSpace(path.ActionPathType) {
+	case ActionPathTypeUnknownExecutablePath:
+		score -= 20
+		reasons = append(reasons, "action_path_type:unknown_executable_path")
+	case ActionPathTypePlainSourceCode:
+		score -= 10
+		reasons = append(reasons, "action_path_type:plain_source_code")
+	}
+	if signals.ReducedCoverage {
+		score -= 25
+		reasons = append(reasons, "scan_quality:reduced")
+	}
+	if len(signals.UnsupportedSurfaces) > 0 {
+		score -= 10
+		reasons = append(reasons, "unsupported_surfaces:"+strings.Join(signals.UnsupportedSurfaces, ","))
+	}
+	return EvidenceCompletenessAxisScore{
+		Axis:    CompletenessAxisDiscovery,
+		Score:   clampScore(score),
+		Reasons: dedupeSortedStrings(reasons),
+	}
+}
+
+func authorityCompletenessAxis(path ActionPath) EvidenceCompletenessAxisScore {
+	ownerScore := evidenceStateCompletenessScore(path.OwnerEvidenceState)
+	approvalScore := evidenceStateCompletenessScore(path.ApprovalEvidenceState)
+	score := int(math.Round(float64(ownerScore+approvalScore) / 2.0))
+	reasons := []string{
+		"owner:" + normalizeEvidenceState(path.OwnerEvidenceState),
+		"approval:" + normalizeEvidenceState(path.ApprovalEvidenceState),
+	}
+	return EvidenceCompletenessAxisScore{
+		Axis:    CompletenessAxisAuthority,
+		Score:   clampScore(score),
+		Reasons: dedupeSortedStrings(reasons),
+	}
+}
+
+func blastCompletenessAxis(path ActionPath) EvidenceCompletenessAxisScore {
+	targetScore := evidenceStateCompletenessScore(path.TargetEvidenceState)
+	credentialScore := evidenceStateCompletenessScore(path.CredentialEvidenceState)
+	score := int(math.Round(float64(targetScore+credentialScore) / 2.0))
+	reasons := []string{
+		"target:" + normalizeEvidenceState(path.TargetEvidenceState),
+		"credential:" + normalizeEvidenceState(path.CredentialEvidenceState),
+	}
+	if path.ProductionWrite && normalizeEvidenceState(path.TargetEvidenceState) == EvidenceStateUnknown {
+		score -= 20
+		reasons = append(reasons, "production_target:unknown")
+	}
+	if path.CredentialAccess && normalizeEvidenceState(path.CredentialEvidenceState) == EvidenceStateUnknown {
+		score -= 20
+		reasons = append(reasons, "credential_scope:unknown")
+	}
+	return EvidenceCompletenessAxisScore{
+		Axis:    CompletenessAxisBlast,
+		Score:   clampScore(score),
+		Reasons: dedupeSortedStrings(reasons),
+	}
+}
+
+func controlCompletenessAxis(path ActionPath) EvidenceCompletenessAxisScore {
+	score := controlResolutionCompletenessScore(path.ControlResolutionState)
+	reasons := []string{
+		"control_resolution:" + normalizeControlResolutionState(path.ControlResolutionState),
+	}
+	if pathNeedsDeploymentConstraintEvidence(path) {
+		score -= 20
+		reasons = append(reasons, "constraint_evidence:missing")
+	}
+	for _, penalty := range freshnessPenaltyReasons(path) {
+		score -= 10
+		reasons = append(reasons, penalty)
+	}
+	for _, penalty := range contradictionPenaltyReasons(path) {
+		score -= 15
+		reasons = append(reasons, penalty)
+	}
+	return EvidenceCompletenessAxisScore{
+		Axis:    CompletenessAxisControl,
+		Score:   clampScore(score),
+		Reasons: dedupeSortedStrings(reasons),
+	}
+}
+
+func runtimeCompletenessAxis(path ActionPath) EvidenceCompletenessAxisScore {
+	absence := RuntimeEvidenceAbsenceStatus(path)
+	score := evidenceStateCompletenessScore(path.RuntimeEvidenceState)
+	reasons := []string{
+		"runtime:" + normalizeEvidenceState(path.RuntimeEvidenceState),
+	}
+	switch absence {
+	case RuntimeEvidenceAbsenceNotApplicable:
+		score = 100
+		reasons = append(reasons, "runtime_absence_status:not_applicable")
+	case RuntimeEvidenceAbsenceMissingRequired, RuntimeEvidenceAbsenceMissingForClaim:
+		score = 20
+		reasons = append(reasons, "runtime_absence_status:"+absence)
+	case RuntimeEvidenceAbsenceNotCollected:
+		score = 35
+		reasons = append(reasons, "runtime_absence_status:not_collected")
+	}
+	if path.GaitCoverage != nil && GaitCoverageHasStatus(path.GaitCoverage, GaitStatusStale) {
+		score = minInt(score, 45)
+		reasons = append(reasons, "runtime:stale")
+	}
+	return EvidenceCompletenessAxisScore{
+		Axis:    CompletenessAxisRuntime,
+		Score:   clampScore(score),
+		Reasons: dedupeSortedStrings(reasons),
+	}
+}
+
+func proofCompletenessAxis(path ActionPath) EvidenceCompletenessAxisScore {
+	score := evidenceStateCompletenessScore(path.ProofEvidenceState)
+	reasons := []string{
+		"proof:" + normalizeEvidenceState(path.ProofEvidenceState),
+	}
+	switch strings.TrimSpace(path.PolicyCoverageStatus) {
+	case PolicyCoverageStatusNone:
+		score = 25
+		reasons = append(reasons, "policy_coverage:none")
+	case PolicyCoverageStatusDeclared:
+		score = maxInt(score, 75)
+		reasons = append(reasons, "policy_coverage:declared")
+	case PolicyCoverageStatusMatched, PolicyCoverageStatusRuntimeProven:
+		score = maxInt(score, 85)
+		reasons = append(reasons, "policy_coverage:"+strings.TrimSpace(path.PolicyCoverageStatus))
+	case PolicyCoverageStatusStale:
+		score = minInt(score, 40)
+		reasons = append(reasons, "policy_coverage:stale")
+	case PolicyCoverageStatusConflict:
+		score = 0
+		reasons = append(reasons, "policy_coverage:conflict")
+	}
+	return EvidenceCompletenessAxisScore{
+		Axis:    CompletenessAxisProof,
+		Score:   clampScore(score),
+		Reasons: dedupeSortedStrings(reasons),
+	}
+}
+
+func freshnessPenaltyReasons(path ActionPath) []string {
+	reasons := []string{}
+	for _, issue := range freshnessIssuesForPath(path) {
+		reasons = append(reasons, issue.reason)
+	}
+	return dedupeSortedStrings(reasons)
+}
+
+func contradictionPenaltyReasons(path ActionPath) []string {
+	reasons := contradictionReasonCodes(path.Contradictions)
+	for _, item := range []struct {
+		prefix string
+		state  string
+	}{
+		{"owner", path.OwnerEvidenceState},
+		{"approval", path.ApprovalEvidenceState},
+		{"proof", path.ProofEvidenceState},
+		{"runtime", path.RuntimeEvidenceState},
+		{"target", path.TargetEvidenceState},
+		{"credential", path.CredentialEvidenceState},
+	} {
+		if normalizeEvidenceState(item.state) == EvidenceStateContradictory {
+			reasons = append(reasons, item.prefix+":contradictory")
+		}
+	}
+	return dedupeSortedStrings(reasons)
+}
+
+func evidenceGapsForCompleteness(path ActionPath) []string {
+	gaps := []string{}
+	if normalizeEvidenceState(path.OwnerEvidenceState) == EvidenceStateUnknown {
+		gaps = append(gaps, "owner_evidence:none")
+	}
+	if normalizeEvidenceState(path.ApprovalEvidenceState) == EvidenceStateUnknown {
+		gaps = append(gaps, "approval_evidence:none")
+	}
+	if normalizeEvidenceState(path.ProofEvidenceState) == EvidenceStateUnknown {
+		gaps = append(gaps, "proof_evidence:none")
+	}
+	if normalizeEvidenceState(path.RuntimeEvidenceState) == EvidenceStateUnknown {
+		gaps = append(gaps, "runtime_evidence:none")
+	}
+	if pathNeedsDeploymentConstraintEvidence(path) {
+		gaps = append(gaps, "constraint_evidence:missing")
+	}
+	return dedupeSortedStrings(gaps)
+}
+
+func evidenceStateCompletenessScore(state string) int {
+	switch normalizeEvidenceState(state) {
+	case EvidenceStateVerified:
+		return 100
+	case EvidenceStateDeclared:
+		return 85
+	case EvidenceStateInferred:
+		return 70
+	case EvidenceStateContradictory:
+		return 0
+	default:
+		return 35
+	}
+}
+
+func controlResolutionCompletenessScore(state string) int {
+	switch normalizeControlResolutionState(state) {
+	case ControlResolutionStateDetectedControl:
+		return 100
+	case ControlResolutionStateExternalControlReference:
+		return 85
+	case ControlResolutionStateDeclaredControl:
+		return 80
+	case ControlResolutionStateNotApplicable:
+		return 90
+	case ControlResolutionStateContradictoryControl:
+		return 0
+	default:
+		return 35
+	}
+}
+
+func ownerClosureSeverity(path ActionPath) string {
+	if path.ControlPriority == ControlPriorityControlFirst || path.CredentialAccess || path.ProductionWrite {
+		return ClosureSeverityHigh
+	}
+	return ClosureSeverityMedium
+}
+
+func approvalClosureSeverity(path ActionPath) string {
+	if path.ControlPriority == ControlPriorityControlFirst || path.DeployWrite || path.ProductionWrite {
+		return ClosureSeverityHigh
+	}
+	return ClosureSeverityMedium
+}
+
+func proofClosureSeverity(path ActionPath) string {
+	if path.ControlPriority == ControlPriorityControlFirst || path.ProductionWrite || path.DeployWrite {
+		return ClosureSeverityHigh
+	}
+	return ClosureSeverityMedium
+}
+
+func runtimeClosureSeverity(path ActionPath, absence string) string {
+	if absence == RuntimeEvidenceAbsenceMissingRequired || absence == RuntimeEvidenceAbsenceMissingForClaim {
+		return ClosureSeverityHigh
+	}
+	if path.CredentialAccess || path.ProductionWrite {
+		return ClosureSeverityHigh
+	}
+	return ClosureSeverityMedium
+}
+
+func freshnessSourceClasses(field string) []string {
+	switch strings.TrimSpace(field) {
+	case evidencepolicy.FieldOwner:
+		return []string{evidencepolicy.SourceTypeProviderExport, evidencepolicy.SourceTypeCustomerOwnerMap, evidencepolicy.SourceTypeSignedDeclaration}
+	case evidencepolicy.FieldApproval:
+		return []string{evidencepolicy.SourceTypeProviderExport, evidencepolicy.SourceTypeTicketExport, evidencepolicy.SourceTypeSignedDeclaration}
+	case "runtime":
+		return []string{evidencepolicy.SourceTypeRuntime, evidencepolicy.SourceTypeProviderExport}
+	default:
+		return []string{evidencepolicy.SourceTypeProviderExport, evidencepolicy.SourceTypeRepoPolicy, evidencepolicy.SourceTypeSignedDeclaration}
+	}
+}
+
+func freshnessExamples(field string) []string {
+	switch strings.TrimSpace(field) {
+	case evidencepolicy.FieldOwner:
+		return []string{"Refresh the owner export or declaration with a current observed_at and valid_until value."}
+	case evidencepolicy.FieldApproval:
+		return []string{"Refresh the approval export or signed declaration with a current approval window."}
+	case "runtime":
+		return []string{"Recollect runtime evidence for the current execution window and correlate it to this path."}
+	default:
+		return []string{"Refresh the evidence with a current validity window and rescan."}
+	}
+}
+
+func pathNeedsDeploymentConstraintEvidence(path ActionPath) bool {
+	if !(path.DeployWrite || path.ProductionWrite || len(path.MatchedProductionTargets) > 0 || strings.TrimSpace(path.WorkflowTriggerClass) == "deploy_pipeline") {
+		return false
+	}
+	return len(path.ConstraintEvidenceClasses) == 0 && len(path.ConstraintEvidenceRefs) == 0
+}
+
+func likelyJITCredential(path ActionPath) bool {
+	if path.CredentialAuthority != nil && path.CredentialAuthority.LikelyJIT {
+		return true
+	}
+	return path.CredentialProvenance != nil && path.CredentialProvenance.LikelyJIT
+}
+
+func closureRequirementID(pathID, requirementType, discriminator string) string {
+	parts := []string{
+		firstNonEmptyString(strings.TrimSpace(pathID), "path"),
+		strings.TrimSpace(requirementType),
+		strings.TrimSpace(discriminator),
+	}
+	sum := shortDigest(parts...)
+	return "clr-" + sum
+}
+
+func closureSeverityPriority(value string) int {
+	switch strings.TrimSpace(value) {
+	case ClosureSeverityCritical:
+		return 0
+	case ClosureSeverityHigh:
+		return 1
+	case ClosureSeverityMedium:
+		return 2
+	case ClosureSeverityLow:
+		return 3
+	default:
+		return 99
+	}
+}
+
+func evidenceCompletenessLabel(score int) string {
+	switch {
+	case score >= 85:
+		return EvidenceCompletenessStrong
+	case score >= 60:
+		return EvidenceCompletenessPartial
+	default:
+		return EvidenceCompletenessInsufficient
+	}
+}
+
+func clampScore(value int) int {
+	if value < 0 {
+		return 0
+	}
+	if value > 100 {
+		return 100
+	}
+	return value
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func shortDigest(parts ...string) string {
+	joined := strings.Join(parts, "|")
+	sum := sha256.Sum256([]byte(joined))
+	return strings.ToLower(strings.TrimSpace(hex.EncodeToString(sum[:4])))
+}

--- a/core/risk/evidence_context_test.go
+++ b/core/risk/evidence_context_test.go
@@ -216,6 +216,39 @@ func TestLowCompletenessDoesNotDowngradeRiskAndAccountsForReducedCoverage(t *tes
 	}
 }
 
+func TestEvidenceCompletenessSummaryCountsReducedCoverageWithoutUnsupportedSurfaces(t *testing.T) {
+	t.Parallel()
+
+	paths := DecorateEvidenceContext([]ActionPath{{
+		PathID:               "apc-reduced-coverage-summary",
+		Org:                  "acme",
+		Repo:                 "payments",
+		ToolType:             "mcp",
+		Location:             ".cursor/mcp.json",
+		WriteCapable:         true,
+		ConfidenceLane:       ConfidenceLaneConfirmedActionPath,
+		ActionPathType:       ActionPathTypeAgentFramework,
+		ControlPriority:      ControlPriorityControlFirst,
+		PolicyCoverageStatus: PolicyCoverageStatusNone,
+	}}, &scanquality.Report{
+		Detectors: []scanquality.DetectorHealth{{
+			Org:             "acme",
+			Repo:            "payments",
+			Detector:        "mcp",
+			Status:          "reduced",
+			CoverageReasons: []string{"generated_suppression"},
+		}},
+	})
+
+	summary := BuildEvidenceCompletenessSummary(paths)
+	if summary == nil {
+		t.Fatal("expected completeness summary")
+	}
+	if summary.ReducedCoveragePathCount != 1 {
+		t.Fatalf("expected reduced coverage path count to include detector-only reduction, got %+v", summary)
+	}
+}
+
 func findClosureRequirement(items []ClosureRequirement, requirementType string) (ClosureRequirement, bool) {
 	for _, item := range items {
 		if strings.TrimSpace(item.RequirementType) == strings.TrimSpace(requirementType) {

--- a/core/risk/evidence_context_test.go
+++ b/core/risk/evidence_context_test.go
@@ -1,0 +1,245 @@
+package risk
+
+import (
+	"strings"
+	"testing"
+
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/aggregate/scanquality"
+	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
+)
+
+func TestClosureRequirementsForUnknownOwnerAndApproval(t *testing.T) {
+	t.Parallel()
+
+	paths := DecorateEvidenceContext([]ActionPath{{
+		PathID:                 "apc-owner-approval",
+		Org:                    "acme",
+		Repo:                   "platform",
+		ToolType:               "compiled_action",
+		Location:               ".github/workflows/release.yml",
+		WriteCapable:           true,
+		DeployWrite:            true,
+		ApprovalGap:            true,
+		ApprovalGapReasons:     []string{"approval_source_missing"},
+		OwnerEvidenceState:     EvidenceStateUnknown,
+		ControlResolutionState: ControlResolutionStateNoVisibleControl,
+		PolicyCoverageStatus:   PolicyCoverageStatusNone,
+		ConfidenceLane:         ConfidenceLaneConfirmedActionPath,
+		ActionPathType:         ActionPathTypeCICDWorkflow,
+		ControlPriority:        ControlPriorityControlFirst,
+		RiskTier:               RiskTierHigh,
+	}}, nil)
+
+	if len(paths) != 1 {
+		t.Fatalf("expected one path, got %+v", paths)
+	}
+	requirements := paths[0].ClosureRequirements
+	if _, ok := findClosureRequirement(requirements, ClosureRequirementAssignOwner); !ok {
+		t.Fatalf("expected assign_owner requirement, got %+v", requirements)
+	}
+	if _, ok := findClosureRequirement(requirements, ClosureRequirementAttachApproval); !ok {
+		t.Fatalf("expected attach_approval requirement, got %+v", requirements)
+	}
+	policyRequirement, ok := findClosureRequirement(requirements, ClosureRequirementAttachPolicyReference)
+	if !ok {
+		t.Fatalf("expected attach_policy_reference requirement, got %+v", requirements)
+	}
+	if !strings.Contains(strings.ToLower(policyRequirement.Guidance), "policy") {
+		t.Fatalf("expected policy guidance, got %+v", policyRequirement)
+	}
+}
+
+func TestClosureRequirementsForExpiredEvidenceAndRuntimeGap(t *testing.T) {
+	t.Parallel()
+
+	paths := DecorateEvidenceContext([]ActionPath{{
+		PathID:       "apc-expired-runtime",
+		Org:          "acme",
+		Repo:         "payments",
+		ToolType:     "compiled_action",
+		Location:     ".github/workflows/deploy.yml",
+		WriteCapable: true,
+		DeployWrite:  true,
+		ProductionWrite: true,
+		CredentialAccess: true,
+		CredentialProvenance: &credentialProvenanceJIT,
+		EvidenceDecisions: []evidencepolicy.Decision{{
+			Field:                  evidencepolicy.FieldApproval,
+			SelectedSourceType:     evidencepolicy.SourceTypeProviderExport,
+			SelectedFreshnessState: evidencepolicy.FreshnessStateExpired,
+			SelectedEvidenceRefs:   []string{"evidence://approval/export.json#release"},
+		}},
+		GaitCoverage: &GaitCoverage{
+			PolicyDecision: GaitCoverageDetail{
+				Status:  GaitStatusMissing,
+				Reasons: []string{"runtime_absence_status:" + RuntimeEvidenceAbsenceNotCollected},
+			},
+		},
+		PolicyCoverageStatus: PolicyCoverageStatusMatched,
+		PolicyEvidenceRefs:   []string{"policy://release-gate"},
+		ControlPriority:      ControlPriorityControlFirst,
+		RiskTier:             RiskTierHigh,
+	}}, nil)
+
+	requirements := paths[0].ClosureRequirements
+	if _, ok := findClosureRequirement(requirements, ClosureRequirementRefreshExpiredEvidence); !ok {
+		t.Fatalf("expected refresh_expired_evidence requirement, got %+v", requirements)
+	}
+	if _, ok := findClosureRequirement(requirements, ClosureRequirementProveJITCredential); !ok {
+		t.Fatalf("expected prove_jit_credential requirement, got %+v", requirements)
+	}
+	if _, ok := findClosureRequirement(requirements, ClosureRequirementProveDeploymentConstraint); !ok {
+		t.Fatalf("expected deployment constraint requirement, got %+v", requirements)
+	}
+}
+
+func TestClosureRequirementsForAcceptedInternalTooling(t *testing.T) {
+	t.Parallel()
+
+	paths := DecorateEvidenceContext([]ActionPath{{
+		PathID:               "apc-internal-tooling",
+		Org:                  "acme",
+		Repo:                 "platform",
+		ToolType:             "codex",
+		Location:             ".codex/config.toml",
+		ConfidenceLane:       ConfidenceLaneLikelyActionPath,
+		ActionPathType:       ActionPathTypeAgentFramework,
+		TargetClass:          TargetClassInternalTooling,
+		TargetEvidenceState:  EvidenceStateDeclared,
+		ControlPriority:      ControlPriorityReviewQueue,
+		RiskTier:             RiskTierMedium,
+	}}, nil)
+
+	requirement, ok := findClosureRequirement(paths[0].ClosureRequirements, ClosureRequirementAcceptInternalTooling)
+	if !ok {
+		t.Fatalf("expected accepted internal tooling requirement, got %+v", paths[0].ClosureRequirements)
+	}
+	if !strings.Contains(strings.ToLower(requirement.Guidance), "internal-only") {
+		t.Fatalf("expected internal-tooling guidance, got %+v", requirement)
+	}
+}
+
+func TestEvidenceCompletenessAxes(t *testing.T) {
+	t.Parallel()
+
+	paths := DecorateEvidenceContext([]ActionPath{{
+		PathID:                  "apc-complete",
+		Org:                     "acme",
+		Repo:                    "platform",
+		ToolType:                "compiled_action",
+		Location:                ".github/workflows/release.yml",
+		WriteCapable:            true,
+		DeployWrite:             true,
+		ProductionWrite:         true,
+		ApprovalEvidenceState:   EvidenceStateVerified,
+		OwnerEvidenceState:      EvidenceStateVerified,
+		ProofEvidenceState:      EvidenceStateVerified,
+		RuntimeEvidenceState:    EvidenceStateVerified,
+		TargetEvidenceState:     EvidenceStateVerified,
+		CredentialEvidenceState: EvidenceStateVerified,
+		ControlResolutionState:  ControlResolutionStateDetectedControl,
+		ConstraintEvidenceRefs:  []string{"constraint://release-gate"},
+		PolicyCoverageStatus:    PolicyCoverageStatusMatched,
+		PolicyEvidenceRefs:      []string{"policy://release"},
+		ConfidenceLane:          ConfidenceLaneConfirmedActionPath,
+		ActionPathType:          ActionPathTypeCICDWorkflow,
+	}}, nil)
+
+	completeness := paths[0].EvidenceCompleteness
+	if completeness == nil {
+		t.Fatal("expected completeness")
+	}
+	if completeness.TotalScore < 85 {
+		t.Fatalf("expected strong completeness score, got %+v", completeness)
+	}
+	if completeness.Label != EvidenceCompletenessStrong {
+		t.Fatalf("expected strong completeness label, got %+v", completeness)
+	}
+	if len(completeness.AxisScores) != len(completenessAxisOrder) {
+		t.Fatalf("expected one score per completeness axis, got %+v", completeness.AxisScores)
+	}
+}
+
+func TestLowCompletenessDoesNotDowngradeRiskAndAccountsForReducedCoverage(t *testing.T) {
+	t.Parallel()
+
+	scanSignals := &scanquality.Report{
+		Detectors: []scanquality.DetectorHealth{{
+			Org:             "acme",
+			Repo:            "payments",
+			Detector:        "mcp",
+			Status:          "reduced",
+			CoverageReasons: []string{"generated_suppression"},
+		}},
+		AbsenceClaims: []scanquality.AbsenceClaim{{
+			Org:     "acme",
+			Repo:    "payments",
+			Surface: scanquality.SurfaceMCPServer,
+			Status:  scanquality.AbsenceStatusUnsupportedSurface,
+		}},
+	}
+	projected := ProjectActionPath(ActionPath{
+		PathID:                 "apc-low-completeness",
+		Org:                    "acme",
+		Repo:                   "payments",
+		ToolType:               "mcp",
+		Location:               ".cursor/mcp.json",
+		WriteCapable:           true,
+		CredentialAccess:       true,
+		ProductionWrite:        true,
+		ApprovalGap:            true,
+		OwnerEvidenceState:     EvidenceStateUnknown,
+		PolicyCoverageStatus:   PolicyCoverageStatusNone,
+		ControlPriority:        ControlPriorityControlFirst,
+		RiskTier:               RiskTierHigh,
+		ConfidenceLane:         ConfidenceLaneConfirmedActionPath,
+		ActionPathType:         ActionPathTypeAgentFramework,
+	})
+
+	paths := DecorateEvidenceContext([]ActionPath{projected}, scanSignals)
+	if len(paths) != 1 {
+		t.Fatalf("expected one path, got %+v", paths)
+	}
+	if paths[0].ControlPriority != projected.ControlPriority || paths[0].RiskTier != projected.RiskTier {
+		t.Fatalf("expected completeness decoration not to change risk posture\nbefore=%+v\nafter=%+v", projected, paths[0])
+	}
+	completeness := paths[0].EvidenceCompleteness
+	if completeness == nil || completeness.Label != EvidenceCompletenessInsufficient {
+		t.Fatalf("expected insufficient completeness, got %+v", completeness)
+	}
+	if len(completeness.UnsupportedSurfaces) == 0 || completeness.UnsupportedSurfaces[0] != scanquality.SurfaceMCPServer {
+		t.Fatalf("expected unsupported surface penalty, got %+v", completeness)
+	}
+	if axisScore(t, completeness, CompletenessAxisDiscovery) >= 100 {
+		t.Fatalf("expected reduced discovery score, got %+v", completeness)
+	}
+}
+
+func findClosureRequirement(items []ClosureRequirement, requirementType string) (ClosureRequirement, bool) {
+	for _, item := range items {
+		if strings.TrimSpace(item.RequirementType) == strings.TrimSpace(requirementType) {
+			return item, true
+		}
+	}
+	return ClosureRequirement{}, false
+}
+
+func axisScore(t *testing.T, completeness *EvidenceCompleteness, axis string) int {
+	t.Helper()
+	for _, item := range completeness.AxisScores {
+		if item.Axis == axis {
+			return item.Score
+		}
+	}
+	t.Fatalf("missing axis %s in %+v", axis, completeness.AxisScores)
+	return 0
+}
+
+var credentialProvenanceJIT = agginventory.CredentialProvenance{
+	Type:           agginventory.CredentialProvenanceJIT,
+	Scope:          agginventory.CredentialScopeWorkflow,
+	Confidence:     "high",
+	LikelyJIT:      true,
+	RiskMultiplier: 1,
+}

--- a/core/risk/evidence_context_test.go
+++ b/core/risk/evidence_context_test.go
@@ -54,15 +54,15 @@ func TestClosureRequirementsForExpiredEvidenceAndRuntimeGap(t *testing.T) {
 	t.Parallel()
 
 	paths := DecorateEvidenceContext([]ActionPath{{
-		PathID:       "apc-expired-runtime",
-		Org:          "acme",
-		Repo:         "payments",
-		ToolType:     "compiled_action",
-		Location:     ".github/workflows/deploy.yml",
-		WriteCapable: true,
-		DeployWrite:  true,
-		ProductionWrite: true,
-		CredentialAccess: true,
+		PathID:               "apc-expired-runtime",
+		Org:                  "acme",
+		Repo:                 "payments",
+		ToolType:             "compiled_action",
+		Location:             ".github/workflows/deploy.yml",
+		WriteCapable:         true,
+		DeployWrite:          true,
+		ProductionWrite:      true,
+		CredentialAccess:     true,
 		CredentialProvenance: &credentialProvenanceJIT,
 		EvidenceDecisions: []evidencepolicy.Decision{{
 			Field:                  evidencepolicy.FieldApproval,
@@ -98,17 +98,17 @@ func TestClosureRequirementsForAcceptedInternalTooling(t *testing.T) {
 	t.Parallel()
 
 	paths := DecorateEvidenceContext([]ActionPath{{
-		PathID:               "apc-internal-tooling",
-		Org:                  "acme",
-		Repo:                 "platform",
-		ToolType:             "codex",
-		Location:             ".codex/config.toml",
-		ConfidenceLane:       ConfidenceLaneLikelyActionPath,
-		ActionPathType:       ActionPathTypeAgentFramework,
-		TargetClass:          TargetClassInternalTooling,
-		TargetEvidenceState:  EvidenceStateDeclared,
-		ControlPriority:      ControlPriorityReviewQueue,
-		RiskTier:             RiskTierMedium,
+		PathID:              "apc-internal-tooling",
+		Org:                 "acme",
+		Repo:                "platform",
+		ToolType:            "codex",
+		Location:            ".codex/config.toml",
+		ConfidenceLane:      ConfidenceLaneLikelyActionPath,
+		ActionPathType:      ActionPathTypeAgentFramework,
+		TargetClass:         TargetClassInternalTooling,
+		TargetEvidenceState: EvidenceStateDeclared,
+		ControlPriority:     ControlPriorityReviewQueue,
+		RiskTier:            RiskTierMedium,
 	}}, nil)
 
 	requirement, ok := findClosureRequirement(paths[0].ClosureRequirements, ClosureRequirementAcceptInternalTooling)
@@ -180,21 +180,21 @@ func TestLowCompletenessDoesNotDowngradeRiskAndAccountsForReducedCoverage(t *tes
 		}},
 	}
 	projected := ProjectActionPath(ActionPath{
-		PathID:                 "apc-low-completeness",
-		Org:                    "acme",
-		Repo:                   "payments",
-		ToolType:               "mcp",
-		Location:               ".cursor/mcp.json",
-		WriteCapable:           true,
-		CredentialAccess:       true,
-		ProductionWrite:        true,
-		ApprovalGap:            true,
-		OwnerEvidenceState:     EvidenceStateUnknown,
-		PolicyCoverageStatus:   PolicyCoverageStatusNone,
-		ControlPriority:        ControlPriorityControlFirst,
-		RiskTier:               RiskTierHigh,
-		ConfidenceLane:         ConfidenceLaneConfirmedActionPath,
-		ActionPathType:         ActionPathTypeAgentFramework,
+		PathID:               "apc-low-completeness",
+		Org:                  "acme",
+		Repo:                 "payments",
+		ToolType:             "mcp",
+		Location:             ".cursor/mcp.json",
+		WriteCapable:         true,
+		CredentialAccess:     true,
+		ProductionWrite:      true,
+		ApprovalGap:          true,
+		OwnerEvidenceState:   EvidenceStateUnknown,
+		PolicyCoverageStatus: PolicyCoverageStatusNone,
+		ControlPriority:      ControlPriorityControlFirst,
+		RiskTier:             RiskTierHigh,
+		ConfidenceLane:       ConfidenceLaneConfirmedActionPath,
+		ActionPathType:       ActionPathTypeAgentFramework,
 	})
 
 	paths := DecorateEvidenceContext([]ActionPath{projected}, scanSignals)

--- a/core/risk/evidence_language.go
+++ b/core/risk/evidence_language.go
@@ -125,3 +125,31 @@ func BuyerRuntimeEvidenceLabel(state string, absenceStatus string, coverage *Gai
 		return BuyerEvidenceStateLabel("runtime", state)
 	}
 }
+
+func BuyerEvidenceCompletenessLabel(completeness *EvidenceCompleteness) string {
+	if completeness == nil {
+		return "evidence completeness unavailable"
+	}
+	switch strings.TrimSpace(completeness.Label) {
+	case EvidenceCompletenessStrong:
+		return "strong evidence coverage"
+	case EvidenceCompletenessPartial:
+		return "partial evidence coverage"
+	default:
+		return "insufficient evidence coverage"
+	}
+}
+
+func BuyerEvidenceCompletenessSummaryLabel(summary *EvidenceCompletenessSummary) string {
+	if summary == nil {
+		return "aggregate evidence completeness unavailable"
+	}
+	switch strings.TrimSpace(summary.Label) {
+	case EvidenceCompletenessStrong:
+		return "aggregate evidence coverage is strong"
+	case EvidenceCompletenessPartial:
+		return "aggregate evidence coverage is partial"
+	default:
+		return "aggregate evidence coverage is insufficient"
+	}
+}

--- a/scenarios/wrkr/agent-action-bom-demo/expected/after-evidence-report.json
+++ b/scenarios/wrkr/agent-action-bom-demo/expected/after-evidence-report.json
@@ -187,6 +187,95 @@
         "coverage_reduced=false"
       ]
     },
+    "evidence_completeness": {
+      "path_count": 8,
+      "average_total_score": 73,
+      "label": "partial_evidence",
+      "axis_scores": [
+        {
+          "axis": "discovery",
+          "score": 81,
+          "reasons": [
+            "action_path_type:plain_source_code",
+            "action_path_type:unknown_executable_path",
+            "confidence_lane:confirmed_action_path",
+            "confidence_lane:context_only",
+            "confidence_lane:likely_action_path",
+            "confidence_lane:semantic_review_candidate"
+          ]
+        },
+        {
+          "axis": "authority",
+          "score": 53,
+          "reasons": [
+            "approval:unknown",
+            "owner:inferred"
+          ]
+        },
+        {
+          "axis": "blast_radius",
+          "score": 73,
+          "reasons": [
+            "credential:inferred",
+            "credential:verified",
+            "target:inferred",
+            "target:unknown",
+            "target:verified"
+          ]
+        },
+        {
+          "axis": "control",
+          "score": 85,
+          "reasons": [
+            "constraint_evidence:missing",
+            "control_resolution:detected_control"
+          ]
+        },
+        {
+          "axis": "runtime_evidence",
+          "score": 43,
+          "reasons": [
+            "runtime:unknown",
+            "runtime:verified",
+            "runtime_absence_status:not_collected"
+          ]
+        },
+        {
+          "axis": "proof",
+          "score": 100,
+          "reasons": [
+            "policy_coverage:matched",
+            "policy_coverage:runtime_proven",
+            "proof:verified"
+          ]
+        }
+      ],
+      "reasons": [
+        "action_path_type:plain_source_code",
+        "action_path_type:unknown_executable_path",
+        "approval:unknown",
+        "approval_evidence:none",
+        "confidence_lane:confirmed_action_path",
+        "confidence_lane:context_only",
+        "confidence_lane:likely_action_path",
+        "confidence_lane:semantic_review_candidate",
+        "constraint_evidence:missing",
+        "control_resolution:detected_control",
+        "credential:inferred",
+        "credential:verified",
+        "owner:inferred",
+        "policy_coverage:matched",
+        "policy_coverage:runtime_proven",
+        "proof:verified",
+        "runtime:unknown",
+        "runtime:verified",
+        "runtime_absence_status:not_collected",
+        "runtime_evidence:none",
+        "target:inferred",
+        "target:unknown",
+        "target:verified"
+      ]
+    },
     "scan_coverage": {
       "coverage_confidence": "complete",
       "impact_statement": "Coverage for scanned inputs was complete enough to support scoped negative claims."

--- a/scenarios/wrkr/agent-action-bom-demo/expected/after-report.json
+++ b/scenarios/wrkr/agent-action-bom-demo/expected/after-report.json
@@ -71,6 +71,95 @@
         "coverage_reduced=false"
       ]
     },
+    "evidence_completeness": {
+      "path_count": 8,
+      "average_total_score": 73,
+      "label": "partial_evidence",
+      "axis_scores": [
+        {
+          "axis": "discovery",
+          "score": 81,
+          "reasons": [
+            "action_path_type:plain_source_code",
+            "action_path_type:unknown_executable_path",
+            "confidence_lane:confirmed_action_path",
+            "confidence_lane:context_only",
+            "confidence_lane:likely_action_path",
+            "confidence_lane:semantic_review_candidate"
+          ]
+        },
+        {
+          "axis": "authority",
+          "score": 53,
+          "reasons": [
+            "approval:unknown",
+            "owner:inferred"
+          ]
+        },
+        {
+          "axis": "blast_radius",
+          "score": 73,
+          "reasons": [
+            "credential:inferred",
+            "credential:verified",
+            "target:inferred",
+            "target:unknown",
+            "target:verified"
+          ]
+        },
+        {
+          "axis": "control",
+          "score": 85,
+          "reasons": [
+            "constraint_evidence:missing",
+            "control_resolution:detected_control"
+          ]
+        },
+        {
+          "axis": "runtime_evidence",
+          "score": 43,
+          "reasons": [
+            "runtime:unknown",
+            "runtime:verified",
+            "runtime_absence_status:not_collected"
+          ]
+        },
+        {
+          "axis": "proof",
+          "score": 100,
+          "reasons": [
+            "policy_coverage:matched",
+            "policy_coverage:runtime_proven",
+            "proof:verified"
+          ]
+        }
+      ],
+      "reasons": [
+        "action_path_type:plain_source_code",
+        "action_path_type:unknown_executable_path",
+        "approval:unknown",
+        "approval_evidence:none",
+        "confidence_lane:confirmed_action_path",
+        "confidence_lane:context_only",
+        "confidence_lane:likely_action_path",
+        "confidence_lane:semantic_review_candidate",
+        "constraint_evidence:missing",
+        "control_resolution:detected_control",
+        "credential:inferred",
+        "credential:verified",
+        "owner:inferred",
+        "policy_coverage:matched",
+        "policy_coverage:runtime_proven",
+        "proof:verified",
+        "runtime:unknown",
+        "runtime:verified",
+        "runtime_absence_status:not_collected",
+        "runtime_evidence:none",
+        "target:inferred",
+        "target:unknown",
+        "target:verified"
+      ]
+    },
     "scan_coverage": {
       "coverage_confidence": "complete",
       "impact_statement": "Coverage for scanned inputs was complete enough to support scoped negative claims."

--- a/scenarios/wrkr/agent-action-bom-demo/expected/before-report.json
+++ b/scenarios/wrkr/agent-action-bom-demo/expected/before-report.json
@@ -6,10 +6,11 @@
     "standing_privilege_items": 2,
     "static_credential_items": 2,
     "production_target_items": 5,
+    "lifecycle_queue_items": 5,
     "approval_evidence_unknown_items": 6,
+    "proof_evidence_unknown_items": 6,
     "missing_approval_items": 6,
     "missing_policy_items": 0,
-    "proof_evidence_unknown_items": 6,
     "missing_proof_items": 6,
     "runtime_proven_items": 0,
     "unresolved_owner_items": 0,
@@ -17,7 +18,6 @@
     "likely_action_path_items": 2,
     "semantic_review_candidate_items": 1,
     "context_only_items": 1,
-    "lifecycle_queue_items": 5,
     "empty_state_status": "not_eligible",
     "empty_state_reasons": [
       "approval_evidence_unknown_paths_present",
@@ -67,6 +67,91 @@
         "policy_gaps=6",
         "missing_proof_paths=14",
         "coverage_reduced=false"
+      ]
+    },
+    "evidence_completeness": {
+      "path_count": 6,
+      "average_total_score": 59,
+      "label": "insufficient_evidence",
+      "low_evidence_path_count": 3,
+      "axis_scores": [
+        {
+          "axis": "discovery",
+          "score": 81,
+          "reasons": [
+            "action_path_type:plain_source_code",
+            "confidence_lane:confirmed_action_path",
+            "confidence_lane:context_only",
+            "confidence_lane:likely_action_path",
+            "confidence_lane:semantic_review_candidate"
+          ]
+        },
+        {
+          "axis": "authority",
+          "score": 53,
+          "reasons": [
+            "approval:unknown",
+            "owner:inferred"
+          ]
+        },
+        {
+          "axis": "blast_radius",
+          "score": 77,
+          "reasons": [
+            "credential:inferred",
+            "credential:verified",
+            "target:inferred",
+            "target:unknown",
+            "target:verified"
+          ]
+        },
+        {
+          "axis": "control",
+          "score": 83,
+          "reasons": [
+            "constraint_evidence:missing",
+            "control_resolution:detected_control"
+          ]
+        },
+        {
+          "axis": "runtime_evidence",
+          "score": 35,
+          "reasons": [
+            "runtime:unknown",
+            "runtime_absence_status:not_collected"
+          ]
+        },
+        {
+          "axis": "proof",
+          "score": 25,
+          "reasons": [
+            "policy_coverage:none",
+            "proof:unknown"
+          ]
+        }
+      ],
+      "reasons": [
+        "action_path_type:plain_source_code",
+        "approval:unknown",
+        "approval_evidence:none",
+        "confidence_lane:confirmed_action_path",
+        "confidence_lane:context_only",
+        "confidence_lane:likely_action_path",
+        "confidence_lane:semantic_review_candidate",
+        "constraint_evidence:missing",
+        "control_resolution:detected_control",
+        "credential:inferred",
+        "credential:verified",
+        "owner:inferred",
+        "policy_coverage:none",
+        "proof:unknown",
+        "proof_evidence:none",
+        "runtime:unknown",
+        "runtime_absence_status:not_collected",
+        "runtime_evidence:none",
+        "target:inferred",
+        "target:unknown",
+        "target:verified"
       ]
     },
     "scan_coverage": {

--- a/schemas/v1/agent-action-bom.schema.json
+++ b/schemas/v1/agent-action-bom.schema.json
@@ -62,6 +62,7 @@
         "source_privacy": {"$ref": "#/$defs/sourcePrivacy"},
         "operational_exposure": {"$ref": "#/$defs/axisSummary"},
         "governance_readiness": {"$ref": "#/$defs/axisSummary"},
+        "evidence_completeness": {"$ref": "#/$defs/evidenceCompletenessSummary"},
         "scan_coverage": {"$ref": "#/$defs/compactCoverageSummary"},
         "coverage_confidence": {"type": "string", "enum": ["complete", "reduced", "unknown"]}
       },
@@ -162,6 +163,8 @@
         "queue": {"type": "string", "enum": ["control_first", "review_queue", "accepted_risk_queue", "inventory_hygiene", "debug_only"]},
         "finding_visibility": {"type": "string", "enum": ["primary", "appendix", "debug"]},
         "remediation": {"type": "string"},
+        "closure_requirements": {"type": "array", "items": {"$ref": "#/$defs/closureRequirement"}},
+        "evidence_completeness": {"$ref": "#/$defs/evidenceCompleteness"},
         "attack_path_refs": {"type": "array", "items": {"type": "string"}},
         "source_finding_keys": {"type": "array", "items": {"type": "string"}},
         "exclusion_reason": {"type": "string"},
@@ -199,6 +202,63 @@
         }
       },
       "additionalProperties": true
+    },
+    "closureRequirement": {
+      "type": "object",
+      "required": ["id", "severity", "requirement_type", "required_evidence", "guidance"],
+      "properties": {
+        "id": {"type": "string"},
+        "severity": {"type": "string", "enum": ["critical", "high", "medium", "low"]},
+        "requirement_type": {"type": "string"},
+        "current_evidence_state": {"type": "string", "enum": ["verified", "declared", "inferred", "unknown", "contradictory"]},
+        "required_evidence": {"type": "string"},
+        "acceptable_source_classes": {"type": "array", "items": {"type": "string"}},
+        "freshness_requirement": {"type": "string"},
+        "examples": {"type": "array", "items": {"type": "string"}},
+        "closure_refs": {"type": "array", "items": {"type": "string"}},
+        "reason_codes": {"type": "array", "items": {"type": "string"}},
+        "guidance": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "evidenceCompletenessAxisScore": {
+      "type": "object",
+      "required": ["axis", "score"],
+      "properties": {
+        "axis": {"type": "string", "enum": ["discovery", "authority", "blast_radius", "control", "runtime_evidence", "proof"]},
+        "score": {"type": "integer"},
+        "reasons": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "evidenceCompleteness": {
+      "type": "object",
+      "required": ["total_score", "label", "axis_scores"],
+      "properties": {
+        "total_score": {"type": "integer"},
+        "label": {"type": "string", "enum": ["strong_evidence", "partial_evidence", "insufficient_evidence"]},
+        "axis_scores": {"type": "array", "items": {"$ref": "#/$defs/evidenceCompletenessAxisScore"}},
+        "evidence_gaps": {"type": "array", "items": {"type": "string"}},
+        "unsupported_surfaces": {"type": "array", "items": {"type": "string"}},
+        "freshness_penalties": {"type": "array", "items": {"type": "string"}},
+        "contradiction_penalties": {"type": "array", "items": {"type": "string"}},
+        "reasons": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "evidenceCompletenessSummary": {
+      "type": "object",
+      "required": ["path_count", "average_total_score", "label"],
+      "properties": {
+        "path_count": {"type": "integer"},
+        "average_total_score": {"type": "integer"},
+        "label": {"type": "string", "enum": ["strong_evidence", "partial_evidence", "insufficient_evidence"]},
+        "low_evidence_path_count": {"type": "integer"},
+        "reduced_coverage_path_count": {"type": "integer"},
+        "axis_scores": {"type": "array", "items": {"$ref": "#/$defs/evidenceCompletenessAxisScore"}},
+        "reasons": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
     },
     "evidenceCandidate": {
       "type": "object",

--- a/schemas/v1/report/report-summary.schema.json
+++ b/schemas/v1/report/report-summary.schema.json
@@ -62,6 +62,9 @@
     "governance_readiness": {
       "$ref": "#/$defs/axisSummary"
     },
+    "evidence_completeness": {
+      "$ref": "#/$defs/evidenceCompletenessSummary"
+    },
     "methodology": {
       "$ref": "#/$defs/methodology"
     },
@@ -362,8 +365,67 @@
         "standing_privilege_reasons": {"type": "array", "items": {"type": "string"}},
         "write_path_classes": {"type": "array", "items": {"type": "string"}},
         "governance_controls": {"type": "array", "items": {"type": "object"}},
+        "closure_requirements": {"type": "array", "items": {"$ref": "#/$defs/closureRequirement"}},
+        "evidence_completeness": {"$ref": "#/$defs/evidenceCompleteness"},
         "action_lineage": {"$ref": "#/$defs/actionLineage"}
       }
+    },
+    "closureRequirement": {
+      "type": "object",
+      "required": ["id", "severity", "requirement_type", "required_evidence", "guidance"],
+      "properties": {
+        "id": {"type": "string"},
+        "severity": {"type": "string", "enum": ["critical", "high", "medium", "low"]},
+        "requirement_type": {"type": "string"},
+        "current_evidence_state": {"type": "string", "enum": ["verified", "declared", "inferred", "unknown", "contradictory"]},
+        "required_evidence": {"type": "string"},
+        "acceptable_source_classes": {"type": "array", "items": {"type": "string"}},
+        "freshness_requirement": {"type": "string"},
+        "examples": {"type": "array", "items": {"type": "string"}},
+        "closure_refs": {"type": "array", "items": {"type": "string"}},
+        "reason_codes": {"type": "array", "items": {"type": "string"}},
+        "guidance": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "evidenceCompletenessAxisScore": {
+      "type": "object",
+      "required": ["axis", "score"],
+      "properties": {
+        "axis": {"type": "string", "enum": ["discovery", "authority", "blast_radius", "control", "runtime_evidence", "proof"]},
+        "score": {"type": "integer"},
+        "reasons": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "evidenceCompleteness": {
+      "type": "object",
+      "required": ["total_score", "label", "axis_scores"],
+      "properties": {
+        "total_score": {"type": "integer"},
+        "label": {"type": "string", "enum": ["strong_evidence", "partial_evidence", "insufficient_evidence"]},
+        "axis_scores": {"type": "array", "items": {"$ref": "#/$defs/evidenceCompletenessAxisScore"}},
+        "evidence_gaps": {"type": "array", "items": {"type": "string"}},
+        "unsupported_surfaces": {"type": "array", "items": {"type": "string"}},
+        "freshness_penalties": {"type": "array", "items": {"type": "string"}},
+        "contradiction_penalties": {"type": "array", "items": {"type": "string"}},
+        "reasons": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "evidenceCompletenessSummary": {
+      "type": "object",
+      "required": ["path_count", "average_total_score", "label"],
+      "properties": {
+        "path_count": {"type": "integer"},
+        "average_total_score": {"type": "integer"},
+        "label": {"type": "string", "enum": ["strong_evidence", "partial_evidence", "insufficient_evidence"]},
+        "low_evidence_path_count": {"type": "integer"},
+        "reduced_coverage_path_count": {"type": "integer"},
+        "axis_scores": {"type": "array", "items": {"$ref": "#/$defs/evidenceCompletenessAxisScore"}},
+        "reasons": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
     },
     "evidenceCandidate": {
       "type": "object",

--- a/schemas/v1/risk/risk-report.schema.json
+++ b/schemas/v1/risk/risk-report.schema.json
@@ -124,9 +124,54 @@
         "source_finding_keys": {"type": "array", "items": {"type": "string"}},
         "matched_production_targets": {"type": "array", "items": {"type": "string"}},
         "governance_controls": {"type": "array"},
+        "closure_requirements": {"type": "array", "items": {"$ref": "#/$defs/closureRequirement"}},
+        "evidence_completeness": {"$ref": "#/$defs/evidenceCompleteness"},
         "action_lineage": {"$ref": "#/$defs/actionLineage"}
       },
       "additionalProperties": true
+    },
+    "closureRequirement": {
+      "type": "object",
+      "required": ["id", "severity", "requirement_type", "required_evidence", "guidance"],
+      "properties": {
+        "id": {"type": "string"},
+        "severity": {"type": "string", "enum": ["critical", "high", "medium", "low"]},
+        "requirement_type": {"type": "string"},
+        "current_evidence_state": {"type": "string", "enum": ["verified", "declared", "inferred", "unknown", "contradictory"]},
+        "required_evidence": {"type": "string"},
+        "acceptable_source_classes": {"type": "array", "items": {"type": "string"}},
+        "freshness_requirement": {"type": "string"},
+        "examples": {"type": "array", "items": {"type": "string"}},
+        "closure_refs": {"type": "array", "items": {"type": "string"}},
+        "reason_codes": {"type": "array", "items": {"type": "string"}},
+        "guidance": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "evidenceCompletenessAxisScore": {
+      "type": "object",
+      "required": ["axis", "score"],
+      "properties": {
+        "axis": {"type": "string", "enum": ["discovery", "authority", "blast_radius", "control", "runtime_evidence", "proof"]},
+        "score": {"type": "integer"},
+        "reasons": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "evidenceCompleteness": {
+      "type": "object",
+      "required": ["total_score", "label", "axis_scores"],
+      "properties": {
+        "total_score": {"type": "integer"},
+        "label": {"type": "string", "enum": ["strong_evidence", "partial_evidence", "insufficient_evidence"]},
+        "axis_scores": {"type": "array", "items": {"$ref": "#/$defs/evidenceCompletenessAxisScore"}},
+        "evidence_gaps": {"type": "array", "items": {"type": "string"}},
+        "unsupported_surfaces": {"type": "array", "items": {"type": "string"}},
+        "freshness_penalties": {"type": "array", "items": {"type": "string"}},
+        "contradiction_penalties": {"type": "array", "items": {"type": "string"}},
+        "reasons": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
     },
     "evidenceCandidate": {
       "type": "object",

--- a/testinfra/contracts/demo_action_bom_readiness_contracts_test.go
+++ b/testinfra/contracts/demo_action_bom_readiness_contracts_test.go
@@ -47,6 +47,8 @@ func TestDemoActionBOMReadinessSchemasDeclareBuyerFacingPathFields(t *testing.T)
 				"review_burden",
 				"review_burden_reasons",
 				"gait_coverage",
+				"closure_requirements",
+				"evidence_completeness",
 			} {
 				if _, ok := props[field].(map[string]any); !ok {
 					t.Fatalf("%s schema missing %s contract field: %v", tc.name, field, props)
@@ -78,6 +80,39 @@ func TestDemoActionBOMReadinessSchemasDeclareBuyerFacingPathFields(t *testing.T)
 			})
 			assertGaitCoverageContract(t, schemaRef(t, schema, props["gait_coverage"]))
 		})
+	}
+}
+
+func TestDemoActionBOMReadinessSchemasDeclareClosureAndCompletenessSummaryContracts(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	bomSchema := mustReadJSON(t, filepath.Join(repoRoot, "schemas", "v1", "agent-action-bom.schema.json"))
+	reportSchema := mustReadJSON(t, filepath.Join(repoRoot, "schemas", "v1", "report", "report-summary.schema.json"))
+
+	bomSummaryProps := schemaDefinitionProperties(t, bomSchema, "summary")
+	if _, ok := bomSummaryProps["evidence_completeness"].(map[string]any); !ok {
+		t.Fatalf("agent action bom summary missing evidence_completeness: %v", bomSummaryProps)
+	}
+	reportProps, ok := reportSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("report summary schema missing properties: %v", reportSchema)
+	}
+	if _, ok := reportProps["evidence_completeness"].(map[string]any); !ok {
+		t.Fatalf("report summary schema missing evidence_completeness: %v", reportProps)
+	}
+
+	closureRequirement := schemaDefinition(t, bomSchema, "closureRequirement")
+	for _, field := range []string{"id", "severity", "requirement_type", "required_evidence", "guidance"} {
+		if _, ok := closureRequirement["properties"].(map[string]any)[field]; !ok {
+			t.Fatalf("closure requirement schema missing %s: %v", field, closureRequirement)
+		}
+	}
+	completeness := schemaDefinition(t, bomSchema, "evidenceCompleteness")
+	for _, field := range []string{"total_score", "label", "axis_scores"} {
+		if _, ok := completeness["properties"].(map[string]any)[field]; !ok {
+			t.Fatalf("evidence completeness schema missing %s: %v", field, completeness)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem
- wave 4 of the evidence ingest / closure / control context plan needed path-specific closure guidance instead of generic gap wording
- the same wave also required deterministic evidence completeness scoring that stays separate from risk posture

## Changes
- add shared closure requirement derivation and six-axis evidence completeness scoring in `core/risk`
- propagate closure/completeness into action paths, control backlog, Agent Action BOM, markdown/evidence reports, and scan quality inputs
- extend v1 BOM/report/risk schemas plus scenario and contract fixtures for the additive public surface
- update unreleased changelog entries for stories 4.1 and 4.2

## Validation
- `make prepush-full`
- `make test-contracts`
- `make test-scenarios`
- `make test-hardening`
- `make test-chaos`

## Risks
- additive report/schema contract changes require downstream consumers to tolerate new fields
- scenario fixtures were updated to capture the new aggregate completeness surface

## Notes
- no submodule pointer changes
- scoped to wave 4 of `product/plans/adhoc/PLAN_ADHOC_2026-05-25_173030_evidence-ingest-closure-control-context.md`
