### PR TITLE
feat: add gitlab and azure ci authority coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - [semver:minor] Added documentation, schemas, scenarios, and acceptance coverage for Sprint 2 enterprise evidence ingest, contradiction handling, accepted-risk visibility, lifecycle queues, closure guidance, and completeness scoring.
 - [semver:minor] Added a focused one-page Agent Action BOM view for a single workflow/action path with appendix details for raw findings, graph refs, proof details, and detector diagnostics.
 - [semver:minor] Documented Sprint 3 Agent Action BOM focused-path contracts and schema coverage for primary workflow BOM output, evidence bundles, and local review workflows.
+- [semver:minor] Added first-class GitLab CI/CD detection for local pipelines, safe local includes, jobs, stages, variables, manual gates, deploy/release authority, secrets by reference, AI agent execution, and MCP/tool invocation.
+- [semver:minor] Added GitLab CI/CD workflow authority to action paths, privilege budget, Agent Action BOM, control backlog, graph, evidence packets, and scan quality summaries.
+- [semver:minor] Added first-class Azure DevOps pipeline detection for local pipelines, safe local templates, stages, jobs, service connections, variable groups, environments, approvals/check hints, agent pools, deployment jobs, secrets by reference, AI agent execution, and MCP/tool invocation.
+- [semver:minor] Added Azure DevOps pipeline authority to action paths, privilege budget, Agent Action BOM, control backlog, graph, evidence packets, and scan quality summaries.
 
 ### Changed
 

--- a/core/aggregate/inventory/inventory.go
+++ b/core/aggregate/inventory/inventory.go
@@ -1237,7 +1237,10 @@ func classifyAdoptionPattern(repos []string, locations []ToolLocation) string {
 	if repoCount == 1 {
 		for _, item := range locations {
 			path := strings.ToLower(strings.TrimSpace(item.Location))
-			if strings.Contains(path, ".github/") || strings.Contains(path, ".gitlab/") || strings.HasSuffix(path, "jenkinsfile") {
+			if strings.Contains(path, ".github/") || strings.Contains(path, ".gitlab/") || strings.HasSuffix(path, ".gitlab-ci.yml") ||
+				strings.HasSuffix(path, ".gitlab-ci.yaml") || strings.Contains(path, ".azure/pipelines/") ||
+				strings.HasSuffix(path, "azure-pipelines.yml") || strings.HasSuffix(path, "azure-pipelines.yaml") ||
+				strings.HasSuffix(path, "jenkinsfile") {
 				return "team_level"
 			}
 		}

--- a/core/aggregate/inventory/privileges.go
+++ b/core/aggregate/inventory/privileges.go
@@ -212,7 +212,10 @@ func ClassifyPathContext(location string) *PathContext {
 		strings.Contains(lower, "_test.") || strings.Contains(lower, ".test.") || strings.Contains(lower, ".spec."):
 		return &PathContext{Kind: PathContextUnitTest, Confidence: "high", Reasons: []string{"unit_or_fixture_test_path"}}
 	case hasAnySegment(segmentSet, ".github", "workflows", "deploy", "deployments", "helm", "k8s", "kubernetes") ||
-		strings.Contains(lower, "dockerfile") || strings.Contains(lower, "jenkinsfile"):
+		strings.Contains(lower, "dockerfile") || strings.Contains(lower, "jenkinsfile") ||
+		strings.HasSuffix(lower, ".gitlab-ci.yml") || strings.HasSuffix(lower, ".gitlab-ci.yaml") ||
+		strings.Contains(lower, "/.gitlab/ci/") || strings.HasSuffix(lower, "azure-pipelines.yml") ||
+		strings.HasSuffix(lower, "azure-pipelines.yaml") || strings.Contains(lower, "/.azure/pipelines/"):
 		return &PathContext{Kind: PathContextDeployableSource, Confidence: "high", Reasons: []string{"deployment_or_ci_path"}}
 	case hasRuntimeExtension(ext):
 		return &PathContext{Kind: PathContextRuntimeSource, Confidence: "medium", Reasons: []string{"runtime_source_extension"}}

--- a/core/aggregate/privilegebudget/budget.go
+++ b/core/aggregate/privilegebudget/budget.go
@@ -1627,7 +1627,14 @@ func inferredCredentialScope(signals findingSignals, authSurfaces []string) stri
 	for _, location := range signals.Locations {
 		lower := normalizeToken(location)
 		switch {
-		case strings.Contains(lower, ".github/workflows"), lower == "jenkinsfile":
+		case strings.Contains(lower, ".github/workflows"),
+			strings.Contains(lower, ".gitlab-ci.yml"),
+			strings.Contains(lower, ".gitlab-ci.yaml"),
+			strings.Contains(lower, ".gitlab/ci/"),
+			strings.Contains(lower, "azure-pipelines.yml"),
+			strings.Contains(lower, "azure-pipelines.yaml"),
+			strings.Contains(lower, ".azure/pipelines/"),
+			lower == "jenkinsfile":
 			return agginventory.CredentialScopeWorkflow
 		case strings.HasPrefix(lower, ".env"):
 			return agginventory.CredentialScopeEnvironment

--- a/core/aggregate/scanquality/scanquality.go
+++ b/core/aggregate/scanquality/scanquality.go
@@ -443,7 +443,7 @@ func collectDetectorHealth(input Input) []DetectorHealth {
 
 	out := make([]DetectorHealth, 0)
 	for _, scope := range input.Scopes {
-		for _, detectorID := range []string{"dependency", "mcp", "webmcp"} {
+		for _, detectorID := range []string{"ciagent", "dependency", "mcp", "webmcp"} {
 			scopeKey := detectorScopeKey{
 				org:      strings.TrimSpace(scope.Org),
 				repo:     strings.TrimSpace(scope.Repo),
@@ -751,6 +751,8 @@ func buildDetectorErrorIndex(in []detect.DetectorError) map[detectorScopeKey]int
 
 func collectDetectorScopeMetrics(scope detect.Scope, detectorID, mode string) detectorPathMetrics {
 	switch detectorID {
+	case "ciagent":
+		return collectCIAgentScopeMetrics(scope.Root)
 	case "dependency":
 		return collectDependencyScopeMetrics(scope.Root, mode)
 	case "mcp":
@@ -760,6 +762,32 @@ func collectDetectorScopeMetrics(scope detect.Scope, detectorID, mode string) de
 	default:
 		return detectorPathMetrics{}
 	}
+}
+
+func collectCIAgentScopeMetrics(root string) detectorPathMetrics {
+	metrics := detectorPathMetrics{}
+	paths := []string{
+		".gitlab-ci.yml",
+		".gitlab-ci.yaml",
+		"Jenkinsfile",
+		"azure-pipelines.yml",
+		"azure-pipelines.yaml",
+	}
+	for _, rel := range paths {
+		exists, parseErr := detect.FileExistsWithinRoot("scanquality", root, rel)
+		if parseErr != nil || exists {
+			metrics.attemptedPaths = append(metrics.attemptedPaths, rel)
+		}
+	}
+	for _, pattern := range []string{".github/workflows/*", ".azure/pipelines/*.yml", ".azure/pipelines/*.yaml"} {
+		matches, err := detect.Glob(root, pattern)
+		if err != nil {
+			continue
+		}
+		metrics.attemptedPaths = append(metrics.attemptedPaths, matches...)
+	}
+	metrics.attemptedPaths = dedupeStrings(metrics.attemptedPaths)
+	return metrics
 }
 
 func collectDependencyScopeMetrics(root, mode string) detectorPathMetrics {
@@ -955,6 +983,28 @@ func sortedReasonKeys(values map[string]struct{}) []string {
 func hasReason(values map[string]struct{}, reason string) bool {
 	_, ok := values[reason]
 	return ok
+}
+
+func dedupeStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	set := map[string]struct{}{}
+	for _, item := range in {
+		if strings.TrimSpace(item) == "" {
+			continue
+		}
+		set[strings.TrimSpace(item)] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for item := range set {
+		out = append(out, item)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func cloneDetectorErrors(in []detect.DetectorError) []detect.DetectorError {

--- a/core/aggregate/scanquality/scanquality_test.go
+++ b/core/aggregate/scanquality/scanquality_test.go
@@ -280,6 +280,52 @@ func TestScanQualityReportsPartialCoverageWhenFallbackKeepsPositiveSignal(t *tes
 	}
 }
 
+func TestScanQualityReportsCIAgentPartialCoverageForWorkflowFallback(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".gitlab-ci.yml"), []byte("deploy:\n  script:\n    - codex --full-auto --approval never\n"), 0o600); err != nil {
+		t.Fatalf("write gitlab pipeline: %v", err)
+	}
+
+	report := Build(Input{
+		Mode:   "governance",
+		Scopes: []detect.Scope{{Org: "acme", Repo: "payments", Root: root}},
+		Findings: []model.Finding{
+			{
+				FindingType: "parse_error",
+				Location:    ".gitlab-ci.yml",
+				Repo:        "payments",
+				Org:         "acme",
+				ParseError:  &model.ParseError{Kind: "parse_error", Path: ".gitlab-ci.yml", Detector: "ciagent", Message: "unsupported remote include"},
+			},
+			{
+				FindingType: "ci_autonomy",
+				Location:    ".gitlab-ci.yml",
+				Repo:        "payments",
+				Org:         "acme",
+				Detector:    "ciagent",
+				ToolType:    "ci_agent",
+				Evidence: []model.Evidence{
+					{Key: "ci_platform", Value: "gitlab_ci"},
+					{Key: "include_resolution_status", Value: "partial"},
+				},
+			},
+		},
+	})
+
+	ciagent := findDetectorHealth(t, report, "ciagent")
+	if ciagent.Status != "partial" {
+		t.Fatalf("expected partial ciagent coverage, got %+v", ciagent)
+	}
+	if ciagent.PartialParses != 1 {
+		t.Fatalf("expected one partial parse, got %+v", ciagent)
+	}
+	if !containsReason(ciagent.CoverageReasons, "partial_parse") {
+		t.Fatalf("expected partial_parse reason, got %+v", ciagent)
+	}
+}
+
 func TestScanQualityReportsCompleteMCPCoverageForCleanNegativeResult(t *testing.T) {
 	t.Parallel()
 

--- a/core/detect/ciagent/detector.go
+++ b/core/detect/ciagent/detector.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Clyra-AI/wrkr/core/detect/workflowcap"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/risk/autonomy"
+	"github.com/Clyra-AI/wrkr/core/workflowloc"
 )
 
 const detectorID = "ciagent"
@@ -24,29 +25,23 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 		return nil, err
 	}
 
-	files := make([]string, 0)
-	workflowFiles, wfErr := detect.Glob(scope.Root, ".github/workflows/*")
-	if wfErr != nil {
-		return nil, wfErr
+	files, err := collectWorkflowFiles(scope.Root)
+	if err != nil {
+		return nil, err
 	}
-	files = append(files, workflowFiles...)
-	jenkinsfileExists, parseErr := detect.FileExistsWithinRoot(detectorID, scope.Root, "Jenkinsfile")
-	if parseErr != nil {
-		return nil, detect.ParseErrorAsError(parseErr)
-	}
-	if jenkinsfileExists {
-		files = append(files, "Jenkinsfile")
-	}
-	sort.Strings(files)
 
 	findings := make([]model.Finding, 0)
 	for _, rel := range files {
 		payload, parseErr := detect.ReadFileWithinRoot(detectorID, scope.Root, rel)
 		if parseErr != nil {
-			return nil, detect.ParseErrorAsError(parseErr)
+			findings = append(findings, parseErrorFinding(scope, rel, parseErr))
+			continue
 		}
 		content := string(payload)
-		workflowAnalysis, workflowErr := workflowcap.Analyze(rel, payload)
+		workflowAnalysis, workflowErr := workflowcap.AnalyzeInRoot(scope.Root, rel, payload)
+		if workflowErr != nil {
+			findings = append(findings, parseErrorFinding(scope, rel, workflowErr))
+		}
 		signals := autonomy.Signals{
 			Tool:            workflowAnalysis.Tool,
 			Headless:        workflowAnalysis.Headless,
@@ -73,21 +68,25 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 		if !signals.DangerousFlags {
 			signals.DangerousFlags = hasDangerousFlags(content)
 		}
-		if !signals.Headless && signals.Tool == "" {
+		permissions := permissionsFromSignals(signals)
+		permissions = append(permissions, workflowAnalysis.Capabilities...)
+		if !signals.Headless && signals.Tool == "" && len(uniqueStrings(permissions)) == 0 {
 			continue
 		}
 		level := autonomy.Classify(signals)
-		severity := severityForSignals(signals, level)
+		severity := severityForWorkflow(signals, level, permissions)
 		checkResult := model.CheckResultPass
 		if signals.Headless && signals.HasSecretAccess && !signals.HasApprovalGate {
 			checkResult = model.CheckResultFail
 		}
 		evidence := []model.Evidence{
-			{Key: "tool", Value: signals.Tool},
 			{Key: "headless", Value: boolString(signals.Headless)},
 			{Key: "approval_gate", Value: boolString(signals.HasApprovalGate)},
 			{Key: "secret_access", Value: boolString(signals.HasSecretAccess)},
 			{Key: "dangerous_flags", Value: boolString(signals.DangerousFlags)},
+		}
+		if strings.TrimSpace(signals.Tool) != "" {
+			evidence = append(evidence, model.Evidence{Key: "tool", Value: signals.Tool})
 		}
 		if provenanceType, subject := credentialProvenanceForWorkflow(content); provenanceType != "" {
 			evidence = append(evidence,
@@ -99,10 +98,8 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 		}
 		if workflowErr == nil {
 			evidence = append(evidence, workflowAnalysis.Evidence...)
-		}
-		permissions := permissionsFromSignals(signals)
-		if workflowErr == nil {
-			permissions = append(permissions, workflowAnalysis.Capabilities...)
+		} else if len(workflowAnalysis.Evidence) > 0 {
+			evidence = append(evidence, workflowAnalysis.Evidence...)
 		}
 		findings = append(findings, model.Finding{
 			FindingType: "ci_autonomy",
@@ -122,6 +119,60 @@ func (Detector) Detect(_ context.Context, scope detect.Scope, _ detect.Options) 
 
 	model.SortFindings(findings)
 	return findings, nil
+}
+
+func collectWorkflowFiles(root string) ([]string, error) {
+	set := map[string]struct{}{}
+	patterns := []string{
+		".github/workflows/*",
+		".azure/pipelines/*.yml",
+		".azure/pipelines/*.yaml",
+	}
+	for _, pattern := range patterns {
+		matches, err := detect.Glob(root, pattern)
+		if err != nil {
+			return nil, err
+		}
+		for _, rel := range matches {
+			if workflowloc.IsCIWorkflow(rel) {
+				set[rel] = struct{}{}
+			}
+		}
+	}
+	for _, rel := range []string{"Jenkinsfile", ".gitlab-ci.yml", ".gitlab-ci.yaml", "azure-pipelines.yml", "azure-pipelines.yaml"} {
+		exists, parseErr := detect.FileExistsWithinRoot(detectorID, root, rel)
+		if parseErr != nil {
+			return nil, detect.ParseErrorAsError(parseErr)
+		}
+		if exists {
+			set[rel] = struct{}{}
+		}
+	}
+	files := make([]string, 0, len(set))
+	for rel := range set {
+		files = append(files, rel)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func parseErrorFinding(scope detect.Scope, rel string, parseErr *model.ParseError) model.Finding {
+	if parseErr == nil {
+		parseErr = &model.ParseError{Kind: "parse_error", Path: rel, Detector: detectorID, Message: "unknown parse error"}
+	}
+	normalized := *parseErr
+	normalized.Path = strings.TrimSpace(rel)
+	normalized.Detector = detectorID
+	return model.Finding{
+		FindingType: "parse_error",
+		Severity:    model.SeverityMedium,
+		ToolType:    "ci_agent",
+		Location:    rel,
+		Repo:        scope.Repo,
+		Org:         fallbackOrg(scope.Org),
+		Detector:    detectorID,
+		ParseError:  &normalized,
+	}
 }
 
 func detectTool(content string) string {
@@ -196,6 +247,23 @@ func severityForSignals(signals autonomy.Signals, level string) string {
 	}
 }
 
+func severityForWorkflow(signals autonomy.Signals, level string, permissions []string) string {
+	if base := severityForSignals(signals, level); base != model.SeverityInfo {
+		return base
+	}
+	normalized := uniqueStrings(permissions)
+	switch {
+	case containsPermission(normalized, "deploy.write", "db.write", "iac.write", "release.write"):
+		return model.SeverityHigh
+	case containsPermission(normalized, "merge.execute", "package.write", "repo.write", "pull_request.write"):
+		return model.SeverityMedium
+	case containsPermission(normalized, "secret.read"):
+		return model.SeverityLow
+	default:
+		return model.SeverityInfo
+	}
+}
+
 func permissionsFromSignals(signals autonomy.Signals) []string {
 	perms := make([]string, 0)
 	if signals.HasSecretAccess {
@@ -231,6 +299,17 @@ func uniqueStrings(values []string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func containsPermission(values []string, targets ...string) bool {
+	for _, value := range values {
+		for _, target := range targets {
+			if value == target {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func boolString(v bool) string {

--- a/core/detect/ciagent/detector_test.go
+++ b/core/detect/ciagent/detector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Clyra-AI/wrkr/core/detect"
@@ -175,6 +176,87 @@ jobs:
 	}
 	if value := evidenceValue(findings[0], "credential_provenance_type"); value != "jit" {
 		t.Fatalf("expected jit credential provenance, got %q", value)
+	}
+}
+
+func TestDetectCIAutonomyDiscoversAzurePipelines(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "azure-pipelines.yml"), []byte(`trigger:
+- main
+jobs:
+- job: deploy
+  steps:
+  - script: codex --full-auto --approval never
+  - script: az webapp deploy --resource-group prod-rg --name api
+`), 0o600); err != nil {
+		t.Fatalf("write azure pipeline: %v", err)
+	}
+
+	findings, err := New().Detect(context.Background(), detect.Scope{Org: "acme", Repo: "payments", Root: root}, detect.Options{})
+	if err != nil {
+		t.Fatalf("detect ciagent: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one ciagent finding, got %+v", findings)
+	}
+	if findings[0].Location != "azure-pipelines.yml" {
+		t.Fatalf("expected azure pipeline location, got %q", findings[0].Location)
+	}
+	if evidenceValue(findings[0], "ci_platform") != "azure_devops" {
+		t.Fatalf("expected azure_devops platform evidence, got %q", evidenceValue(findings[0], "ci_platform"))
+	}
+	if !hasPermission(findings[0].Permissions, "deploy.write") {
+		t.Fatalf("expected deploy.write permission in %+v", findings[0].Permissions)
+	}
+}
+
+func TestDetectCIAutonomyKeepsGitLabUnsupportedRemoteIncludesVisible(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".gitlab-ci.yml"), []byte(`include:
+  - project: acme/shared
+    file: /deploy.yml
+deploy:
+  stage: deploy
+  script:
+    - codex --full-auto --approval never
+    - kubectl apply -f k8s/
+`), 0o600); err != nil {
+		t.Fatalf("write gitlab workflow: %v", err)
+	}
+
+	findings, err := New().Detect(context.Background(), detect.Scope{Org: "acme", Repo: "payments", Root: root}, detect.Options{})
+	if err != nil {
+		t.Fatalf("detect ciagent: %v", err)
+	}
+
+	var parseFinding *model.Finding
+	var workflowFinding *model.Finding
+	for idx := range findings {
+		switch findings[idx].FindingType {
+		case "parse_error":
+			parseFinding = &findings[idx]
+		case "ci_autonomy":
+			workflowFinding = &findings[idx]
+		}
+	}
+	if parseFinding == nil {
+		t.Fatalf("expected parse_error finding for unsupported include, got %+v", findings)
+	}
+	if workflowFinding == nil {
+		t.Fatalf("expected ci_autonomy finding to survive unsupported include, got %+v", findings)
+	}
+	if parseFinding.ParseError == nil || !strings.Contains(parseFinding.ParseError.Message, "unsupported remote include") {
+		t.Fatalf("expected unsupported remote include parse error, got %+v", parseFinding)
+	}
+	if evidenceValue(*workflowFinding, "ci_platform") != "gitlab_ci" {
+		t.Fatalf("expected gitlab_ci platform evidence, got %q", evidenceValue(*workflowFinding, "ci_platform"))
+	}
+	if evidenceValue(*workflowFinding, "include_resolution_status") != "partial" {
+		t.Fatalf("expected partial include resolution evidence, got %q", evidenceValue(*workflowFinding, "include_resolution_status"))
 	}
 }
 

--- a/core/detect/workflowcap/analyze.go
+++ b/core/detect/workflowcap/analyze.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/Clyra-AI/wrkr/core/model"
@@ -178,6 +177,10 @@ func (t *triggerField) UnmarshalYAML(node *yaml.Node) error {
 }
 
 func Analyze(path string, payload []byte) (Result, *model.ParseError) {
+	return AnalyzeInRoot("", path, payload)
+}
+
+func analyzeGitHubWorkflow(path string, payload []byte) (Result, *model.ParseError) {
 	var doc workflowDocument
 	if err := yaml.Unmarshal(payload, &doc); err != nil {
 		return Result{}, &model.ParseError{
@@ -407,6 +410,7 @@ func Analyze(path string, payload []byte) (Result, *model.ParseError) {
 		evidence = append(evidence, model.Evidence{Key: "authority_binding", Value: binding})
 	}
 	result.Evidence = evidence
+	result.Evidence = appendPlatformEvidence(result.Evidence, "github_actions", "high")
 	return result, nil
 }
 
@@ -454,213 +458,51 @@ func effectivePermissions(root, job permissionField) permissionField {
 }
 
 func detectTool(step workflowStep) string {
-	values := normalizedStepValues(step, nil)
-	for _, value := range values {
-		switch {
-		case strings.Contains(value, "claude"):
-			return "claude"
-		case strings.Contains(value, "codex"):
-			return "codex"
-		case strings.Contains(value, "copilot"):
-			return "copilot"
-		case strings.Contains(value, "cursor"):
-			return "cursor"
-		case strings.Contains(value, "gait eval --script"):
-			return "gait"
-		}
-	}
-	return ""
+	return detectToolFromValues(normalizedStepValues(step, nil))
 }
 
 func isHeadlessStep(step workflowStep) bool {
-	for _, value := range normalizedStepValues(step, nil) {
-		switch {
-		case strings.Contains(value, "claude -p"),
-			strings.Contains(value, "claude code -p"),
-			strings.Contains(value, "codex --full-auto"),
-			strings.Contains(value, "gait eval --script"):
-			return true
-		}
-	}
-	return false
+	return isHeadlessValues(normalizedStepValues(step, nil))
 }
 
 func hasDangerousFlags(step workflowStep) bool {
-	for _, value := range normalizedStepValues(step, nil) {
-		switch {
-		case strings.Contains(value, "--dangerouslyskippermissions"),
-			strings.Contains(value, "--dangerously-skip-permissions"),
-			strings.Contains(value, "--approval never"):
-			return true
-		}
-	}
-	return false
+	return hasDangerousFlagsValues(normalizedStepValues(step, nil))
 }
 
 func stepHasSecretAccess(step workflowStep, jobEnv map[string]string) bool {
-	values := normalizedStepValues(step, jobEnv)
-	for _, value := range values {
-		if strings.Contains(value, "secrets.") || strings.Contains(value, "${{ secrets.") || strings.Contains(value, "github.token") {
-			return true
-		}
-	}
-	return false
+	return hasSecretAccessValues(normalizedStepValues(step, jobEnv))
 }
 
 func mergeExecuteReason(step workflowStep) string {
-	for _, value := range normalizedStepValues(step, nil) {
-		switch {
-		case strings.Contains(value, "gh pr merge"):
-			return "step.run:gh_pr_merge"
-		case strings.Contains(value, "enable-pull-request-automerge"):
-			return "step.uses:enable_pull_request_automerge"
-		case strings.Contains(value, "automerge-action"):
-			return "step.uses:automerge_action"
-		}
-	}
-	return ""
+	return mergeExecuteReasonValues(normalizedStepValues(step, nil))
 }
 
 func deployWriteReason(step workflowStep) string {
-	for _, value := range normalizedStepValues(step, nil) {
-		switch {
-		case strings.Contains(value, "kubectl apply"):
-			return "step.run:kubectl_apply"
-		case strings.Contains(value, "helm upgrade"), strings.Contains(value, "helm install"):
-			return "step.run:helm_release"
-		case strings.Contains(value, "terraform apply"):
-			return "step.run:terraform_apply"
-		case strings.Contains(value, "terragrunt apply"):
-			return "step.run:terragrunt_apply"
-		case strings.Contains(value, "pulumi up"):
-			return "step.run:pulumi_up"
-		case strings.Contains(value, "serverless deploy"):
-			return "step.run:serverless_deploy"
-		case strings.Contains(value, "fly deploy"):
-			return "step.run:fly_deploy"
-		case strings.Contains(value, "vercel deploy --prod"):
-			return "step.run:vercel_prod_deploy"
-		case strings.Contains(value, "netlify deploy --prod"):
-			return "step.run:netlify_prod_deploy"
-		case strings.Contains(value, "aws ecs update-service"):
-			return "step.run:aws_ecs_update_service"
-		case strings.Contains(value, "gcloud run deploy"):
-			return "step.run:gcloud_run_deploy"
-		case strings.Contains(value, "azure/k8s-deploy"):
-			return "step.uses:azure_k8s_deploy"
-		case strings.Contains(value, "amazon-ecs-deploy-task-definition"):
-			return "step.uses:amazon_ecs_deploy"
-		case strings.Contains(value, "deploy-cloudrun"):
-			return "step.uses:deploy_cloudrun"
-		}
-	}
-	return ""
+	return deployWriteReasonValues(normalizedStepValues(step, nil))
 }
 
 func releaseWriteReason(step workflowStep) string {
-	for _, value := range normalizedStepValues(step, nil) {
-		switch {
-		case strings.Contains(value, "goreleaser release"):
-			return "step.run:goreleaser_release"
-		case strings.Contains(value, "gh release create"):
-			return "step.run:gh_release_create"
-		case strings.Contains(value, "softprops/action-gh-release"):
-			return "step.uses:action_gh_release"
-		case strings.Contains(value, "actions/create-release"):
-			return "step.uses:create_release"
-		}
-	}
-	return ""
+	return releaseWriteReasonValues(normalizedStepValues(step, nil))
 }
 
 func packagePublishReason(step workflowStep) string {
-	for _, value := range normalizedStepValues(step, nil) {
-		switch {
-		case strings.Contains(value, "npm publish"):
-			return "step.run:npm_publish"
-		case strings.Contains(value, "pnpm publish"):
-			return "step.run:pnpm_publish"
-		case strings.Contains(value, "yarn npm publish"):
-			return "step.run:yarn_npm_publish"
-		case strings.Contains(value, "twine upload"):
-			return "step.run:twine_upload"
-		case strings.Contains(value, "docker push"):
-			return "step.run:docker_push"
-		case strings.Contains(value, "docker/build-push-action"):
-			return "step.uses:docker_build_push_action"
-		case strings.Contains(value, "pypa/gh-action-pypi-publish"):
-			return "step.uses:pypi_publish"
-		}
-	}
-	return ""
+	return packagePublishReasonValues(normalizedStepValues(step, nil))
 }
 
 func dbWriteReason(step workflowStep) string {
-	for _, value := range normalizedStepValues(step, nil) {
-		switch {
-		case strings.Contains(value, "alembic upgrade"):
-			return "step.run:alembic_upgrade"
-		case strings.Contains(value, "prisma migrate deploy"):
-			return "step.run:prisma_migrate_deploy"
-		case strings.Contains(value, "liquibase update"):
-			return "step.run:liquibase_update"
-		case strings.Contains(value, "flyway migrate"):
-			return "step.run:flyway_migrate"
-		case strings.Contains(value, "goose up"):
-			return "step.run:goose_up"
-		case strings.Contains(value, "dbmate up"):
-			return "step.run:dbmate_up"
-		case strings.Contains(value, "rails db:migrate"):
-			return "step.run:rails_db_migrate"
-		case strings.Contains(value, "knex migrate:latest"):
-			return "step.run:knex_migrate_latest"
-		case strings.Contains(value, "sqitch deploy"):
-			return "step.run:sqitch_deploy"
-		}
-	}
-	return ""
+	return dbWriteReasonValues(normalizedStepValues(step, nil))
 }
 
 func iacWriteReason(step workflowStep) string {
-	for _, value := range normalizedStepValues(step, nil) {
-		switch {
-		case strings.Contains(value, "terraform apply"):
-			return "step.run:terraform_apply"
-		case strings.Contains(value, "terragrunt apply"):
-			return "step.run:terragrunt_apply"
-		case strings.Contains(value, "pulumi up"):
-			return "step.run:pulumi_up"
-		case strings.Contains(value, "helm upgrade"), strings.Contains(value, "helm install"):
-			return "step.run:helm_release"
-		}
-	}
-	return ""
+	return iacWriteReasonValues(normalizedStepValues(step, nil))
 }
 
 func manualApprovalSource(step workflowStep) string {
-	for _, value := range normalizedStepValues(step, nil) {
-		if strings.Contains(value, "manual-approval") {
-			return "manual_approval_step"
-		}
-	}
-	return ""
+	return manualApprovalSourceValues(normalizedStepValues(step, nil))
 }
 
 func proofRequirement(step workflowStep) string {
-	for _, value := range normalizedStepValues(step, nil) {
-		switch {
-		case strings.Contains(value, "wrkr evidence"),
-			strings.Contains(value, "wrkr verify"):
-			return "evidence"
-		case strings.Contains(value, "cosign attest"),
-			strings.Contains(value, "attest-build-provenance"),
-			strings.Contains(value, "slsa-github-generator"),
-			strings.Contains(value, "gh attestation"),
-			strings.Contains(value, "slsa-verifier"):
-			return "attestation"
-		}
-	}
-	return ""
+	return proofRequirementValues(normalizedStepValues(step, nil))
 }
 
 func normalizedStepValues(step workflowStep, jobEnv map[string]string) []string {
@@ -746,29 +588,13 @@ func sensitiveCredentialName(key string) bool {
 	}
 	return strings.Contains(key, "TOKEN") ||
 		strings.Contains(key, "SECRET") ||
+		strings.Contains(key, "PAT") ||
 		strings.Contains(key, "KEY") ||
 		strings.Contains(key, "CREDENTIAL")
 }
 
 func workflowAuthSurfaces(step workflowStep, jobEnv map[string]string) []string {
-	values := normalizedStepValues(step, jobEnv)
-	out := map[string]struct{}{}
-	for _, value := range values {
-		switch {
-		case strings.Contains(value, "aws-actions/configure-aws-credentials"), strings.Contains(value, "role-to-assume"), strings.Contains(value, "assume_role"):
-			out["aws_oidc"] = struct{}{}
-		case strings.Contains(value, "azure/login"), strings.Contains(value, "federatedcredential"), strings.Contains(value, "service connection"):
-			out["azure_federated_credential"] = struct{}{}
-		case strings.Contains(value, "google-github-actions/auth"), strings.Contains(value, "workload_identity_provider"), strings.Contains(value, "service_account"):
-			out["gcp_workload_identity"] = struct{}{}
-		case strings.Contains(value, "kubectl"), strings.Contains(value, "helm"):
-			out["kubernetes_rbac"] = struct{}{}
-		}
-	}
-	for _, ref := range workflowCredentialRefsOnly(step, jobEnv) {
-		out[ref] = struct{}{}
-	}
-	return sortedSet(out)
+	return workflowAuthSurfacesFromValues(normalizedStepValues(step, jobEnv), workflowCredentialRefsOnly(step, jobEnv), nil)
 }
 
 func workflowCredentialRefsOnly(step workflowStep, jobEnv map[string]string) []string {
@@ -777,49 +603,7 @@ func workflowCredentialRefsOnly(step workflowStep, jobEnv map[string]string) []s
 }
 
 func workflowAuthorityBindings(step workflowStep, environment string) []string {
-	values := normalizedStepValues(step, nil)
-	production := workflowEnvironmentSuggestsProduction([]string{environment})
-	out := []string{}
-	add := func(kind, provider, subject, targetSystem, resource, scope, access string) {
-		out = append(out, strings.Join([]string{
-			kind,
-			provider,
-			subject,
-			targetSystem,
-			resource,
-			scope,
-			access,
-			environment,
-			strconv.FormatBool(production),
-			"high",
-		}, "|"))
-	}
-	for _, value := range values {
-		switch {
-		case strings.Contains(value, "aws-actions/configure-aws-credentials"), strings.Contains(value, "role-to-assume"), strings.Contains(value, "assume_role"):
-			add("workload_identity", "aws", "workflow_aws_oidc", "aws", "aws_role", "cloud_or_infra_access", "write")
-		case strings.Contains(value, "azure/login"):
-			add("workload_identity", "azure", "workflow_azure_federation", "azure", "azure_federated_credential", "cloud_or_infra_access", "write")
-		case strings.Contains(value, "google-github-actions/auth"), strings.Contains(value, "workload_identity_provider"):
-			add("workload_identity", "gcp", "workflow_gcp_workload_identity", "gcp", "gcp_workload_identity", "cloud_or_infra_access", "write")
-		case strings.Contains(value, "kubectl apply"), strings.Contains(value, "azure/k8s-deploy"), strings.Contains(value, "helm upgrade"), strings.Contains(value, "helm install"):
-			add("deployment_path", "kubernetes", "workflow_kubernetes_deploy", "kubernetes", "cluster_apply", "deploy_write", "write")
-		case strings.Contains(value, "terraform apply"), strings.Contains(value, "terragrunt apply"):
-			add("deployment_path", "terraform", "workflow_terraform_apply", "terraform", "terraform_apply", "infrastructure_apply", "write")
-		case strings.Contains(value, "pulumi up"):
-			add("deployment_path", "pulumi", "workflow_pulumi_up", "pulumi", "pulumi_up", "infrastructure_apply", "write")
-		case strings.Contains(value, "gcloud run deploy"):
-			add("deployment_path", "gcp", "workflow_gcloud_run_deploy", "gcp", "cloud_run", "deploy_write", "write")
-		case strings.Contains(value, "aws ecs update-service"), strings.Contains(value, "amazon-ecs-deploy-task-definition"):
-			add("deployment_path", "aws", "workflow_ecs_deploy", "aws", "ecs_service", "deploy_write", "write")
-		case strings.Contains(value, "vercel deploy --prod"):
-			add("service_connection", "vercel", "workflow_vercel_token", "deployment_platform", "vercel", "deploy_write", "write")
-		case strings.Contains(value, "netlify deploy --prod"):
-			add("service_connection", "netlify", "workflow_netlify_token", "deployment_platform", "netlify", "deploy_write", "write")
-		}
-	}
-	sort.Strings(out)
-	return dedupeSlice(out)
+	return workflowAuthorityBindingsFromValues(normalizedStepValues(step, nil), environment, nil)
 }
 
 func dedupeSlice(in []string) []string {

--- a/core/detect/workflowcap/analyze_test.go
+++ b/core/detect/workflowcap/analyze_test.go
@@ -1,6 +1,8 @@
 package workflowcap
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -364,6 +366,140 @@ jobs:
 	}
 	if evidenceValue(result, "target_class_hint") != "release_adjacent" {
 		t.Fatalf("expected release-adjacent hint, got %q", evidenceValue(result, "target_class_hint"))
+	}
+}
+
+func TestAnalyzeGitLabPipelineResolvesLocalIncludesAndManualGate(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".gitlab", "ci"), 0o755); err != nil {
+		t.Fatalf("mkdir gitlab include path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitlab", "ci", "deploy.yml"), []byte(`deploy:
+  stage: deploy
+  when: manual
+  environment:
+    name: production
+  script:
+    - codex --full-auto --approval never
+    - kubectl apply -f k8s/
+    - wrkr evidence --state .wrkr/last-scan.json
+  variables:
+    PROD_DEPLOY_PAT: "$PROD_DEPLOY_PAT"
+`), 0o600); err != nil {
+		t.Fatalf("write gitlab include: %v", err)
+	}
+
+	result, parseErr := AnalyzeInRoot(root, ".gitlab-ci.yml", []byte(`stages:
+  - build
+  - deploy
+include:
+  - local: .gitlab/ci/deploy.yml
+build:
+  stage: build
+  script:
+    - go test ./...
+`))
+	if parseErr != nil {
+		t.Fatalf("analyze gitlab workflow: %v", parseErr)
+	}
+	for _, capability := range []string{"deploy.write"} {
+		if !contains(result.Capabilities, capability) {
+			t.Fatalf("expected capability %q in %v", capability, result.Capabilities)
+		}
+	}
+	if result.Tool != "codex" {
+		t.Fatalf("expected tool codex, got %q", result.Tool)
+	}
+	if !result.Headless {
+		t.Fatal("expected headless detection from gitlab script")
+	}
+	if result.ApprovalSource != "manual_job" {
+		t.Fatalf("expected manual_job approval source, got %q", result.ApprovalSource)
+	}
+	if result.DeploymentGate != "approved" {
+		t.Fatalf("expected approved deployment gate, got %q", result.DeploymentGate)
+	}
+	if evidenceValue(result, "ci_platform") != "gitlab_ci" {
+		t.Fatalf("expected ci_platform=gitlab_ci, got %q", evidenceValue(result, "ci_platform"))
+	}
+	if evidenceValue(result, "include_resolution_status") != "resolved" {
+		t.Fatalf("expected include resolution evidence, got %q", evidenceValue(result, "include_resolution_status"))
+	}
+	if evidenceValue(result, "workflow_environment") != "production" {
+		t.Fatalf("expected production environment evidence, got %q", evidenceValue(result, "workflow_environment"))
+	}
+	if evidenceValue(result, "workflow_secret_refs") != "PROD_DEPLOY_PAT" {
+		t.Fatalf("expected secret ref evidence, got %q", evidenceValue(result, "workflow_secret_refs"))
+	}
+}
+
+func TestAnalyzeAzurePipelineResolvesLocalTemplateAndKeepsApprovalClaimScoped(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".azure", "pipelines"), 0o755); err != nil {
+		t.Fatalf("mkdir azure template path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".azure", "pipelines", "deploy.yml"), []byte(`jobs:
+- deployment: deploy_prod
+  environment: production
+  strategy:
+    runOnce:
+      deploy:
+        steps:
+        - script: codex --full-auto --approval never
+        - script: az webapp deploy --resource-group prod-rg --name api
+        - script: wrkr verify --chain --json
+          env:
+            PROD_DEPLOY_TOKEN: $(PROD_DEPLOY_TOKEN)
+        - task: AzureCLI@2
+          inputs:
+            azureSubscription: prod-service-conn
+            scriptType: bash
+            scriptLocation: inlineScript
+            inlineScript: |
+              az aks get-credentials --name prod-aks --resource-group prod-rg
+`), 0o600); err != nil {
+		t.Fatalf("write azure template: %v", err)
+	}
+
+	result, parseErr := AnalyzeInRoot(root, "azure-pipelines.yml", []byte(`trigger:
+- main
+extends:
+  template: .azure/pipelines/deploy.yml
+variables:
+- group: ProdSecrets
+`))
+	if parseErr != nil {
+		t.Fatalf("analyze azure pipeline: %v", parseErr)
+	}
+	for _, capability := range []string{"deploy.write"} {
+		if !contains(result.Capabilities, capability) {
+			t.Fatalf("expected capability %q in %v", capability, result.Capabilities)
+		}
+	}
+	if result.Tool != "codex" {
+		t.Fatalf("expected tool codex, got %q", result.Tool)
+	}
+	if result.DeploymentGate != "ambiguous" {
+		t.Fatalf("expected ambiguous deployment gate, got %q", result.DeploymentGate)
+	}
+	if evidenceValue(result, "ci_platform") != "azure_devops" {
+		t.Fatalf("expected ci_platform=azure_devops, got %q", evidenceValue(result, "ci_platform"))
+	}
+	if evidenceValue(result, "template_resolution_status") != "resolved" {
+		t.Fatalf("expected template resolution evidence, got %q", evidenceValue(result, "template_resolution_status"))
+	}
+	if evidenceValue(result, "workflow_environment") != "production" {
+		t.Fatalf("expected production environment evidence, got %q", evidenceValue(result, "workflow_environment"))
+	}
+	if !strings.Contains(evidenceValue(result, "auth_surfaces"), "prod-service-conn") {
+		t.Fatalf("expected service connection auth surface, got %q", evidenceValue(result, "auth_surfaces"))
+	}
+	if evidenceValue(result, "workflow_secret_refs") != "PROD_DEPLOY_TOKEN" {
+		t.Fatalf("expected secret ref evidence, got %q", evidenceValue(result, "workflow_secret_refs"))
 	}
 }
 

--- a/core/detect/workflowcap/analyze_test.go
+++ b/core/detect/workflowcap/analyze_test.go
@@ -503,6 +503,79 @@ variables:
 	}
 }
 
+func TestAnalyzeAzurePipelineDoesNotTreatOrdinaryRuntimeVariablesAsSecrets(t *testing.T) {
+	t.Parallel()
+
+	result, parseErr := AnalyzeInRoot("", "azure-pipelines.yml", []byte(`trigger:
+- main
+jobs:
+- job: info
+  steps:
+  - script: |
+      codex --full-auto --approval never
+      echo $(Build.BuildNumber)
+      echo $(System.DefaultWorkingDirectory)
+`))
+	if parseErr != nil {
+		t.Fatalf("analyze azure pipeline: %v", parseErr)
+	}
+	if result.HasSecretAccess {
+		t.Fatalf("did not expect ordinary Azure runtime variables to imply secret access: %+v", result)
+	}
+	if evidenceValue(result, "workflow_secret_refs") != "" {
+		t.Fatalf("did not expect secret ref evidence, got %q", evidenceValue(result, "workflow_secret_refs"))
+	}
+}
+
+func TestAnalyzeGitLabSkipsHiddenTemplateJobsUntilExtended(t *testing.T) {
+	t.Parallel()
+
+	result, parseErr := AnalyzeInRoot("", ".gitlab-ci.yml", []byte(`.deploy_template:
+  stage: deploy
+  script:
+    - kubectl apply -f k8s/
+
+lint:
+  stage: test
+  script:
+    - go test ./...
+`))
+	if parseErr != nil {
+		t.Fatalf("analyze gitlab workflow: %v", parseErr)
+	}
+	if contains(result.Capabilities, "deploy.write") {
+		t.Fatalf("did not expect hidden template job to create deploy authority: %v", result.Capabilities)
+	}
+}
+
+func TestAnalyzeGitLabExtendsHiddenTemplatesAndDefaultScripts(t *testing.T) {
+	t.Parallel()
+
+	result, parseErr := AnalyzeInRoot("", ".gitlab-ci.yml", []byte(`default:
+  before_script:
+    - codex --full-auto --approval never
+
+.deploy_template:
+  stage: deploy
+  script:
+    - kubectl apply -f k8s/
+
+deploy:
+  extends: .deploy_template
+  environment:
+    name: production
+`))
+	if parseErr != nil {
+		t.Fatalf("analyze gitlab workflow: %v", parseErr)
+	}
+	if !result.Headless {
+		t.Fatalf("expected inherited default.before_script to mark headless execution: %+v", result)
+	}
+	if !contains(result.Capabilities, "deploy.write") {
+		t.Fatalf("expected inherited hidden template to project deploy.write, got %v", result.Capabilities)
+	}
+}
+
 func evidenceValue(result Result, key string) string {
 	for _, evidence := range result.Evidence {
 		if evidence.Key == key {

--- a/core/detect/workflowcap/platform_ci.go
+++ b/core/detect/workflowcap/platform_ci.go
@@ -1,0 +1,1289 @@
+package workflowcap
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/Clyra-AI/wrkr/core/detect"
+	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/workflowloc"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	shellVariableRefRE = regexp.MustCompile(`\$(?:\{)?([A-Za-z_][A-Za-z0-9_]*)`)
+	azureVariableRefRE = regexp.MustCompile(`\$\(([A-Za-z0-9_.-]+)\)`)
+)
+
+func AnalyzeInRoot(root, path string, payload []byte) (Result, *model.ParseError) {
+	switch {
+	case workflowloc.IsGitLabEntryPipeline(path):
+		return analyzeGitLabWorkflow(root, path, payload)
+	case workflowloc.IsAzurePipelinePath(path):
+		return analyzeAzureWorkflow(root, path, payload)
+	default:
+		return analyzeGitHubWorkflow(path, payload)
+	}
+}
+
+func appendPlatformEvidence(in []model.Evidence, platform string, confidence string) []model.Evidence {
+	out := append([]model.Evidence(nil), in...)
+	if strings.TrimSpace(platform) != "" {
+		out = append(out, model.Evidence{Key: "ci_platform", Value: strings.TrimSpace(platform)})
+	}
+	if strings.TrimSpace(confidence) != "" {
+		out = append(out, model.Evidence{Key: "parser_confidence", Value: strings.TrimSpace(confidence)})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Key == out[j].Key {
+			return out[i].Value < out[j].Value
+		}
+		return out[i].Key < out[j].Key
+	})
+	return out
+}
+
+func detectToolFromValues(values []string) string {
+	for _, value := range values {
+		switch {
+		case strings.Contains(value, "claude"):
+			return "claude"
+		case strings.Contains(value, "codex"):
+			return "codex"
+		case strings.Contains(value, "copilot"):
+			return "copilot"
+		case strings.Contains(value, "cursor"):
+			return "cursor"
+		case strings.Contains(value, "gait eval --script"):
+			return "gait"
+		}
+	}
+	return ""
+}
+
+func isHeadlessValues(values []string) bool {
+	for _, value := range values {
+		switch {
+		case strings.Contains(value, "claude -p"),
+			strings.Contains(value, "claude code -p"),
+			strings.Contains(value, "codex --full-auto"),
+			strings.Contains(value, "gait eval --script"):
+			return true
+		}
+	}
+	return false
+}
+
+func hasDangerousFlagsValues(values []string) bool {
+	for _, value := range values {
+		switch {
+		case strings.Contains(value, "--dangerouslyskippermissions"),
+			strings.Contains(value, "--dangerously-skip-permissions"),
+			strings.Contains(value, "--approval never"):
+			return true
+		}
+	}
+	return false
+}
+
+func hasSecretAccessValues(values []string) bool {
+	for _, value := range values {
+		if strings.Contains(value, "secrets.") ||
+			strings.Contains(value, "${{ secrets.") ||
+			strings.Contains(value, "github.token") ||
+			strings.Contains(value, "$(") {
+			return true
+		}
+	}
+	return false
+}
+
+func mergeExecuteReasonValues(values []string) string {
+	for _, value := range values {
+		switch {
+		case strings.Contains(value, "gh pr merge"):
+			return "step.run:gh_pr_merge"
+		case strings.Contains(value, "glab mr merge"):
+			return "job.script:glab_mr_merge"
+		case strings.Contains(value, "enable-pull-request-automerge"):
+			return "step.uses:enable_pull_request_automerge"
+		case strings.Contains(value, "automerge-action"):
+			return "step.uses:automerge_action"
+		}
+	}
+	return ""
+}
+
+func deployWriteReasonValues(values []string) string {
+	for _, value := range values {
+		switch {
+		case strings.Contains(value, "kubectl apply"):
+			return "step.run:kubectl_apply"
+		case strings.Contains(value, "helm upgrade"), strings.Contains(value, "helm install"):
+			return "step.run:helm_release"
+		case strings.Contains(value, "terraform apply"):
+			return "step.run:terraform_apply"
+		case strings.Contains(value, "terragrunt apply"):
+			return "step.run:terragrunt_apply"
+		case strings.Contains(value, "pulumi up"):
+			return "step.run:pulumi_up"
+		case strings.Contains(value, "serverless deploy"):
+			return "step.run:serverless_deploy"
+		case strings.Contains(value, "fly deploy"):
+			return "step.run:fly_deploy"
+		case strings.Contains(value, "vercel deploy --prod"):
+			return "step.run:vercel_prod_deploy"
+		case strings.Contains(value, "netlify deploy --prod"):
+			return "step.run:netlify_prod_deploy"
+		case strings.Contains(value, "aws ecs update-service"):
+			return "step.run:aws_ecs_update_service"
+		case strings.Contains(value, "gcloud run deploy"):
+			return "step.run:gcloud_run_deploy"
+		case strings.Contains(value, "az webapp deploy"), strings.Contains(value, "az deployment group create"), strings.Contains(value, "az deployment sub create"):
+			return "step.run:azure_deploy"
+		case strings.Contains(value, "azure/k8s-deploy"):
+			return "step.uses:azure_k8s_deploy"
+		case strings.Contains(value, "amazon-ecs-deploy-task-definition"):
+			return "step.uses:amazon_ecs_deploy"
+		case strings.Contains(value, "deploy-cloudrun"):
+			return "step.uses:deploy_cloudrun"
+		}
+	}
+	return ""
+}
+
+func releaseWriteReasonValues(values []string) string {
+	for _, value := range values {
+		switch {
+		case strings.Contains(value, "goreleaser release"):
+			return "step.run:goreleaser_release"
+		case strings.Contains(value, "gh release create"):
+			return "step.run:gh_release_create"
+		case strings.Contains(value, "glab release create"):
+			return "job.script:glab_release_create"
+		case strings.Contains(value, "softprops/action-gh-release"):
+			return "step.uses:action_gh_release"
+		case strings.Contains(value, "actions/create-release"):
+			return "step.uses:create_release"
+		}
+	}
+	return ""
+}
+
+func packagePublishReasonValues(values []string) string {
+	for _, value := range values {
+		switch {
+		case strings.Contains(value, "npm publish"):
+			return "step.run:npm_publish"
+		case strings.Contains(value, "pnpm publish"):
+			return "step.run:pnpm_publish"
+		case strings.Contains(value, "yarn npm publish"):
+			return "step.run:yarn_npm_publish"
+		case strings.Contains(value, "twine upload"):
+			return "step.run:twine_upload"
+		case strings.Contains(value, "docker push"):
+			return "step.run:docker_push"
+		case strings.Contains(value, "docker/build-push-action"):
+			return "step.uses:docker_build_push_action"
+		case strings.Contains(value, "pypa/gh-action-pypi-publish"):
+			return "step.uses:pypi_publish"
+		}
+	}
+	return ""
+}
+
+func dbWriteReasonValues(values []string) string {
+	for _, value := range values {
+		switch {
+		case strings.Contains(value, "alembic upgrade"):
+			return "step.run:alembic_upgrade"
+		case strings.Contains(value, "prisma migrate deploy"):
+			return "step.run:prisma_migrate_deploy"
+		case strings.Contains(value, "liquibase update"):
+			return "step.run:liquibase_update"
+		case strings.Contains(value, "flyway migrate"):
+			return "step.run:flyway_migrate"
+		case strings.Contains(value, "goose up"):
+			return "step.run:goose_up"
+		case strings.Contains(value, "dbmate up"):
+			return "step.run:dbmate_up"
+		case strings.Contains(value, "rails db:migrate"):
+			return "step.run:rails_db_migrate"
+		case strings.Contains(value, "knex migrate:latest"):
+			return "step.run:knex_migrate_latest"
+		case strings.Contains(value, "sqitch deploy"):
+			return "step.run:sqitch_deploy"
+		}
+	}
+	return ""
+}
+
+func iacWriteReasonValues(values []string) string {
+	for _, value := range values {
+		switch {
+		case strings.Contains(value, "terraform apply"):
+			return "step.run:terraform_apply"
+		case strings.Contains(value, "terragrunt apply"):
+			return "step.run:terragrunt_apply"
+		case strings.Contains(value, "pulumi up"):
+			return "step.run:pulumi_up"
+		case strings.Contains(value, "helm upgrade"), strings.Contains(value, "helm install"):
+			return "step.run:helm_release"
+		}
+	}
+	return ""
+}
+
+func manualApprovalSourceValues(values []string) string {
+	for _, value := range values {
+		if strings.Contains(value, "manual-approval") {
+			return "manual_approval_step"
+		}
+	}
+	return ""
+}
+
+func proofRequirementValues(values []string) string {
+	for _, value := range values {
+		switch {
+		case strings.Contains(value, "wrkr evidence"),
+			strings.Contains(value, "wrkr verify"):
+			return "evidence"
+		case strings.Contains(value, "cosign attest"),
+			strings.Contains(value, "attest-build-provenance"),
+			strings.Contains(value, "slsa-github-generator"),
+			strings.Contains(value, "gh attestation"),
+			strings.Contains(value, "slsa-verifier"):
+			return "attestation"
+		}
+	}
+	return ""
+}
+
+func workflowAuthSurfacesFromValues(values []string, refs []string, explicit []string) []string {
+	out := map[string]struct{}{}
+	for _, value := range values {
+		switch {
+		case strings.Contains(value, "aws-actions/configure-aws-credentials"), strings.Contains(value, "role-to-assume"), strings.Contains(value, "assume_role"):
+			out["aws_oidc"] = struct{}{}
+		case strings.Contains(value, "azure/login"), strings.Contains(value, "federatedcredential"), strings.Contains(value, "service connection"):
+			out["azure_federated_credential"] = struct{}{}
+		case strings.Contains(value, "google-github-actions/auth"), strings.Contains(value, "workload_identity_provider"), strings.Contains(value, "service_account"):
+			out["gcp_workload_identity"] = struct{}{}
+		case strings.Contains(value, "kubectl"), strings.Contains(value, "helm"):
+			out["kubernetes_rbac"] = struct{}{}
+		}
+	}
+	for _, ref := range append(append([]string(nil), refs...), explicit...) {
+		if strings.TrimSpace(ref) != "" {
+			out[strings.TrimSpace(ref)] = struct{}{}
+		}
+	}
+	return sortedSet(out)
+}
+
+func workflowAuthorityBindingsFromValues(values []string, environment string, explicit []string) []string {
+	production := workflowEnvironmentSuggestsProduction([]string{environment})
+	out := append([]string(nil), explicit...)
+	add := func(kind, provider, subject, targetSystem, resource, scope, access string) {
+		out = append(out, strings.Join([]string{
+			kind,
+			provider,
+			subject,
+			targetSystem,
+			resource,
+			scope,
+			access,
+			environment,
+			strconv.FormatBool(production),
+			"high",
+		}, "|"))
+	}
+	for _, value := range values {
+		switch {
+		case strings.Contains(value, "aws-actions/configure-aws-credentials"), strings.Contains(value, "role-to-assume"), strings.Contains(value, "assume_role"):
+			add("workload_identity", "aws", "workflow_aws_oidc", "aws", "aws_role", "cloud_or_infra_access", "write")
+		case strings.Contains(value, "azure/login"):
+			add("workload_identity", "azure", "workflow_azure_federation", "azure", "azure_federated_credential", "cloud_or_infra_access", "write")
+		case strings.Contains(value, "google-github-actions/auth"), strings.Contains(value, "workload_identity_provider"):
+			add("workload_identity", "gcp", "workflow_gcp_workload_identity", "gcp", "gcp_workload_identity", "cloud_or_infra_access", "write")
+		case strings.Contains(value, "kubectl apply"), strings.Contains(value, "azure/k8s-deploy"), strings.Contains(value, "helm upgrade"), strings.Contains(value, "helm install"):
+			add("deployment_path", "kubernetes", "workflow_kubernetes_deploy", "kubernetes", "cluster_apply", "deploy_write", "write")
+		case strings.Contains(value, "terraform apply"), strings.Contains(value, "terragrunt apply"):
+			add("deployment_path", "terraform", "workflow_terraform_apply", "terraform", "terraform_apply", "infrastructure_apply", "write")
+		case strings.Contains(value, "pulumi up"):
+			add("deployment_path", "pulumi", "workflow_pulumi_up", "pulumi", "pulumi_up", "infrastructure_apply", "write")
+		case strings.Contains(value, "gcloud run deploy"):
+			add("deployment_path", "gcp", "workflow_gcloud_run_deploy", "gcp", "cloud_run", "deploy_write", "write")
+		case strings.Contains(value, "aws ecs update-service"), strings.Contains(value, "amazon-ecs-deploy-task-definition"):
+			add("deployment_path", "aws", "workflow_ecs_deploy", "aws", "ecs_service", "deploy_write", "write")
+		case strings.Contains(value, "vercel deploy --prod"):
+			add("service_connection", "vercel", "workflow_vercel_token", "deployment_platform", "vercel", "deploy_write", "write")
+		case strings.Contains(value, "netlify deploy --prod"):
+			add("service_connection", "netlify", "workflow_netlify_token", "deployment_platform", "netlify", "deploy_write", "write")
+		}
+	}
+	sort.Strings(out)
+	return dedupeSlice(out)
+}
+
+func extractShellVariableRefs(values ...string) []string {
+	refs := map[string]struct{}{}
+	for _, value := range values {
+		for _, match := range shellVariableRefRE.FindAllStringSubmatch(value, -1) {
+			if len(match) > 1 {
+				name := strings.TrimSpace(match[1])
+				if name != "" {
+					refs[name] = struct{}{}
+				}
+			}
+		}
+		for _, match := range azureVariableRefRE.FindAllStringSubmatch(value, -1) {
+			if len(match) > 1 {
+				name := strings.TrimSpace(match[1])
+				if name != "" {
+					refs[name] = struct{}{}
+				}
+			}
+		}
+	}
+	return sortedSet(refs)
+}
+
+type jobObservation struct {
+	name              string
+	environment       string
+	values            []string
+	secretRefs        []string
+	authSurfaces      []string
+	authorityBindings []string
+	manualStrong      bool
+	manualDeclared    bool
+	ambiguousApproval bool
+	stepCount         int
+}
+
+type workflowObservation struct {
+	platform         string
+	workflowName     string
+	triggers         []string
+	jobNames         []string
+	environments     []string
+	jobs             []jobObservation
+	resolutionKey    string
+	resolutionStatus string
+}
+
+func analyzeObservation(obs workflowObservation) Result {
+	result := Result{
+		WorkflowName:     strings.TrimSpace(obs.workflowName),
+		Triggers:         dedupeSlice(obs.triggers),
+		JobNames:         dedupeSlice(obs.jobNames),
+		EnvironmentNames: dedupeSlice(obs.environments),
+	}
+
+	capabilityReasons := map[string]map[string]struct{}{}
+	approvalSources := map[string]struct{}{}
+	deploymentGates := map[string]struct{}{}
+	proofRequirements := map[string]struct{}{}
+	secretRefs := map[string]struct{}{}
+	authSurfaces := map[string]struct{}{}
+	authorityBindings := map[string]struct{}{}
+	hasDeliverySurface := false
+	partialResolution := strings.TrimSpace(obs.resolutionStatus) == "partial"
+
+	for _, job := range obs.jobs {
+		result.StepCount += job.stepCount
+		jobTool := detectToolFromValues(job.values)
+		jobHeadless := isHeadlessValues(job.values)
+		jobDangerous := hasDangerousFlagsValues(job.values)
+		jobSecretAccess := hasSecretAccessValues(job.values) || len(job.secretRefs) > 0
+		if result.Tool == "" {
+			result.Tool = jobTool
+		}
+		if jobHeadless {
+			result.Headless = true
+		}
+		if jobDangerous {
+			result.DangerousFlags = true
+		}
+		if jobSecretAccess {
+			result.HasSecretAccess = true
+		}
+		for _, ref := range job.secretRefs {
+			secretRefs[ref] = struct{}{}
+		}
+		for _, surface := range job.authSurfaces {
+			authSurfaces[surface] = struct{}{}
+		}
+		for _, binding := range job.authorityBindings {
+			authorityBindings[binding] = struct{}{}
+		}
+
+		jobHasDeliverySurface := false
+		jobHasGovernanceSurface := jobTool != "" || jobHeadless || jobDangerous || job.manualDeclared || jobSecretAccess
+		if reason := mergeExecuteReasonValues(job.values); reason != "" {
+			addCapabilityReason(capabilityReasons, "merge.execute", reason)
+			jobHasDeliverySurface = true
+			hasDeliverySurface = true
+		}
+		if reason := releaseWriteReasonValues(job.values); reason != "" {
+			addCapabilityReason(capabilityReasons, "release.write", reason)
+			jobHasDeliverySurface = true
+			hasDeliverySurface = true
+		}
+		if reason := packagePublishReasonValues(job.values); reason != "" {
+			addCapabilityReason(capabilityReasons, "package.write", reason)
+			jobHasDeliverySurface = true
+			hasDeliverySurface = true
+		}
+		if reason := deployWriteReasonValues(job.values); reason != "" {
+			addCapabilityReason(capabilityReasons, "deploy.write", reason)
+			jobHasDeliverySurface = true
+			hasDeliverySurface = true
+		}
+		if reason := dbWriteReasonValues(job.values); reason != "" {
+			addCapabilityReason(capabilityReasons, "db.write", reason)
+			jobHasDeliverySurface = true
+			hasDeliverySurface = true
+		}
+		if reason := iacWriteReasonValues(job.values); reason != "" {
+			addCapabilityReason(capabilityReasons, "iac.write", reason)
+			jobHasDeliverySurface = true
+			hasDeliverySurface = true
+		}
+
+		jobApprovalSource := ""
+		jobDeploymentGate := ""
+		switch {
+		case job.manualStrong:
+			jobApprovalSource = "manual_job"
+			jobDeploymentGate = "approved"
+			result.HasApprovalGate = true
+		case job.manualDeclared || job.ambiguousApproval || partialResolution:
+			jobApprovalSource = "ambiguous"
+			jobDeploymentGate = "ambiguous"
+		}
+
+		if jobHasDeliverySurface || jobHasGovernanceSurface {
+			if jobHasDeliverySurface && jobDeploymentGate == "" {
+				jobDeploymentGate = "open"
+			}
+			if requirement := proofRequirementValues(job.values); requirement != "" {
+				proofRequirements[requirement] = struct{}{}
+			} else if jobHasDeliverySurface {
+				proofRequirements["missing"] = struct{}{}
+			}
+			if jobApprovalSource == "" && (jobHasDeliverySurface || jobHasGovernanceSurface) {
+				jobApprovalSource = "missing"
+			}
+			if jobApprovalSource != "" {
+				approvalSources[jobApprovalSource] = struct{}{}
+			}
+			if jobHasDeliverySurface && jobDeploymentGate != "" {
+				deploymentGates[jobDeploymentGate] = struct{}{}
+			}
+		}
+	}
+
+	if hasDeliverySurface && len(proofRequirements) == 0 {
+		proofRequirements["missing"] = struct{}{}
+	}
+
+	result.Capabilities = sortedKeys(capabilityReasons)
+	result.ApprovalSource = chooseApprovalSource(approvalSources)
+	result.DeploymentGate = chooseDeploymentGate(deploymentGates)
+	result.ProofRequirement = chooseProofRequirement(proofRequirements)
+	result.HasApprovalGate = result.HasApprovalGate || result.DeploymentGate == "approved"
+
+	evidence := make([]model.Evidence, 0, len(result.Capabilities)+12)
+	if len(result.Capabilities) > 0 {
+		evidence = append(evidence, model.Evidence{Key: "workflow_capabilities", Value: strings.Join(result.Capabilities, ",")})
+		for _, capability := range result.Capabilities {
+			evidence = append(evidence, model.Evidence{
+				Key:   "workflow_capability." + capability,
+				Value: strings.Join(sortedSet(capabilityReasons[capability]), ","),
+			})
+		}
+	}
+	if len(result.Triggers) > 0 {
+		evidence = append(evidence, model.Evidence{Key: "workflow_triggers", Value: strings.Join(result.Triggers, ",")})
+	}
+	if strings.TrimSpace(result.WorkflowName) != "" {
+		evidence = append(evidence, model.Evidence{Key: "workflow_name", Value: result.WorkflowName})
+	}
+	if len(result.JobNames) > 0 {
+		evidence = append(evidence, model.Evidence{Key: "workflow_jobs", Value: strings.Join(result.JobNames, ",")})
+	}
+	if len(result.EnvironmentNames) > 0 {
+		evidence = append(evidence, model.Evidence{Key: "workflow_environment", Value: strings.Join(result.EnvironmentNames, ",")})
+	}
+	if strings.TrimSpace(obs.resolutionKey) != "" && strings.TrimSpace(obs.resolutionStatus) != "" {
+		evidence = append(evidence, model.Evidence{Key: obs.resolutionKey, Value: strings.TrimSpace(obs.resolutionStatus)})
+	}
+	if result.ApprovalSource != "" {
+		evidence = append(evidence, model.Evidence{Key: "approval_source", Value: result.ApprovalSource})
+	}
+	if result.DeploymentGate != "" {
+		evidence = append(evidence, model.Evidence{Key: "deployment_gate", Value: result.DeploymentGate})
+	}
+	if result.ProofRequirement != "" {
+		evidence = append(evidence, model.Evidence{Key: "proof_requirement", Value: result.ProofRequirement})
+	}
+	if targetClassHint := workflowTargetClassHint(result); targetClassHint != "" {
+		evidence = append(evidence, model.Evidence{Key: "target_class_hint", Value: targetClassHint})
+	}
+	for _, ref := range sortedSet(secretRefs) {
+		evidence = append(evidence, model.Evidence{Key: "workflow_secret_refs", Value: ref})
+	}
+	if len(authSurfaces) > 0 {
+		evidence = append(evidence, model.Evidence{Key: "auth_surfaces", Value: strings.Join(sortedSet(authSurfaces), ",")})
+	}
+	for _, binding := range sortedSet(authorityBindings) {
+		evidence = append(evidence, model.Evidence{Key: "authority_binding", Value: binding})
+	}
+	result.Evidence = appendPlatformEvidence(evidence, obs.platform, "high")
+	return result
+}
+
+type stringListField []string
+
+func (s *stringListField) UnmarshalYAML(node *yaml.Node) error {
+	*s = nil
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		value := strings.TrimSpace(node.Value)
+		if value != "" {
+			*s = []string{value}
+		}
+		return nil
+	case yaml.SequenceNode:
+		values := make([]string, 0, len(node.Content))
+		for _, child := range node.Content {
+			value := strings.TrimSpace(child.Value)
+			if value != "" {
+				values = append(values, value)
+			}
+		}
+		*s = values
+		return nil
+	default:
+		return fmt.Errorf("unsupported string list shape")
+	}
+}
+
+type gitlabDocument struct {
+	Name         string                 `yaml:"name"`
+	Stages       stringListField        `yaml:"stages"`
+	Variables    map[string]any         `yaml:"variables"`
+	Include      yaml.Node              `yaml:"include"`
+	Workflow     yaml.Node              `yaml:"workflow"`
+	Default      gitlabDefaults         `yaml:"default"`
+	BeforeScript stringListField        `yaml:"before_script"`
+	AfterScript  stringListField        `yaml:"after_script"`
+	Image        any                    `yaml:"image"`
+	Services     []any                  `yaml:"services"`
+	Raw          map[string]*yaml.Node  `yaml:",inline"`
+}
+
+type gitlabDefaults struct {
+	BeforeScript stringListField `yaml:"before_script"`
+	AfterScript  stringListField `yaml:"after_script"`
+	Image        any             `yaml:"image"`
+	Services     []any           `yaml:"services"`
+}
+
+type gitlabJob struct {
+	Stage        string            `yaml:"stage"`
+	Script       stringListField   `yaml:"script"`
+	BeforeScript stringListField   `yaml:"before_script"`
+	AfterScript  stringListField   `yaml:"after_script"`
+	Variables    map[string]any    `yaml:"variables"`
+	Environment  environmentField  `yaml:"environment"`
+	When         string            `yaml:"when"`
+	Rules        []gitlabRule      `yaml:"rules"`
+	Only         any               `yaml:"only"`
+	Except       any               `yaml:"except"`
+	Image        any               `yaml:"image"`
+	Services     []any             `yaml:"services"`
+	Needs        []any             `yaml:"needs"`
+	Dependencies []any             `yaml:"dependencies"`
+	Artifacts    map[string]any    `yaml:"artifacts"`
+	Release      map[string]any    `yaml:"release"`
+}
+
+type gitlabRule struct {
+	When string `yaml:"when"`
+	If   string `yaml:"if"`
+}
+
+func analyzeGitLabWorkflow(root, path string, payload []byte) (Result, *model.ParseError) {
+	obs := workflowObservation{
+		platform:      "gitlab_ci",
+		workflowName:  strings.TrimSpace(filepath.Base(path)),
+		resolutionKey: "include_resolution_status",
+	}
+	loadErr := loadGitLabDocument(root, path, payload, map[string]struct{}{}, &obs)
+	if strings.TrimSpace(obs.resolutionStatus) == "" {
+		obs.resolutionStatus = "not_present"
+	}
+	return analyzeObservation(obs), loadErr
+}
+
+func loadGitLabDocument(root, path string, payload []byte, stack map[string]struct{}, obs *workflowObservation) *model.ParseError {
+	normalizedPath := workflowloc.Normalize(path)
+	if _, ok := stack[normalizedPath]; ok {
+		obs.resolutionStatus = "partial"
+		return &model.ParseError{Kind: "schema_validation_error", Format: "yaml", Path: path, Detector: detectorID, Message: "cyclic local include"}
+	}
+	stack[normalizedPath] = struct{}{}
+	defer delete(stack, normalizedPath)
+
+	var doc gitlabDocument
+	if err := yaml.Unmarshal(payload, &doc); err != nil {
+		return &model.ParseError{Kind: "parse_error", Format: "yaml", Path: path, Detector: detectorID, Message: err.Error()}
+	}
+	if strings.TrimSpace(doc.Name) != "" {
+		obs.workflowName = strings.TrimSpace(doc.Name)
+	}
+	obs.triggers = append(obs.triggers, gitlabTriggerHints(doc.Workflow)...)
+	var firstErr *model.ParseError
+
+	if len(doc.Include.Content) > 0 {
+		if obs.resolutionStatus == "" || obs.resolutionStatus == "not_present" {
+			obs.resolutionStatus = "resolved"
+		}
+		for _, includeRef := range gitlabIncludeRefs(&doc.Include) {
+			if includeRef.kind != "local" {
+				obs.resolutionStatus = "partial"
+				if firstErr == nil {
+					firstErr = &model.ParseError{Kind: "schema_validation_error", Format: "yaml", Path: path, Detector: detectorID, Message: "unsupported remote include"}
+				}
+				continue
+			}
+			if strings.TrimSpace(root) == "" {
+				obs.resolutionStatus = "partial"
+				if firstErr == nil {
+					firstErr = &model.ParseError{Kind: "schema_validation_error", Format: "yaml", Path: path, Detector: detectorID, Message: "local include requires scan root"}
+				}
+				continue
+			}
+			rel := normalizeGitLabLocalPath(includeRef.path)
+			childPayload, parseErr := detect.ReadFileWithinRoot(detectorID, root, rel)
+			if parseErr != nil {
+				obs.resolutionStatus = "partial"
+				parseErr.Path = path
+				if parseErr.Message == "" {
+					parseErr.Message = "failed to resolve local include"
+				}
+				if firstErr == nil {
+					firstErr = parseErr
+				}
+				continue
+			}
+			if childErr := loadGitLabDocument(root, rel, childPayload, stack, obs); childErr != nil {
+				obs.resolutionStatus = "partial"
+				childErr.Path = path
+				if firstErr == nil {
+					firstErr = childErr
+				}
+			}
+		}
+	}
+
+	rootNode, err := yamlDocumentNode(payload)
+	if err != nil {
+		return &model.ParseError{Kind: "parse_error", Format: "yaml", Path: path, Detector: detectorID, Message: err.Error()}
+	}
+	for key, value := range mappingChildren(rootNode) {
+		if isGitLabReservedKey(key) {
+			continue
+		}
+		var job gitlabJob
+		if decodeErr := value.Decode(&job); decodeErr != nil {
+			obs.resolutionStatus = "partial"
+			if firstErr == nil {
+				firstErr = &model.ParseError{Kind: "parse_error", Format: "yaml", Path: path, Detector: detectorID, Message: decodeErr.Error()}
+			}
+			continue
+		}
+		jobObs := observeGitLabJob(key, doc, job)
+		obs.jobNames = append(obs.jobNames, jobObs.name)
+		if strings.TrimSpace(jobObs.environment) != "" {
+			obs.environments = append(obs.environments, jobObs.environment)
+		}
+		obs.jobs = append(obs.jobs, jobObs)
+	}
+	return firstErr
+}
+
+func observeGitLabJob(name string, doc gitlabDocument, job gitlabJob) jobObservation {
+	values := []string{strings.ToLower(strings.TrimSpace(name)), strings.ToLower(strings.TrimSpace(job.Stage))}
+	values = append(values, normalizeStringList(doc.BeforeScript)...)
+	values = append(values, normalizeStringList(job.BeforeScript)...)
+	values = append(values, normalizeStringList(job.Script)...)
+	values = append(values, normalizeStringList(job.AfterScript)...)
+	values = append(values, normalizeStringList(doc.AfterScript)...)
+	values = append(values, normalizeDynamicValues(job.Release)...)
+	values = append(values, normalizeDynamicValues(job.Artifacts)...)
+	values = append(values, normalizeStringSlice(job.Services)...)
+	values = append(values, normalizeDynamicValue(job.Image)...)
+	values = append(values, normalizeDynamicValue(doc.Image)...)
+	values = append(values, normalizeStringSlice(job.Dependencies)...)
+	values = append(values, normalizeStringSlice(job.Needs)...)
+	values = append(values, strings.ToLower(strings.TrimSpace(job.When)))
+	for _, rule := range job.Rules {
+		values = append(values, strings.ToLower(strings.TrimSpace(rule.When)))
+		values = append(values, strings.ToLower(strings.TrimSpace(rule.If)))
+	}
+	for _, key := range sortedMapKeys(job.Variables) {
+		values = append(values, strings.ToLower(strings.TrimSpace(key)))
+		values = append(values, extractShellVariableRefs(fmt.Sprint(job.Variables[key]))...)
+	}
+
+	secretRefs := map[string]struct{}{}
+	for _, ref := range extractShellVariableRefs(strings.Join(normalizeStringList(job.Script), "\n"), strings.Join(normalizeStringList(job.BeforeScript), "\n"), strings.Join(normalizeStringList(job.AfterScript), "\n")) {
+		if sensitiveCredentialName(ref) {
+			secretRefs[ref] = struct{}{}
+		}
+	}
+	for _, key := range sortedMapKeys(job.Variables) {
+		if sensitiveCredentialName(key) {
+			secretRefs[key] = struct{}{}
+		}
+	}
+	manualDeclared := strings.EqualFold(strings.TrimSpace(job.When), "manual")
+	manualStrong := manualDeclared
+	ambiguousApproval := false
+	for _, rule := range job.Rules {
+		if strings.EqualFold(strings.TrimSpace(rule.When), "manual") {
+			manualDeclared = true
+			if strings.TrimSpace(rule.If) == "" {
+				manualStrong = true
+			} else {
+				ambiguousApproval = true
+			}
+		}
+	}
+	authSurfaces := workflowAuthSurfacesFromValues(values, sortedSet(secretRefs), nil)
+	bindings := workflowAuthorityBindingsFromValues(values, job.Environment.Name, nil)
+	return jobObservation{
+		name:              strings.TrimSpace(name),
+		environment:       strings.TrimSpace(job.Environment.Name),
+		values:            dedupeSlice(values),
+		secretRefs:        sortedSet(secretRefs),
+		authSurfaces:      authSurfaces,
+		authorityBindings: bindings,
+		manualStrong:      manualStrong,
+		manualDeclared:    manualDeclared,
+		ambiguousApproval: ambiguousApproval,
+		stepCount:         len(job.Script) + len(job.BeforeScript) + len(job.AfterScript),
+	}
+}
+
+type gitlabIncludeRef struct {
+	kind string
+	path string
+}
+
+func gitlabIncludeRefs(node *yaml.Node) []gitlabIncludeRef {
+	if node == nil || len(node.Content) == 0 {
+		return nil
+	}
+	work := node
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		work = node.Content[0]
+	}
+	out := []gitlabIncludeRef{}
+	add := func(kind, path string) {
+		out = append(out, gitlabIncludeRef{kind: strings.TrimSpace(kind), path: strings.TrimSpace(path)})
+	}
+	switch work.Kind {
+	case yaml.ScalarNode:
+		add("local", work.Value)
+	case yaml.SequenceNode:
+		for _, child := range work.Content {
+			out = append(out, gitlabIncludeRefs(child)...)
+		}
+	case yaml.MappingNode:
+		mapping := mappingChildren(work)
+		switch {
+		case strings.TrimSpace(mappingValue(mapping, "local")) != "":
+			add("local", mappingValue(mapping, "local"))
+		case strings.TrimSpace(mappingValue(mapping, "file")) != "" && strings.TrimSpace(mappingValue(mapping, "project")) == "":
+			add("local", mappingValue(mapping, "file"))
+		default:
+			add("remote", firstNonEmptyString(mappingValue(mapping, "remote"), mappingValue(mapping, "project"), mappingValue(mapping, "template"), mappingValue(mapping, "component"), "remote"))
+		}
+	}
+	return out
+}
+
+func gitlabTriggerHints(node yaml.Node) []string {
+	work := &node
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		work = node.Content[0]
+	}
+	if work == nil || work.Kind == 0 {
+		return nil
+	}
+	triggers := map[string]struct{}{}
+	switch work.Kind {
+	case yaml.MappingNode:
+		for key, value := range mappingChildren(work) {
+			if strings.EqualFold(key, "rules") {
+				for _, item := range value.Content {
+					for childKey, childValue := range mappingChildren(item) {
+						if strings.EqualFold(childKey, "if") && strings.TrimSpace(childValue.Value) != "" {
+							triggers["conditional"] = struct{}{}
+						}
+						if strings.EqualFold(childKey, "when") && strings.EqualFold(strings.TrimSpace(childValue.Value), "manual") {
+							triggers["manual"] = struct{}{}
+						}
+					}
+				}
+			}
+		}
+	}
+	if len(triggers) == 0 {
+		triggers["push"] = struct{}{}
+	}
+	return sortedSet(triggers)
+}
+
+func isGitLabReservedKey(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "name", "stages", "variables", "include", "workflow", "default", "before_script", "after_script", "image", "services", "cache", "pages":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeGitLabLocalPath(path string) string {
+	path = filepath.ToSlash(strings.TrimSpace(path))
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimPrefix(path, "./")
+	return filepath.ToSlash(filepath.Clean(path))
+}
+
+type azureDocument struct {
+	Name      string            `yaml:"name"`
+	Trigger   triggerField      `yaml:"trigger"`
+	PR        triggerField      `yaml:"pr"`
+	Variables yaml.Node         `yaml:"variables"`
+	Extends   azureTemplateRef  `yaml:"extends"`
+	Stages    []azureStage      `yaml:"stages"`
+	Jobs      []azureJob        `yaml:"jobs"`
+	Steps     []azureStep       `yaml:"steps"`
+}
+
+type azureTemplateRef struct {
+	Template string `yaml:"template"`
+}
+
+type azureStage struct {
+	Stage     string           `yaml:"stage"`
+	Template  string           `yaml:"template"`
+	Jobs      []azureJob       `yaml:"jobs"`
+	Variables yaml.Node        `yaml:"variables"`
+}
+
+type azureJob struct {
+	Job         string          `yaml:"job"`
+	Deployment  string          `yaml:"deployment"`
+	Template    string          `yaml:"template"`
+	Environment environmentField `yaml:"environment"`
+	Steps       []azureStep     `yaml:"steps"`
+	Strategy    azureStrategy   `yaml:"strategy"`
+	Variables   yaml.Node       `yaml:"variables"`
+}
+
+type azureStrategy struct {
+	RunOnce struct {
+		Deploy struct {
+			Steps []azureStep `yaml:"steps"`
+		} `yaml:"deploy"`
+	} `yaml:"runOnce"`
+}
+
+type azureStep struct {
+	DisplayName string            `yaml:"displayName"`
+	Script      string            `yaml:"script"`
+	Bash        string            `yaml:"bash"`
+	Pwsh        string            `yaml:"pwsh"`
+	Cmd         string            `yaml:"cmd"`
+	Task        string            `yaml:"task"`
+	Template    string            `yaml:"template"`
+	Inputs      map[string]any    `yaml:"inputs"`
+	Env         map[string]string `yaml:"env"`
+}
+
+func analyzeAzureWorkflow(root, path string, payload []byte) (Result, *model.ParseError) {
+	obs := workflowObservation{
+		platform:      "azure_devops",
+		workflowName:  strings.TrimSpace(filepath.Base(path)),
+		resolutionKey: "template_resolution_status",
+	}
+	loadErr := loadAzureDocument(root, path, payload, map[string]struct{}{}, &obs)
+	if strings.TrimSpace(obs.resolutionStatus) == "" {
+		obs.resolutionStatus = "not_present"
+	}
+	return analyzeObservation(obs), loadErr
+}
+
+func loadAzureDocument(root, path string, payload []byte, stack map[string]struct{}, obs *workflowObservation) *model.ParseError {
+	normalizedPath := workflowloc.Normalize(path)
+	if _, ok := stack[normalizedPath]; ok {
+		obs.resolutionStatus = "partial"
+		return &model.ParseError{Kind: "schema_validation_error", Format: "yaml", Path: path, Detector: detectorID, Message: "cyclic local template"}
+	}
+	stack[normalizedPath] = struct{}{}
+	defer delete(stack, normalizedPath)
+
+	var doc azureDocument
+	if err := yaml.Unmarshal(payload, &doc); err != nil {
+		return &model.ParseError{Kind: "parse_error", Format: "yaml", Path: path, Detector: detectorID, Message: err.Error()}
+	}
+	if strings.TrimSpace(doc.Name) != "" {
+		obs.workflowName = strings.TrimSpace(doc.Name)
+	}
+	obs.triggers = append(obs.triggers, doc.Trigger.Names...)
+	if len(doc.PR.Names) > 0 {
+		for _, trigger := range doc.PR.Names {
+			if strings.TrimSpace(trigger) != "" {
+				obs.triggers = append(obs.triggers, "pull_request")
+			}
+		}
+	}
+	var firstErr *model.ParseError
+
+	templateRefs := collectAzureTemplateRefs(doc)
+	if len(templateRefs) > 0 {
+		if obs.resolutionStatus == "" || obs.resolutionStatus == "not_present" {
+			obs.resolutionStatus = "resolved"
+		}
+		for _, ref := range templateRefs {
+			if strings.Contains(ref, "@") || strings.Contains(ref, "${{") || strings.Contains(ref, "$(") {
+				obs.resolutionStatus = "partial"
+				if firstErr == nil {
+					firstErr = &model.ParseError{Kind: "schema_validation_error", Format: "yaml", Path: path, Detector: detectorID, Message: "unsupported remote template"}
+				}
+				continue
+			}
+			if strings.TrimSpace(root) == "" {
+				obs.resolutionStatus = "partial"
+				if firstErr == nil {
+					firstErr = &model.ParseError{Kind: "schema_validation_error", Format: "yaml", Path: path, Detector: detectorID, Message: "local template requires scan root"}
+				}
+				continue
+			}
+			rel := normalizeAzureTemplatePath(path, ref)
+			childPayload, parseErr := detect.ReadFileWithinRoot(detectorID, root, rel)
+			if parseErr != nil {
+				obs.resolutionStatus = "partial"
+				parseErr.Path = path
+				if firstErr == nil {
+					firstErr = parseErr
+				}
+				continue
+			}
+			if childErr := loadAzureDocument(root, rel, childPayload, stack, obs); childErr != nil {
+				obs.resolutionStatus = "partial"
+				childErr.Path = path
+				if firstErr == nil {
+					firstErr = childErr
+				}
+			}
+		}
+	}
+
+	variableNames, variableGroups := extractAzureVariables(&doc.Variables)
+	_ = variableNames
+	jobs := observeAzureJobs(doc, variableGroups)
+	for _, job := range jobs {
+		obs.jobNames = append(obs.jobNames, job.name)
+		if strings.TrimSpace(job.environment) != "" {
+			obs.environments = append(obs.environments, job.environment)
+		}
+		obs.jobs = append(obs.jobs, job)
+	}
+	return firstErr
+}
+
+func observeAzureJobs(doc azureDocument, variableGroups []string) []jobObservation {
+	out := []jobObservation{}
+	if len(doc.Jobs) > 0 {
+		for _, job := range doc.Jobs {
+			out = append(out, observeAzureJob(job, variableGroups)...)
+		}
+	}
+	for _, stage := range doc.Stages {
+		stageVars, stageGroups := extractAzureVariables(&stage.Variables)
+		_ = stageVars
+		groups := dedupeSlice(append(append([]string(nil), variableGroups...), stageGroups...))
+		for _, job := range stage.Jobs {
+			out = append(out, observeAzureJob(job, groups)...)
+		}
+	}
+	if len(doc.Steps) > 0 {
+		out = append(out, newAzureJobObservation("pipeline", "", doc.Steps, variableGroups, false))
+	}
+	return out
+}
+
+func observeAzureJob(job azureJob, variableGroups []string) []jobObservation {
+	jobName := firstNonEmptyString(job.Deployment, job.Job, "job")
+	steps := append([]azureStep(nil), job.Steps...)
+	if len(job.Strategy.RunOnce.Deploy.Steps) > 0 {
+		steps = append(steps, job.Strategy.RunOnce.Deploy.Steps...)
+	}
+	jobVariableNames, jobGroups := extractAzureVariables(&job.Variables)
+	_ = jobVariableNames
+	groups := dedupeSlice(append(append([]string(nil), variableGroups...), jobGroups...))
+	return []jobObservation{newAzureJobObservation(jobName, job.Environment.Name, steps, groups, strings.TrimSpace(job.Environment.Name) != "")}
+}
+
+func newAzureJobObservation(name, environment string, steps []azureStep, variableGroups []string, ambiguousApproval bool) jobObservation {
+	values := []string{strings.ToLower(strings.TrimSpace(name)), strings.ToLower(strings.TrimSpace(environment))}
+	secretRefs := map[string]struct{}{}
+	serviceConnections := []string{}
+	for _, group := range variableGroups {
+		values = append(values, strings.ToLower(strings.TrimSpace(group)))
+	}
+	for _, step := range steps {
+		values = append(values, strings.ToLower(strings.TrimSpace(step.DisplayName)))
+		values = append(values, strings.ToLower(strings.TrimSpace(step.Script)))
+		values = append(values, strings.ToLower(strings.TrimSpace(step.Bash)))
+		values = append(values, strings.ToLower(strings.TrimSpace(step.Pwsh)))
+		values = append(values, strings.ToLower(strings.TrimSpace(step.Cmd)))
+		values = append(values, strings.ToLower(strings.TrimSpace(step.Task)))
+		values = append(values, normalizeDynamicValues(step.Inputs)...)
+		for key, value := range step.Env {
+			values = append(values, strings.ToLower(strings.TrimSpace(key)))
+			values = append(values, strings.ToLower(strings.TrimSpace(value)))
+			if sensitiveCredentialName(key) {
+				secretRefs[strings.TrimSpace(key)] = struct{}{}
+			}
+			for _, ref := range extractShellVariableRefs(value) {
+				if sensitiveCredentialName(ref) {
+					secretRefs[ref] = struct{}{}
+				}
+			}
+		}
+		for _, ref := range extractShellVariableRefs(step.Script, step.Bash, step.Pwsh, step.Cmd, fmt.Sprint(step.Inputs)) {
+			if sensitiveCredentialName(ref) {
+				secretRefs[ref] = struct{}{}
+			}
+		}
+		for key, value := range step.Inputs {
+			lowerKey := strings.ToLower(strings.TrimSpace(key))
+			if strings.Contains(lowerKey, "azuresubscription") ||
+				strings.Contains(lowerKey, "connectedservice") ||
+				strings.Contains(lowerKey, "serviceconnection") {
+				serviceConnections = append(serviceConnections, strings.TrimSpace(fmt.Sprint(value)))
+			}
+		}
+	}
+	explicitBindings := []string{}
+	production := workflowEnvironmentSuggestsProduction([]string{environment})
+	for _, connection := range dedupeSlice(serviceConnections) {
+		if strings.TrimSpace(connection) == "" {
+			continue
+		}
+		explicitBindings = append(explicitBindings, strings.Join([]string{
+			"service_connection",
+			"azure",
+			strings.TrimSpace(connection),
+			"azure",
+			"service_connection",
+			"cloud_or_infra_access",
+			"write",
+			environment,
+			strconv.FormatBool(production),
+			"medium",
+		}, "|"))
+	}
+	authSurfaces := workflowAuthSurfacesFromValues(values, sortedSet(secretRefs), serviceConnections)
+	return jobObservation{
+		name:              strings.TrimSpace(name),
+		environment:       strings.TrimSpace(environment),
+		values:            dedupeSlice(values),
+		secretRefs:        sortedSet(secretRefs),
+		authSurfaces:      authSurfaces,
+		authorityBindings: workflowAuthorityBindingsFromValues(values, environment, explicitBindings),
+		manualDeclared:    false,
+		manualStrong:      false,
+		ambiguousApproval: ambiguousApproval,
+		stepCount:         len(steps),
+	}
+}
+
+func collectAzureTemplateRefs(doc azureDocument) []string {
+	refs := []string{}
+	if strings.TrimSpace(doc.Extends.Template) != "" {
+		refs = append(refs, strings.TrimSpace(doc.Extends.Template))
+	}
+	for _, stage := range doc.Stages {
+		if strings.TrimSpace(stage.Template) != "" {
+			refs = append(refs, strings.TrimSpace(stage.Template))
+		}
+		for _, job := range stage.Jobs {
+			if strings.TrimSpace(job.Template) != "" {
+				refs = append(refs, strings.TrimSpace(job.Template))
+			}
+			for _, step := range append([]azureStep(nil), append(job.Steps, job.Strategy.RunOnce.Deploy.Steps...)...) {
+				if strings.TrimSpace(step.Template) != "" {
+					refs = append(refs, strings.TrimSpace(step.Template))
+				}
+			}
+		}
+	}
+	for _, job := range doc.Jobs {
+		if strings.TrimSpace(job.Template) != "" {
+			refs = append(refs, strings.TrimSpace(job.Template))
+		}
+		for _, step := range append([]azureStep(nil), append(job.Steps, job.Strategy.RunOnce.Deploy.Steps...)...) {
+			if strings.TrimSpace(step.Template) != "" {
+				refs = append(refs, strings.TrimSpace(step.Template))
+			}
+		}
+	}
+	for _, step := range doc.Steps {
+		if strings.TrimSpace(step.Template) != "" {
+			refs = append(refs, strings.TrimSpace(step.Template))
+		}
+	}
+	return dedupeSlice(refs)
+}
+
+func extractAzureVariables(node *yaml.Node) ([]string, []string) {
+	if node == nil || node.Kind == 0 {
+		return nil, nil
+	}
+	work := node
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		work = node.Content[0]
+	}
+	names := map[string]struct{}{}
+	groups := map[string]struct{}{}
+	switch work.Kind {
+	case yaml.MappingNode:
+		for key := range mappingChildren(work) {
+			if strings.TrimSpace(key) != "" {
+				names[strings.TrimSpace(key)] = struct{}{}
+			}
+		}
+	case yaml.SequenceNode:
+		for _, item := range work.Content {
+			mapping := mappingChildren(item)
+			if group := strings.TrimSpace(mappingValue(mapping, "group")); group != "" {
+				groups[group] = struct{}{}
+			}
+			if name := strings.TrimSpace(mappingValue(mapping, "name")); name != "" {
+				names[name] = struct{}{}
+			}
+		}
+	}
+	return sortedSet(names), sortedSet(groups)
+}
+
+func normalizeAzureTemplatePath(currentPath, templatePath string) string {
+	baseDir := filepath.Dir(filepath.ToSlash(strings.TrimSpace(currentPath)))
+	templatePath = filepath.ToSlash(strings.TrimSpace(templatePath))
+	if strings.HasPrefix(templatePath, "/") {
+		return filepath.ToSlash(filepath.Clean(strings.TrimPrefix(templatePath, "/")))
+	}
+	return filepath.ToSlash(filepath.Clean(filepath.Join(baseDir, templatePath)))
+}
+
+func yamlDocumentNode(payload []byte) (*yaml.Node, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(payload, &root); err != nil {
+		return nil, err
+	}
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
+		return root.Content[0], nil
+	}
+	return &root, nil
+}
+
+func mappingChildren(node *yaml.Node) map[string]*yaml.Node {
+	out := map[string]*yaml.Node{}
+	if node == nil || node.Kind != yaml.MappingNode {
+		return out
+	}
+	for idx := 0; idx+1 < len(node.Content); idx += 2 {
+		key := strings.TrimSpace(node.Content[idx].Value)
+		if key != "" {
+			out[key] = node.Content[idx+1]
+		}
+	}
+	return out
+}
+
+func mappingValue(values map[string]*yaml.Node, key string) string {
+	node := values[key]
+	if node == nil {
+		return ""
+	}
+	return strings.TrimSpace(node.Value)
+}
+
+func normalizeStringList(values stringListField) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if trimmed := strings.ToLower(strings.TrimSpace(value)); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func normalizeStringSlice(values []any) []string {
+	out := []string{}
+	for _, value := range values {
+		if trimmed := strings.ToLower(strings.TrimSpace(fmt.Sprint(value))); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func normalizeDynamicValue(value any) []string {
+	trimmed := strings.ToLower(strings.TrimSpace(fmt.Sprint(value)))
+	if trimmed == "" || trimmed == "<nil>" {
+		return nil
+	}
+	return []string{trimmed}
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func sortedMapKeys(values map[string]any) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		if strings.TrimSpace(key) != "" {
+			keys = append(keys, strings.TrimSpace(key))
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/core/detect/workflowcap/platform_ci.go
+++ b/core/detect/workflowcap/platform_ci.go
@@ -94,8 +94,7 @@ func hasSecretAccessValues(values []string) bool {
 	for _, value := range values {
 		if strings.Contains(value, "secrets.") ||
 			strings.Contains(value, "${{ secrets.") ||
-			strings.Contains(value, "github.token") ||
-			strings.Contains(value, "$(") {
+			strings.Contains(value, "github.token") {
 			return true
 		}
 	}
@@ -376,6 +375,7 @@ type workflowObservation struct {
 	jobs             []jobObservation
 	resolutionKey    string
 	resolutionStatus string
+	gitlabTemplates  map[string]gitlabJob
 }
 
 func analyzeObservation(obs workflowObservation) Result {
@@ -580,17 +580,17 @@ func (s *stringListField) UnmarshalYAML(node *yaml.Node) error {
 }
 
 type gitlabDocument struct {
-	Name         string                 `yaml:"name"`
-	Stages       stringListField        `yaml:"stages"`
-	Variables    map[string]any         `yaml:"variables"`
-	Include      yaml.Node              `yaml:"include"`
-	Workflow     yaml.Node              `yaml:"workflow"`
-	Default      gitlabDefaults         `yaml:"default"`
-	BeforeScript stringListField        `yaml:"before_script"`
-	AfterScript  stringListField        `yaml:"after_script"`
-	Image        any                    `yaml:"image"`
-	Services     []any                  `yaml:"services"`
-	Raw          map[string]*yaml.Node  `yaml:",inline"`
+	Name         string                `yaml:"name"`
+	Stages       stringListField       `yaml:"stages"`
+	Variables    map[string]any        `yaml:"variables"`
+	Include      yaml.Node             `yaml:"include"`
+	Workflow     yaml.Node             `yaml:"workflow"`
+	Default      gitlabDefaults        `yaml:"default"`
+	BeforeScript stringListField       `yaml:"before_script"`
+	AfterScript  stringListField       `yaml:"after_script"`
+	Image        any                   `yaml:"image"`
+	Services     []any                 `yaml:"services"`
+	Raw          map[string]*yaml.Node `yaml:",inline"`
 }
 
 type gitlabDefaults struct {
@@ -601,22 +601,23 @@ type gitlabDefaults struct {
 }
 
 type gitlabJob struct {
-	Stage        string            `yaml:"stage"`
-	Script       stringListField   `yaml:"script"`
-	BeforeScript stringListField   `yaml:"before_script"`
-	AfterScript  stringListField   `yaml:"after_script"`
-	Variables    map[string]any    `yaml:"variables"`
-	Environment  environmentField  `yaml:"environment"`
-	When         string            `yaml:"when"`
-	Rules        []gitlabRule      `yaml:"rules"`
-	Only         any               `yaml:"only"`
-	Except       any               `yaml:"except"`
-	Image        any               `yaml:"image"`
-	Services     []any             `yaml:"services"`
-	Needs        []any             `yaml:"needs"`
-	Dependencies []any             `yaml:"dependencies"`
-	Artifacts    map[string]any    `yaml:"artifacts"`
-	Release      map[string]any    `yaml:"release"`
+	Stage        string           `yaml:"stage"`
+	Extends      stringListField  `yaml:"extends"`
+	Script       stringListField  `yaml:"script"`
+	BeforeScript stringListField  `yaml:"before_script"`
+	AfterScript  stringListField  `yaml:"after_script"`
+	Variables    map[string]any   `yaml:"variables"`
+	Environment  environmentField `yaml:"environment"`
+	When         string           `yaml:"when"`
+	Rules        []gitlabRule     `yaml:"rules"`
+	Only         any              `yaml:"only"`
+	Except       any              `yaml:"except"`
+	Image        any              `yaml:"image"`
+	Services     []any            `yaml:"services"`
+	Needs        []any            `yaml:"needs"`
+	Dependencies []any            `yaml:"dependencies"`
+	Artifacts    map[string]any   `yaml:"artifacts"`
+	Release      map[string]any   `yaml:"release"`
 }
 
 type gitlabRule struct {
@@ -626,9 +627,10 @@ type gitlabRule struct {
 
 func analyzeGitLabWorkflow(root, path string, payload []byte) (Result, *model.ParseError) {
 	obs := workflowObservation{
-		platform:      "gitlab_ci",
-		workflowName:  strings.TrimSpace(filepath.Base(path)),
-		resolutionKey: "include_resolution_status",
+		platform:        "gitlab_ci",
+		workflowName:    strings.TrimSpace(filepath.Base(path)),
+		resolutionKey:   "include_resolution_status",
+		gitlabTemplates: map[string]gitlabJob{},
 	}
 	loadErr := loadGitLabDocument(root, path, payload, map[string]struct{}{}, &obs)
 	if strings.TrimSpace(obs.resolutionStatus) == "" {
@@ -702,6 +704,7 @@ func loadGitLabDocument(root, path string, payload []byte, stack map[string]stru
 	if err != nil {
 		return &model.ParseError{Kind: "parse_error", Format: "yaml", Path: path, Detector: detectorID, Message: err.Error()}
 	}
+	decodedJobs := map[string]gitlabJob{}
 	for key, value := range mappingChildren(rootNode) {
 		if isGitLabReservedKey(key) {
 			continue
@@ -714,7 +717,17 @@ func loadGitLabDocument(root, path string, payload []byte, stack map[string]stru
 			}
 			continue
 		}
-		jobObs := observeGitLabJob(key, doc, job)
+		decodedJobs[key] = job
+		if isGitLabHiddenJob(key) {
+			obs.gitlabTemplates[key] = job
+		}
+	}
+	for key, job := range decodedJobs {
+		if isGitLabHiddenJob(key) {
+			continue
+		}
+		resolvedJob := resolveGitLabJob(key, job, decodedJobs, obs.gitlabTemplates, map[string]struct{}{})
+		jobObs := observeGitLabJob(key, doc, resolvedJob)
 		obs.jobNames = append(obs.jobNames, jobObs.name)
 		if strings.TrimSpace(jobObs.environment) != "" {
 			obs.environments = append(obs.environments, jobObs.environment)
@@ -725,17 +738,36 @@ func loadGitLabDocument(root, path string, payload []byte, stack map[string]stru
 }
 
 func observeGitLabJob(name string, doc gitlabDocument, job gitlabJob) jobObservation {
+	effectiveBefore := normalizeStringList(job.BeforeScript)
+	if len(effectiveBefore) == 0 {
+		effectiveBefore = append(effectiveBefore, normalizeStringList(doc.BeforeScript)...)
+		effectiveBefore = append(effectiveBefore, normalizeStringList(doc.Default.BeforeScript)...)
+	}
+	effectiveAfter := normalizeStringList(job.AfterScript)
+	if len(effectiveAfter) == 0 {
+		effectiveAfter = append(effectiveAfter, normalizeStringList(doc.Default.AfterScript)...)
+		effectiveAfter = append(effectiveAfter, normalizeStringList(doc.AfterScript)...)
+	}
+	effectiveServices := normalizeStringSlice(job.Services)
+	if len(effectiveServices) == 0 {
+		effectiveServices = append(effectiveServices, normalizeStringSlice(doc.Default.Services)...)
+	}
+	effectiveImage := normalizeDynamicValue(job.Image)
+	if len(effectiveImage) == 0 {
+		effectiveImage = normalizeDynamicValue(doc.Default.Image)
+	}
+	if len(effectiveImage) == 0 {
+		effectiveImage = normalizeDynamicValue(doc.Image)
+	}
+
 	values := []string{strings.ToLower(strings.TrimSpace(name)), strings.ToLower(strings.TrimSpace(job.Stage))}
-	values = append(values, normalizeStringList(doc.BeforeScript)...)
-	values = append(values, normalizeStringList(job.BeforeScript)...)
+	values = append(values, effectiveBefore...)
 	values = append(values, normalizeStringList(job.Script)...)
-	values = append(values, normalizeStringList(job.AfterScript)...)
-	values = append(values, normalizeStringList(doc.AfterScript)...)
+	values = append(values, effectiveAfter...)
 	values = append(values, normalizeDynamicValues(job.Release)...)
 	values = append(values, normalizeDynamicValues(job.Artifacts)...)
-	values = append(values, normalizeStringSlice(job.Services)...)
-	values = append(values, normalizeDynamicValue(job.Image)...)
-	values = append(values, normalizeDynamicValue(doc.Image)...)
+	values = append(values, effectiveServices...)
+	values = append(values, effectiveImage...)
 	values = append(values, normalizeStringSlice(job.Dependencies)...)
 	values = append(values, normalizeStringSlice(job.Needs)...)
 	values = append(values, strings.ToLower(strings.TrimSpace(job.When)))
@@ -749,7 +781,7 @@ func observeGitLabJob(name string, doc gitlabDocument, job gitlabJob) jobObserva
 	}
 
 	secretRefs := map[string]struct{}{}
-	for _, ref := range extractShellVariableRefs(strings.Join(normalizeStringList(job.Script), "\n"), strings.Join(normalizeStringList(job.BeforeScript), "\n"), strings.Join(normalizeStringList(job.AfterScript), "\n")) {
+	for _, ref := range extractShellVariableRefs(strings.Join(normalizeStringList(job.Script), "\n"), strings.Join(effectiveBefore, "\n"), strings.Join(effectiveAfter, "\n")) {
 		if sensitiveCredentialName(ref) {
 			secretRefs[ref] = struct{}{}
 		}
@@ -784,8 +816,116 @@ func observeGitLabJob(name string, doc gitlabDocument, job gitlabJob) jobObserva
 		manualStrong:      manualStrong,
 		manualDeclared:    manualDeclared,
 		ambiguousApproval: ambiguousApproval,
-		stepCount:         len(job.Script) + len(job.BeforeScript) + len(job.AfterScript),
+		stepCount:         len(job.Script) + len(effectiveBefore) + len(effectiveAfter),
 	}
+}
+
+func isGitLabHiddenJob(name string) bool {
+	return strings.HasPrefix(strings.TrimSpace(name), ".")
+}
+
+func resolveGitLabJob(name string, job gitlabJob, localJobs map[string]gitlabJob, sharedTemplates map[string]gitlabJob, stack map[string]struct{}) gitlabJob {
+	if len(job.Extends) == 0 {
+		return job
+	}
+	trimmedName := strings.TrimSpace(name)
+	if trimmedName != "" {
+		if _, ok := stack[trimmedName]; ok {
+			return job
+		}
+		stack[trimmedName] = struct{}{}
+		defer delete(stack, trimmedName)
+	}
+	merged := gitlabJob{}
+	for _, ref := range job.Extends {
+		templateName := strings.TrimSpace(ref)
+		if templateName == "" {
+			continue
+		}
+		if _, ok := stack[templateName]; ok {
+			continue
+		}
+		parent, ok := localJobs[templateName]
+		if !ok {
+			parent, ok = sharedTemplates[templateName]
+		}
+		if !ok {
+			continue
+		}
+		parent = resolveGitLabJob(templateName, parent, localJobs, sharedTemplates, stack)
+		merged = mergeGitLabJob(merged, parent)
+	}
+	return mergeGitLabJob(merged, job)
+}
+
+func mergeGitLabJob(base gitlabJob, override gitlabJob) gitlabJob {
+	merged := base
+	if strings.TrimSpace(override.Stage) != "" {
+		merged.Stage = override.Stage
+	}
+	if len(override.Extends) > 0 {
+		merged.Extends = append([]string(nil), override.Extends...)
+	}
+	if len(override.Script) > 0 {
+		merged.Script = append([]string(nil), override.Script...)
+	}
+	if len(override.BeforeScript) > 0 {
+		merged.BeforeScript = append([]string(nil), override.BeforeScript...)
+	}
+	if len(override.AfterScript) > 0 {
+		merged.AfterScript = append([]string(nil), override.AfterScript...)
+	}
+	if len(override.Variables) > 0 {
+		merged.Variables = mergeStringAnyMaps(merged.Variables, override.Variables)
+	}
+	if strings.TrimSpace(override.Environment.Name) != "" {
+		merged.Environment = override.Environment
+	}
+	if strings.TrimSpace(override.When) != "" {
+		merged.When = override.When
+	}
+	if len(override.Rules) > 0 {
+		merged.Rules = append([]gitlabRule(nil), override.Rules...)
+	}
+	if override.Only != nil {
+		merged.Only = override.Only
+	}
+	if override.Except != nil {
+		merged.Except = override.Except
+	}
+	if override.Image != nil {
+		merged.Image = override.Image
+	}
+	if len(override.Services) > 0 {
+		merged.Services = append([]any(nil), override.Services...)
+	}
+	if len(override.Needs) > 0 {
+		merged.Needs = append([]any(nil), override.Needs...)
+	}
+	if len(override.Dependencies) > 0 {
+		merged.Dependencies = append([]any(nil), override.Dependencies...)
+	}
+	if len(override.Artifacts) > 0 {
+		merged.Artifacts = mergeStringAnyMaps(merged.Artifacts, override.Artifacts)
+	}
+	if len(override.Release) > 0 {
+		merged.Release = mergeStringAnyMaps(merged.Release, override.Release)
+	}
+	return merged
+}
+
+func mergeStringAnyMaps(base map[string]any, override map[string]any) map[string]any {
+	if len(base) == 0 && len(override) == 0 {
+		return nil
+	}
+	out := map[string]any{}
+	for key, value := range base {
+		out[key] = value
+	}
+	for key, value := range override {
+		out[key] = value
+	}
+	return out
 }
 
 type gitlabIncludeRef struct {
@@ -875,14 +1015,14 @@ func normalizeGitLabLocalPath(path string) string {
 }
 
 type azureDocument struct {
-	Name      string            `yaml:"name"`
-	Trigger   triggerField      `yaml:"trigger"`
-	PR        triggerField      `yaml:"pr"`
-	Variables yaml.Node         `yaml:"variables"`
-	Extends   azureTemplateRef  `yaml:"extends"`
-	Stages    []azureStage      `yaml:"stages"`
-	Jobs      []azureJob        `yaml:"jobs"`
-	Steps     []azureStep       `yaml:"steps"`
+	Name      string           `yaml:"name"`
+	Trigger   triggerField     `yaml:"trigger"`
+	PR        triggerField     `yaml:"pr"`
+	Variables yaml.Node        `yaml:"variables"`
+	Extends   azureTemplateRef `yaml:"extends"`
+	Stages    []azureStage     `yaml:"stages"`
+	Jobs      []azureJob       `yaml:"jobs"`
+	Steps     []azureStep      `yaml:"steps"`
 }
 
 type azureTemplateRef struct {
@@ -890,20 +1030,20 @@ type azureTemplateRef struct {
 }
 
 type azureStage struct {
-	Stage     string           `yaml:"stage"`
-	Template  string           `yaml:"template"`
-	Jobs      []azureJob       `yaml:"jobs"`
-	Variables yaml.Node        `yaml:"variables"`
+	Stage     string     `yaml:"stage"`
+	Template  string     `yaml:"template"`
+	Jobs      []azureJob `yaml:"jobs"`
+	Variables yaml.Node  `yaml:"variables"`
 }
 
 type azureJob struct {
-	Job         string          `yaml:"job"`
-	Deployment  string          `yaml:"deployment"`
-	Template    string          `yaml:"template"`
+	Job         string           `yaml:"job"`
+	Deployment  string           `yaml:"deployment"`
+	Template    string           `yaml:"template"`
 	Environment environmentField `yaml:"environment"`
-	Steps       []azureStep     `yaml:"steps"`
-	Strategy    azureStrategy   `yaml:"strategy"`
-	Variables   yaml.Node       `yaml:"variables"`
+	Steps       []azureStep      `yaml:"steps"`
+	Strategy    azureStrategy    `yaml:"strategy"`
+	Variables   yaml.Node        `yaml:"variables"`
 }
 
 type azureStrategy struct {

--- a/core/report/action_surface_registry.go
+++ b/core/report/action_surface_registry.go
@@ -143,7 +143,11 @@ func actionSurfaceType(path risk.ActionPath) string {
 	location := strings.ToLower(strings.TrimSpace(path.Location))
 	toolType := strings.ToLower(strings.TrimSpace(path.ToolType))
 	switch {
-	case strings.Contains(location, ".github/workflows") || strings.Contains(location, "jenkinsfile"):
+	case strings.Contains(location, ".github/workflows") || strings.Contains(location, "jenkinsfile") ||
+		strings.HasSuffix(location, ".gitlab-ci.yml") || strings.HasSuffix(location, ".gitlab-ci.yaml") ||
+		strings.Contains(location, "/.gitlab/ci/") || strings.HasSuffix(location, "azure-pipelines.yml") ||
+		strings.HasSuffix(location, "azure-pipelines.yaml") || strings.Contains(location, "/.azure/pipelines/") ||
+		toolType == "ci_agent":
 		return "workflow"
 	case toolType == "openapi":
 		return "api_schema"

--- a/core/risk/classify/classify.go
+++ b/core/risk/classify/classify.go
@@ -18,12 +18,29 @@ func EndpointClass(finding model.Finding) string {
 		deploymentStatus := evidenceValue(finding, "deployment_status")
 		autoDeploy := evidenceBool(finding, "auto_deploy")
 		switch {
-		case strings.Contains(deploymentArtifacts, ".github/workflows"), strings.Contains(deploymentArtifacts, "jenkinsfile"), deploymentStatus == "deployed" || deploymentStatus == "ambiguous", autoDeploy:
+		case strings.Contains(deploymentArtifacts, ".github/workflows"),
+			strings.Contains(deploymentArtifacts, ".gitlab-ci.yml"),
+			strings.Contains(deploymentArtifacts, ".gitlab-ci.yaml"),
+			strings.Contains(deploymentArtifacts, ".gitlab/ci/"),
+			strings.Contains(deploymentArtifacts, "azure-pipelines.yml"),
+			strings.Contains(deploymentArtifacts, "azure-pipelines.yaml"),
+			strings.Contains(deploymentArtifacts, ".azure/pipelines/"),
+			strings.Contains(deploymentArtifacts, "jenkinsfile"),
+			deploymentStatus == "deployed" || deploymentStatus == "ambiguous",
+			autoDeploy:
 			return "ci_pipeline"
 		default:
 			return "repo_config"
 		}
-	case finding.FindingType == "ci_autonomy" || strings.Contains(location, ".github/workflows") || strings.Contains(location, "jenkinsfile"):
+	case finding.FindingType == "ci_autonomy" ||
+		strings.Contains(location, ".github/workflows") ||
+		strings.HasSuffix(location, ".gitlab-ci.yml") ||
+		strings.HasSuffix(location, ".gitlab-ci.yaml") ||
+		strings.Contains(location, "/.gitlab/ci/") ||
+		strings.HasSuffix(location, "azure-pipelines.yml") ||
+		strings.HasSuffix(location, "azure-pipelines.yaml") ||
+		strings.Contains(location, "/.azure/pipelines/") ||
+		strings.Contains(location, "jenkinsfile"):
 		return "ci_pipeline"
 	case finding.FindingType == "compiled_action" || strings.Contains(location, "agent-plans") || strings.Contains(location, "workflows/"):
 		return "compiled_action"
@@ -65,7 +82,15 @@ func DataClass(finding model.Finding) string {
 	if strings.Contains(location, "customer") || strings.Contains(location, "profile") || strings.Contains(location, "user") {
 		return "pii"
 	}
-	if strings.Contains(location, ".github/workflows") || strings.Contains(location, "deploy") {
+	if finding.FindingType == "ci_autonomy" ||
+		strings.Contains(location, ".github/workflows") ||
+		strings.HasSuffix(location, ".gitlab-ci.yml") ||
+		strings.HasSuffix(location, ".gitlab-ci.yaml") ||
+		strings.Contains(location, "/.gitlab/ci/") ||
+		strings.HasSuffix(location, "azure-pipelines.yml") ||
+		strings.HasSuffix(location, "azure-pipelines.yaml") ||
+		strings.Contains(location, "/.azure/pipelines/") ||
+		strings.Contains(location, "deploy") {
 		return "delivery"
 	}
 	return "code"

--- a/core/workflowloc/workflowloc.go
+++ b/core/workflowloc/workflowloc.go
@@ -1,0 +1,46 @@
+package workflowloc
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func Normalize(path string) string {
+	return strings.ToLower(filepath.ToSlash(strings.TrimSpace(path)))
+}
+
+func IsGitHubWorkflow(path string) bool {
+	return strings.HasPrefix(Normalize(path), ".github/workflows/")
+}
+
+func IsJenkinsfile(path string) bool {
+	return filepath.Base(Normalize(path)) == "jenkinsfile"
+}
+
+func IsGitLabEntryPipeline(path string) bool {
+	normalized := Normalize(path)
+	return normalized == ".gitlab-ci.yml" || normalized == ".gitlab-ci.yaml"
+}
+
+func IsGitLabCIPath(path string) bool {
+	normalized := Normalize(path)
+	if IsGitLabEntryPipeline(normalized) {
+		return true
+	}
+	return strings.HasPrefix(normalized, ".gitlab/ci/") &&
+		(strings.HasSuffix(normalized, ".yml") || strings.HasSuffix(normalized, ".yaml"))
+}
+
+func IsAzurePipelinePath(path string) bool {
+	normalized := Normalize(path)
+	base := filepath.Base(normalized)
+	if base == "azure-pipelines.yml" || base == "azure-pipelines.yaml" {
+		return true
+	}
+	return strings.HasPrefix(normalized, ".azure/pipelines/") &&
+		(strings.HasSuffix(normalized, ".yml") || strings.HasSuffix(normalized, ".yaml"))
+}
+
+func IsCIWorkflow(path string) bool {
+	return IsGitHubWorkflow(path) || IsJenkinsfile(path) || IsGitLabCIPath(path) || IsAzurePipelinePath(path)
+}

--- a/internal/scenarios/workflow_capabilities_scenario_test.go
+++ b/internal/scenarios/workflow_capabilities_scenario_test.go
@@ -4,6 +4,7 @@ package scenarios
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -19,24 +20,32 @@ func TestWorkflowCapabilitiesScenario(t *testing.T) {
 		t.Fatalf("expected findings array, got %T", payload["findings"])
 	}
 
-	var workflowFinding map[string]any
+	platformFindings := map[string]map[string]any{}
 	for _, item := range findings {
 		typed, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
 		if typed["finding_type"] == "ci_autonomy" {
-			workflowFinding = typed
-			break
+			if platform := scenarioEvidenceValue(typed, "ci_platform"); platform != "" {
+				platformFindings[platform] = typed
+			}
 		}
 	}
-	if workflowFinding == nil {
-		t.Fatalf("expected ci_autonomy finding, got %v", findings)
+	for _, platform := range []string{"github_actions", "gitlab_ci", "azure_devops"} {
+		if platformFindings[platform] == nil {
+			t.Fatalf("expected ci_autonomy finding for %s, got %v", platform, findings)
+		}
 	}
-	permissions := toStringSlice(workflowFinding["permissions"])
+	permissions := toStringSlice(platformFindings["github_actions"]["permissions"])
 	for _, required := range []string{"repo.write", "pull_request.write", "merge.execute", "deploy.write", "db.write", "iac.write"} {
 		if !containsString(permissions, required) {
 			t.Fatalf("expected permission %q in %v", required, permissions)
+		}
+	}
+	for _, platform := range []string{"gitlab_ci", "azure_devops"} {
+		if !containsString(toStringSlice(platformFindings[platform]["permissions"]), "deploy.write") {
+			t.Fatalf("expected deploy.write permission for %s, got %v", platform, platformFindings[platform]["permissions"])
 		}
 	}
 
@@ -44,13 +53,26 @@ func TestWorkflowCapabilitiesScenario(t *testing.T) {
 	if !ok || len(actionPaths) == 0 {
 		t.Fatalf("expected action_paths payload, got %v", payload["action_paths"])
 	}
+	pathsByLocation := map[string]map[string]any{}
 	for _, item := range actionPaths {
 		path, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
-		if path["business_state_surface"] != "db" {
-			t.Fatalf("expected db business_state_surface, got %v", path)
+		if location, _ := path["location"].(string); location != "" {
+			pathsByLocation[location] = path
+		}
+	}
+	if path := pathsByLocation[".github/workflows/release.yml"]; path == nil || path["business_state_surface"] != "db" {
+		t.Fatalf("expected github workflow db surface, got %v", path)
+	}
+	for _, location := range []string{".gitlab-ci.yml", "azure-pipelines.yml"} {
+		path := pathsByLocation[location]
+		if path == nil {
+			t.Fatalf("expected action path for %s, got %v", location, pathsByLocation)
+		}
+		if surface, _ := path["business_state_surface"].(string); strings.TrimSpace(surface) == "" {
+			t.Fatalf("expected non-empty business_state_surface for %s, got %v", location, path)
 		}
 	}
 }
@@ -62,4 +84,20 @@ func containsString(values []string, target string) bool {
 		}
 	}
 	return false
+}
+
+func scenarioEvidenceValue(finding map[string]any, key string) string {
+	evidence, _ := finding["evidence"].([]any)
+	for _, item := range evidence {
+		record, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if recordKey, _ := record["key"].(string); recordKey == key {
+			if value, _ := record["value"].(string); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
 }

--- a/scenarios/wrkr/workflow-capabilities/repos/azure-release/.azure/pipelines/deploy.yml
+++ b/scenarios/wrkr/workflow-capabilities/repos/azure-release/.azure/pipelines/deploy.yml
@@ -1,0 +1,19 @@
+jobs:
+  - deployment: deploy_prod
+    environment: production
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - script: codex --full-auto --approval never
+            - script: az webapp deploy --resource-group prod-rg --name api
+            - script: wrkr verify --chain --json
+              env:
+                PROD_DEPLOY_TOKEN: $(PROD_DEPLOY_TOKEN)
+            - task: AzureCLI@2
+              inputs:
+                azureSubscription: prod-service-conn
+                scriptType: bash
+                scriptLocation: inlineScript
+                inlineScript: |
+                  az aks get-credentials --name prod-aks --resource-group prod-rg

--- a/scenarios/wrkr/workflow-capabilities/repos/azure-release/azure-pipelines.yml
+++ b/scenarios/wrkr/workflow-capabilities/repos/azure-release/azure-pipelines.yml
@@ -1,0 +1,6 @@
+trigger:
+  - main
+extends:
+  template: .azure/pipelines/deploy.yml
+variables:
+  - group: ProdSecrets

--- a/scenarios/wrkr/workflow-capabilities/repos/gitlab-release/.gitlab-ci.yml
+++ b/scenarios/wrkr/workflow-capabilities/repos/gitlab-release/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+stages:
+  - build
+  - deploy
+include:
+  - local: .gitlab/ci/deploy.yml
+
+build:
+  stage: build
+  script:
+    - go test ./...

--- a/scenarios/wrkr/workflow-capabilities/repos/gitlab-release/.gitlab/ci/deploy.yml
+++ b/scenarios/wrkr/workflow-capabilities/repos/gitlab-release/.gitlab/ci/deploy.yml
@@ -1,0 +1,11 @@
+deploy:
+  stage: deploy
+  when: manual
+  environment:
+    name: production
+  script:
+    - codex --full-auto --approval never
+    - kubectl apply -f k8s/
+    - wrkr evidence --state .wrkr/last-scan.json
+  variables:
+    PROD_DEPLOY_PAT: "$PROD_DEPLOY_PAT"


### PR DESCRIPTION
## Problem
- Wrkr wave 1 needed first-class GitLab CI/CD and Azure DevOps workflow authority coverage alongside existing GitHub and Jenkins support.
- CI workflow partials like unresolved includes or templates needed to stay deterministic and visible in scan quality instead of disappearing as detector aborts.

## Changes
- Added root-aware workflow capability analysis for GitHub Actions, GitLab CI/CD, and Azure DevOps pipelines.
- Extended `ciagent` discovery to `.gitlab-ci.yml`, Azure pipeline entrypoints, and partial parse handling that preserves `parse_error` plus workflow authority evidence.
- Wired GitLab and Azure workflow surfaces through inventory, privilege budget, scan quality, risk classification, action surface registry, and workflow capability scenarios.
- Added scenario fixtures for GitLab and Azure workflow capability coverage and updated the planned changelog entries.

## Validation
- `make prepush-full`
- `make test-contracts`
- `make test-scenarios`
- `make test-hardening`
- `go test ./core/detect/ciagent ./core/detect/workflowcap -count=1`
- `go test ./core/detect/workflowcap ./core/aggregate/inventory ./core/aggregate/privilegebudget ./core/risk ./core/report ./core/aggregate/controlbacklog ./core/aggregate/scanquality -count=1`

## Risks
- GitLab and Azure workflow semantics intentionally stay evidence-scoped and fail closed for unresolved remote includes/templates or ambiguous approval signals.
- CodeQL ran successfully in the local `make prepush-full` lane; SARIF output is at `.tmp/codeql-results.sarif`.

## Submodule Notes
- No submodule pointer changes.
- `factory` submodule remained clean at `afe76f1dcf68af7345a67601f096ed51eca4892d`.
