### PR TITLE
feat: add workflow chains and graph v2 lineage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Added
 
+- [semver:minor] Added workflow chain artifacts that group delegated SDLC paths by repo, PR/MR, workflow, tool, credential, owner, approval, target, evidence, and outcome.
+- [semver:minor] Added Control Path Graph V2 nodes and edges for delegated SDLC intent, human, agent team, PR/MR, approval, deployment, asset, evidence, and outcome paths.
+- [semver:minor] Added intent-to-outcome action lineage segments for delegated SDLC workflows.
 - [semver:minor] Added Agentic SDLC autonomy tiers, delegation readiness states, and recommended control outcomes to govern-first action paths, Agent Action BOM items, control backlog items, and markdown report rollups.
 - [semver:minor] Added draft recommended action contracts plus today-versus-governed path views for control-first and high-stakes action paths in report and backlog artifacts.
 - [semver:minor] Added canonical control resolution and evidence confidence fields for action paths, reports, backlog items, and v1 schemas so control gaps are evidence-scoped instead of inferred from local absence.

--- a/core/aggregate/agentresolver/workflow_chain.go
+++ b/core/aggregate/agentresolver/workflow_chain.go
@@ -1,0 +1,574 @@
+package agentresolver
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/attribution"
+)
+
+const WorkflowChainVersion = "1"
+
+type WorkflowChainArtifact struct {
+	Version string               `json:"version"`
+	Summary WorkflowChainSummary `json:"summary"`
+	Chains  []WorkflowChain      `json:"chains"`
+}
+
+type WorkflowChainSummary struct {
+	TotalChains               int                   `json:"total_chains"`
+	Workflows                 []WorkflowChainRollup `json:"workflows,omitempty"`
+	Repos                     []WorkflowChainRollup `json:"repos,omitempty"`
+	AutonomyTiers             []WorkflowChainRollup `json:"autonomy_tiers,omitempty"`
+	DelegationReadinessStates []WorkflowChainRollup `json:"delegation_readiness_states,omitempty"`
+	RecommendedControls       []WorkflowChainRollup `json:"recommended_controls,omitempty"`
+	TargetClasses             []WorkflowChainRollup `json:"target_classes,omitempty"`
+	EvidenceCompleteness      []WorkflowChainRollup `json:"evidence_completeness,omitempty"`
+}
+
+type WorkflowChainRollup struct {
+	Value string `json:"value"`
+	Count int    `json:"count"`
+}
+
+type WorkflowChainDimension struct {
+	Key          string   `json:"key"`
+	Label        string   `json:"label,omitempty"`
+	Status       string   `json:"status,omitempty"`
+	EvidenceRefs []string `json:"evidence_refs,omitempty"`
+}
+
+type WorkflowChain struct {
+	ChainID                  string                 `json:"chain_id"`
+	PathIDs                  []string               `json:"path_ids,omitempty"`
+	GraphNodeRefs            []string               `json:"graph_node_refs,omitempty"`
+	GraphEdgeRefs            []string               `json:"graph_edge_refs,omitempty"`
+	ProofRefs                []string               `json:"proof_refs,omitempty"`
+	EvidenceRefs             []string               `json:"evidence_refs,omitempty"`
+	SourceFindingKeys        []string               `json:"source_finding_keys,omitempty"`
+	IntroducedBy             *attribution.Result    `json:"introduced_by,omitempty"`
+	Repo                     WorkflowChainDimension `json:"repo"`
+	PullRequest              WorkflowChainDimension `json:"pull_request"`
+	Workflow                 WorkflowChainDimension `json:"workflow"`
+	Task                     WorkflowChainDimension `json:"task"`
+	Tool                     WorkflowChainDimension `json:"tool"`
+	Credential               WorkflowChainDimension `json:"credential"`
+	Owner                    WorkflowChainDimension `json:"owner"`
+	Approval                 WorkflowChainDimension `json:"approval"`
+	Target                   WorkflowChainDimension `json:"target"`
+	Evidence                 WorkflowChainDimension `json:"evidence"`
+	Outcome                  WorkflowChainDimension `json:"outcome"`
+	AutonomyTier             string                 `json:"autonomy_tier,omitempty"`
+	DelegationReadinessState string                 `json:"delegation_readiness_state,omitempty"`
+	RecommendedControl       string                 `json:"recommended_control,omitempty"`
+	TargetClass              string                 `json:"target_class,omitempty"`
+	EvidenceCompleteness     string                 `json:"evidence_completeness,omitempty"`
+}
+
+type WorkflowChainInput struct {
+	PathID                    string
+	Org                       string
+	Repo                      string
+	AgentID                   string
+	ToolFamilyID              string
+	ToolInstanceID            string
+	ToolType                  string
+	Location                  string
+	Purpose                   string
+	PurposeSource             string
+	OperationalOwner          string
+	CredentialAccess          bool
+	CredentialProvenance      *agginventory.CredentialProvenance
+	CredentialAuthority       *agginventory.CredentialAuthority
+	ApprovalEvidenceState     string
+	ProofEvidenceState        string
+	RuntimeEvidenceState      string
+	TargetEvidenceState       string
+	ControlResolutionState    string
+	DeploymentStatus          string
+	DeliveryChainStatus       string
+	TargetClass               string
+	IntroducedBy              *attribution.Result
+	AutonomyTier              string
+	DelegationReadinessState  string
+	RecommendedControl        string
+	MatchedProductionTargets  []string
+	EvidenceCompletenessLabel string
+	GraphNodeRefs             []string
+	GraphEdgeRefs             []string
+	ProofRefs                 []string
+	EvidenceRefs              []string
+	SourceFindingKeys         []string
+}
+
+func BuildWorkflowChains(inputs []WorkflowChainInput) *WorkflowChainArtifact {
+	if len(inputs) == 0 {
+		return nil
+	}
+
+	ordered := append([]WorkflowChainInput(nil), inputs...)
+	sort.Slice(ordered, func(i, j int) bool {
+		if strings.TrimSpace(ordered[i].Org) != strings.TrimSpace(ordered[j].Org) {
+			return strings.TrimSpace(ordered[i].Org) < strings.TrimSpace(ordered[j].Org)
+		}
+		if strings.TrimSpace(ordered[i].Repo) != strings.TrimSpace(ordered[j].Repo) {
+			return strings.TrimSpace(ordered[i].Repo) < strings.TrimSpace(ordered[j].Repo)
+		}
+		if strings.TrimSpace(ordered[i].Location) != strings.TrimSpace(ordered[j].Location) {
+			return strings.TrimSpace(ordered[i].Location) < strings.TrimSpace(ordered[j].Location)
+		}
+		return strings.TrimSpace(ordered[i].PathID) < strings.TrimSpace(ordered[j].PathID)
+	})
+
+	byID := map[string]*WorkflowChain{}
+	for _, input := range ordered {
+		chain := buildWorkflowChain(input)
+		if current, ok := byID[chain.ChainID]; ok {
+			current.PathIDs = uniqueSortedStrings(append(current.PathIDs, chain.PathIDs...))
+			current.GraphNodeRefs = uniqueSortedStrings(append(current.GraphNodeRefs, chain.GraphNodeRefs...))
+			current.GraphEdgeRefs = uniqueSortedStrings(append(current.GraphEdgeRefs, chain.GraphEdgeRefs...))
+			current.ProofRefs = uniqueSortedStrings(append(current.ProofRefs, chain.ProofRefs...))
+			current.EvidenceRefs = uniqueSortedStrings(append(current.EvidenceRefs, chain.EvidenceRefs...))
+			current.SourceFindingKeys = uniqueSortedStrings(append(current.SourceFindingKeys, chain.SourceFindingKeys...))
+			current.IntroducedBy = attribution.Merge(current.IntroducedBy, chain.IntroducedBy)
+			current.Repo.EvidenceRefs = uniqueSortedStrings(append(current.Repo.EvidenceRefs, chain.Repo.EvidenceRefs...))
+			current.PullRequest.EvidenceRefs = uniqueSortedStrings(append(current.PullRequest.EvidenceRefs, chain.PullRequest.EvidenceRefs...))
+			current.Workflow.EvidenceRefs = uniqueSortedStrings(append(current.Workflow.EvidenceRefs, chain.Workflow.EvidenceRefs...))
+			current.Task.EvidenceRefs = uniqueSortedStrings(append(current.Task.EvidenceRefs, chain.Task.EvidenceRefs...))
+			current.Tool.EvidenceRefs = uniqueSortedStrings(append(current.Tool.EvidenceRefs, chain.Tool.EvidenceRefs...))
+			current.Credential.EvidenceRefs = uniqueSortedStrings(append(current.Credential.EvidenceRefs, chain.Credential.EvidenceRefs...))
+			current.Owner.EvidenceRefs = uniqueSortedStrings(append(current.Owner.EvidenceRefs, chain.Owner.EvidenceRefs...))
+			current.Approval.EvidenceRefs = uniqueSortedStrings(append(current.Approval.EvidenceRefs, chain.Approval.EvidenceRefs...))
+			current.Target.EvidenceRefs = uniqueSortedStrings(append(current.Target.EvidenceRefs, chain.Target.EvidenceRefs...))
+			current.Evidence.EvidenceRefs = uniqueSortedStrings(append(current.Evidence.EvidenceRefs, chain.Evidence.EvidenceRefs...))
+			current.Outcome.EvidenceRefs = uniqueSortedStrings(append(current.Outcome.EvidenceRefs, chain.Outcome.EvidenceRefs...))
+			continue
+		}
+		copyChain := chain
+		byID[chain.ChainID] = &copyChain
+	}
+
+	chains := make([]WorkflowChain, 0, len(byID))
+	for _, chain := range byID {
+		chains = append(chains, cloneWorkflowChain(*chain))
+	}
+	sort.Slice(chains, func(i, j int) bool {
+		return chains[i].ChainID < chains[j].ChainID
+	})
+
+	return &WorkflowChainArtifact{
+		Version: WorkflowChainVersion,
+		Summary: summarizeWorkflowChains(chains),
+		Chains:  chains,
+	}
+}
+
+func WorkflowChainRefsByPath(artifact *WorkflowChainArtifact) map[string][]string {
+	byPath := map[string][]string{}
+	if artifact == nil {
+		return byPath
+	}
+	for _, chain := range artifact.Chains {
+		for _, pathID := range chain.PathIDs {
+			trimmed := strings.TrimSpace(pathID)
+			if trimmed == "" {
+				continue
+			}
+			byPath[trimmed] = uniqueSortedStrings(append(byPath[trimmed], chain.ChainID))
+		}
+	}
+	return byPath
+}
+
+func buildWorkflowChain(input WorkflowChainInput) WorkflowChain {
+	repo := newWorkflowChainDimension(
+		dimensionKey(input.Repo, "unknown_repo"),
+		dimensionLabel(input.Repo, "unknown_repo"),
+		presenceStatus(input.Repo),
+		[]string{input.Repo},
+	)
+	pullRequest := pullRequestDimension(input.IntroducedBy)
+	workflow := newWorkflowChainDimension(
+		dimensionKey(input.Location, "unknown_workflow"),
+		dimensionLabel(input.Location, "unknown_workflow"),
+		presenceStatus(input.Location),
+		[]string{input.Location},
+	)
+	task := taskDimension(input.Purpose, input.PurposeSource, input.Location)
+	tool := toolDimension(input)
+	credential := credentialDimension(input)
+	owner := ownerDimension(input)
+	approval := approvalDimension(input)
+	target := targetDimension(input)
+	evidence := evidenceDimension(input)
+	outcome := outcomeDimension(input)
+
+	autonomyTier := strings.TrimSpace(input.AutonomyTier)
+	readiness := strings.TrimSpace(input.DelegationReadinessState)
+	recommendedControl := strings.TrimSpace(input.RecommendedControl)
+	targetClass := strings.TrimSpace(input.TargetClass)
+	evidenceCompleteness := strings.TrimSpace(input.EvidenceCompletenessLabel)
+
+	rawID := strings.Join([]string{
+		repo.Key,
+		pullRequest.Key,
+		workflow.Key,
+		task.Key,
+		tool.Key,
+		credential.Key,
+		owner.Key,
+		approval.Key,
+		target.Key,
+		evidence.Key,
+		outcome.Key,
+		autonomyTier,
+		readiness,
+		recommendedControl,
+		targetClass,
+		evidenceCompleteness,
+	}, "|")
+
+	return WorkflowChain{
+		ChainID:                  stableWorkflowChainID(rawID),
+		PathIDs:                  uniqueSortedStrings([]string{input.PathID}),
+		GraphNodeRefs:            uniqueSortedStrings(input.GraphNodeRefs),
+		GraphEdgeRefs:            uniqueSortedStrings(input.GraphEdgeRefs),
+		ProofRefs:                uniqueSortedStrings(input.ProofRefs),
+		EvidenceRefs:             uniqueSortedStrings(input.EvidenceRefs),
+		SourceFindingKeys:        uniqueSortedStrings(input.SourceFindingKeys),
+		IntroducedBy:             cloneIntroducedBy(input.IntroducedBy),
+		Repo:                     repo,
+		PullRequest:              pullRequest,
+		Workflow:                 workflow,
+		Task:                     task,
+		Tool:                     tool,
+		Credential:               credential,
+		Owner:                    owner,
+		Approval:                 approval,
+		Target:                   target,
+		Evidence:                 evidence,
+		Outcome:                  outcome,
+		AutonomyTier:             autonomyTier,
+		DelegationReadinessState: readiness,
+		RecommendedControl:       recommendedControl,
+		TargetClass:              targetClass,
+		EvidenceCompleteness:     evidenceCompleteness,
+	}
+}
+
+func summarizeWorkflowChains(chains []WorkflowChain) WorkflowChainSummary {
+	summary := WorkflowChainSummary{TotalChains: len(chains)}
+	repoCounts := map[string]int{}
+	workflowCounts := map[string]int{}
+	autonomyCounts := map[string]int{}
+	readinessCounts := map[string]int{}
+	controlCounts := map[string]int{}
+	targetClassCounts := map[string]int{}
+	evidenceCounts := map[string]int{}
+
+	for _, chain := range chains {
+		repoCounts[dimensionKey(chain.Repo.Key, "unknown_repo")]++
+		workflowCounts[dimensionKey(chain.Workflow.Key, "unknown_workflow")]++
+		autonomyCounts[dimensionKey(chain.AutonomyTier, "unknown")]++
+		readinessCounts[dimensionKey(chain.DelegationReadinessState, "unknown")]++
+		controlCounts[dimensionKey(chain.RecommendedControl, "unknown")]++
+		targetClassCounts[dimensionKey(chain.TargetClass, "unknown")]++
+		evidenceCounts[dimensionKey(chain.EvidenceCompleteness, "unknown")]++
+	}
+
+	summary.Repos = summarizeWorkflowChainRollups(repoCounts)
+	summary.Workflows = summarizeWorkflowChainRollups(workflowCounts)
+	summary.AutonomyTiers = summarizeWorkflowChainRollups(autonomyCounts)
+	summary.DelegationReadinessStates = summarizeWorkflowChainRollups(readinessCounts)
+	summary.RecommendedControls = summarizeWorkflowChainRollups(controlCounts)
+	summary.TargetClasses = summarizeWorkflowChainRollups(targetClassCounts)
+	summary.EvidenceCompleteness = summarizeWorkflowChainRollups(evidenceCounts)
+	return summary
+}
+
+func summarizeWorkflowChainRollups(counts map[string]int) []WorkflowChainRollup {
+	if len(counts) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]WorkflowChainRollup, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, WorkflowChainRollup{Value: key, Count: counts[key]})
+	}
+	return out
+}
+
+func pullRequestDimension(result *attribution.Result) WorkflowChainDimension {
+	if result == nil {
+		return newWorkflowChainDimension("unknown_pr", "unknown_pr", "unknown", nil)
+	}
+	label := "unknown_pr"
+	key := "unknown_pr"
+	if result.PRNumber > 0 {
+		label = fmt.Sprintf("PR #%d", result.PRNumber)
+		key = fmt.Sprintf("pr:%d", result.PRNumber)
+	}
+	return newWorkflowChainDimension(key, label, attributionStatus(result), []string{result.ProviderURL, result.ChangedFile})
+}
+
+func taskDimension(purpose, purposeSource, location string) WorkflowChainDimension {
+	if strings.TrimSpace(purpose) != "" {
+		return newWorkflowChainDimension("task:"+strings.TrimSpace(purpose), strings.TrimSpace(purpose), "declared", []string{purposeSource})
+	}
+	if strings.TrimSpace(purposeSource) != "" {
+		return newWorkflowChainDimension("task_source:"+strings.TrimSpace(purposeSource), "unknown_task", "unknown", []string{purposeSource, location})
+	}
+	return newWorkflowChainDimension("unknown_task", "unknown_task", "unknown", []string{location})
+}
+
+func toolDimension(input WorkflowChainInput) WorkflowChainDimension {
+	label := firstNonEmpty(input.ToolInstanceID, input.ToolFamilyID, input.ToolType)
+	if label == "" {
+		return newWorkflowChainDimension("unknown_tool", "unknown_tool", "unknown", nil)
+	}
+	return newWorkflowChainDimension("tool:"+label, label, "present", []string{input.Location})
+}
+
+func credentialDimension(input WorkflowChainInput) WorkflowChainDimension {
+	if input.CredentialAuthority != nil && strings.TrimSpace(input.CredentialAuthority.CredentialKind) != "" {
+		status := "present"
+		if !input.CredentialAuthority.CredentialUsableByPath {
+			status = "declared"
+		}
+		label := strings.TrimSpace(input.CredentialAuthority.CredentialKind)
+		return newWorkflowChainDimension("credential:"+label, label, status, append([]string(nil), input.CredentialAuthority.ReasonCodes...))
+	}
+	if input.CredentialProvenance != nil {
+		label := firstNonEmpty(input.CredentialProvenance.CredentialKind, input.CredentialProvenance.Type)
+		if label == "" {
+			label = "credential_access"
+		}
+		return newWorkflowChainDimension("credential:"+label, label, "declared", append([]string(nil), input.CredentialProvenance.EvidenceBasis...))
+	}
+	if input.CredentialAccess {
+		return newWorkflowChainDimension("credential_access", "credential_access", "unknown", nil)
+	}
+	return newWorkflowChainDimension("unknown_credential", "unknown_credential", "unknown", nil)
+}
+
+func ownerDimension(input WorkflowChainInput) WorkflowChainDimension {
+	if strings.TrimSpace(input.OperationalOwner) == "" {
+		return newWorkflowChainDimension("unknown_owner", "unknown_owner", "unknown", nil)
+	}
+	return newWorkflowChainDimension("owner:"+strings.TrimSpace(input.OperationalOwner), strings.TrimSpace(input.OperationalOwner), "declared", nil)
+}
+
+func approvalDimension(input WorkflowChainInput) WorkflowChainDimension {
+	state := strongestWorkflowChainStatus(input.ApprovalEvidenceState, input.ControlResolutionState)
+	if state == "" {
+		state = "unknown"
+	}
+	label := "approval:" + state
+	if state == "contradictory_control" {
+		label = "approval:contradictory"
+		state = "contradictory"
+	}
+	return newWorkflowChainDimension("approval:"+state, label, state, nil)
+}
+
+func targetDimension(input WorkflowChainInput) WorkflowChainDimension {
+	targets := uniqueSortedStrings(input.MatchedProductionTargets)
+	if len(targets) > 0 {
+		status := firstNonEmpty(strings.TrimSpace(input.TargetEvidenceState), "present")
+		label := strings.Join(targets, ",")
+		return newWorkflowChainDimension("target:"+label, label, status, targets)
+	}
+	if strings.TrimSpace(input.TargetClass) != "" {
+		return newWorkflowChainDimension("target_class:"+strings.TrimSpace(input.TargetClass), strings.TrimSpace(input.TargetClass), "unknown", nil)
+	}
+	return newWorkflowChainDimension("unknown_target", "unknown_target", "unknown", nil)
+}
+
+func evidenceDimension(input WorkflowChainInput) WorkflowChainDimension {
+	label := firstNonEmpty(strings.TrimSpace(input.EvidenceCompletenessLabel), strongestWorkflowChainStatus(input.ProofEvidenceState, input.RuntimeEvidenceState, input.TargetEvidenceState), "unknown_evidence")
+	status := strongestWorkflowChainStatus(input.ProofEvidenceState, input.RuntimeEvidenceState, input.TargetEvidenceState)
+	if status == "" {
+		status = "unknown"
+	}
+	return newWorkflowChainDimension("evidence:"+label, label, status, append(append([]string(nil), input.EvidenceRefs...), input.ProofRefs...))
+}
+
+func outcomeDimension(input WorkflowChainInput) WorkflowChainDimension {
+	if strings.TrimSpace(input.DeliveryChainStatus) != "" {
+		return newWorkflowChainDimension("outcome:"+strings.TrimSpace(input.DeliveryChainStatus), strings.TrimSpace(input.DeliveryChainStatus), "declared", nil)
+	}
+	if strings.TrimSpace(input.DeploymentStatus) != "" {
+		return newWorkflowChainDimension("outcome:"+strings.TrimSpace(input.DeploymentStatus), strings.TrimSpace(input.DeploymentStatus), "declared", nil)
+	}
+	if len(input.MatchedProductionTargets) > 0 || strings.TrimSpace(input.TargetClass) != "" {
+		status := strongestWorkflowChainStatus(input.ProofEvidenceState, input.RuntimeEvidenceState)
+		if status == "" {
+			status = "unknown"
+		}
+		return newWorkflowChainDimension("unknown_outcome", "unknown_outcome", status, append([]string(nil), input.ProofRefs...))
+	}
+	return newWorkflowChainDimension("unknown_outcome", "unknown_outcome", "unknown", nil)
+}
+
+func newWorkflowChainDimension(key, label, status string, evidenceRefs []string) WorkflowChainDimension {
+	return WorkflowChainDimension{
+		Key:          dimensionKey(key, "unknown"),
+		Label:        strings.TrimSpace(label),
+		Status:       dimensionKey(status, "unknown"),
+		EvidenceRefs: uniqueSortedStrings(evidenceRefs),
+	}
+}
+
+func stableWorkflowChainID(raw string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(raw)))
+	return "wch-" + hex.EncodeToString(sum[:6])
+}
+
+func attributionStatus(result *attribution.Result) string {
+	if result == nil {
+		return "unknown"
+	}
+	switch strings.TrimSpace(result.Confidence) {
+	case attribution.ConfidenceHigh:
+		return "verified"
+	case attribution.ConfidenceLow:
+		return "inferred"
+	default:
+		return "unknown"
+	}
+}
+
+func strongestWorkflowChainStatus(values ...string) string {
+	bestRank := -1
+	best := ""
+	for _, value := range values {
+		normalized := strings.TrimSpace(value)
+		if normalized == "" {
+			continue
+		}
+		rank := workflowChainStatusRank(normalized)
+		if rank > bestRank {
+			bestRank = rank
+			best = normalized
+		}
+	}
+	return best
+}
+
+func workflowChainStatusRank(value string) int {
+	switch strings.TrimSpace(value) {
+	case "contradictory", "contradictory_control":
+		return 5
+	case "verified":
+		return 4
+	case "declared", "present":
+		return 3
+	case "inferred":
+		return 2
+	case "unknown", "missing":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func presenceStatus(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "unknown"
+	}
+	return "present"
+}
+
+func dimensionKey(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return strings.TrimSpace(fallback)
+	}
+	return strings.TrimSpace(value)
+}
+
+func dimensionLabel(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return strings.TrimSpace(fallback)
+	}
+	return strings.TrimSpace(value)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func uniqueSortedStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	set := map[string]struct{}{}
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		set[trimmed] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func cloneWorkflowChain(in WorkflowChain) WorkflowChain {
+	out := in
+	out.PathIDs = append([]string(nil), in.PathIDs...)
+	out.GraphNodeRefs = append([]string(nil), in.GraphNodeRefs...)
+	out.GraphEdgeRefs = append([]string(nil), in.GraphEdgeRefs...)
+	out.ProofRefs = append([]string(nil), in.ProofRefs...)
+	out.EvidenceRefs = append([]string(nil), in.EvidenceRefs...)
+	out.SourceFindingKeys = append([]string(nil), in.SourceFindingKeys...)
+	out.IntroducedBy = cloneIntroducedBy(in.IntroducedBy)
+	out.Repo = cloneWorkflowChainDimension(in.Repo)
+	out.PullRequest = cloneWorkflowChainDimension(in.PullRequest)
+	out.Workflow = cloneWorkflowChainDimension(in.Workflow)
+	out.Task = cloneWorkflowChainDimension(in.Task)
+	out.Tool = cloneWorkflowChainDimension(in.Tool)
+	out.Credential = cloneWorkflowChainDimension(in.Credential)
+	out.Owner = cloneWorkflowChainDimension(in.Owner)
+	out.Approval = cloneWorkflowChainDimension(in.Approval)
+	out.Target = cloneWorkflowChainDimension(in.Target)
+	out.Evidence = cloneWorkflowChainDimension(in.Evidence)
+	out.Outcome = cloneWorkflowChainDimension(in.Outcome)
+	return out
+}
+
+func cloneWorkflowChainDimension(in WorkflowChainDimension) WorkflowChainDimension {
+	out := in
+	out.Key = strings.TrimSpace(out.Key)
+	out.Label = strings.TrimSpace(out.Label)
+	out.Status = strings.TrimSpace(out.Status)
+	out.EvidenceRefs = append([]string(nil), in.EvidenceRefs...)
+	return out
+}
+
+func cloneIntroducedBy(in *attribution.Result) *attribution.Result {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}

--- a/core/aggregate/agentresolver/workflow_chain_test.go
+++ b/core/aggregate/agentresolver/workflow_chain_test.go
@@ -1,0 +1,148 @@
+package agentresolver
+
+import (
+	"reflect"
+	"testing"
+
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/attribution"
+)
+
+func TestBuildWorkflowChainsStableGroupingAndUnknownStates(t *testing.T) {
+	t.Parallel()
+
+	inputs := []WorkflowChainInput{
+		{
+			PathID:                    "apc-chain-a",
+			Org:                       "acme",
+			Repo:                      "acme/payments",
+			ToolType:                  "compiled_action",
+			Location:                  ".github/workflows/release.yml",
+			Purpose:                   "release automation",
+			PurposeSource:             "workflow_name",
+			CredentialAccess:          true,
+			CredentialProvenance:      &agginventory.CredentialProvenance{Type: agginventory.CredentialProvenanceStaticSecret, CredentialKind: agginventory.CredentialKindGitHubPAT, AccessType: agginventory.CredentialAccessTypeStanding},
+			CredentialAuthority:       &agginventory.CredentialAuthority{CredentialPresent: true, CredentialUsableByPath: true, CredentialKind: agginventory.CredentialKindGitHubPAT, AccessType: agginventory.CredentialAccessTypeStanding},
+			OperationalOwner:          "@acme/release",
+			ApprovalEvidenceState:     "unknown",
+			ProofEvidenceState:        "unknown",
+			TargetEvidenceState:       "declared",
+			TargetClass:               "production_impacting",
+			AutonomyTier:              "tier_4_prod_privileged_or_customer_impacting",
+			DelegationReadinessState:  "approval_required",
+			RecommendedControl:        "approval_required",
+			MatchedProductionTargets:  []string{"cluster/prod"},
+			EvidenceCompletenessLabel: "partial_evidence",
+			GraphNodeRefs:             []string{"node-a"},
+			GraphEdgeRefs:             []string{"edge-a"},
+			ProofRefs:                 []string{"proof://release"},
+			EvidenceRefs:              []string{"evidence://release"},
+			SourceFindingKeys:         []string{"finding:a"},
+		},
+		{
+			PathID:                    "apc-chain-b",
+			Org:                       "acme",
+			Repo:                      "acme/payments",
+			ToolType:                  "compiled_action",
+			Location:                  ".github/workflows/release.yml",
+			Purpose:                   "release automation",
+			PurposeSource:             "workflow_name",
+			CredentialAccess:          true,
+			CredentialProvenance:      &agginventory.CredentialProvenance{Type: agginventory.CredentialProvenanceStaticSecret, CredentialKind: agginventory.CredentialKindGitHubPAT, AccessType: agginventory.CredentialAccessTypeStanding},
+			CredentialAuthority:       &agginventory.CredentialAuthority{CredentialPresent: true, CredentialUsableByPath: true, CredentialKind: agginventory.CredentialKindGitHubPAT, AccessType: agginventory.CredentialAccessTypeStanding},
+			OperationalOwner:          "@acme/release",
+			ApprovalEvidenceState:     "unknown",
+			ProofEvidenceState:        "unknown",
+			TargetEvidenceState:       "declared",
+			TargetClass:               "production_impacting",
+			AutonomyTier:              "tier_4_prod_privileged_or_customer_impacting",
+			DelegationReadinessState:  "approval_required",
+			RecommendedControl:        "approval_required",
+			MatchedProductionTargets:  []string{"cluster/prod"},
+			EvidenceCompletenessLabel: "partial_evidence",
+			GraphNodeRefs:             []string{"node-b"},
+			GraphEdgeRefs:             []string{"edge-b"},
+			ProofRefs:                 []string{"proof://release"},
+			EvidenceRefs:              []string{"evidence://release"},
+			SourceFindingKeys:         []string{"finding:b"},
+		},
+		{
+			PathID:                    "apc-chain-c",
+			Org:                       "acme",
+			Repo:                      "acme/payments",
+			ToolType:                  "compiled_action",
+			Location:                  ".github/workflows/release.yml",
+			Purpose:                   "release automation",
+			PurposeSource:             "workflow_name",
+			CredentialAccess:          true,
+			CredentialProvenance:      &agginventory.CredentialProvenance{Type: agginventory.CredentialProvenanceJIT, CredentialKind: agginventory.CredentialKindJITCredential, AccessType: agginventory.CredentialAccessTypeJIT},
+			CredentialAuthority:       &agginventory.CredentialAuthority{CredentialPresent: true, CredentialUsableByPath: true, CredentialKind: agginventory.CredentialKindJITCredential, AccessType: agginventory.CredentialAccessTypeJIT},
+			OperationalOwner:          "@acme/platform",
+			ApprovalEvidenceState:     "verified",
+			ProofEvidenceState:        "verified",
+			TargetEvidenceState:       "verified",
+			TargetClass:               "internal_tooling",
+			AutonomyTier:              "tier_2_app_code_owner_review",
+			DelegationReadinessState:  "review_required",
+			RecommendedControl:        "owner_review",
+			IntroducedBy:              &attribution.Result{Source: attribution.SourceSidecar, Confidence: attribution.ConfidenceHigh, PRNumber: 17, Author: "octocat"},
+			MatchedProductionTargets:  []string{"repo:release"},
+			EvidenceCompletenessLabel: "strong_evidence",
+			GraphNodeRefs:             []string{"node-c"},
+			GraphEdgeRefs:             []string{"edge-c"},
+			ProofRefs:                 []string{"proof://review"},
+			EvidenceRefs:              []string{"evidence://review"},
+			SourceFindingKeys:         []string{"finding:c"},
+		},
+	}
+
+	first := BuildWorkflowChains(inputs)
+	second := BuildWorkflowChains([]WorkflowChainInput{inputs[2], inputs[1], inputs[0]})
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("expected deterministic workflow-chain artifact\nfirst=%+v\nsecond=%+v", first, second)
+	}
+	if first == nil {
+		t.Fatal("expected workflow chains")
+	}
+	if first.Summary.TotalChains != 2 {
+		t.Fatalf("expected 2 chains after duplicate collapse, got %+v", first.Summary)
+	}
+
+	var collapsed WorkflowChain
+	for _, chain := range first.Chains {
+		if len(chain.PathIDs) == 2 {
+			collapsed = chain
+			break
+		}
+	}
+	if collapsed.ChainID == "" {
+		t.Fatalf("expected collapsed chain, got %+v", first.Chains)
+	}
+	if !reflect.DeepEqual(collapsed.PathIDs, []string{"apc-chain-a", "apc-chain-b"}) {
+		t.Fatalf("expected stable grouped path ids, got %+v", collapsed.PathIDs)
+	}
+	if collapsed.PullRequest.Status != "unknown" {
+		t.Fatalf("expected missing PR metadata to become explicit unknown state, got %+v", collapsed.PullRequest)
+	}
+	if collapsed.Outcome.Status != "unknown" {
+		t.Fatalf("expected missing outcome metadata to become explicit unknown state, got %+v", collapsed.Outcome)
+	}
+	if !containsWorkflowChainRollup(first.Summary.AutonomyTiers, "tier_4_prod_privileged_or_customer_impacting", 1) {
+		t.Fatalf("expected autonomy tier rollup, got %+v", first.Summary.AutonomyTiers)
+	}
+	if !containsWorkflowChainRollup(first.Summary.DelegationReadinessStates, "approval_required", 1) {
+		t.Fatalf("expected readiness rollup, got %+v", first.Summary.DelegationReadinessStates)
+	}
+	if !containsWorkflowChainRollup(first.Summary.EvidenceCompleteness, "partial_evidence", 1) {
+		t.Fatalf("expected evidence completeness rollup, got %+v", first.Summary.EvidenceCompleteness)
+	}
+}
+
+func containsWorkflowChainRollup(values []WorkflowChainRollup, wantValue string, wantCount int) bool {
+	for _, value := range values {
+		if value.Value == wantValue && value.Count == wantCount {
+			return true
+		}
+	}
+	return false
+}

--- a/core/aggregate/attackpath/graph.go
+++ b/core/aggregate/attackpath/graph.go
@@ -465,8 +465,8 @@ const (
 	ControlPathEdgeHumanDelegatesTask           = "human_delegates_task"
 	ControlPathEdgeTaskExecutedByAgentTeam      = "task_executed_by_agent_team"
 	ControlPathEdgeAgentTeamUsesTool            = "agent_team_uses_tool"
-	ControlPathEdgeToolUsesCredential           = "tool_uses_credential"
-	ControlPathEdgeCredentialAuthorizesWorkflow = "credential_authorizes_workflow"
+	ControlPathEdgeToolUsesCredential           = "tool_uses_credential"           // #nosec G101 -- deterministic graph edge label, not credential material.
+	ControlPathEdgeCredentialAuthorizesWorkflow = "credential_authorizes_workflow" // #nosec G101 -- deterministic graph edge label, not credential material.
 	ControlPathEdgeWorkflowChangesRepo          = "workflow_changes_repo"
 	ControlPathEdgeRepoProducesPullRequest      = "repo_produces_pull_request"
 	ControlPathEdgePullRequestRunsChecks        = "pull_request_runs_checks"

--- a/core/aggregate/attackpath/graph.go
+++ b/core/aggregate/attackpath/graph.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/attribution"
 	"github.com/Clyra-AI/wrkr/core/identity"
 	"github.com/Clyra-AI/wrkr/core/model"
 )
@@ -444,40 +445,79 @@ const (
 	ControlPathNodeGovernanceControl = "governance_control"
 	ControlPathNodeTarget            = "target"
 	ControlPathNodeActionCapability  = "action_capability"
+	ControlPathNodeIntent            = "intent"
+	ControlPathNodeTask              = "task"
+	ControlPathNodeHumanIdentity     = "human_identity"
+	ControlPathNodeAgentTeam         = "agent_team"
+	ControlPathNodePullRequest       = "pull_request"
+	ControlPathNodeApprovalIdentity  = "approval_identity"
+	ControlPathNodePolicyIdentity    = "policy_identity"
+	ControlPathNodeAssetIdentity     = "asset_identity"
+	ControlPathNodeEvidenceIdentity  = "evidence_identity"
+	ControlPathNodeDeploymentPath    = "deployment_path"
+	ControlPathNodeCICDRun           = "ci_cd_run"
+	ControlPathNodeWorkflowRun       = "workflow_run"
+	ControlPathNodeOutcome           = "outcome"
+)
+
+const (
+	ControlPathEdgeRequestToHuman               = "request_to_human"
+	ControlPathEdgeHumanDelegatesTask           = "human_delegates_task"
+	ControlPathEdgeTaskExecutedByAgentTeam      = "task_executed_by_agent_team"
+	ControlPathEdgeAgentTeamUsesTool            = "agent_team_uses_tool"
+	ControlPathEdgeToolUsesCredential           = "tool_uses_credential"
+	ControlPathEdgeCredentialAuthorizesWorkflow = "credential_authorizes_workflow"
+	ControlPathEdgeWorkflowChangesRepo          = "workflow_changes_repo"
+	ControlPathEdgeRepoProducesPullRequest      = "repo_produces_pull_request"
+	ControlPathEdgePullRequestRunsChecks        = "pull_request_runs_checks"
+	ControlPathEdgeChecksGateApproval           = "checks_gate_approval"
+	ControlPathEdgeApprovalAuthorizesDeploy     = "approval_authorizes_deploy"
+	ControlPathEdgeDeployAffectsAsset           = "deploy_affects_asset"
+	ControlPathEdgeEvidenceProvesOutcome        = "evidence_proves_outcome"
 )
 
 type ControlPathInput struct {
-	PathID                   string
-	AgentID                  string
-	Org                      string
-	Repo                     string
-	ToolType                 string
-	Location                 string
-	Purpose                  string
-	PurposeSource            string
-	PurposeConfidence        string
-	Version                  string
-	VersionSource            string
-	ConfigFingerprint        string
-	ConfigSource             string
-	ExecutionIdentity        string
-	ExecutionIdentityType    string
-	ExecutionIdentitySource  string
-	ExecutionIdentityStatus  string
-	CredentialAccess         bool
-	CredentialProvenance     *agginventory.CredentialProvenance
-	CredentialAuthority      *agginventory.CredentialAuthority
-	MutableEndpointSemantics []agginventory.MutableEndpointSemantic
-	GovernanceControls       []agginventory.GovernanceControlMapping
-	MatchedProductionTargets []string
-	WritePathClasses         []string
-	PullRequestWrite         bool
-	MergeExecute             bool
-	DeployWrite              bool
-	ProductionWrite          bool
-	ApprovalGap              bool
-	AttackPathRefs           []string
-	SourceFindingKeys        []string
+	PathID                    string
+	AgentID                   string
+	Org                       string
+	Repo                      string
+	ToolType                  string
+	Location                  string
+	Purpose                   string
+	PurposeSource             string
+	PurposeConfidence         string
+	Version                   string
+	VersionSource             string
+	ConfigFingerprint         string
+	ConfigSource              string
+	ExecutionIdentity         string
+	ExecutionIdentityType     string
+	ExecutionIdentitySource   string
+	ExecutionIdentityStatus   string
+	CredentialAccess          bool
+	CredentialProvenance      *agginventory.CredentialProvenance
+	CredentialAuthority       *agginventory.CredentialAuthority
+	MutableEndpointSemantics  []agginventory.MutableEndpointSemantic
+	GovernanceControls        []agginventory.GovernanceControlMapping
+	MatchedProductionTargets  []string
+	WritePathClasses          []string
+	PullRequestWrite          bool
+	MergeExecute              bool
+	DeployWrite               bool
+	ProductionWrite           bool
+	ApprovalGap               bool
+	IntroducedBy              *attribution.Result
+	PolicyRefs                []string
+	ControlResolutionState    string
+	AutonomyTier              string
+	DelegationReadinessState  string
+	ApprovalEvidenceState     string
+	ProofEvidenceState        string
+	RuntimeEvidenceState      string
+	TargetEvidenceState       string
+	EvidenceCompletenessLabel string
+	AttackPathRefs            []string
+	SourceFindingKeys         []string
 }
 
 type ControlPathGraph struct {
@@ -488,10 +528,13 @@ type ControlPathGraph struct {
 }
 
 type ControlPathGraphSummary struct {
-	TotalNodes int                     `json:"total_nodes"`
-	TotalEdges int                     `json:"total_edges"`
-	NodeKinds  []ControlPathKindRollup `json:"node_kinds"`
-	EdgeKinds  []ControlPathKindRollup `json:"edge_kinds"`
+	TotalNodes                int                     `json:"total_nodes"`
+	TotalEdges                int                     `json:"total_edges"`
+	NodeKinds                 []ControlPathKindRollup `json:"node_kinds"`
+	EdgeKinds                 []ControlPathKindRollup `json:"edge_kinds"`
+	AutonomyTiers             []ControlPathKindRollup `json:"autonomy_tiers,omitempty"`
+	DelegationReadinessStates []ControlPathKindRollup `json:"delegation_readiness_states,omitempty"`
+	EvidenceStates            []ControlPathKindRollup `json:"evidence_states,omitempty"`
 }
 
 type ControlPathKindRollup struct {
@@ -558,6 +601,9 @@ func BuildControlPathGraph(paths []ControlPathInput) *ControlPathGraph {
 	edges := make([]ControlPathEdge, 0, len(ordered)*8)
 	nodeCounts := map[string]int{}
 	edgeCounts := map[string]int{}
+	autonomyCounts := map[string]int{}
+	readinessCounts := map[string]int{}
+	evidenceCounts := map[string]int{}
 	for _, path := range ordered {
 		pathNodes, pathEdges := buildControlPath(path)
 		nodes = append(nodes, pathNodes...)
@@ -567,6 +613,15 @@ func BuildControlPathGraph(paths []ControlPathInput) *ControlPathGraph {
 		}
 		for _, edge := range pathEdges {
 			edgeCounts[edge.Kind]++
+		}
+		if tier := strings.TrimSpace(path.AutonomyTier); tier != "" {
+			autonomyCounts[tier]++
+		}
+		if readiness := strings.TrimSpace(path.DelegationReadinessState); readiness != "" {
+			readinessCounts[readiness]++
+		}
+		if evidence := controlPathEvidenceState(path); evidence != "" {
+			evidenceCounts[evidence]++
 		}
 	}
 
@@ -592,10 +647,13 @@ func BuildControlPathGraph(paths []ControlPathInput) *ControlPathGraph {
 	return &ControlPathGraph{
 		Version: ControlPathGraphVersion,
 		Summary: ControlPathGraphSummary{
-			TotalNodes: len(nodes),
-			TotalEdges: len(edges),
-			NodeKinds:  summarizeControlPathKinds(nodeCounts),
-			EdgeKinds:  summarizeControlPathKinds(edgeCounts),
+			TotalNodes:                len(nodes),
+			TotalEdges:                len(edges),
+			NodeKinds:                 summarizeControlPathKinds(nodeCounts),
+			EdgeKinds:                 summarizeControlPathKinds(edgeCounts),
+			AutonomyTiers:             summarizeControlPathKinds(autonomyCounts),
+			DelegationReadinessStates: summarizeControlPathKinds(readinessCounts),
+			EvidenceStates:            summarizeControlPathKinds(evidenceCounts),
 		},
 		Nodes: nodes,
 		Edges: edges,
@@ -648,6 +706,38 @@ func buildControlPath(path ControlPathInput) ([]ControlPathNode, []ControlPathEd
 	nodes = append(nodes, execNode)
 	edges = append(edges, newControlPathEdge(pathID, "path_runs_as", pathNode.NodeID, execNode.NodeID, execEvidence, controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys))
 
+	intentNode := newControlPathNode(pathID, ControlPathNodeIntent, org, repo, controlValue(path.Purpose, "unknown_intent"), toolType, location, strings.TrimSpace(path.AgentID), controlPathIntentStatus(path), append(controlEvidenceRefs(path), "purpose_source:"+controlValue(path.PurposeSource, "unknown")), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys)
+	applyNodeMetadata(&intentNode, path, "intent")
+	nodes = append(nodes, intentNode)
+
+	taskNode := newControlPathNode(pathID, ControlPathNodeTask, org, repo, controlPathTaskLabel(path), toolType, location, strings.TrimSpace(path.AgentID), controlPathTaskStatus(path), append(controlEvidenceRefs(path), "task_source:"+controlValue(path.PurposeSource, "unknown")), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys)
+	applyNodeMetadata(&taskNode, path, "task")
+	nodes = append(nodes, taskNode)
+
+	humanNode := newControlPathNode(pathID, ControlPathNodeHumanIdentity, org, repo, controlPathHumanLabel(path.IntroducedBy), toolType, location, strings.TrimSpace(path.AgentID), controlPathIntroducedByStatus(path.IntroducedBy), controlPathIntroducedByEvidence(path.IntroducedBy), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys)
+	applyNodeMetadata(&humanNode, path, "human")
+	nodes = append(nodes, humanNode)
+
+	agentTeamNode := newControlPathNode(pathID, ControlPathNodeAgentTeam, org, repo, controlValue(firstNonEmpty(path.AgentID, toolType), "unknown_agent_team"), toolType, location, strings.TrimSpace(path.AgentID), "present", controlEvidenceRefs(path), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys)
+	applyNodeMetadata(&agentTeamNode, path, "agent")
+	nodes = append(nodes, agentTeamNode)
+
+	prNode := newControlPathNode(pathID, ControlPathNodePullRequest, org, repo, controlPathPullRequestLabel(path.IntroducedBy), toolType, location, strings.TrimSpace(path.AgentID), controlPathIntroducedByStatus(path.IntroducedBy), controlPathIntroducedByEvidence(path.IntroducedBy), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys)
+	applyNodeMetadata(&prNode, path, "pr")
+	nodes = append(nodes, prNode)
+
+	workflowRunNode := newControlPathNode(pathID, ControlPathNodeWorkflowRun, org, repo, controlPathWorkflowRunLabel(path), toolType, location, strings.TrimSpace(path.AgentID), controlPathWorkflowRunStatus(path), controlEvidenceRefs(path), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys)
+	applyNodeMetadata(&workflowRunNode, path, "workflow_run")
+	nodes = append(nodes, workflowRunNode)
+
+	approvalIdentityNode := newControlPathNode(pathID, ControlPathNodeApprovalIdentity, org, repo, controlPathApprovalIdentityLabel(path), toolType, location, strings.TrimSpace(path.AgentID), controlPathApprovalIdentityStatus(path), controlEvidenceRefs(path), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys)
+	applyNodeMetadata(&approvalIdentityNode, path, "approval")
+	nodes = append(nodes, approvalIdentityNode)
+
+	policyIdentityNode := newControlPathNode(pathID, ControlPathNodePolicyIdentity, org, repo, controlPathPolicyIdentityLabel(path), toolType, location, strings.TrimSpace(path.AgentID), controlPathPolicyIdentityStatus(path), controlEvidenceRefs(path), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys)
+	applyNodeMetadata(&policyIdentityNode, path, "control")
+	nodes = append(nodes, policyIdentityNode)
+
 	credentialNode := controlCredentialNode(pathID, path, org, repo, toolType, location)
 	if credentialNode != nil {
 		nodes = append(nodes, *credentialNode)
@@ -674,6 +764,38 @@ func buildControlPath(path ControlPathInput) ([]ControlPathNode, []ControlPathEd
 		nodes = append(nodes, controlNode)
 		edges = append(edges, newControlPathEdge(pathID, "path_governed_by", pathNode.NodeID, controlNode.NodeID, controlNode.EvidenceRefs, controlNode.SourceRefs, path.AttackPathRefs, path.SourceFindingKeys))
 	}
+
+	deploymentNode := newControlPathNode(pathID, ControlPathNodeDeploymentPath, org, repo, controlPathDeploymentLabel(path), toolType, location, strings.TrimSpace(path.AgentID), controlPathDeploymentStatus(path), controlEvidenceRefs(path), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys)
+	applyNodeMetadata(&deploymentNode, path, "deployment")
+	nodes = append(nodes, deploymentNode)
+
+	assetNode := newControlPathNode(pathID, ControlPathNodeAssetIdentity, org, repo, controlPathAssetLabel(path), toolType, location, strings.TrimSpace(path.AgentID), controlPathAssetStatus(path), controlEvidenceRefs(path), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys)
+	applyNodeMetadata(&assetNode, path, "target")
+	nodes = append(nodes, assetNode)
+
+	evidenceNode := newControlPathNode(pathID, ControlPathNodeEvidenceIdentity, org, repo, controlPathEvidenceLabel(path), toolType, location, strings.TrimSpace(path.AgentID), controlPathEvidenceState(path), controlEvidenceRefs(path), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys)
+	applyNodeMetadata(&evidenceNode, path, "evidence")
+	nodes = append(nodes, evidenceNode)
+
+	outcomeNode := newControlPathNode(pathID, ControlPathNodeOutcome, org, repo, controlPathOutcomeLabel(path), toolType, location, strings.TrimSpace(path.AgentID), controlPathOutcomeStatus(path), controlEvidenceRefs(path), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys)
+	applyNodeMetadata(&outcomeNode, path, "outcome")
+	nodes = append(nodes, outcomeNode)
+
+	edges = append(edges, newControlPathEdge(pathID, ControlPathEdgeRequestToHuman, intentNode.NodeID, humanNode.NodeID, humanNode.EvidenceRefs, humanNode.SourceRefs, path.AttackPathRefs, path.SourceFindingKeys))
+	edges = append(edges, newControlPathEdge(pathID, ControlPathEdgeHumanDelegatesTask, humanNode.NodeID, taskNode.NodeID, humanNode.EvidenceRefs, humanNode.SourceRefs, path.AttackPathRefs, path.SourceFindingKeys))
+	edges = append(edges, newControlPathEdge(pathID, ControlPathEdgeTaskExecutedByAgentTeam, taskNode.NodeID, agentTeamNode.NodeID, controlEvidenceRefs(path), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys))
+	edges = append(edges, newControlPathEdge(pathID, ControlPathEdgeAgentTeamUsesTool, agentTeamNode.NodeID, toolNode.NodeID, controlEvidenceRefs(path), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys))
+	if credentialNode != nil {
+		edges = append(edges, newControlPathEdge(pathID, ControlPathEdgeToolUsesCredential, toolNode.NodeID, credentialNode.NodeID, credentialNode.EvidenceRefs, credentialNode.SourceRefs, path.AttackPathRefs, path.SourceFindingKeys))
+		edges = append(edges, newControlPathEdge(pathID, ControlPathEdgeCredentialAuthorizesWorkflow, credentialNode.NodeID, workflowNode.NodeID, credentialNode.EvidenceRefs, credentialNode.SourceRefs, path.AttackPathRefs, path.SourceFindingKeys))
+	}
+	edges = append(edges, newControlPathEdge(pathID, ControlPathEdgeWorkflowChangesRepo, workflowNode.NodeID, repoNode.NodeID, controlEvidenceRefs(path), []string{repo}, path.AttackPathRefs, path.SourceFindingKeys))
+	edges = append(edges, newControlPathEdge(pathID, ControlPathEdgeRepoProducesPullRequest, repoNode.NodeID, prNode.NodeID, prNode.EvidenceRefs, prNode.SourceRefs, path.AttackPathRefs, path.SourceFindingKeys))
+	edges = append(edges, newControlPathEdge(pathID, ControlPathEdgePullRequestRunsChecks, prNode.NodeID, workflowRunNode.NodeID, controlEvidenceRefs(path), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys))
+	edges = append(edges, newControlPathEdge(pathID, ControlPathEdgeChecksGateApproval, workflowRunNode.NodeID, approvalIdentityNode.NodeID, controlEvidenceRefs(path), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys))
+	edges = append(edges, newControlPathEdge(pathID, ControlPathEdgeApprovalAuthorizesDeploy, approvalIdentityNode.NodeID, deploymentNode.NodeID, controlEvidenceRefs(path), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys))
+	edges = append(edges, newControlPathEdge(pathID, ControlPathEdgeDeployAffectsAsset, deploymentNode.NodeID, assetNode.NodeID, controlEvidenceRefs(path), controlSourceRefs(repo, location), path.AttackPathRefs, path.SourceFindingKeys))
+	edges = append(edges, newControlPathEdge(pathID, ControlPathEdgeEvidenceProvesOutcome, evidenceNode.NodeID, outcomeNode.NodeID, evidenceNode.EvidenceRefs, evidenceNode.SourceRefs, path.AttackPathRefs, path.SourceFindingKeys))
 
 	return nodes, edges
 }
@@ -830,6 +952,229 @@ func controlTargets(path ControlPathInput) []string {
 	return values
 }
 
+func controlPathIntentStatus(path ControlPathInput) string {
+	if strings.TrimSpace(path.Purpose) == "" {
+		return "unknown"
+	}
+	return "declared"
+}
+
+func controlPathTaskLabel(path ControlPathInput) string {
+	if strings.TrimSpace(path.Purpose) != "" {
+		return strings.TrimSpace(path.Purpose)
+	}
+	if strings.TrimSpace(path.PurposeSource) != "" {
+		return "unknown_task"
+	}
+	return "unknown_task"
+}
+
+func controlPathTaskStatus(path ControlPathInput) string {
+	if strings.TrimSpace(path.Purpose) != "" {
+		return "declared"
+	}
+	return "unknown"
+}
+
+func controlPathHumanLabel(result *attribution.Result) string {
+	if result != nil && strings.TrimSpace(result.Author) != "" {
+		return strings.TrimSpace(result.Author)
+	}
+	return "unknown_human"
+}
+
+func controlPathPullRequestLabel(result *attribution.Result) string {
+	if result != nil && result.PRNumber > 0 {
+		return fmt.Sprintf("PR #%d", result.PRNumber)
+	}
+	return "unknown_pr"
+}
+
+func controlPathWorkflowRunLabel(path ControlPathInput) string {
+	if strings.TrimSpace(path.Location) == "" {
+		return "unknown_workflow_run"
+	}
+	return strings.TrimSpace(path.Location)
+}
+
+func controlPathWorkflowRunStatus(path ControlPathInput) string {
+	if strings.TrimSpace(path.Location) == "" {
+		return "unknown"
+	}
+	return "present"
+}
+
+func controlPathApprovalIdentityLabel(path ControlPathInput) string {
+	if state := strings.TrimSpace(path.ApprovalEvidenceState); state != "" {
+		return "approval:" + state
+	}
+	return "unknown_approval_identity"
+}
+
+func controlPathApprovalIdentityStatus(path ControlPathInput) string {
+	if state := strings.TrimSpace(path.ApprovalEvidenceState); state != "" {
+		return state
+	}
+	return "unknown"
+}
+
+func controlPathPolicyIdentityLabel(path ControlPathInput) string {
+	if len(path.PolicyRefs) > 0 {
+		return strings.TrimSpace(path.PolicyRefs[0])
+	}
+	if strings.TrimSpace(path.ControlResolutionState) != "" {
+		return strings.TrimSpace(path.ControlResolutionState)
+	}
+	return "unknown_policy"
+}
+
+func controlPathPolicyIdentityStatus(path ControlPathInput) string {
+	if strings.TrimSpace(path.ControlResolutionState) == "contradictory_control" {
+		return "contradictory"
+	}
+	if len(path.PolicyRefs) > 0 {
+		return "declared"
+	}
+	return "unknown"
+}
+
+func controlPathDeploymentLabel(path ControlPathInput) string {
+	if len(path.MatchedProductionTargets) > 0 {
+		return strings.TrimSpace(path.MatchedProductionTargets[0])
+	}
+	if path.DeployWrite || path.ProductionWrite {
+		return "unknown_deployment_path"
+	}
+	return "unknown_deployment_path"
+}
+
+func controlPathDeploymentStatus(path ControlPathInput) string {
+	if path.DeployWrite || path.ProductionWrite {
+		if state := strongestControlPathEvidenceState(path.ProofEvidenceState, path.RuntimeEvidenceState); state != "" {
+			return state
+		}
+		return "unknown"
+	}
+	return "unknown"
+}
+
+func controlPathAssetLabel(path ControlPathInput) string {
+	targets := controlTargets(path)
+	if len(targets) > 0 {
+		return targets[0]
+	}
+	return "unknown_asset"
+}
+
+func controlPathAssetStatus(path ControlPathInput) string {
+	if state := strings.TrimSpace(path.TargetEvidenceState); state != "" {
+		return state
+	}
+	if path.ProductionWrite {
+		return "unknown"
+	}
+	return "unknown"
+}
+
+func controlPathEvidenceLabel(path ControlPathInput) string {
+	if strings.TrimSpace(path.EvidenceCompletenessLabel) != "" {
+		return strings.TrimSpace(path.EvidenceCompletenessLabel)
+	}
+	if state := controlPathEvidenceState(path); state != "" {
+		return state
+	}
+	return "unknown_evidence"
+}
+
+func controlPathEvidenceState(path ControlPathInput) string {
+	if label := strings.TrimSpace(path.EvidenceCompletenessLabel); label != "" {
+		return label
+	}
+	if state := strongestControlPathEvidenceState(path.ProofEvidenceState, path.RuntimeEvidenceState, path.TargetEvidenceState); state != "" {
+		return state
+	}
+	return ""
+}
+
+func controlPathOutcomeLabel(path ControlPathInput) string {
+	if state := strongestControlPathEvidenceState(path.ProofEvidenceState, path.RuntimeEvidenceState); state != "" {
+		return "outcome:" + state
+	}
+	return "unknown_outcome"
+}
+
+func controlPathOutcomeStatus(path ControlPathInput) string {
+	if state := strongestControlPathEvidenceState(path.ProofEvidenceState, path.RuntimeEvidenceState); state != "" {
+		return state
+	}
+	return "unknown"
+}
+
+func controlPathIntroducedByStatus(result *attribution.Result) string {
+	if result == nil {
+		return "unknown"
+	}
+	switch strings.TrimSpace(result.Confidence) {
+	case attribution.ConfidenceHigh:
+		return "verified"
+	case attribution.ConfidenceLow:
+		return "inferred"
+	default:
+		return "unknown"
+	}
+}
+
+func controlPathIntroducedByEvidence(result *attribution.Result) []string {
+	if result == nil {
+		return nil
+	}
+	values := []string{strings.TrimSpace(result.ProviderURL), strings.TrimSpace(result.ChangedFile)}
+	if result.PRNumber > 0 {
+		values = append(values, fmt.Sprintf("pr:%d", result.PRNumber))
+	}
+	return uniqueSortedStrings(values)
+}
+
+func strongestControlPathEvidenceState(values ...string) string {
+	bestRank := -1
+	best := ""
+	for _, value := range values {
+		normalized := strings.TrimSpace(value)
+		if normalized == "" {
+			continue
+		}
+		rank := controlPathEvidenceStateRank(normalized)
+		if rank > bestRank {
+			bestRank = rank
+			best = normalized
+		}
+	}
+	return best
+}
+
+func controlPathEvidenceStateRank(value string) int {
+	switch strings.TrimSpace(value) {
+	case "contradictory":
+		return 5
+	case "verified":
+		return 4
+	case "declared", "present":
+		return 3
+	case "inferred":
+		return 2
+	case "unknown", "missing":
+		return 1
+	case "strong_evidence":
+		return 4
+	case "partial_evidence":
+		return 3
+	case "insufficient_evidence":
+		return 2
+	default:
+		return 0
+	}
+}
+
 func controlMappings(values []agginventory.GovernanceControlMapping) []agginventory.GovernanceControlMapping {
 	if len(values) == 0 {
 		return nil
@@ -917,4 +1262,13 @@ func uniqueSortedStrings(values []string) []string {
 		return nil
 	}
 	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
 }

--- a/core/aggregate/attackpath/graph_v2_test.go
+++ b/core/aggregate/attackpath/graph_v2_test.go
@@ -1,0 +1,102 @@
+package attackpath
+
+import (
+	"testing"
+
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/attribution"
+)
+
+func TestControlPathGraphV2AddsNodeEdgeKindsAndSummaryRollups(t *testing.T) {
+	t.Parallel()
+
+	graph := BuildControlPathGraph([]ControlPathInput{{
+		PathID:                    "apc-v2-graph",
+		AgentID:                   "wrkr:compiled_action:acme",
+		Org:                       "acme",
+		Repo:                      "acme/payments",
+		ToolType:                  "compiled_action",
+		Location:                  ".github/workflows/release.yml",
+		Purpose:                   "release automation",
+		PurposeSource:             "workflow_name",
+		ExecutionIdentity:         "release-bot",
+		ExecutionIdentityStatus:   "known",
+		CredentialAccess:          true,
+		CredentialProvenance:      &agginventory.CredentialProvenance{Type: agginventory.CredentialProvenanceStaticSecret, CredentialKind: agginventory.CredentialKindGitHubPAT, AccessType: agginventory.CredentialAccessTypeStanding},
+		CredentialAuthority:       &agginventory.CredentialAuthority{CredentialPresent: true, CredentialUsableByPath: true, CredentialKind: agginventory.CredentialKindGitHubPAT, AccessType: agginventory.CredentialAccessTypeStanding},
+		GovernanceControls:        []agginventory.GovernanceControlMapping{{Control: agginventory.GovernanceControlApproval, Status: agginventory.ControlStatusSatisfied}, {Control: agginventory.GovernanceControlProof, Status: agginventory.ControlStatusSatisfied}},
+		MatchedProductionTargets:  []string{"cluster:prod"},
+		PullRequestWrite:          true,
+		DeployWrite:               true,
+		ProductionWrite:           true,
+		IntroducedBy:              &attribution.Result{Source: attribution.SourceSidecar, Confidence: attribution.ConfidenceHigh, PRNumber: 17, Author: "octocat"},
+		AutonomyTier:              "tier_4_prod_privileged_or_customer_impacting",
+		DelegationReadinessState:  "approval_required",
+		ApprovalEvidenceState:     "verified",
+		ProofEvidenceState:        "verified",
+		RuntimeEvidenceState:      "declared",
+		TargetEvidenceState:       "verified",
+		EvidenceCompletenessLabel: "strong_evidence",
+	}})
+	if graph == nil {
+		t.Fatal("expected control_path_graph")
+	}
+
+	for _, want := range []string{
+		ControlPathNodeIntent,
+		ControlPathNodeTask,
+		ControlPathNodeHumanIdentity,
+		ControlPathNodeAgentTeam,
+		ControlPathNodePullRequest,
+		ControlPathNodeWorkflowRun,
+		ControlPathNodeApprovalIdentity,
+		ControlPathNodePolicyIdentity,
+		ControlPathNodeDeploymentPath,
+		ControlPathNodeAssetIdentity,
+		ControlPathNodeEvidenceIdentity,
+		ControlPathNodeOutcome,
+	} {
+		if !hasControlPathNodeKind(graph.Nodes, want) {
+			t.Fatalf("expected v2 node kind %s in %+v", want, graph.Nodes)
+		}
+	}
+
+	for _, want := range []string{
+		ControlPathEdgeRequestToHuman,
+		ControlPathEdgeHumanDelegatesTask,
+		ControlPathEdgeTaskExecutedByAgentTeam,
+		ControlPathEdgeAgentTeamUsesTool,
+		ControlPathEdgeToolUsesCredential,
+		ControlPathEdgeCredentialAuthorizesWorkflow,
+		ControlPathEdgeWorkflowChangesRepo,
+		ControlPathEdgeRepoProducesPullRequest,
+		ControlPathEdgePullRequestRunsChecks,
+		ControlPathEdgeChecksGateApproval,
+		ControlPathEdgeApprovalAuthorizesDeploy,
+		ControlPathEdgeDeployAffectsAsset,
+		ControlPathEdgeEvidenceProvesOutcome,
+	} {
+		if !hasControlPathEdgeKind(graph.Edges, want) {
+			t.Fatalf("expected v2 edge kind %s in %+v", want, graph.Edges)
+		}
+	}
+
+	if !containsControlPathRollup(graph.Summary.AutonomyTiers, "tier_4_prod_privileged_or_customer_impacting", 1) {
+		t.Fatalf("expected autonomy tier rollup, got %+v", graph.Summary.AutonomyTiers)
+	}
+	if !containsControlPathRollup(graph.Summary.DelegationReadinessStates, "approval_required", 1) {
+		t.Fatalf("expected readiness rollup, got %+v", graph.Summary.DelegationReadinessStates)
+	}
+	if !containsControlPathRollup(graph.Summary.EvidenceStates, "strong_evidence", 1) {
+		t.Fatalf("expected evidence-state rollup, got %+v", graph.Summary.EvidenceStates)
+	}
+}
+
+func containsControlPathRollup(values []ControlPathKindRollup, wantKind string, wantCount int) bool {
+	for _, value := range values {
+		if value.Kind == wantKind && value.Count == wantCount {
+			return true
+		}
+	}
+	return false
+}

--- a/core/cli/report.go
+++ b/core/cli/report.go
@@ -35,6 +35,7 @@ type reportPayload struct {
 	AgentActionBOM           any                          `json:"agent_action_bom,omitempty"`
 	ActionPathToControlFirst any                          `json:"action_path_to_control_first,omitempty"`
 	ControlPathGraph         any                          `json:"control_path_graph,omitempty"`
+	WorkflowChains           any                          `json:"workflow_chains,omitempty"`
 	RuntimeEvidence          *ingest.Summary              `json:"runtime_evidence,omitempty"`
 	AssessmentSummary        any                          `json:"assessment_summary,omitempty"`
 	ExposureGroups           any                          `json:"exposure_groups,omitempty"`
@@ -200,6 +201,7 @@ func runReport(args []string, stdout io.Writer, stderr io.Writer) int {
 		AgentActionBOM:           summary.AgentActionBOM,
 		ActionPathToControlFirst: summary.ActionPathToControlFirst,
 		ControlPathGraph:         summary.ControlPathGraph,
+		WorkflowChains:           summary.WorkflowChains,
 		RuntimeEvidence:          summary.RuntimeEvidence,
 		AssessmentSummary:        summary.AssessmentSummary,
 		ExposureGroups:           summary.ExposureGroups,

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -525,9 +525,6 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	}
 	profileResult := profileeval.Evaluate(profileDef, findings, previousProfile)
 	riskReport.ActionPaths, riskReport.ActionPathToControlFirst = risk.ApplyGovernFirstProfile(profileResult.ProfileName, riskReport.ActionPaths)
-	riskReport.ControlPathGraph = risk.BuildControlPathGraph(riskReport.ActionPaths)
-	riskReport.ActionPaths = risk.DecorateActionLineage(riskReport.ActionPaths, riskReport.ControlPathGraph)
-	riskReport.ActionPathToControlFirst = risk.BuildActionPathChoice(riskReport.ActionPaths)
 	if err := checkScanContext(); err != nil {
 		return emitScanFailure(err)
 	}
@@ -538,6 +535,10 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		DetectorErrors: detectorErrors,
 	})
 	riskReport.ActionPaths = risk.DecorateEvidenceContext(riskReport.ActionPaths, &scanQuality)
+	riskReport.ControlPathGraph = risk.BuildControlPathGraph(riskReport.ActionPaths)
+	riskReport.WorkflowChains = risk.BuildWorkflowChains(riskReport.ActionPaths, riskReport.ControlPathGraph)
+	riskReport.ActionPaths = risk.DecorateWorkflowChainRefs(riskReport.ActionPaths, riskReport.WorkflowChains)
+	riskReport.ActionPaths = risk.DecorateActionLineage(riskReport.ActionPaths, riskReport.ControlPathGraph)
 	riskReport.ActionPathToControlFirst = risk.BuildActionPathChoice(riskReport.ActionPaths)
 	lifecycleGaps := lifecycle.DetectGaps(lifecycle.GapInput{
 		Identities:  nextManifest.Identities,

--- a/core/cli/state_mutation.go
+++ b/core/cli/state_mutation.go
@@ -92,6 +92,8 @@ func refreshDerivedMutationSnapshot(snapshot *state.Snapshot) error {
 	if snapshot.RiskReport != nil && snapshot.Inventory != nil {
 		snapshot.RiskReport.ActionPaths, snapshot.RiskReport.ActionPathToControlFirst = risk.BuildActionPaths(snapshot.RiskReport.AttackPaths, snapshot.Inventory)
 		snapshot.RiskReport.ControlPathGraph = risk.BuildControlPathGraph(snapshot.RiskReport.ActionPaths)
+		snapshot.RiskReport.WorkflowChains = risk.BuildWorkflowChains(snapshot.RiskReport.ActionPaths, snapshot.RiskReport.ControlPathGraph)
+		snapshot.RiskReport.ActionPaths = risk.DecorateWorkflowChainRefs(snapshot.RiskReport.ActionPaths, snapshot.RiskReport.WorkflowChains)
 		snapshot.RiskReport.ActionPaths = risk.DecorateActionLineage(snapshot.RiskReport.ActionPaths, snapshot.RiskReport.ControlPathGraph)
 		snapshot.RiskReport.ActionPathToControlFirst = risk.BuildActionPathChoice(snapshot.RiskReport.ActionPaths)
 		actionPaths = snapshot.RiskReport.ActionPaths

--- a/core/report/agent_action_bom.go
+++ b/core/report/agent_action_bom.go
@@ -175,6 +175,7 @@ type AgentActionBOMItem struct {
 	LifecycleQueue                      *governancequeue.Item                  `json:"lifecycle_queue,omitempty"`
 	AttackPathRefs                      []string                               `json:"attack_path_refs,omitempty"`
 	SourceFindingKeys                   []string                               `json:"source_finding_keys,omitempty"`
+	WorkflowChainRefs                   []string                               `json:"workflow_chain_refs,omitempty"`
 	ExclusionReason                     string                                 `json:"exclusion_reason,omitempty"`
 	GraphRefs                           AgentActionBOMGraphRefs                `json:"graph_refs,omitempty"`
 	EvidenceRefs                        []string                               `json:"evidence_refs,omitempty"`
@@ -352,6 +353,7 @@ func buildAgentActionBOM(summary Summary, findings []model.Finding) *AgentAction
 			LifecycleQueue:                      cloneLifecycleQueue(backlogItem.LifecycleQueue),
 			AttackPathRefs:                      append([]string(nil), path.AttackPathRefs...),
 			SourceFindingKeys:                   append([]string(nil), path.SourceFindingKeys...),
+			WorkflowChainRefs:                   append([]string(nil), path.WorkflowChainRefs...),
 			GraphRefs:                           itemGraphRefs,
 			Reachability:                        reachability,
 			ReachableServers:                    reachableServers,

--- a/core/report/artifacts.go
+++ b/core/report/artifacts.go
@@ -6,25 +6,27 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/Clyra-AI/wrkr/core/aggregate/agentresolver"
 	aggattack "github.com/Clyra-AI/wrkr/core/aggregate/attackpath"
 	"github.com/Clyra-AI/wrkr/core/aggregate/controlbacklog"
 	"github.com/Clyra-AI/wrkr/core/ingest"
 )
 
 type EvidenceBundle struct {
-	ReportBundleVersion   string                       `json:"report_bundle_version"`
-	GeneratedAt           string                       `json:"generated_at"`
-	Template              string                       `json:"template"`
-	ShareProfile          string                       `json:"share_profile"`
-	ShareProfileMetadata  *ShareProfileMetadata        `json:"share_profile_metadata,omitempty"`
-	ControlBacklog        *controlbacklog.Backlog      `json:"control_backlog,omitempty"`
-	ControlPathGraph      *aggattack.ControlPathGraph  `json:"control_path_graph,omitempty"`
-	ActionSurfaceRegistry []ActionSurfaceRegistryEntry `json:"action_surface_registry,omitempty"`
-	RuntimeEvidence       *ingest.Summary              `json:"runtime_evidence,omitempty"`
-	AgentActionBOM        *AgentActionBOM              `json:"agent_action_bom,omitempty"`
-	ComplianceSummary     any                          `json:"compliance_summary"`
-	Proof                 ProofReference               `json:"proof"`
-	NextActions           []ChecklistItem              `json:"next_actions"`
+	ReportBundleVersion   string                               `json:"report_bundle_version"`
+	GeneratedAt           string                               `json:"generated_at"`
+	Template              string                               `json:"template"`
+	ShareProfile          string                               `json:"share_profile"`
+	ShareProfileMetadata  *ShareProfileMetadata                `json:"share_profile_metadata,omitempty"`
+	ControlBacklog        *controlbacklog.Backlog              `json:"control_backlog,omitempty"`
+	ControlPathGraph      *aggattack.ControlPathGraph          `json:"control_path_graph,omitempty"`
+	WorkflowChains        *agentresolver.WorkflowChainArtifact `json:"workflow_chains,omitempty"`
+	ActionSurfaceRegistry []ActionSurfaceRegistryEntry         `json:"action_surface_registry,omitempty"`
+	RuntimeEvidence       *ingest.Summary                      `json:"runtime_evidence,omitempty"`
+	AgentActionBOM        *AgentActionBOM                      `json:"agent_action_bom,omitempty"`
+	ComplianceSummary     any                                  `json:"compliance_summary"`
+	Proof                 ProofReference                       `json:"proof"`
+	NextActions           []ChecklistItem                      `json:"next_actions"`
 }
 
 func BuildEvidenceBundle(summary Summary) EvidenceBundle {
@@ -36,6 +38,7 @@ func BuildEvidenceBundle(summary Summary) EvidenceBundle {
 		ShareProfileMetadata:  cloneShareProfileMetadata(summary.ShareProfileMetadata),
 		ControlBacklog:        summary.ControlBacklog,
 		ControlPathGraph:      summary.ControlPathGraph,
+		WorkflowChains:        summary.WorkflowChains,
 		ActionSurfaceRegistry: append([]ActionSurfaceRegistryEntry(nil), summary.ActionSurfaceRegistry...),
 		RuntimeEvidence:       summary.RuntimeEvidence,
 		AgentActionBOM:        summary.AgentActionBOM,

--- a/core/report/build.go
+++ b/core/report/build.go
@@ -1694,7 +1694,7 @@ func sanitizeWorkflowChainsPublic(in *agentresolver.WorkflowChainArtifact) *agen
 	}
 	out := &agentresolver.WorkflowChainArtifact{
 		Version: strings.TrimSpace(in.Version),
-		Summary: in.Summary,
+		Summary: sanitizeWorkflowChainSummaryPublic(in.Summary),
 		Chains:  make([]agentresolver.WorkflowChain, 0, len(in.Chains)),
 	}
 	for _, chain := range in.Chains {
@@ -1733,6 +1733,26 @@ func sanitizeWorkflowChainDimensionPublic(in agentresolver.WorkflowChainDimensio
 	out.Key = redactValue(prefix, out.Key, 8)
 	out.Label = redactValue(prefix, out.Label, 8)
 	out.EvidenceRefs = redactStringSlice(out.EvidenceRefs, "evidence")
+	return out
+}
+
+func sanitizeWorkflowChainSummaryPublic(in agentresolver.WorkflowChainSummary) agentresolver.WorkflowChainSummary {
+	out := in
+	out.Repos = sanitizeWorkflowChainRollupsPublic(in.Repos, "repo")
+	out.Workflows = sanitizeWorkflowChainRollupsPublic(in.Workflows, "workflow")
+	return out
+}
+
+func sanitizeWorkflowChainRollupsPublic(in []agentresolver.WorkflowChainRollup, prefix string) []agentresolver.WorkflowChainRollup {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]agentresolver.WorkflowChainRollup, 0, len(in))
+	for _, item := range in {
+		copyItem := item
+		copyItem.Value = redactValue(prefix, copyItem.Value, 8)
+		out = append(out, copyItem)
+	}
 	return out
 }
 

--- a/core/report/build.go
+++ b/core/report/build.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Clyra-AI/wrkr/core/aggregate/agentresolver"
 	aggattack "github.com/Clyra-AI/wrkr/core/aggregate/attackpath"
 	"github.com/Clyra-AI/wrkr/core/aggregate/controlbacklog"
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
@@ -76,11 +77,6 @@ func BuildSummary(in BuildInput) (Summary, error) {
 		profileName = in.Snapshot.Profile.ProfileName
 	}
 	riskReport.ActionPaths, riskReport.ActionPathToControlFirst = risk.ApplyGovernFirstProfile(profileName, riskReport.ActionPaths)
-	if len(riskReport.ActionPaths) > 0 {
-		riskReport.ControlPathGraph = risk.BuildControlPathGraph(riskReport.ActionPaths)
-	}
-	riskReport.ActionPaths = risk.DecorateActionLineage(riskReport.ActionPaths, riskReport.ControlPathGraph)
-	riskReport.ActionPathToControlFirst = risk.BuildActionPathChoice(riskReport.ActionPaths)
 	topFindings := SelectTopFindings(*riskReport, top)
 
 	proofRef, err := buildProofReference(in.StatePath, topFindings)
@@ -109,6 +105,12 @@ func BuildSummary(in BuildInput) (Summary, error) {
 	runtimeEvidence := buildRuntimeEvidenceSummary(in.StatePath, in.Snapshot)
 	riskReport.ActionPaths = decorateActionPathsForReport(riskReport.ActionPaths, runtimeEvidence)
 	riskReport.ActionPaths = risk.DecorateEvidenceContext(riskReport.ActionPaths, scanQuality)
+	if len(riskReport.ActionPaths) > 0 {
+		riskReport.ControlPathGraph = risk.BuildControlPathGraph(riskReport.ActionPaths)
+		riskReport.WorkflowChains = risk.BuildWorkflowChains(riskReport.ActionPaths, riskReport.ControlPathGraph)
+		riskReport.ActionPaths = risk.DecorateWorkflowChainRefs(riskReport.ActionPaths, riskReport.WorkflowChains)
+		riskReport.ActionPaths = risk.DecorateActionLineage(riskReport.ActionPaths, riskReport.ControlPathGraph)
+	}
 	riskReport.ActionPathToControlFirst = decorateControlFirstForReport(riskReport.ActionPaths, scanQualityCoverageReduced(scanQuality))
 	activation := BuildActivation(in.Snapshot.Target.Mode, riskReport.Ranked, in.Snapshot.Inventory, riskReport.ActionPaths, top)
 	exposureGroups := risk.BuildExposureGroups(riskReport.ActionPaths)
@@ -133,6 +135,7 @@ func BuildSummary(in BuildInput) (Summary, error) {
 	rawActionPaths := append([]risk.ActionPath(nil), riskReport.ActionPaths...)
 	rawActionPathToControlFirst := riskReport.ActionPathToControlFirst
 	rawControlPathGraph := riskReport.ControlPathGraph
+	rawWorkflowChains := riskReport.WorkflowChains
 	controlProofStatus, err := buildControlProofStatusForSummary(in.StatePath, in.Snapshot, riskReport)
 	if err != nil {
 		return Summary{}, err
@@ -150,6 +153,7 @@ func BuildSummary(in BuildInput) (Summary, error) {
 		riskReport.ActionPaths = sanitizeActionPathsPublic(riskReport.ActionPaths)
 		riskReport.ActionPathToControlFirst = sanitizeActionPathToControlFirstPublic(riskReport.ActionPathToControlFirst)
 		riskReport.ControlPathGraph = sanitizeControlPathGraphPublic(riskReport.ControlPathGraph)
+		riskReport.WorkflowChains = sanitizeWorkflowChainsPublic(riskReport.WorkflowChains)
 		exposureGroups = sanitizeExposureGroupsPublic(exposureGroups)
 		assessmentSummary = sanitizeAssessmentSummaryPublic(assessmentSummary)
 		controlBacklog = sanitizeControlBacklogPublic(controlBacklog)
@@ -163,6 +167,7 @@ func BuildSummary(in BuildInput) (Summary, error) {
 		riskReport.ActionPaths = sanitizeActionPathsWithConfig(riskReport.ActionPaths, redactionConfig)
 		riskReport.ActionPathToControlFirst = sanitizeActionPathToControlFirstWithConfig(riskReport.ActionPathToControlFirst, redactionConfig)
 		riskReport.ControlPathGraph = sanitizeControlPathGraphWithConfig(riskReport.ControlPathGraph, redactionConfig)
+		riskReport.WorkflowChains = sanitizeWorkflowChainsWithConfig(riskReport.WorkflowChains, redactionConfig)
 		exposureGroups = sanitizeExposureGroupsWithConfig(exposureGroups, redactionConfig)
 		assessmentSummary = sanitizeAssessmentSummaryWithConfig(assessmentSummary, redactionConfig)
 		controlBacklog = sanitizeControlBacklogWithConfig(controlBacklog, redactionConfig)
@@ -228,6 +233,7 @@ func BuildSummary(in BuildInput) (Summary, error) {
 		ActionPaths:              riskReport.ActionPaths,
 		ActionPathToControlFirst: riskReport.ActionPathToControlFirst,
 		ControlPathGraph:         riskReport.ControlPathGraph,
+		WorkflowChains:           riskReport.WorkflowChains,
 		ExposureGroups:           exposureGroups,
 		SourcePrivacy:            sourcePrivacy,
 		controlProofStatus:       controlProofStatus,
@@ -237,6 +243,7 @@ func BuildSummary(in BuildInput) (Summary, error) {
 	bomSource.ActionPaths = append([]risk.ActionPath(nil), rawActionPaths...)
 	bomSource.ActionPathToControlFirst = rawActionPathToControlFirst
 	bomSource.ControlPathGraph = rawControlPathGraph
+	bomSource.WorkflowChains = rawWorkflowChains
 	summary.AgentActionBOM = buildAgentActionBOMFromSnapshot(bomSource, in.Snapshot)
 	registrySource := bomSource
 	registrySource.AgentActionBOM = summary.AgentActionBOM
@@ -1679,6 +1686,54 @@ func sanitizeActionPathToControlFirstPublic(in *risk.ActionPathToControlFirst) *
 		Summary: copySummary,
 		Path:    paths[0],
 	}
+}
+
+func sanitizeWorkflowChainsPublic(in *agentresolver.WorkflowChainArtifact) *agentresolver.WorkflowChainArtifact {
+	if in == nil {
+		return nil
+	}
+	out := &agentresolver.WorkflowChainArtifact{
+		Version: strings.TrimSpace(in.Version),
+		Summary: in.Summary,
+		Chains:  make([]agentresolver.WorkflowChain, 0, len(in.Chains)),
+	}
+	for _, chain := range in.Chains {
+		copyChain := chain
+		copyChain.PathIDs = redactStringSlice(copyChain.PathIDs, "path")
+		copyChain.GraphNodeRefs = redactStringSlice(copyChain.GraphNodeRefs, "node")
+		copyChain.GraphEdgeRefs = redactStringSlice(copyChain.GraphEdgeRefs, "edge")
+		copyChain.ProofRefs = redactStringSlice(copyChain.ProofRefs, "proof")
+		copyChain.EvidenceRefs = redactStringSlice(copyChain.EvidenceRefs, "evidence")
+		copyChain.SourceFindingKeys = redactStringSlice(copyChain.SourceFindingKeys, "finding")
+		copyChain.Repo = sanitizeWorkflowChainDimensionPublic(copyChain.Repo, "repo")
+		copyChain.PullRequest = sanitizeWorkflowChainDimensionPublic(copyChain.PullRequest, "pr")
+		copyChain.Workflow = sanitizeWorkflowChainDimensionPublic(copyChain.Workflow, "workflow")
+		copyChain.Task = sanitizeWorkflowChainDimensionPublic(copyChain.Task, "task")
+		copyChain.Tool = sanitizeWorkflowChainDimensionPublic(copyChain.Tool, "tool")
+		copyChain.Credential = sanitizeWorkflowChainDimensionPublic(copyChain.Credential, "credential")
+		copyChain.Owner = sanitizeWorkflowChainDimensionPublic(copyChain.Owner, "owner")
+		copyChain.Approval = sanitizeWorkflowChainDimensionPublic(copyChain.Approval, "approval")
+		copyChain.Target = sanitizeWorkflowChainDimensionPublic(copyChain.Target, "target")
+		copyChain.Evidence = sanitizeWorkflowChainDimensionPublic(copyChain.Evidence, "evidence")
+		copyChain.Outcome = sanitizeWorkflowChainDimensionPublic(copyChain.Outcome, "outcome")
+		if copyChain.IntroducedBy != nil {
+			introduced := *copyChain.IntroducedBy
+			introduced.Author = redactValue("author", introduced.Author, 8)
+			introduced.ChangedFile = redactValue("file", introduced.ChangedFile, 8)
+			introduced.ProviderURL = redactValue("provider", introduced.ProviderURL, 8)
+			copyChain.IntroducedBy = &introduced
+		}
+		out.Chains = append(out.Chains, copyChain)
+	}
+	return out
+}
+
+func sanitizeWorkflowChainDimensionPublic(in agentresolver.WorkflowChainDimension, prefix string) agentresolver.WorkflowChainDimension {
+	out := in
+	out.Key = redactValue(prefix, out.Key, 8)
+	out.Label = redactValue(prefix, out.Label, 8)
+	out.EvidenceRefs = redactStringSlice(out.EvidenceRefs, "evidence")
+	return out
 }
 
 func sanitizeActionSurfaceRegistryPublic(in []ActionSurfaceRegistryEntry) []ActionSurfaceRegistryEntry {

--- a/core/report/redaction_summary.go
+++ b/core/report/redaction_summary.go
@@ -281,7 +281,7 @@ func sanitizeWorkflowChainsWithConfig(in *agentresolver.WorkflowChainArtifact, c
 	}
 	copyArtifact := &agentresolver.WorkflowChainArtifact{
 		Version: strings.TrimSpace(in.Version),
-		Summary: in.Summary,
+		Summary: sanitizeWorkflowChainSummaryWithConfig(in.Summary, config),
 		Chains:  make([]agentresolver.WorkflowChain, 0, len(in.Chains)),
 	}
 	for _, chain := range in.Chains {
@@ -324,6 +324,39 @@ func sanitizeWorkflowChainDimensionWithConfig(in agentresolver.WorkflowChainDime
 	out.Label = maybeRedactRepo(out.Label, config)
 	out.Label = maybeRedactOwner(out.Label, config)
 	out.EvidenceRefs = maybeRedactStringSlice(out.EvidenceRefs, "evidence", config.Has(RedactionProofRefs) || config.Has(RedactionProviders))
+	return out
+}
+
+func sanitizeWorkflowChainSummaryWithConfig(in agentresolver.WorkflowChainSummary, config RedactionConfig) agentresolver.WorkflowChainSummary {
+	out := in
+	out.Repos = sanitizeWorkflowChainRepoRollupsWithConfig(in.Repos, config)
+	out.Workflows = sanitizeWorkflowChainWorkflowRollupsWithConfig(in.Workflows, config)
+	return out
+}
+
+func sanitizeWorkflowChainRepoRollupsWithConfig(in []agentresolver.WorkflowChainRollup, config RedactionConfig) []agentresolver.WorkflowChainRollup {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]agentresolver.WorkflowChainRollup, 0, len(in))
+	for _, item := range in {
+		copyItem := item
+		copyItem.Value = maybeRedactRepo(copyItem.Value, config)
+		out = append(out, copyItem)
+	}
+	return out
+}
+
+func sanitizeWorkflowChainWorkflowRollupsWithConfig(in []agentresolver.WorkflowChainRollup, config RedactionConfig) []agentresolver.WorkflowChainRollup {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]agentresolver.WorkflowChainRollup, 0, len(in))
+	for _, item := range in {
+		copyItem := item
+		copyItem.Value = maybeRedactLocationLike(copyItem.Value, config)
+		out = append(out, copyItem)
+	}
 	return out
 }
 

--- a/core/report/redaction_summary.go
+++ b/core/report/redaction_summary.go
@@ -3,6 +3,7 @@ package report
 import (
 	"strings"
 
+	"github.com/Clyra-AI/wrkr/core/aggregate/agentresolver"
 	aggattack "github.com/Clyra-AI/wrkr/core/aggregate/attackpath"
 	"github.com/Clyra-AI/wrkr/core/aggregate/controlbacklog"
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
@@ -272,6 +273,58 @@ func sanitizeControlPathGraphWithConfig(in *aggattack.ControlPathGraph, config R
 		copyGraph.Edges[idx].SourceFindingKeys = maybeRedactStringSlice(copyGraph.Edges[idx].SourceFindingKeys, "finding", shouldRedactFindingKeys(config))
 	}
 	return &copyGraph
+}
+
+func sanitizeWorkflowChainsWithConfig(in *agentresolver.WorkflowChainArtifact, config RedactionConfig) *agentresolver.WorkflowChainArtifact {
+	if in == nil {
+		return nil
+	}
+	copyArtifact := &agentresolver.WorkflowChainArtifact{
+		Version: strings.TrimSpace(in.Version),
+		Summary: in.Summary,
+		Chains:  make([]agentresolver.WorkflowChain, 0, len(in.Chains)),
+	}
+	for _, chain := range in.Chains {
+		copyChain := chain
+		copyChain.PathIDs = maybeRedactStringSlice(copyChain.PathIDs, "path", config.Has(RedactionPaths))
+		copyChain.GraphNodeRefs = maybeRedactStringSlice(copyChain.GraphNodeRefs, "node", config.Has(RedactionGraphRefs))
+		copyChain.GraphEdgeRefs = maybeRedactStringSlice(copyChain.GraphEdgeRefs, "edge", config.Has(RedactionGraphRefs))
+		copyChain.ProofRefs = maybeRedactStringSlice(copyChain.ProofRefs, "proof", config.Has(RedactionProofRefs))
+		copyChain.EvidenceRefs = maybeRedactStringSlice(copyChain.EvidenceRefs, "evidence", config.Has(RedactionProofRefs) || config.Has(RedactionProviders))
+		copyChain.SourceFindingKeys = maybeRedactStringSlice(copyChain.SourceFindingKeys, "finding", shouldRedactFindingKeys(config))
+		copyChain.Repo = sanitizeWorkflowChainDimensionWithConfig(copyChain.Repo, config)
+		copyChain.PullRequest = sanitizeWorkflowChainDimensionWithConfig(copyChain.PullRequest, config)
+		copyChain.Workflow = sanitizeWorkflowChainDimensionWithConfig(copyChain.Workflow, config)
+		copyChain.Task = sanitizeWorkflowChainDimensionWithConfig(copyChain.Task, config)
+		copyChain.Tool = sanitizeWorkflowChainDimensionWithConfig(copyChain.Tool, config)
+		copyChain.Credential = sanitizeWorkflowChainDimensionWithConfig(copyChain.Credential, config)
+		copyChain.Owner = sanitizeWorkflowChainDimensionWithConfig(copyChain.Owner, config)
+		copyChain.Approval = sanitizeWorkflowChainDimensionWithConfig(copyChain.Approval, config)
+		copyChain.Target = sanitizeWorkflowChainDimensionWithConfig(copyChain.Target, config)
+		copyChain.Evidence = sanitizeWorkflowChainDimensionWithConfig(copyChain.Evidence, config)
+		copyChain.Outcome = sanitizeWorkflowChainDimensionWithConfig(copyChain.Outcome, config)
+		if copyChain.IntroducedBy != nil {
+			introduced := *copyChain.IntroducedBy
+			introduced.Author = maybeRedactAuthor(introduced.Author, config)
+			introduced.ChangedFile = maybeRedactLocationLike(introduced.ChangedFile, config)
+			introduced.ProviderURL = maybeRedactProvider(introduced.ProviderURL, config)
+			copyChain.IntroducedBy = &introduced
+		}
+		copyArtifact.Chains = append(copyArtifact.Chains, copyChain)
+	}
+	return copyArtifact
+}
+
+func sanitizeWorkflowChainDimensionWithConfig(in agentresolver.WorkflowChainDimension, config RedactionConfig) agentresolver.WorkflowChainDimension {
+	out := in
+	out.Key = maybeRedactLocationLike(out.Key, config)
+	out.Key = maybeRedactRepo(out.Key, config)
+	out.Key = maybeRedactOwner(out.Key, config)
+	out.Label = maybeRedactLocationLike(out.Label, config)
+	out.Label = maybeRedactRepo(out.Label, config)
+	out.Label = maybeRedactOwner(out.Label, config)
+	out.EvidenceRefs = maybeRedactStringSlice(out.EvidenceRefs, "evidence", config.Has(RedactionProofRefs) || config.Has(RedactionProviders))
+	return out
 }
 
 func sanitizeControlBacklogWithConfig(in *controlbacklog.Backlog, config RedactionConfig) *controlbacklog.Backlog {

--- a/core/report/types.go
+++ b/core/report/types.go
@@ -3,6 +3,7 @@ package report
 import (
 	"time"
 
+	"github.com/Clyra-AI/wrkr/core/aggregate/agentresolver"
 	aggattack "github.com/Clyra-AI/wrkr/core/aggregate/attackpath"
 	"github.com/Clyra-AI/wrkr/core/aggregate/controlbacklog"
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
@@ -106,6 +107,7 @@ type Summary struct {
 	ActionPathToControlFirst *risk.ActionPathToControlFirst         `json:"action_path_to_control_first,omitempty"`
 	ActionSurfaceRegistry    []ActionSurfaceRegistryEntry           `json:"action_surface_registry,omitempty"`
 	ControlPathGraph         *aggattack.ControlPathGraph            `json:"control_path_graph,omitempty"`
+	WorkflowChains           *agentresolver.WorkflowChainArtifact   `json:"workflow_chains,omitempty"`
 	ExposureGroups           []risk.ExposureGroup                   `json:"exposure_groups,omitempty"`
 	SourcePrivacy            *sourceprivacy.Contract                `json:"source_privacy,omitempty"`
 	controlProofStatus       []ControlProofStatus

--- a/core/report/workflow_chain_test.go
+++ b/core/report/workflow_chain_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Clyra-AI/wrkr/core/aggregate/agentresolver"
 	"github.com/Clyra-AI/wrkr/core/attribution"
 	"github.com/Clyra-AI/wrkr/core/risk"
 	"github.com/Clyra-AI/wrkr/core/state"
@@ -53,5 +54,68 @@ func TestBuildSummaryIncludesWorkflowChainsAndBOMRefs(t *testing.T) {
 	}
 	if summary.AgentActionBOM == nil || len(summary.AgentActionBOM.Items) != 1 || len(summary.AgentActionBOM.Items[0].WorkflowChainRefs) == 0 {
 		t.Fatalf("expected workflow chain refs on BOM items, got %+v", summary.AgentActionBOM)
+	}
+}
+
+func TestSanitizeWorkflowChainsPublicRedactsSummaryRollups(t *testing.T) {
+	t.Parallel()
+
+	input := &agentresolver.WorkflowChainArtifact{
+		Version: agentresolver.WorkflowChainVersion,
+		Summary: agentresolver.WorkflowChainSummary{
+			TotalChains: 1,
+			Repos: []agentresolver.WorkflowChainRollup{
+				{Value: "acme/release", Count: 1},
+			},
+			Workflows: []agentresolver.WorkflowChainRollup{
+				{Value: ".github/workflows/release.yml", Count: 1},
+			},
+			AutonomyTiers: []agentresolver.WorkflowChainRollup{
+				{Value: "tier_4_prod_privileged_or_customer_impacting", Count: 1},
+			},
+		},
+	}
+
+	redacted := sanitizeWorkflowChainsPublic(input)
+	if redacted == nil {
+		t.Fatal("expected redacted workflow chains")
+	}
+	if redacted.Summary.Repos[0].Value == input.Summary.Repos[0].Value {
+		t.Fatalf("expected repo summary rollup to redact, got %+v", redacted.Summary.Repos)
+	}
+	if redacted.Summary.Workflows[0].Value == input.Summary.Workflows[0].Value {
+		t.Fatalf("expected workflow summary rollup to redact, got %+v", redacted.Summary.Workflows)
+	}
+	if redacted.Summary.AutonomyTiers[0].Value != input.Summary.AutonomyTiers[0].Value {
+		t.Fatalf("expected enum rollup to remain visible, got %+v", redacted.Summary.AutonomyTiers)
+	}
+}
+
+func TestSanitizeWorkflowChainsWithConfigRedactsSummaryRollups(t *testing.T) {
+	t.Parallel()
+
+	input := &agentresolver.WorkflowChainArtifact{
+		Version: agentresolver.WorkflowChainVersion,
+		Summary: agentresolver.WorkflowChainSummary{
+			TotalChains: 1,
+			Repos: []agentresolver.WorkflowChainRollup{
+				{Value: "acme/release", Count: 1},
+			},
+			Workflows: []agentresolver.WorkflowChainRollup{
+				{Value: ".github/workflows/release.yml", Count: 1},
+			},
+		},
+	}
+
+	config := ResolveRedactionConfig(ShareProfileInternal, []RedactionField{RedactionRepos, RedactionPaths})
+	redacted := sanitizeWorkflowChainsWithConfig(input, config)
+	if redacted == nil {
+		t.Fatal("expected redacted workflow chains")
+	}
+	if redacted.Summary.Repos[0].Value == input.Summary.Repos[0].Value {
+		t.Fatalf("expected repo summary rollup to redact with config, got %+v", redacted.Summary.Repos)
+	}
+	if redacted.Summary.Workflows[0].Value == input.Summary.Workflows[0].Value {
+		t.Fatalf("expected workflow summary rollup to redact with config, got %+v", redacted.Summary.Workflows)
 	}
 }

--- a/core/report/workflow_chain_test.go
+++ b/core/report/workflow_chain_test.go
@@ -1,0 +1,57 @@
+package report
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Clyra-AI/wrkr/core/attribution"
+	"github.com/Clyra-AI/wrkr/core/risk"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+func TestBuildSummaryIncludesWorkflowChainsAndBOMRefs(t *testing.T) {
+	t.Parallel()
+
+	summary, err := BuildSummary(BuildInput{
+		StatePath: filepath.Join(t.TempDir(), "state.json"),
+		Snapshot: state.Snapshot{
+			RiskReport: &risk.Report{
+				ActionPaths: []risk.ActionPath{{
+					PathID:                   "apc-wave2-summary",
+					AgentID:                  "wrkr:ci:acme",
+					Org:                      "acme",
+					Repo:                     "acme/release",
+					ToolType:                 "compiled_action",
+					Location:                 ".github/workflows/release.yml",
+					Purpose:                  "release automation",
+					PurposeSource:            "workflow_name",
+					WriteCapable:             true,
+					PullRequestWrite:         true,
+					DeployWrite:              true,
+					ProductionWrite:          true,
+					RecommendedAction:        "proof",
+					BusinessStateSurface:     "deploy",
+					PolicyCoverageStatus:     risk.PolicyCoverageStatusMatched,
+					IntroducedBy:             &attribution.Result{Source: attribution.SourceSidecar, Confidence: attribution.ConfidenceHigh, PRNumber: 17, Author: "octocat"},
+					AutonomyTier:             "tier_4_prod_privileged_or_customer_impacting",
+					DelegationReadinessState: "approval_required",
+					RecommendedControl:       "approval_required",
+				}},
+			},
+		},
+		GeneratedAt: time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("build summary: %v", err)
+	}
+	if summary.WorkflowChains == nil || len(summary.WorkflowChains.Chains) == 0 {
+		t.Fatalf("expected workflow chains on summary, got %+v", summary.WorkflowChains)
+	}
+	if len(summary.ActionPaths) != 1 || len(summary.ActionPaths[0].WorkflowChainRefs) == 0 {
+		t.Fatalf("expected workflow chain refs on action paths, got %+v", summary.ActionPaths)
+	}
+	if summary.AgentActionBOM == nil || len(summary.AgentActionBOM.Items) != 1 || len(summary.AgentActionBOM.Items[0].WorkflowChainRefs) == 0 {
+		t.Fatalf("expected workflow chain refs on BOM items, got %+v", summary.AgentActionBOM)
+	}
+}

--- a/core/risk/action_lineage.go
+++ b/core/risk/action_lineage.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"sort"
+	"strconv"
 	"strings"
 
 	aggattack "github.com/Clyra-AI/wrkr/core/aggregate/attackpath"
@@ -93,15 +94,24 @@ func buildActionLineage(path ActionPath, index controlPathLineageIndex) *ActionL
 	approvalNodeIDs := matchingNodeIDs(nodes, "governance_control", "approval")
 	proofNodeIDs := matchingNodeIDs(nodes, "governance_control", "proof")
 	segments := []ActionLineageSegment{
+		newLineageSegment(pathID, "intent", intentLineageLabel(path), intentLineageStatus(path), matchingNodeIDs(nodes, aggattack.ControlPathNodeIntent, "intent"), matchingEdgeIDs(edges, aggattack.ControlPathEdgeRequestToHuman), intentLineageEvidence(path)),
+		newLineageSegment(pathID, "task", taskLineageLabel(path), taskLineageStatus(path), matchingNodeIDs(nodes, aggattack.ControlPathNodeTask, "task"), matchingEdgeIDsAny(edges, aggattack.ControlPathEdgeHumanDelegatesTask, aggattack.ControlPathEdgeTaskExecutedByAgentTeam), taskLineageEvidence(path)),
+		newLineageSegment(pathID, "human", humanLineageLabel(path), humanLineageStatus(path), matchingNodeIDs(nodes, aggattack.ControlPathNodeHumanIdentity, "human"), matchingEdgeIDsAny(edges, aggattack.ControlPathEdgeRequestToHuman, aggattack.ControlPathEdgeHumanDelegatesTask), humanLineageEvidence(path)),
 		newLineageSegment(pathID, "repo", path.Repo, statusForPresence(path.Repo), matchingNodeIDs(nodes, "repo", ""), matchingEdgeIDs(edges, "workflow_in_repo"), []string{path.Repo}),
+		newLineageSegment(pathID, "pr", pullRequestLineageLabel(path), pullRequestLineageStatus(path), matchingNodeIDs(nodes, aggattack.ControlPathNodePullRequest, "pr"), matchingEdgeIDsAny(edges, aggattack.ControlPathEdgeRepoProducesPullRequest, aggattack.ControlPathEdgePullRequestRunsChecks), pullRequestLineageEvidence(path)),
 		newLineageSegment(pathID, "workflow", path.Location, statusForPresence(path.Location), matchingNodeIDs(nodes, "workflow", ""), matchingEdgeIDs(edges, "path_executes_workflow"), []string{path.Location}),
+		newLineageSegment(pathID, "workflow_run", workflowRunLineageLabel(path), workflowRunLineageStatus(path), matchingNodeIDsAny(nodes, []string{aggattack.ControlPathNodeWorkflowRun, aggattack.ControlPathNodeCICDRun}, "workflow_run"), matchingEdgeIDsAny(edges, aggattack.ControlPathEdgePullRequestRunsChecks, aggattack.ControlPathEdgeChecksGateApproval), workflowRunLineageEvidence(path)),
 		newLineageSegment(pathID, "agent", firstNonEmpty(path.AgentID, path.ToolType), statusForPresence(firstNonEmpty(path.AgentID, path.ToolType)), matchingNodeIDs(nodes, "agent", ""), matchingEdgeIDs(edges, "agent_controls_path"), []string{path.AgentID}),
 		newLineageSegment(pathID, "action", actionLineageLabel(path), actionLineageStatus(path), matchingNodeIDs(nodes, "action_capability", ""), matchingEdgeIDs(edges, "path_enables_action"), append([]string(nil), path.ActionReasons...)),
 		newLineageSegment(pathID, "credential", credentialLineageLabel(path), credentialLineageStatus(path), matchingNodeIDs(nodes, "credential", ""), matchingEdgeIDs(edges, "execution_uses_credential"), credentialLineageEvidence(path)),
 		newLineageSegment(pathID, "target", targetLineageLabel(path), targetLineageStatus(path), matchingNodeIDs(nodes, "target", ""), matchingEdgeIDs(edges, "path_targets_surface"), append([]string(nil), path.MatchedProductionTargets...)),
 		newLineageSegment(pathID, "owner", path.OperationalOwner, ownerLineageStatus(path), nil, nil, append([]string(nil), path.OwnershipEvidence...)),
 		newLineageSegment(pathID, "approval", approvalLineageLabel(path), approvalLineageStatus(path), approvalNodeIDs, matchingEdgeIDsForNodeIDs(edges, "path_governed_by", approvalNodeIDs), append([]string(nil), path.ApprovalGapReasons...)),
+		newLineageSegment(pathID, "control", controlLineageLabel(path), controlLineageStatus(path), matchingNodeIDs(nodes, aggattack.ControlPathNodePolicyIdentity, "control"), matchingEdgeIDs(edges, aggattack.ControlPathEdgeChecksGateApproval), append([]string(nil), path.ControlEvidenceRefs...)),
+		newLineageSegment(pathID, "deployment", deploymentLineageLabel(path), deploymentLineageStatus(path), matchingNodeIDs(nodes, aggattack.ControlPathNodeDeploymentPath, "deployment"), matchingEdgeIDsAny(edges, aggattack.ControlPathEdgeApprovalAuthorizesDeploy, aggattack.ControlPathEdgeDeployAffectsAsset), deploymentLineageEvidence(path)),
+		newLineageSegment(pathID, "outcome", outcomeLineageLabel(path), outcomeLineageStatus(path), matchingNodeIDs(nodes, aggattack.ControlPathNodeOutcome, "outcome"), matchingEdgeIDs(edges, aggattack.ControlPathEdgeEvidenceProvesOutcome), outcomeLineageEvidence(path)),
 		newLineageSegment(pathID, "proof", proofLineageLabel(path), proofLineageStatus(path), proofNodeIDs, matchingEdgeIDsForNodeIDs(edges, "path_governed_by", proofNodeIDs), append([]string(nil), path.PolicyEvidenceRefs...)),
+		newLineageSegment(pathID, "evidence", evidenceLineageLabel(path), evidenceLineageStatus(path), matchingNodeIDs(nodes, aggattack.ControlPathNodeEvidenceIdentity, "evidence"), matchingEdgeIDs(edges, aggattack.ControlPathEdgeEvidenceProvesOutcome), evidenceLineageEvidence(path)),
 	}
 	return &ActionLineage{Segments: segments}
 }
@@ -141,6 +151,14 @@ func matchingNodeIDs(nodes []aggattack.ControlPathNode, kind string, lineageSegm
 	return out
 }
 
+func matchingNodeIDsAny(nodes []aggattack.ControlPathNode, kinds []string, lineageSegment string) []string {
+	out := []string{}
+	for _, kind := range kinds {
+		out = append(out, matchingNodeIDs(nodes, kind, lineageSegment)...)
+	}
+	return dedupeSortedStrings(out)
+}
+
 func matchingEdgeIDs(edges []aggattack.ControlPathEdge, kind string) []string {
 	out := []string{}
 	for _, edge := range edges {
@@ -150,6 +168,14 @@ func matchingEdgeIDs(edges []aggattack.ControlPathEdge, kind string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func matchingEdgeIDsAny(edges []aggattack.ControlPathEdge, kinds ...string) []string {
+	out := []string{}
+	for _, kind := range kinds {
+		out = append(out, matchingEdgeIDs(edges, kind)...)
+	}
+	return dedupeSortedStrings(out)
 }
 
 func matchingEdgeIDsForNodeIDs(edges []aggattack.ControlPathEdge, kind string, nodeIDs []string) []string {
@@ -318,6 +344,228 @@ func proofLineageStatus(path ActionPath) string {
 		return "missing"
 	default:
 		return "missing"
+	}
+}
+
+func intentLineageLabel(path ActionPath) string {
+	return firstNonEmpty(path.Purpose, "unknown_intent")
+}
+
+func intentLineageStatus(path ActionPath) string {
+	if strings.TrimSpace(path.Purpose) == "" {
+		return "unknown"
+	}
+	return "declared"
+}
+
+func intentLineageEvidence(path ActionPath) []string {
+	return dedupeSortedStrings([]string{path.PurposeSource, path.ConfigSource})
+}
+
+func taskLineageLabel(path ActionPath) string {
+	if strings.TrimSpace(path.Purpose) != "" {
+		return strings.TrimSpace(path.Purpose)
+	}
+	return "unknown_task"
+}
+
+func taskLineageStatus(path ActionPath) string {
+	if strings.TrimSpace(path.Purpose) != "" {
+		return "declared"
+	}
+	return "unknown"
+}
+
+func taskLineageEvidence(path ActionPath) []string {
+	return dedupeSortedStrings([]string{path.PurposeSource, path.Location})
+}
+
+func humanLineageLabel(path ActionPath) string {
+	if path.IntroducedBy != nil && strings.TrimSpace(path.IntroducedBy.Author) != "" {
+		return strings.TrimSpace(path.IntroducedBy.Author)
+	}
+	return "unknown_human"
+}
+
+func humanLineageStatus(path ActionPath) string {
+	if path.IntroducedBy == nil {
+		return "unknown"
+	}
+	switch strings.TrimSpace(path.IntroducedBy.Confidence) {
+	case "high":
+		return EvidenceStateVerified
+	case "low":
+		return EvidenceStateInferred
+	default:
+		return "unknown"
+	}
+}
+
+func humanLineageEvidence(path ActionPath) []string {
+	if path.IntroducedBy == nil {
+		return nil
+	}
+	return dedupeSortedStrings([]string{path.IntroducedBy.ProviderURL, path.IntroducedBy.ChangedFile})
+}
+
+func pullRequestLineageLabel(path ActionPath) string {
+	if path.IntroducedBy != nil && path.IntroducedBy.PRNumber > 0 {
+		return "PR #" + strings.TrimSpace(strconv.Itoa(path.IntroducedBy.PRNumber))
+	}
+	return "unknown_pr"
+}
+
+func pullRequestLineageStatus(path ActionPath) string {
+	if path.IntroducedBy == nil || path.IntroducedBy.PRNumber <= 0 {
+		return "unknown"
+	}
+	return humanLineageStatus(path)
+}
+
+func pullRequestLineageEvidence(path ActionPath) []string {
+	if path.IntroducedBy == nil {
+		return nil
+	}
+	return dedupeSortedStrings([]string{path.IntroducedBy.ProviderURL, path.IntroducedBy.CommitSHA, path.IntroducedBy.ChangedFile})
+}
+
+func workflowRunLineageLabel(path ActionPath) string {
+	return firstNonEmpty(path.Location, "unknown_workflow_run")
+}
+
+func workflowRunLineageStatus(path ActionPath) string {
+	if strings.TrimSpace(path.Location) == "" {
+		return "unknown"
+	}
+	return "present"
+}
+
+func workflowRunLineageEvidence(path ActionPath) []string {
+	return dedupeSortedStrings([]string{path.Location, path.ConfigSource})
+}
+
+func controlLineageLabel(path ActionPath) string {
+	return firstNonEmpty(path.ControlResolutionState, path.PolicyCoverageStatus, "unknown_control")
+}
+
+func controlLineageStatus(path ActionPath) string {
+	if strings.TrimSpace(path.ControlResolutionState) == ControlResolutionStateContradictoryControl {
+		return EvidenceStateContradictory
+	}
+	switch strings.TrimSpace(path.PolicyCoverageStatus) {
+	case PolicyCoverageStatusRuntimeProven:
+		return EvidenceStateVerified
+	case PolicyCoverageStatusMatched, PolicyCoverageStatusDeclared:
+		return EvidenceStateDeclared
+	case PolicyCoverageStatusConflict:
+		return EvidenceStateContradictory
+	case PolicyCoverageStatusStale, PolicyCoverageStatusNone, "":
+		if strings.TrimSpace(path.ControlResolutionState) == "" {
+			return "unknown"
+		}
+		return EvidenceStateDeclared
+	default:
+		return "unknown"
+	}
+}
+
+func deploymentLineageLabel(path ActionPath) string {
+	if len(path.MatchedProductionTargets) > 0 {
+		return strings.Join(path.MatchedProductionTargets, ",")
+	}
+	if path.DeployWrite || path.ProductionWrite {
+		return "unknown_deployment_path"
+	}
+	return "unknown_deployment_path"
+}
+
+func deploymentLineageStatus(path ActionPath) string {
+	if !path.DeployWrite && !path.ProductionWrite && len(path.MatchedProductionTargets) == 0 {
+		return "missing"
+	}
+	if state := strongestLineageEvidenceState(path.ProofEvidenceState, path.RuntimeEvidenceState); state != "" {
+		return state
+	}
+	return "unknown"
+}
+
+func deploymentLineageEvidence(path ActionPath) []string {
+	return dedupeSortedStrings(append(append([]string(nil), path.MatchedProductionTargets...), path.PolicyEvidenceRefs...))
+}
+
+func outcomeLineageLabel(path ActionPath) string {
+	if state := strongestLineageEvidenceState(path.ProofEvidenceState, path.RuntimeEvidenceState); state != "" {
+		return "outcome:" + state
+	}
+	return "unknown_outcome"
+}
+
+func outcomeLineageStatus(path ActionPath) string {
+	if state := strongestLineageEvidenceState(path.ProofEvidenceState, path.RuntimeEvidenceState); state != "" {
+		return state
+	}
+	return "unknown"
+}
+
+func outcomeLineageEvidence(path ActionPath) []string {
+	return dedupeSortedStrings(append(append([]string(nil), path.PolicyEvidenceRefs...), path.ControlEvidenceRefs...))
+}
+
+func evidenceLineageLabel(path ActionPath) string {
+	if path.EvidenceCompleteness != nil && strings.TrimSpace(path.EvidenceCompleteness.Label) != "" {
+		return strings.TrimSpace(path.EvidenceCompleteness.Label)
+	}
+	if state := strongestLineageEvidenceState(path.ProofEvidenceState, path.RuntimeEvidenceState, path.TargetEvidenceState); state != "" {
+		return state
+	}
+	return "unknown_evidence"
+}
+
+func evidenceLineageStatus(path ActionPath) string {
+	if state := strongestLineageEvidenceState(path.ProofEvidenceState, path.RuntimeEvidenceState, path.TargetEvidenceState); state != "" {
+		return state
+	}
+	return "unknown"
+}
+
+func evidenceLineageEvidence(path ActionPath) []string {
+	values := append([]string(nil), path.ControlEvidenceRefs...)
+	values = append(values, path.PolicyEvidenceRefs...)
+	values = append(values, path.TargetClassEvidenceRefs...)
+	return dedupeSortedStrings(values)
+}
+
+func strongestLineageEvidenceState(values ...string) string {
+	bestRank := -1
+	best := ""
+	for _, value := range values {
+		normalized := strings.TrimSpace(value)
+		if normalized == "" {
+			continue
+		}
+		rank := lineageEvidenceStateRank(normalized)
+		if rank > bestRank {
+			bestRank = rank
+			best = normalized
+		}
+	}
+	return best
+}
+
+func lineageEvidenceStateRank(value string) int {
+	switch strings.TrimSpace(value) {
+	case EvidenceStateContradictory:
+		return 5
+	case EvidenceStateVerified:
+		return 4
+	case EvidenceStateDeclared:
+		return 3
+	case EvidenceStateInferred:
+		return 2
+	case EvidenceStateUnknown:
+		return 1
+	default:
+		return 0
 	}
 }
 

--- a/core/risk/action_paths.go
+++ b/core/risk/action_paths.go
@@ -162,6 +162,7 @@ type ActionPath struct {
 	RecommendedAction                   string                                  `json:"recommended_action"`
 	AttackPathRefs                      []string                                `json:"attack_path_refs,omitempty"`
 	SourceFindingKeys                   []string                                `json:"source_finding_keys,omitempty"`
+	WorkflowChainRefs                   []string                                `json:"workflow_chain_refs,omitempty"`
 	MatchedProductionTargets            []string                                `json:"matched_production_targets,omitempty"`
 	GovernanceControls                  []agginventory.GovernanceControlMapping `json:"governance_controls,omitempty"`
 	ClosureRequirements                 []ClosureRequirement                    `json:"closure_requirements,omitempty"`
@@ -478,6 +479,7 @@ func mergeActionPath(current, incoming ActionPath) ActionPath {
 	merged.EvidenceCompleteness = firstNonNilEvidenceCompleteness(current.EvidenceCompleteness, incoming.EvidenceCompleteness)
 	merged.AttackPathRefs = dedupeSortedStrings(append(append([]string(nil), current.AttackPathRefs...), incoming.AttackPathRefs...))
 	merged.SourceFindingKeys = dedupeSortedStrings(append(append([]string(nil), current.SourceFindingKeys...), incoming.SourceFindingKeys...))
+	merged.WorkflowChainRefs = dedupeSortedStrings(append(append([]string(nil), current.WorkflowChainRefs...), incoming.WorkflowChainRefs...))
 	merged.ActionLineage = CloneActionLineage(firstNonNilLineage(current.ActionLineage, incoming.ActionLineage))
 	return merged
 }
@@ -545,40 +547,57 @@ func BuildControlPathGraph(paths []ActionPath) *aggattack.ControlPathGraph {
 	inputs := make([]aggattack.ControlPathInput, 0, len(paths))
 	for _, path := range paths {
 		inputs = append(inputs, aggattack.ControlPathInput{
-			PathID:                   strings.TrimSpace(path.PathID),
-			AgentID:                  strings.TrimSpace(path.AgentID),
-			Org:                      strings.TrimSpace(path.Org),
-			Repo:                     strings.TrimSpace(path.Repo),
-			ToolType:                 strings.TrimSpace(path.ToolType),
-			Location:                 strings.TrimSpace(path.Location),
-			Purpose:                  strings.TrimSpace(path.Purpose),
-			PurposeSource:            strings.TrimSpace(path.PurposeSource),
-			PurposeConfidence:        strings.TrimSpace(path.PurposeConfidence),
-			Version:                  strings.TrimSpace(path.Version),
-			VersionSource:            strings.TrimSpace(path.VersionSource),
-			ConfigFingerprint:        strings.TrimSpace(path.ConfigFingerprint),
-			ConfigSource:             strings.TrimSpace(path.ConfigSource),
-			ExecutionIdentity:        strings.TrimSpace(path.ExecutionIdentity),
-			ExecutionIdentityType:    strings.TrimSpace(path.ExecutionIdentityType),
-			ExecutionIdentitySource:  strings.TrimSpace(path.ExecutionIdentitySource),
-			ExecutionIdentityStatus:  strings.TrimSpace(path.ExecutionIdentityStatus),
-			CredentialAccess:         path.CredentialAccess,
-			CredentialProvenance:     agginventory.CloneCredentialProvenance(path.CredentialProvenance),
-			CredentialAuthority:      agginventory.CloneCredentialAuthority(path.CredentialAuthority),
-			MutableEndpointSemantics: agginventory.CloneMutableEndpointSemantics(path.MutableEndpointSemantics),
-			GovernanceControls:       append([]agginventory.GovernanceControlMapping(nil), path.GovernanceControls...),
-			MatchedProductionTargets: dedupeSortedStrings(path.MatchedProductionTargets),
-			WritePathClasses:         dedupeSortedStrings(path.WritePathClasses),
-			PullRequestWrite:         path.PullRequestWrite,
-			MergeExecute:             path.MergeExecute,
-			DeployWrite:              path.DeployWrite,
-			ProductionWrite:          path.ProductionWrite,
-			ApprovalGap:              path.ApprovalGap,
-			AttackPathRefs:           dedupeSortedStrings(path.AttackPathRefs),
-			SourceFindingKeys:        dedupeSortedStrings(path.SourceFindingKeys),
+			PathID:                    strings.TrimSpace(path.PathID),
+			AgentID:                   strings.TrimSpace(path.AgentID),
+			Org:                       strings.TrimSpace(path.Org),
+			Repo:                      strings.TrimSpace(path.Repo),
+			ToolType:                  strings.TrimSpace(path.ToolType),
+			Location:                  strings.TrimSpace(path.Location),
+			Purpose:                   strings.TrimSpace(path.Purpose),
+			PurposeSource:             strings.TrimSpace(path.PurposeSource),
+			PurposeConfidence:         strings.TrimSpace(path.PurposeConfidence),
+			Version:                   strings.TrimSpace(path.Version),
+			VersionSource:             strings.TrimSpace(path.VersionSource),
+			ConfigFingerprint:         strings.TrimSpace(path.ConfigFingerprint),
+			ConfigSource:              strings.TrimSpace(path.ConfigSource),
+			ExecutionIdentity:         strings.TrimSpace(path.ExecutionIdentity),
+			ExecutionIdentityType:     strings.TrimSpace(path.ExecutionIdentityType),
+			ExecutionIdentitySource:   strings.TrimSpace(path.ExecutionIdentitySource),
+			ExecutionIdentityStatus:   strings.TrimSpace(path.ExecutionIdentityStatus),
+			CredentialAccess:          path.CredentialAccess,
+			CredentialProvenance:      agginventory.CloneCredentialProvenance(path.CredentialProvenance),
+			CredentialAuthority:       agginventory.CloneCredentialAuthority(path.CredentialAuthority),
+			MutableEndpointSemantics:  agginventory.CloneMutableEndpointSemantics(path.MutableEndpointSemantics),
+			GovernanceControls:        append([]agginventory.GovernanceControlMapping(nil), path.GovernanceControls...),
+			MatchedProductionTargets:  dedupeSortedStrings(path.MatchedProductionTargets),
+			WritePathClasses:          dedupeSortedStrings(path.WritePathClasses),
+			PullRequestWrite:          path.PullRequestWrite,
+			MergeExecute:              path.MergeExecute,
+			DeployWrite:               path.DeployWrite,
+			ProductionWrite:           path.ProductionWrite,
+			ApprovalGap:               path.ApprovalGap,
+			IntroducedBy:              path.IntroducedBy,
+			PolicyRefs:                dedupeSortedStrings(path.PolicyRefs),
+			ControlResolutionState:    strings.TrimSpace(path.ControlResolutionState),
+			AutonomyTier:              strings.TrimSpace(path.AutonomyTier),
+			DelegationReadinessState:  strings.TrimSpace(path.DelegationReadinessState),
+			ApprovalEvidenceState:     strings.TrimSpace(path.ApprovalEvidenceState),
+			ProofEvidenceState:        strings.TrimSpace(path.ProofEvidenceState),
+			RuntimeEvidenceState:      strings.TrimSpace(path.RuntimeEvidenceState),
+			TargetEvidenceState:       strings.TrimSpace(path.TargetEvidenceState),
+			EvidenceCompletenessLabel: evidenceCompletenessProjectionLabel(path.EvidenceCompleteness),
+			AttackPathRefs:            dedupeSortedStrings(path.AttackPathRefs),
+			SourceFindingKeys:         dedupeSortedStrings(path.SourceFindingKeys),
 		})
 	}
 	return aggattack.BuildControlPathGraph(inputs)
+}
+
+func evidenceCompletenessProjectionLabel(in *EvidenceCompleteness) string {
+	if in == nil {
+		return ""
+	}
+	return strings.TrimSpace(in.Label)
 }
 
 func dedupeSortedStrings(values []string) []string {

--- a/core/risk/risk.go
+++ b/core/risk/risk.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Clyra-AI/wrkr/core/aggregate/agentresolver"
 	aggattack "github.com/Clyra-AI/wrkr/core/aggregate/attackpath"
 	"github.com/Clyra-AI/wrkr/core/identity"
 	"github.com/Clyra-AI/wrkr/core/model"
@@ -36,15 +37,16 @@ type RepoAggregate struct {
 }
 
 type Report struct {
-	GeneratedAt              string                      `json:"generated_at"`
-	TopN                     []ScoredFinding             `json:"top_findings"`
-	Ranked                   []ScoredFinding             `json:"ranked_findings"`
-	Repos                    []RepoAggregate             `json:"repo_risk"`
-	AttackPaths              []riskattack.ScoredPath     `json:"attack_paths,omitempty"`
-	TopAttackPaths           []riskattack.ScoredPath     `json:"top_attack_paths,omitempty"`
-	ActionPaths              []ActionPath                `json:"action_paths,omitempty"`
-	ActionPathToControlFirst *ActionPathToControlFirst   `json:"action_path_to_control_first,omitempty"`
-	ControlPathGraph         *aggattack.ControlPathGraph `json:"control_path_graph,omitempty"`
+	GeneratedAt              string                               `json:"generated_at"`
+	TopN                     []ScoredFinding                      `json:"top_findings"`
+	Ranked                   []ScoredFinding                      `json:"ranked_findings"`
+	Repos                    []RepoAggregate                      `json:"repo_risk"`
+	AttackPaths              []riskattack.ScoredPath              `json:"attack_paths,omitempty"`
+	TopAttackPaths           []riskattack.ScoredPath              `json:"top_attack_paths,omitempty"`
+	ActionPaths              []ActionPath                         `json:"action_paths,omitempty"`
+	ActionPathToControlFirst *ActionPathToControlFirst            `json:"action_path_to_control_first,omitempty"`
+	ControlPathGraph         *aggattack.ControlPathGraph          `json:"control_path_graph,omitempty"`
+	WorkflowChains           *agentresolver.WorkflowChainArtifact `json:"workflow_chains,omitempty"`
 }
 
 type promptCooccurrence struct {

--- a/core/risk/workflow_chain.go
+++ b/core/risk/workflow_chain.go
@@ -1,0 +1,113 @@
+package risk
+
+import (
+	"strings"
+
+	"github.com/Clyra-AI/wrkr/core/aggregate/agentresolver"
+	aggattack "github.com/Clyra-AI/wrkr/core/aggregate/attackpath"
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+)
+
+func BuildWorkflowChains(paths []ActionPath, graph *aggattack.ControlPathGraph) *agentresolver.WorkflowChainArtifact {
+	if len(paths) == 0 {
+		return nil
+	}
+
+	graphRefsByPath := workflowChainGraphRefsByPath(graph)
+	inputs := make([]agentresolver.WorkflowChainInput, 0, len(paths))
+	for _, path := range paths {
+		refs := graphRefsByPath[strings.TrimSpace(path.PathID)]
+		inputs = append(inputs, agentresolver.WorkflowChainInput{
+			PathID:                    strings.TrimSpace(path.PathID),
+			Org:                       strings.TrimSpace(path.Org),
+			Repo:                      strings.TrimSpace(path.Repo),
+			AgentID:                   strings.TrimSpace(path.AgentID),
+			ToolFamilyID:              strings.TrimSpace(path.ToolFamilyID),
+			ToolInstanceID:            strings.TrimSpace(path.ToolInstanceID),
+			ToolType:                  strings.TrimSpace(path.ToolType),
+			Location:                  strings.TrimSpace(path.Location),
+			Purpose:                   strings.TrimSpace(path.Purpose),
+			PurposeSource:             strings.TrimSpace(path.PurposeSource),
+			OperationalOwner:          strings.TrimSpace(path.OperationalOwner),
+			CredentialAccess:          path.CredentialAccess,
+			CredentialProvenance:      agginventory.CloneCredentialProvenance(path.CredentialProvenance),
+			CredentialAuthority:       agginventory.CloneCredentialAuthority(path.CredentialAuthority),
+			ApprovalEvidenceState:     strings.TrimSpace(path.ApprovalEvidenceState),
+			ProofEvidenceState:        strings.TrimSpace(path.ProofEvidenceState),
+			RuntimeEvidenceState:      strings.TrimSpace(path.RuntimeEvidenceState),
+			TargetEvidenceState:       strings.TrimSpace(path.TargetEvidenceState),
+			ControlResolutionState:    strings.TrimSpace(path.ControlResolutionState),
+			DeploymentStatus:          strings.TrimSpace(path.DeploymentStatus),
+			DeliveryChainStatus:       strings.TrimSpace(path.DeliveryChainStatus),
+			TargetClass:               strings.TrimSpace(path.TargetClass),
+			IntroducedBy:              path.IntroducedBy,
+			AutonomyTier:              strings.TrimSpace(path.AutonomyTier),
+			DelegationReadinessState:  strings.TrimSpace(path.DelegationReadinessState),
+			RecommendedControl:        strings.TrimSpace(path.RecommendedControl),
+			MatchedProductionTargets:  dedupeSortedStrings(path.MatchedProductionTargets),
+			EvidenceCompletenessLabel: evidenceCompletenessProjectionLabel(path.EvidenceCompleteness),
+			GraphNodeRefs:             refs.NodeIDs,
+			GraphEdgeRefs:             refs.EdgeIDs,
+			ProofRefs:                 dedupeSortedStrings(path.PolicyEvidenceRefs),
+			EvidenceRefs:              workflowChainEvidenceRefs(path),
+			SourceFindingKeys:         dedupeSortedStrings(path.SourceFindingKeys),
+		})
+	}
+	return agentresolver.BuildWorkflowChains(inputs)
+}
+
+func DecorateWorkflowChainRefs(paths []ActionPath, artifact *agentresolver.WorkflowChainArtifact) []ActionPath {
+	if len(paths) == 0 {
+		return nil
+	}
+	refsByPath := agentresolver.WorkflowChainRefsByPath(artifact)
+	out := make([]ActionPath, 0, len(paths))
+	for _, path := range paths {
+		copyPath := path
+		copyPath.WorkflowChainRefs = dedupeSortedStrings(refsByPath[strings.TrimSpace(path.PathID)])
+		out = append(out, copyPath)
+	}
+	return out
+}
+
+type workflowChainGraphRefs struct {
+	NodeIDs []string
+	EdgeIDs []string
+}
+
+func workflowChainGraphRefsByPath(graph *aggattack.ControlPathGraph) map[string]workflowChainGraphRefs {
+	byPath := map[string]workflowChainGraphRefs{}
+	if graph == nil {
+		return byPath
+	}
+	for _, node := range graph.Nodes {
+		pathID := strings.TrimSpace(node.PathID)
+		if pathID == "" {
+			continue
+		}
+		current := byPath[pathID]
+		current.NodeIDs = dedupeSortedStrings(append(current.NodeIDs, strings.TrimSpace(node.NodeID)))
+		byPath[pathID] = current
+	}
+	for _, edge := range graph.Edges {
+		pathID := strings.TrimSpace(edge.PathID)
+		if pathID == "" {
+			continue
+		}
+		current := byPath[pathID]
+		current.EdgeIDs = dedupeSortedStrings(append(current.EdgeIDs, strings.TrimSpace(edge.EdgeID)))
+		byPath[pathID] = current
+	}
+	return byPath
+}
+
+func workflowChainEvidenceRefs(path ActionPath) []string {
+	values := append([]string(nil), path.ControlEvidenceRefs...)
+	values = append(values, path.PolicyEvidenceRefs...)
+	values = append(values, path.TargetClassEvidenceRefs...)
+	if path.IntroducedBy != nil {
+		values = append(values, path.IntroducedBy.ChangedFile)
+		values = append(values, path.IntroducedBy.ProviderURL)
+	}
+	return dedupeSortedStrings(values)
+}

--- a/core/risk/workflow_chain_test.go
+++ b/core/risk/workflow_chain_test.go
@@ -1,0 +1,80 @@
+package risk
+
+import (
+	"testing"
+
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/attribution"
+)
+
+func TestWorkflowChainsDecorateActionPathsAndExtendedLineage(t *testing.T) {
+	t.Parallel()
+
+	paths := DecorateEvidenceContext([]ActionPath{{
+		PathID:                   "apc-wave2-lineage",
+		Org:                      "acme",
+		Repo:                     "acme/release",
+		AgentID:                  "wrkr:compiled_action:acme",
+		ToolType:                 "compiled_action",
+		Location:                 ".github/workflows/release.yml",
+		Purpose:                  "release automation",
+		PurposeSource:            "workflow_name",
+		WriteCapable:             true,
+		CredentialAccess:         true,
+		CredentialProvenance:     &agginventory.CredentialProvenance{Type: agginventory.CredentialProvenanceStaticSecret, CredentialKind: agginventory.CredentialKindGitHubPAT, AccessType: agginventory.CredentialAccessTypeStanding},
+		CredentialAuthority:      &agginventory.CredentialAuthority{CredentialPresent: true, CredentialUsableByPath: true, CredentialKind: agginventory.CredentialKindGitHubPAT, AccessType: agginventory.CredentialAccessTypeStanding},
+		ActionClasses:            []string{"deploy", "write"},
+		MatchedProductionTargets: []string{"cluster/prod"},
+		OperationalOwner:         "@acme/release",
+		OwnershipStatus:          "explicit",
+		ApprovalGap:              false,
+		ApprovalEvidenceState:    EvidenceStateVerified,
+		ProofEvidenceState:       EvidenceStateVerified,
+		RuntimeEvidenceState:     EvidenceStateDeclared,
+		TargetEvidenceState:      EvidenceStateVerified,
+		PolicyCoverageStatus:     PolicyCoverageStatusMatched,
+		PolicyEvidenceRefs:       []string{"proof://release"},
+		GovernanceControls: []agginventory.GovernanceControlMapping{
+			{Control: agginventory.GovernanceControlApproval, Status: agginventory.ControlStatusSatisfied},
+			{Control: agginventory.GovernanceControlProof, Status: agginventory.ControlStatusSatisfied},
+		},
+		IntroducedBy:             &attribution.Result{Source: attribution.SourceSidecar, Confidence: attribution.ConfidenceHigh, PRNumber: 17, Author: "octocat"},
+		AutonomyTier:             "tier_4_prod_privileged_or_customer_impacting",
+		DelegationReadinessState: "approval_required",
+		RecommendedControl:       "approval_required",
+		TargetClass:              "production_impacting",
+	}}, nil)
+
+	graph := BuildControlPathGraph(paths)
+	chains := BuildWorkflowChains(paths, graph)
+	paths = DecorateWorkflowChainRefs(paths, chains)
+	paths = DecorateActionLineage(paths, graph)
+	if len(paths) != 1 {
+		t.Fatalf("expected one path, got %+v", paths)
+	}
+	if len(paths[0].WorkflowChainRefs) == 0 {
+		t.Fatalf("expected workflow chain refs on action path, got %+v", paths[0])
+	}
+	if paths[0].ActionLineage == nil {
+		t.Fatalf("expected action lineage, got %+v", paths[0])
+	}
+
+	segments := map[string]ActionLineageSegment{}
+	for _, segment := range paths[0].ActionLineage.Segments {
+		segments[segment.Kind] = segment
+	}
+	for _, kind := range []string{"intent", "task", "human", "pr", "deployment", "outcome", "evidence"} {
+		if _, ok := segments[kind]; !ok {
+			t.Fatalf("expected extended lineage segment %q, got %+v", kind, paths[0].ActionLineage)
+		}
+	}
+	if segments["pr"].Status != EvidenceStateVerified {
+		t.Fatalf("expected PR lineage to use attribution confidence, got %+v", segments["pr"])
+	}
+	if segments["deployment"].Status == "missing" {
+		t.Fatalf("expected deployment lineage for deploy path, got %+v", segments["deployment"])
+	}
+	if segments["evidence"].Status != EvidenceStateVerified {
+		t.Fatalf("expected evidence lineage to reflect proof/runtime state, got %+v", segments["evidence"])
+	}
+}

--- a/docs/decisions/wave22-workflow-chain-graph-v2.md
+++ b/docs/decisions/wave22-workflow-chain-graph-v2.md
@@ -1,0 +1,39 @@
+# ADR: Wave 22 Workflow Chain, Graph V2, and Intent Lineage
+
+Date: 2026-05-26
+Status: accepted
+
+## Context
+
+Wave 2 of the Sprint 3 Agentic SDLC plan needs Wrkr to describe delegated delivery paths as more than isolated action-path rows. Before this change, Wrkr had deterministic action paths, a first-generation control-path graph, and buyer-facing lineage segments, but it did not expose a stable workflow-chain artifact, could not model intent or PR/MR joins as first-class graph nodes, and forced downstream consumers to infer end-to-end delivery flow from loosely related fields.
+
+## Decision
+
+1. Add a first-class deterministic `workflow_chains` artifact that groups action paths by repo, PR/MR, workflow, task/intent source, tool, credential, owner, approval, target, evidence, and outcome keys.
+2. Keep workflow-chain refs additive on action paths and Agent Action BOM items so downstream consumers can join into the artifact without reparsing graph internals.
+3. Extend `control_path_graph` additively with V2 node kinds for intent, task, human identity, agent team, PR/MR, approval identity, policy identity, deployment path, asset identity, evidence identity, workflow run, CI/CD run, and outcome.
+4. Extend `action_lineage.segments[]` additively with intent, task, human, PR, workflow-run, control, deployment, outcome, and evidence segments while preserving the existing repo/workflow/agent/action/credential/target/owner/approval/proof chain.
+5. Rebuild graph, workflow-chain refs, and lineage from the same decorated action-path projection so report, backlog, and evidence surfaces stay deterministic and joinable.
+
+## Rationale
+
+- Buyers need one deterministic object that represents delegated SDLC flow end to end.
+- Graph V2 should be additive so existing graph consumers keep working while newer report surfaces gain more structure.
+- Workflow chains and lineage are different views over the same path facts; deriving them from one projection avoids drift.
+- Explicit unknown states are safer than silently omitting missing PR, approval, or outcome metadata.
+
+## Consequences
+
+- Risk-report, report-summary, evidence-bundle, and Agent Action BOM contracts now expose workflow-chain refs and a top-level workflow-chain artifact.
+- Public and redacted report paths must sanitize the new workflow-chain labels, refs, and provenance surfaces alongside existing graph and lineage joins.
+- Future provenance sidecars, evidence packets, and focused BOM experiences can extend these artifacts instead of inventing separate delivery-flow models.
+
+## Validation Plan
+
+- `go test ./core/aggregate/agentresolver ./core/aggregate/attackpath ./core/risk ./core/report ./testinfra/contracts -count=1`
+- `make test-contracts`
+- `scripts/validate_scenarios.sh`
+- Acceptance criteria:
+  - Workflow chains collapse duplicate paths deterministically and emit explicit unknown PR/outcome states.
+  - Control Path Graph V2 carries additive node and edge kinds plus summary rollups.
+  - Action-path and BOM outputs expose workflow-chain refs and extended lineage segments without breaking existing consumers.

--- a/scenarios/wrkr/buyer-action-registry-hardening/expected/report-internal-summary.json
+++ b/scenarios/wrkr/buyer-action-registry-hardening/expected/report-internal-summary.json
@@ -26,15 +26,24 @@
       "confidence": "high"
     },
     "lineage_statuses": [
+      {"kind": "intent", "status": "declared"},
+      {"kind": "task", "status": "declared"},
+      {"kind": "human", "status": "inferred"},
       {"kind": "repo", "status": "present"},
+      {"kind": "pr", "status": "unknown"},
       {"kind": "workflow", "status": "present"},
+      {"kind": "workflow_run", "status": "present"},
       {"kind": "agent", "status": "present"},
       {"kind": "action", "status": "present"},
       {"kind": "credential", "status": "present"},
       {"kind": "target", "status": "missing"},
       {"kind": "owner", "status": "present"},
       {"kind": "approval", "status": "missing"},
-      {"kind": "proof", "status": "missing"}
+      {"kind": "control", "status": "declared"},
+      {"kind": "deployment", "status": "missing"},
+      {"kind": "outcome", "status": "unknown"},
+      {"kind": "proof", "status": "missing"},
+      {"kind": "evidence", "status": "unknown"}
     ]
   },
   "semantic_item": {

--- a/scenarios/wrkr/buyer-action-registry-hardening/expected/scan-summary.json
+++ b/scenarios/wrkr/buyer-action-registry-hardening/expected/scan-summary.json
@@ -31,15 +31,24 @@
     ],
     "config_fingerprint": "cfg-25ce41dafe7a",
     "action_lineage_kinds": [
+      "intent",
+      "task",
+      "human",
       "repo",
+      "pr",
       "workflow",
+      "workflow_run",
       "agent",
       "action",
       "credential",
       "target",
       "owner",
       "approval",
-      "proof"
+      "control",
+      "deployment",
+      "outcome",
+      "proof",
+      "evidence"
     ]
   }
 }

--- a/schemas/v1/agent-action-bom.schema.json
+++ b/schemas/v1/agent-action-bom.schema.json
@@ -182,6 +182,7 @@
         "evidence_completeness": {"$ref": "#/$defs/evidenceCompleteness"},
         "attack_path_refs": {"type": "array", "items": {"type": "string"}},
         "source_finding_keys": {"type": "array", "items": {"type": "string"}},
+        "workflow_chain_refs": {"type": "array", "items": {"type": "string"}},
         "exclusion_reason": {"type": "string"},
         "graph_refs": {"$ref": "#/$defs/graphRefs"},
         "evidence_refs": {"type": "array", "items": {"type": "string"}},
@@ -800,7 +801,7 @@
       "required": ["segment_id", "kind"],
       "properties": {
         "segment_id": {"type": "string"},
-        "kind": {"type": "string", "enum": ["repo", "workflow", "agent", "action", "credential", "target", "owner", "approval", "proof"]},
+        "kind": {"type": "string", "enum": ["repo", "workflow", "agent", "action", "credential", "target", "owner", "approval", "proof", "intent", "task", "human", "pr", "workflow_run", "control", "deployment", "outcome", "evidence"]},
         "label": {"type": "string"},
         "status": {"type": "string"},
         "node_ids": {"type": "array", "items": {"type": "string"}},

--- a/schemas/v1/control-path-graph.schema.json
+++ b/schemas/v1/control-path-graph.schema.json
@@ -22,6 +22,18 @@
         "edge_kinds": {
           "type": "array",
           "items": {"$ref": "#/$defs/kindRollup"}
+        },
+        "autonomy_tiers": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/kindRollup"}
+        },
+        "delegation_readiness_states": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/kindRollup"}
+        },
+        "evidence_states": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/kindRollup"}
         }
       },
       "additionalProperties": false
@@ -63,7 +75,20 @@
             "repo",
             "governance_control",
             "target",
-            "action_capability"
+            "action_capability",
+            "intent",
+            "task",
+            "human_identity",
+            "agent_team",
+            "pull_request",
+            "approval_identity",
+            "policy_identity",
+            "asset_identity",
+            "evidence_identity",
+            "deployment_path",
+            "ci_cd_run",
+            "workflow_run",
+            "outcome"
           ]
         },
         "lineage_segment": {"type": "string"},

--- a/schemas/v1/report/report-summary.schema.json
+++ b/schemas/v1/report/report-summary.schema.json
@@ -107,6 +107,9 @@
     "control_path_graph": {
       "$ref": "#/$defs/controlPathGraph"
     },
+    "workflow_chains": {
+      "$ref": "#/$defs/workflowChainArtifact"
+    },
     "scan_quality": {
       "$ref": "#/$defs/scanQuality"
     },
@@ -272,7 +275,7 @@
       "required": ["segment_id", "kind"],
       "properties": {
         "segment_id": {"type": "string"},
-        "kind": {"type": "string", "enum": ["repo", "workflow", "agent", "action", "credential", "target", "owner", "approval", "proof"]},
+        "kind": {"type": "string", "enum": ["repo", "workflow", "agent", "action", "credential", "target", "owner", "approval", "proof", "intent", "task", "human", "pr", "workflow_run", "control", "deployment", "outcome", "evidence"]},
         "label": {"type": "string"},
         "status": {"type": "string"},
         "node_ids": {"type": "array", "items": {"type": "string"}},
@@ -374,6 +377,7 @@
         "recommended_action": {"type": "string"},
         "attack_path_refs": {"type": "array", "items": {"type": "string"}},
         "source_finding_keys": {"type": "array", "items": {"type": "string"}},
+        "workflow_chain_refs": {"type": "array", "items": {"type": "string"}},
         "standing_privilege_reasons": {"type": "array", "items": {"type": "string"}},
         "write_path_classes": {"type": "array", "items": {"type": "string"}},
         "governance_controls": {"type": "array", "items": {"type": "object"}},
@@ -381,6 +385,82 @@
         "evidence_completeness": {"$ref": "#/$defs/evidenceCompleteness"},
         "action_lineage": {"$ref": "#/$defs/actionLineage"}
       }
+    },
+    "workflowChainRollup": {
+      "type": "object",
+      "required": ["value", "count"],
+      "properties": {
+        "value": {"type": "string"},
+        "count": {"type": "integer", "minimum": 0}
+      },
+      "additionalProperties": false
+    },
+    "workflowChainDimension": {
+      "type": "object",
+      "required": ["key"],
+      "properties": {
+        "key": {"type": "string"},
+        "label": {"type": "string"},
+        "status": {"type": "string"},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "workflowChain": {
+      "type": "object",
+      "required": ["chain_id", "repo", "pull_request", "workflow", "task", "tool", "credential", "owner", "approval", "target", "evidence", "outcome"],
+      "properties": {
+        "chain_id": {"type": "string"},
+        "path_ids": {"type": "array", "items": {"type": "string"}},
+        "graph_node_refs": {"type": "array", "items": {"type": "string"}},
+        "graph_edge_refs": {"type": "array", "items": {"type": "string"}},
+        "proof_refs": {"type": "array", "items": {"type": "string"}},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "source_finding_keys": {"type": "array", "items": {"type": "string"}},
+        "introduced_by": {"$ref": "#/$defs/introducedBy"},
+        "repo": {"$ref": "#/$defs/workflowChainDimension"},
+        "pull_request": {"$ref": "#/$defs/workflowChainDimension"},
+        "workflow": {"$ref": "#/$defs/workflowChainDimension"},
+        "task": {"$ref": "#/$defs/workflowChainDimension"},
+        "tool": {"$ref": "#/$defs/workflowChainDimension"},
+        "credential": {"$ref": "#/$defs/workflowChainDimension"},
+        "owner": {"$ref": "#/$defs/workflowChainDimension"},
+        "approval": {"$ref": "#/$defs/workflowChainDimension"},
+        "target": {"$ref": "#/$defs/workflowChainDimension"},
+        "evidence": {"$ref": "#/$defs/workflowChainDimension"},
+        "outcome": {"$ref": "#/$defs/workflowChainDimension"},
+        "autonomy_tier": {"$ref": "#/$defs/autonomyTier"},
+        "delegation_readiness_state": {"$ref": "#/$defs/delegationReadinessState"},
+        "recommended_control": {"$ref": "#/$defs/recommendedControl"},
+        "target_class": {"type": "string"},
+        "evidence_completeness": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "workflowChainSummary": {
+      "type": "object",
+      "required": ["total_chains"],
+      "properties": {
+        "total_chains": {"type": "integer", "minimum": 0},
+        "workflows": {"type": "array", "items": {"$ref": "#/$defs/workflowChainRollup"}},
+        "repos": {"type": "array", "items": {"$ref": "#/$defs/workflowChainRollup"}},
+        "autonomy_tiers": {"type": "array", "items": {"$ref": "#/$defs/workflowChainRollup"}},
+        "delegation_readiness_states": {"type": "array", "items": {"$ref": "#/$defs/workflowChainRollup"}},
+        "recommended_controls": {"type": "array", "items": {"$ref": "#/$defs/workflowChainRollup"}},
+        "target_classes": {"type": "array", "items": {"$ref": "#/$defs/workflowChainRollup"}},
+        "evidence_completeness": {"type": "array", "items": {"$ref": "#/$defs/workflowChainRollup"}}
+      },
+      "additionalProperties": false
+    },
+    "workflowChainArtifact": {
+      "type": "object",
+      "required": ["version", "summary", "chains"],
+      "properties": {
+        "version": {"type": "string", "enum": ["1"]},
+        "summary": {"$ref": "#/$defs/workflowChainSummary"},
+        "chains": {"type": "array", "items": {"$ref": "#/$defs/workflowChain"}}
+      },
+      "additionalProperties": false
     },
     "autonomyTier": {
       "type": "string",
@@ -775,7 +855,34 @@
         "org": {"type": "string"},
         "repo": {"type": "string"},
         "path": {"type": "string"},
-        "kind": {"type": "string"},
+        "kind": {
+          "type": "string",
+          "enum": [
+            "control_path",
+            "agent",
+            "execution_identity",
+            "credential",
+            "tool",
+            "workflow",
+            "repo",
+            "governance_control",
+            "target",
+            "action_capability",
+            "intent",
+            "task",
+            "human_identity",
+            "agent_team",
+            "pull_request",
+            "approval_identity",
+            "policy_identity",
+            "asset_identity",
+            "evidence_identity",
+            "deployment_path",
+            "ci_cd_run",
+            "workflow_run",
+            "outcome"
+          ]
+        },
         "reason": {"type": "string"}
       },
       "additionalProperties": false
@@ -893,7 +1000,10 @@
             "total_nodes": {"type": "integer"},
             "total_edges": {"type": "integer"},
             "node_kinds": {"type": "array", "items": {"$ref": "#/$defs/controlPathKindRollup"}},
-            "edge_kinds": {"type": "array", "items": {"$ref": "#/$defs/controlPathKindRollup"}}
+            "edge_kinds": {"type": "array", "items": {"$ref": "#/$defs/controlPathKindRollup"}},
+            "autonomy_tiers": {"type": "array", "items": {"$ref": "#/$defs/controlPathKindRollup"}},
+            "delegation_readiness_states": {"type": "array", "items": {"$ref": "#/$defs/controlPathKindRollup"}},
+            "evidence_states": {"type": "array", "items": {"$ref": "#/$defs/controlPathKindRollup"}}
           },
           "additionalProperties": false
         },

--- a/schemas/v1/risk/risk-report.schema.json
+++ b/schemas/v1/risk/risk-report.schema.json
@@ -23,6 +23,9 @@
       },
       "additionalProperties": true
     },
+    "workflow_chains": {
+      "$ref": "#/$defs/workflowChainArtifact"
+    },
     "control_path_graph": {
       "$ref": "../control-path-graph.schema.json"
     }
@@ -134,6 +137,7 @@
         "recommended_action": {"type": "string"},
         "attack_path_refs": {"type": "array", "items": {"type": "string"}},
         "source_finding_keys": {"type": "array", "items": {"type": "string"}},
+        "workflow_chain_refs": {"type": "array", "items": {"type": "string"}},
         "matched_production_targets": {"type": "array", "items": {"type": "string"}},
         "governance_controls": {"type": "array"},
         "closure_requirements": {"type": "array", "items": {"$ref": "#/$defs/closureRequirement"}},
@@ -400,12 +404,88 @@
       "required": ["segment_id", "kind"],
       "properties": {
         "segment_id": {"type": "string"},
-        "kind": {"type": "string", "enum": ["repo", "workflow", "agent", "action", "credential", "target", "owner", "approval", "proof"]},
+        "kind": {"type": "string", "enum": ["repo", "workflow", "agent", "action", "credential", "target", "owner", "approval", "proof", "intent", "task", "human", "pr", "workflow_run", "control", "deployment", "outcome", "evidence"]},
         "label": {"type": "string"},
         "status": {"type": "string"},
         "node_ids": {"type": "array", "items": {"type": "string"}},
         "edge_ids": {"type": "array", "items": {"type": "string"}},
         "evidence_refs": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "workflowChainRollup": {
+      "type": "object",
+      "required": ["value", "count"],
+      "properties": {
+        "value": {"type": "string"},
+        "count": {"type": "integer", "minimum": 0}
+      },
+      "additionalProperties": false
+    },
+    "workflowChainDimension": {
+      "type": "object",
+      "required": ["key"],
+      "properties": {
+        "key": {"type": "string"},
+        "label": {"type": "string"},
+        "status": {"type": "string"},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "workflowChain": {
+      "type": "object",
+      "required": ["chain_id", "repo", "pull_request", "workflow", "task", "tool", "credential", "owner", "approval", "target", "evidence", "outcome"],
+      "properties": {
+        "chain_id": {"type": "string"},
+        "path_ids": {"type": "array", "items": {"type": "string"}},
+        "graph_node_refs": {"type": "array", "items": {"type": "string"}},
+        "graph_edge_refs": {"type": "array", "items": {"type": "string"}},
+        "proof_refs": {"type": "array", "items": {"type": "string"}},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "source_finding_keys": {"type": "array", "items": {"type": "string"}},
+        "introduced_by": {"$ref": "#/$defs/introducedBy"},
+        "repo": {"$ref": "#/$defs/workflowChainDimension"},
+        "pull_request": {"$ref": "#/$defs/workflowChainDimension"},
+        "workflow": {"$ref": "#/$defs/workflowChainDimension"},
+        "task": {"$ref": "#/$defs/workflowChainDimension"},
+        "tool": {"$ref": "#/$defs/workflowChainDimension"},
+        "credential": {"$ref": "#/$defs/workflowChainDimension"},
+        "owner": {"$ref": "#/$defs/workflowChainDimension"},
+        "approval": {"$ref": "#/$defs/workflowChainDimension"},
+        "target": {"$ref": "#/$defs/workflowChainDimension"},
+        "evidence": {"$ref": "#/$defs/workflowChainDimension"},
+        "outcome": {"$ref": "#/$defs/workflowChainDimension"},
+        "autonomy_tier": {"$ref": "#/$defs/autonomyTier"},
+        "delegation_readiness_state": {"$ref": "#/$defs/delegationReadinessState"},
+        "recommended_control": {"$ref": "#/$defs/recommendedControl"},
+        "target_class": {"type": "string"},
+        "evidence_completeness": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "workflowChainSummary": {
+      "type": "object",
+      "required": ["total_chains"],
+      "properties": {
+        "total_chains": {"type": "integer", "minimum": 0},
+        "workflows": {"type": "array", "items": {"$ref": "#/$defs/workflowChainRollup"}},
+        "repos": {"type": "array", "items": {"$ref": "#/$defs/workflowChainRollup"}},
+        "autonomy_tiers": {"type": "array", "items": {"$ref": "#/$defs/workflowChainRollup"}},
+        "delegation_readiness_states": {"type": "array", "items": {"$ref": "#/$defs/workflowChainRollup"}},
+        "recommended_controls": {"type": "array", "items": {"$ref": "#/$defs/workflowChainRollup"}},
+        "target_classes": {"type": "array", "items": {"$ref": "#/$defs/workflowChainRollup"}},
+        "evidence_completeness": {"type": "array", "items": {"$ref": "#/$defs/workflowChainRollup"}}
+      },
+      "additionalProperties": false
+    },
+    "workflowChainArtifact": {
+      "type": "object",
+      "required": ["version", "summary", "chains"],
+      "properties": {
+        "version": {"type": "string", "enum": ["1"]},
+        "summary": {"$ref": "#/$defs/workflowChainSummary"},
+        "chains": {"type": "array", "items": {"$ref": "#/$defs/workflowChain"}}
       },
       "additionalProperties": false
     },

--- a/testinfra/contracts/wave2_workflow_chain_contracts_test.go
+++ b/testinfra/contracts/wave2_workflow_chain_contracts_test.go
@@ -1,0 +1,132 @@
+package contracts
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestWave2SchemasDeclareWorkflowChainRefsAndArtifacts(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	cases := []struct {
+		name       string
+		path       string
+		definition string
+	}{
+		{
+			name:       "agent action bom item",
+			path:       filepath.Join(repoRoot, "schemas", "v1", "agent-action-bom.schema.json"),
+			definition: "item",
+		},
+		{
+			name:       "risk report action path",
+			path:       filepath.Join(repoRoot, "schemas", "v1", "risk", "risk-report.schema.json"),
+			definition: "actionPath",
+		},
+		{
+			name:       "report summary action path",
+			path:       filepath.Join(repoRoot, "schemas", "v1", "report", "report-summary.schema.json"),
+			definition: "actionPath",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			schema := mustReadJSON(t, tc.path)
+			props := schemaDefinitionProperties(t, schema, tc.definition)
+			if _, ok := props["workflow_chain_refs"].(map[string]any); !ok {
+				t.Fatalf("%s schema missing workflow_chain_refs: %v", tc.name, props)
+			}
+		})
+	}
+
+	riskSchema := mustReadJSON(t, filepath.Join(repoRoot, "schemas", "v1", "risk", "risk-report.schema.json"))
+	if _, ok := riskSchema["properties"].(map[string]any)["workflow_chains"].(map[string]any); !ok {
+		t.Fatalf("risk report schema missing workflow_chains: %v", riskSchema["properties"])
+	}
+
+	reportSchema := mustReadJSON(t, filepath.Join(repoRoot, "schemas", "v1", "report", "report-summary.schema.json"))
+	if _, ok := reportSchema["properties"].(map[string]any)["workflow_chains"].(map[string]any); !ok {
+		t.Fatalf("report summary schema missing workflow_chains: %v", reportSchema["properties"])
+	}
+}
+
+func TestWave2SchemasDeclareGraphV2AndExtendedLineageKinds(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	graphSchema := mustReadJSON(t, filepath.Join(repoRoot, "schemas", "v1", "control-path-graph.schema.json"))
+	nodeProps := schemaDefinitionProperties(t, graphSchema, "node")
+	assertSchemaEnum(t, map[string]any{
+		"enum": nodeProps["kind"].(map[string]any)["enum"],
+	}, []string{
+		"control_path",
+		"agent",
+		"execution_identity",
+		"credential",
+		"tool",
+		"workflow",
+		"repo",
+		"governance_control",
+		"target",
+		"action_capability",
+		"intent",
+		"task",
+		"human_identity",
+		"agent_team",
+		"pull_request",
+		"approval_identity",
+		"policy_identity",
+		"asset_identity",
+		"evidence_identity",
+		"deployment_path",
+		"ci_cd_run",
+		"workflow_run",
+		"outcome",
+	})
+
+	summaryProps, ok := graphSchema["properties"].(map[string]any)["summary"].(map[string]any)["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("control path graph schema missing summary properties: %v", graphSchema["properties"])
+	}
+	for _, field := range []string{"autonomy_tiers", "delegation_readiness_states", "evidence_states"} {
+		if _, ok := summaryProps[field].(map[string]any); !ok {
+			t.Fatalf("control path graph summary missing %s: %v", field, summaryProps)
+		}
+	}
+
+	for _, path := range []string{
+		filepath.Join(repoRoot, "schemas", "v1", "agent-action-bom.schema.json"),
+		filepath.Join(repoRoot, "schemas", "v1", "risk", "risk-report.schema.json"),
+		filepath.Join(repoRoot, "schemas", "v1", "report", "report-summary.schema.json"),
+	} {
+		schema := mustReadJSON(t, path)
+		segmentProps := schemaDefinitionProperties(t, schema, "actionLineageSegment")
+		assertSchemaEnum(t, map[string]any{
+			"enum": segmentProps["kind"].(map[string]any)["enum"],
+		}, []string{
+			"repo",
+			"workflow",
+			"agent",
+			"action",
+			"credential",
+			"target",
+			"owner",
+			"approval",
+			"proof",
+			"intent",
+			"task",
+			"human",
+			"pr",
+			"workflow_run",
+			"control",
+			"deployment",
+			"outcome",
+			"evidence",
+		})
+	}
+}


### PR DESCRIPTION
## Problem
- Wave 2 of the Sprint 3 action-control plan needs a first-class workflow-chain artifact, additive Control Path Graph V2 structure, and extended intent-to-outcome lineage so buyer-facing outputs can explain delegated SDLC flow deterministically.
- Before this change, Wrkr had govern-first action paths and a first-generation control-path graph, but no stable workflow-chain object or additive PR/deployment/evidence lineage contract.

## Changes
- Added deterministic `workflow_chains` aggregation plus `workflow_chain_refs` on action paths and Agent Action BOM items.
- Extended `control_path_graph` with additive Wave 2 node/edge kinds and summary rollups for autonomy/readiness/evidence state.
- Extended `action_lineage.segments[]` with intent, task, human, PR, workflow-run, control, deployment, outcome, and evidence segments while preserving the existing lineage contract.
- Updated v1 risk/report/BOM/graph schemas, Wave 2 contract tests, scenario expectations, changelog entries, and ADR documentation.

## Validation
- `go test ./core/aggregate/agentresolver ./core/aggregate/attackpath ./core/risk ./core/report ./testinfra/contracts -count=1`
- `go test ./testinfra/contracts -count=1`
- `make test-scenarios`
- `scripts/run_v1_acceptance.sh --mode=local`
- `make test-hardening`
- `make test-chaos`
- `make test-perf`
- `make prepush-full`

## Risks
- This touches high-signal report and schema contracts, so the main risk is downstream consumer drift on the new additive lineage and workflow-chain fields.
- Scenario and contract fixtures were updated together to keep the deterministic public surface aligned.

## Notes
- ADR: `docs/decisions/wave22-workflow-chain-graph-v2.md`
- Plan scope: Wave 2 from `product/plans/adhoc/PLAN_ADHOC_2026-05-26_145853_action-control-graph-evidence-packets-high-stakes-paths.md`
- No submodule pointer changes.
