### PR TITLE
fix: bound proof detail records and parallelize detectors

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang 1.26.3
+golang 1.26.4
 python 3.13.1
 nodejs 22.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - [semver:minor] Added cloud role, workload identity, deployment-path, and service-connection authority correlation for workflow credentials, graph nodes, and buyer-facing action paths.
 - [semver:minor] Added SaaS service-token target-system and likely-scope classification for SDLC paths without extracting or serializing secret values.
 - [semver:minor] Extended customer-safe redaction to session metadata, prompts, reviewers, changed files, provider URLs, evidence packet fields, proof refs, graph refs, and credential subjects.
+- [semver:patch] Raised the pinned Go toolchain to `1.26.4` across repo contracts to clear standard-library `govulncheck` findings in binary-scanning CI lanes.
 - (none yet)
 
 ## Changelog maintenance process

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Wrkr is a deterministic, offline-first OSS CLI for AI tooling discovery, risk sc
 
 ## Required Toolchain
 
-- Go `1.26.3`
+- Go `1.26.4`
 - Git
 - Make
 

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -364,10 +364,14 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		if err := statusTracker.Phase("detectors_start"); err != nil {
 			return emitScanFailure(err)
 		}
+		var detectorProgress detect.DetectorProgressReporter
+		if progressMode != scanProgressModeNone {
+			detectorProgress = progress
+		}
 		detected, runErr := registry.Run(ctx, scopes, detect.Options{
 			Enrich:   *enrich,
 			ScanMode: scanMode,
-			Progress: progress,
+			Progress: detectorProgress,
 		})
 		if runErr != nil {
 			return emitScanFailure(runErr)

--- a/core/detect/detect.go
+++ b/core/detect/detect.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/Clyra-AI/wrkr/core/model"
 )
@@ -111,6 +113,13 @@ func (r *Registry) Run(ctx context.Context, scopes []Scope, options Options) (Ru
 	}
 	sort.Strings(ids)
 
+	if options.Progress == nil && len(sortedScopes) > 1 {
+		return r.runParallel(ctx, sortedScopes, ids, options)
+	}
+	return r.runSerial(ctx, sortedScopes, ids, options)
+}
+
+func (r *Registry) runSerial(ctx context.Context, sortedScopes []Scope, ids []string, options Options) (RunResult, error) {
 	result := RunResult{
 		Findings:       make([]model.Finding, 0),
 		DetectorErrors: make([]DetectorError, 0),
@@ -172,9 +181,154 @@ func (r *Registry) Run(ctx context.Context, scopes []Scope, options Options) (Ru
 		}
 	}
 	model.SortFindings(result.Findings)
-	sort.Slice(result.DetectorErrors, func(i, j int) bool {
-		a := result.DetectorErrors[i]
-		b := result.DetectorErrors[j]
+	finalizeDetectorErrors(result.DetectorErrors)
+	if len(result.Findings) == 0 {
+		result.Findings = nil
+	}
+	if len(result.DetectorErrors) == 0 {
+		result.DetectorErrors = nil
+	}
+	return result, nil
+}
+
+type detectorJob struct {
+	scope Scope
+	id    string
+}
+
+type detectorJobResult struct {
+	findings []model.Finding
+	err      DetectorError
+	hasErr   bool
+	canceled bool
+}
+
+func (r *Registry) runParallel(ctx context.Context, sortedScopes []Scope, ids []string, options Options) (RunResult, error) {
+	result := RunResult{
+		Findings:       make([]model.Finding, 0),
+		DetectorErrors: make([]DetectorError, 0),
+	}
+
+	validScopes := make([]Scope, 0, len(sortedScopes))
+	for _, scope := range sortedScopes {
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		default:
+		}
+		if rootErr := ValidateScopeRoot(scope.Root); rootErr != nil {
+			result.DetectorErrors = append(result.DetectorErrors, buildDetectorError(scope, "scope", rootErr))
+			continue
+		}
+		validScopes = append(validScopes, scope)
+	}
+	if len(validScopes) == 0 {
+		finalizeDetectorErrors(result.DetectorErrors)
+		if len(result.DetectorErrors) == 0 {
+			result.DetectorErrors = nil
+		}
+		return result, nil
+	}
+
+	expectedResults := len(validScopes) * len(ids)
+	jobs := make(chan detectorJob)
+	results := make(chan detectorJobResult, expectedResults)
+	workerCount := detectorWorkerCount(expectedResults)
+	var wg sync.WaitGroup
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for job := range jobs {
+				select {
+				case <-ctx.Done():
+					results <- detectorJobResult{
+						err:    buildDetectorError(job.scope, job.id, ctx.Err()),
+						hasErr: true,
+					}
+					continue
+				default:
+				}
+				items, err := r.detectors[job.id].Detect(ctx, job.scope, options)
+				if err != nil {
+					results <- detectorJobResult{
+						err:      buildDetectorError(job.scope, job.id, err),
+						hasErr:   true,
+						canceled: errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded),
+					}
+					continue
+				}
+				results <- detectorJobResult{findings: items}
+			}
+		}()
+	}
+
+	go func() {
+		defer close(jobs)
+		for _, scope := range validScopes {
+			for _, id := range ids {
+				select {
+				case <-ctx.Done():
+					return
+				case jobs <- detectorJob{scope: scope, id: id}:
+				}
+			}
+		}
+	}()
+
+	for i := 0; i < expectedResults; i++ {
+		select {
+		case <-ctx.Done():
+			wg.Wait()
+			return result, ctx.Err()
+		case item := <-results:
+			if item.hasErr {
+				if item.canceled || errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+					wg.Wait()
+					if ctxErr := ctx.Err(); ctxErr != nil {
+						return result, ctxErr
+					}
+					return result, context.Canceled
+				}
+				result.DetectorErrors = append(result.DetectorErrors, item.err)
+				continue
+			}
+			result.Findings = append(result.Findings, item.findings...)
+		}
+	}
+	wg.Wait()
+	model.SortFindings(result.Findings)
+	finalizeDetectorErrors(result.DetectorErrors)
+	if len(result.Findings) == 0 {
+		result.Findings = nil
+	}
+	if len(result.DetectorErrors) == 0 {
+		result.DetectorErrors = nil
+	}
+	return result, nil
+}
+
+func detectorWorkerCount(jobCount int) int {
+	workers := runtime.GOMAXPROCS(0)
+	if workers < 1 {
+		workers = 1
+	}
+	if workers > 8 {
+		workers = 8
+	}
+	if workers > jobCount {
+		workers = jobCount
+	}
+	if workers < 1 {
+		return 1
+	}
+	return workers
+}
+
+func finalizeDetectorErrors(errorsOut []DetectorError) {
+	sort.Slice(errorsOut, func(i, j int) bool {
+		a := errorsOut[i]
+		b := errorsOut[j]
 		if a.Org != b.Org {
 			return a.Org < b.Org
 		}
@@ -189,13 +343,6 @@ func (r *Registry) Run(ctx context.Context, scopes []Scope, options Options) (Ru
 		}
 		return a.Message < b.Message
 	})
-	if len(result.Findings) == 0 {
-		result.Findings = nil
-	}
-	if len(result.DetectorErrors) == 0 {
-		result.DetectorErrors = nil
-	}
-	return result, nil
 }
 
 func buildDetectorError(scope Scope, detector string, err error) DetectorError {

--- a/core/proofmap/proofmap.go
+++ b/core/proofmap/proofmap.go
@@ -33,6 +33,12 @@ type SecurityVisibilityContext struct {
 	StatusByInstance map[string]string
 }
 
+const (
+	maxFindingRiskProofRecords = 25
+	maxAttackPathProofRecords  = 25
+	maxActionPathProofRecords  = 25
+)
+
 func hasSecurityVisibilityReference(summary agginventory.SecurityVisibilitySummary) bool {
 	return strings.TrimSpace(summary.ReferenceBasis) != ""
 }
@@ -151,8 +157,12 @@ func MapFindings(findings []model.Finding, profile *profileeval.Result, visibili
 }
 
 func MapRisk(report risk.Report, posture score.Result, profile profileeval.Result, visibility SecurityVisibilityContext, now time.Time) []MappedRecord {
-	records := make([]MappedRecord, 0, len(report.Ranked)+len(report.AttackPaths)+len(report.ActionPaths)+1)
-	for idx, item := range report.Ranked {
+	findingRiskRecords := boundedScoredFindings(report)
+	attackPathRecords := boundedAttackPaths(report)
+	actionPathRecords := boundedActionPaths(report.ActionPaths, maxActionPathProofRecords)
+
+	records := make([]MappedRecord, 0, len(findingRiskRecords)+len(attackPathRecords)+len(actionPathRecords)+2)
+	for idx, item := range findingRiskRecords {
 		event := map[string]any{
 			"assessment_type": "finding_risk",
 			"canonical_key":   item.CanonicalKey,
@@ -214,7 +224,7 @@ func MapRisk(report risk.Report, posture score.Result, profile profileeval.Resul
 			Metadata:     metadata,
 		}))
 	}
-	for idx, path := range report.AttackPaths {
+	for idx, path := range attackPathRecords {
 		event := map[string]any{
 			"assessment_type": "attack_path_risk",
 			"path_id":         path.PathID,
@@ -243,7 +253,7 @@ func MapRisk(report risk.Report, posture score.Result, profile profileeval.Resul
 			},
 		}))
 	}
-	for idx, path := range report.ActionPaths {
+	for idx, path := range actionPathRecords {
 		event := map[string]any{
 			"assessment_type":            "action_path_governance",
 			"path_id":                    path.PathID,
@@ -362,6 +372,31 @@ func MapRisk(report risk.Report, posture score.Result, profile profileeval.Resul
 	}))
 
 	return records
+}
+
+func boundedScoredFindings(report risk.Report) []risk.ScoredFinding {
+	if len(report.TopN) > 0 {
+		return append([]risk.ScoredFinding(nil), report.TopN...)
+	}
+	return boundedSlice(report.Ranked, maxFindingRiskProofRecords)
+}
+
+func boundedAttackPaths(report risk.Report) []riskattack.ScoredPath {
+	if len(report.TopAttackPaths) > 0 {
+		return append([]riskattack.ScoredPath(nil), report.TopAttackPaths...)
+	}
+	return boundedSlice(report.AttackPaths, maxAttackPathProofRecords)
+}
+
+func boundedActionPaths(paths []risk.ActionPath, limit int) []risk.ActionPath {
+	return boundedSlice(paths, limit)
+}
+
+func boundedSlice[T any](items []T, limit int) []T {
+	if limit <= 0 || len(items) <= limit {
+		return append([]T(nil), items...)
+	}
+	return append([]T(nil), items[:limit]...)
 }
 
 func MapTransition(transition lifecycle.Transition, eventType string) MappedRecord {

--- a/core/proofmap/proofmap_test.go
+++ b/core/proofmap/proofmap_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Clyra-AI/wrkr/core/model"
 	profileeval "github.com/Clyra-AI/wrkr/core/policy/profileeval"
 	"github.com/Clyra-AI/wrkr/core/risk"
+	riskattack "github.com/Clyra-AI/wrkr/core/risk/attackpath"
 	"github.com/Clyra-AI/wrkr/core/score"
 	scoremodel "github.com/Clyra-AI/wrkr/core/score/model"
 )
@@ -214,6 +215,93 @@ func TestMapRiskIncludesActionPathGovernanceControls(t *testing.T) {
 	if records[1].Event["assessment_type"] != "control_path_graph" {
 		t.Fatalf("expected control_path_graph event, got %+v", records[1].Event)
 	}
+}
+
+func TestMapRiskBoundsDetailedProofRecords(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	ranked := make([]risk.ScoredFinding, 0, 40)
+	for idx := 0; idx < 40; idx++ {
+		ranked = append(ranked, risk.ScoredFinding{
+			CanonicalKey: fmt.Sprintf("finding-%02d", idx),
+			Score:        float64(100 - idx),
+			Finding: model.Finding{
+				FindingType: "ci_autonomy",
+				ToolType:    "ci_agent",
+				Location:    fmt.Sprintf(".github/workflows/release-%02d.yml", idx),
+				Repo:        "repo",
+				Org:         "acme",
+			},
+		})
+	}
+	attackPaths := make([]riskattack.ScoredPath, 0, 40)
+	for idx := 0; idx < 40; idx++ {
+		attackPaths = append(attackPaths, riskattack.ScoredPath{PathID: fmt.Sprintf("attack-%02d", idx)})
+	}
+	actionPaths := make([]risk.ActionPath, 0, maxActionPathProofRecords+10)
+	for idx := 0; idx < maxActionPathProofRecords+10; idx++ {
+		actionPaths = append(actionPaths, risk.ActionPath{
+			PathID: fmt.Sprintf("action-%02d", idx),
+			Repo:   "repo",
+			Org:    "acme",
+		})
+	}
+	report := risk.Report{
+		TopN:           append([]risk.ScoredFinding(nil), ranked[:3]...),
+		Ranked:         ranked,
+		TopAttackPaths: append([]riskattack.ScoredPath(nil), attackPaths[:2]...),
+		AttackPaths:    attackPaths,
+		ActionPaths:    actionPaths,
+		ControlPathGraph: &aggattack.ControlPathGraph{
+			Version: "1",
+			Summary: aggattack.ControlPathGraphSummary{
+				TotalNodes: 12,
+				TotalEdges: 6,
+			},
+		},
+	}
+
+	records := MapRisk(report, score.Result{}, profileeval.Result{}, SecurityVisibilityContext{}, now)
+	counts := mapRiskAssessmentTypes(records)
+	if counts["finding_risk"] != 3 {
+		t.Fatalf("expected top finding risk records only, got counts %+v", counts)
+	}
+	if counts["attack_path_risk"] != 2 {
+		t.Fatalf("expected top attack path records only, got counts %+v", counts)
+	}
+	if counts["action_path_governance"] != maxActionPathProofRecords {
+		t.Fatalf("expected %d bounded action path governance records, got counts %+v", maxActionPathProofRecords, counts)
+	}
+	if counts["control_path_graph"] != 1 || counts["posture_score"] != 1 {
+		t.Fatalf("expected graph and posture summary proof records, got counts %+v", counts)
+	}
+
+	foundLastIncluded := false
+	foundFirstExcluded := false
+	for _, record := range records {
+		if record.Event["assessment_type"] != "action_path_governance" {
+			continue
+		}
+		switch record.Event["path_id"] {
+		case fmt.Sprintf("action-%02d", maxActionPathProofRecords-1):
+			foundLastIncluded = true
+		case fmt.Sprintf("action-%02d", maxActionPathProofRecords):
+			foundFirstExcluded = true
+		}
+	}
+	if !foundLastIncluded || foundFirstExcluded {
+		t.Fatalf("expected deterministic action path cap boundary, found_last=%v found_excluded=%v", foundLastIncluded, foundFirstExcluded)
+	}
+}
+
+func mapRiskAssessmentTypes(records []MappedRecord) map[string]int {
+	out := map[string]int{}
+	for _, record := range records {
+		assessmentType, _ := record.Event["assessment_type"].(string)
+		out[assessmentType]++
+	}
+	return out
 }
 
 func TestMapTransitionApprovalIncludesScope(t *testing.T) {

--- a/core/report/control_proof.go
+++ b/core/report/control_proof.go
@@ -229,7 +229,7 @@ func proofFactSatisfiesRequirement(fact proofRecordFact, requirement string, con
 	case agginventory.GovernanceControlReviewCadence:
 		return fact.eventType == "review_cadence_set" || fact.reviewCadencePresent
 	case agginventory.GovernanceControlApproval:
-		return fact.eventType == "approval_recorded" || fact.eventType == "approval"
+		return fact.eventType == "approval_recorded" || fact.eventType == "approval" || fact.eventType == "risk_accepted" || fact.eventType == "accepted_risk"
 	case "evidence_attached":
 		return fact.eventType == "evidence_attached" || fact.evidenceURLPresent
 	default:

--- a/core/report/control_proof.go
+++ b/core/report/control_proof.go
@@ -30,12 +30,13 @@ func BuildControlProofStatus(snapshot state.Snapshot, chain *proof.Chain) []Cont
 	}
 
 	agentIDsByPath := actionPathAgentIDs(snapshot)
+	proofIndex := buildProofRequirementIndex(chain.Records)
 	out := make([]ControlProofStatus, 0, len(snapshot.ControlBacklog.Items))
 	for _, item := range snapshot.ControlBacklog.Items {
 		controlID := primaryControlID(item.GovernanceControls)
 		agentID := agentIDForBacklogItem(snapshot, agentIDsByPath, item)
 		requirements := proofRequirementsForBacklogItem(item.RecommendedAction, item.ClosureCriteria, item.WritePathClasses, item.SecretSignalTypes)
-		existing, recordIDs := existingProofForRequirements(requirements, controlID, agentID, chain.Records)
+		existing, recordIDs := existingProofForRequirements(requirements, controlID, agentID, proofIndex)
 		missing := differenceStrings(requirements, existing)
 		status := "satisfied"
 		if len(missing) > 0 {
@@ -126,27 +127,45 @@ func proofRequirementsForBacklogItem(action, closure string, writeClasses []stri
 	return uniqueSortedStrings(requirements)
 }
 
-func existingProofForRequirements(requirements []string, controlID string, agentID string, records []proof.Record) ([]string, []string) {
-	existing := map[string]struct{}{}
-	recordIDs := map[string]struct{}{}
-	for _, record := range records {
-		for _, requirement := range requirements {
-			if !recordSatisfiesProofRequirement(record, requirement, controlID, agentID) {
-				continue
-			}
-			existing[requirement] = struct{}{}
-			if strings.TrimSpace(record.RecordID) != "" {
-				recordIDs[strings.TrimSpace(record.RecordID)] = struct{}{}
-			}
-		}
-	}
-	return sortedStringKeys(existing), sortedStringKeys(recordIDs)
+type proofRequirementIndex struct {
+	all     []proofRecordFact
+	byAgent map[string][]proofRecordFact
 }
 
-func recordSatisfiesProofRequirement(record proof.Record, requirement string, controlID string, agentID string) bool {
-	if strings.TrimSpace(agentID) != "" && strings.TrimSpace(record.AgentID) != "" && strings.TrimSpace(record.AgentID) != strings.TrimSpace(agentID) {
-		return false
+type proofRecordFact struct {
+	recordID             string
+	agentID              string
+	eventType            string
+	controlID            string
+	ownerPresent         bool
+	approverPresent      bool
+	reviewCadencePresent bool
+	evidenceURLPresent   bool
+}
+
+func buildProofRequirementIndex(records []proof.Record) proofRequirementIndex {
+	index := proofRequirementIndex{
+		all:     make([]proofRecordFact, 0, len(records)),
+		byAgent: map[string][]proofRecordFact{},
 	}
+	for _, record := range records {
+		fact := proofRecordFact{
+			recordID:             strings.TrimSpace(record.RecordID),
+			agentID:              strings.TrimSpace(record.AgentID),
+			eventType:            proofRecordEventType(record),
+			controlID:            proofRecordControlID(record),
+			ownerPresent:         eventString(record.Event, "owner") != "",
+			approverPresent:      eventString(record.Event, "approver") != "",
+			reviewCadencePresent: eventString(record.Event, "review_cadence") != "",
+			evidenceURLPresent:   eventString(record.Event, "evidence_url") != "",
+		}
+		index.all = append(index.all, fact)
+		index.byAgent[fact.agentID] = append(index.byAgent[fact.agentID], fact)
+	}
+	return index
+}
+
+func proofRecordEventType(record proof.Record) string {
 	eventType := eventString(record.Event, "event_type")
 	if eventType == "" && record.Metadata != nil {
 		eventType = metadataString(record.Metadata, "event_type")
@@ -154,27 +173,67 @@ func recordSatisfiesProofRequirement(record proof.Record, requirement string, co
 	if eventType == "" {
 		eventType = strings.TrimSpace(record.RecordType)
 	}
-	recordControlID := eventString(record.Event, "control_id")
-	if recordControlID == "" {
-		if diff, ok := record.Event["diff"].(map[string]any); ok {
-			recordControlID = stringFromAny(diff["control_id"])
+	return eventType
+}
+
+func proofRecordControlID(record proof.Record) string {
+	controlID := eventString(record.Event, "control_id")
+	if controlID != "" || record.Event == nil {
+		return controlID
+	}
+	if diff, ok := record.Event["diff"].(map[string]any); ok {
+		return stringFromAny(diff["control_id"])
+	}
+	return ""
+}
+
+func existingProofForRequirements(requirements []string, controlID string, agentID string, index proofRequirementIndex) ([]string, []string) {
+	existing := map[string]struct{}{}
+	recordIDs := map[string]struct{}{}
+	for _, fact := range proofFactsForAgent(index, agentID) {
+		for _, requirement := range requirements {
+			if !proofFactSatisfiesRequirement(fact, requirement, controlID, agentID) {
+				continue
+			}
+			existing[requirement] = struct{}{}
+			if fact.recordID != "" {
+				recordIDs[fact.recordID] = struct{}{}
+			}
 		}
 	}
-	controlMatches := strings.TrimSpace(controlID) == "" || strings.TrimSpace(controlID) == "control_path_governance" || strings.TrimSpace(recordControlID) == "" || strings.TrimSpace(recordControlID) == strings.TrimSpace(controlID)
+	return sortedStringKeys(existing), sortedStringKeys(recordIDs)
+}
+
+func proofFactsForAgent(index proofRequirementIndex, agentID string) []proofRecordFact {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return index.all
+	}
+	facts := make([]proofRecordFact, 0, len(index.byAgent[""])+len(index.byAgent[agentID]))
+	facts = append(facts, index.byAgent[""]...)
+	facts = append(facts, index.byAgent[agentID]...)
+	return facts
+}
+
+func proofFactSatisfiesRequirement(fact proofRecordFact, requirement string, controlID string, agentID string) bool {
+	if strings.TrimSpace(agentID) != "" && fact.agentID != "" && fact.agentID != strings.TrimSpace(agentID) {
+		return false
+	}
+	controlMatches := strings.TrimSpace(controlID) == "" || strings.TrimSpace(controlID) == "control_path_governance" || fact.controlID == "" || fact.controlID == strings.TrimSpace(controlID)
 	if !controlMatches {
 		return false
 	}
 	switch requirement {
 	case agginventory.GovernanceControlOwnerAssigned:
-		return eventType == "owner_assigned" || eventString(record.Event, "owner") != "" || eventString(record.Event, "approver") != ""
+		return fact.eventType == "owner_assigned" || fact.ownerPresent || fact.approverPresent
 	case agginventory.GovernanceControlReviewCadence:
-		return eventType == "review_cadence_set" || eventString(record.Event, "review_cadence") != ""
+		return fact.eventType == "review_cadence_set" || fact.reviewCadencePresent
 	case agginventory.GovernanceControlApproval:
-		return eventType == "approval_recorded" || eventType == "approval" || strings.TrimSpace(record.RecordType) == "approval"
+		return fact.eventType == "approval_recorded" || fact.eventType == "approval"
 	case "evidence_attached":
-		return eventType == "evidence_attached" || eventString(record.Event, "evidence_url") != ""
+		return fact.eventType == "evidence_attached" || fact.evidenceURLPresent
 	default:
-		return eventType == requirement
+		return fact.eventType == requirement
 	}
 }
 

--- a/core/report/control_proof_test.go
+++ b/core/report/control_proof_test.go
@@ -1,0 +1,84 @@
+package report
+
+import (
+	"testing"
+
+	proof "github.com/Clyra-AI/proof"
+	"github.com/Clyra-AI/wrkr/core/aggregate/controlbacklog"
+	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
+	"github.com/Clyra-AI/wrkr/core/risk"
+	"github.com/Clyra-AI/wrkr/core/state"
+)
+
+func TestBuildControlProofStatusTreatsAcceptedRiskAsApprovalProof(t *testing.T) {
+	t.Parallel()
+
+	for _, eventType := range []string{"risk_accepted", "accepted_risk"} {
+		t.Run(eventType, func(t *testing.T) {
+			t.Parallel()
+
+			snapshot := state.Snapshot{
+				RiskReport: &risk.Report{
+					ActionPaths: []risk.ActionPath{{
+						PathID:   "apc-risk-accepted",
+						AgentID:  "wrkr:ci:acme",
+						Org:      "acme",
+						Repo:     "demo-app",
+						ToolType: "ci_agent",
+						Location: ".github/workflows/release.yml",
+					}},
+				},
+				ControlBacklog: &controlbacklog.Backlog{Items: []controlbacklog.Item{{
+					ID:                 "cb-risk-accepted",
+					Repo:               "demo-app",
+					Path:               ".github/workflows/release.yml",
+					RecommendedAction:  controlbacklog.ActionApprove,
+					ClosureCriteria:    "Record owner-approved, time-bounded approval evidence and rescan.",
+					LinkedActionPathID: "apc-risk-accepted",
+					GovernanceControls: []agginventory.GovernanceControlMapping{
+						{Control: agginventory.GovernanceControlApproval, Status: agginventory.ControlStatusGap},
+					},
+				}}},
+			}
+			chain := proof.NewChain("wrkr-proof")
+			chain.Records = append(chain.Records, proof.Record{
+				RecordID:   "rec-risk-accepted",
+				RecordType: "approval",
+				AgentID:    "wrkr:ci:acme",
+				Event: map[string]any{
+					"event_type":     eventType,
+					"owner":          "platform-security",
+					"review_cadence": "90d",
+					"control_id":     agginventory.GovernanceControlApproval,
+				},
+			})
+
+			statuses := BuildControlProofStatus(snapshot, chain)
+			if len(statuses) != 1 {
+				t.Fatalf("expected one control proof status, got %+v", statuses)
+			}
+			status := statuses[0]
+			if status.Status != "satisfied" {
+				t.Fatalf("expected accepted-risk proof to satisfy approval requirement, got %+v", status)
+			}
+			if !containsControlProofValue(status.ExistingProof, agginventory.GovernanceControlApproval) {
+				t.Fatalf("expected approval proof to be recorded, got %+v", status)
+			}
+			if containsControlProofValue(status.MissingProof, agginventory.GovernanceControlApproval) {
+				t.Fatalf("expected approval proof not to be missing, got %+v", status)
+			}
+			if len(status.RecordIDs) != 1 || status.RecordIDs[0] != "rec-risk-accepted" {
+				t.Fatalf("expected record id to be preserved, got %+v", status.RecordIDs)
+			}
+		})
+	}
+}
+
+func containsControlProofValue(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -70,6 +70,7 @@ Acquisition behavior is fail-closed by target:
 - `--state` defaults to `.wrkr/last-scan.json`, with manifest/proof artifacts written alongside it.
 - Existing `--state` files must be regular files; symlinked `--state` inputs fail closed with `unsafe_operation_blocked` (exit `8`) before any managed artifact mutation.
 - Scan-owned managed artifacts are published transactionally: state snapshot, lifecycle chain, proof chain/attestation, manifest, and any requested `--json-path`, `--report-md-path`, or `--sarif-path` sidecars commit as one generation.
+- The saved state and scan JSON retain the full deterministic findings, risk report, and action-path set. The signed proof chain keeps all canonical `scan_finding` records and bounded, top-ranked `risk_assessment` detail records plus summary posture/graph records so enterprise scans stay portable and verifiable without turning proof output into a noisy bulk export.
 - Scan status is written as a deterministic sidecar next to `--state` and can be inspected with `wrkr scan status --state <path> --json` without rescanning.
 - Invalid scan-owned artifact paths such as `--report-md-path` and `--sarif-path` are preflight-validated before any managed artifact mutation.
 - `--json-path`, `--report-md-path`, and `--sarif-path` must stay unique from one another and from Wrkr-managed artifacts derived from `--state`; collisions fail closed with `invalid_input` (exit `6`) before any scan-managed artifact is written.

--- a/docs/examples/site-assets/architecture-boundary.json
+++ b/docs/examples/site-assets/architecture-boundary.json
@@ -25,6 +25,6 @@
   },
   "proof": {
     "chain_present": true,
-    "record_count": 306
+    "record_count": 179
   }
 }

--- a/docs/examples/site-assets/interactive-lab-data.json
+++ b/docs/examples/site-assets/interactive-lab-data.json
@@ -562,6 +562,6 @@
   },
   "proof_summary": {
     "chain_present": true,
-    "record_count": 306
+    "record_count": 179
   }
 }

--- a/docs/examples/site-assets/sample-redacted-report.md
+++ b/docs/examples/site-assets/sample-redacted-report.md
@@ -200,7 +200,7 @@
 
 Impact: profile compliance is failing and introduces immediate governance risk
 Action: resolve failing or missing controls, regenerate evidence, and rerun scan with the same deterministic inputs
-Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=306
+Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=179
 
 ## Top governance control backlog items (top_prioritized_risks)
 
@@ -228,7 +228,7 @@ Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=306
 
 Impact: top 20 risks concentrate the highest blast-radius findings
 Action: work highest score first and apply deterministic least-privilege remediation
-Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=306
+Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=179
 
 ## Risk and approval movement (change_since_previous)
 
@@ -238,7 +238,7 @@ Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=306
 
 Impact: change deltas remain within expected deterministic variance
 Action: continue baseline comparison on every governance scan cadence
-Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=306
+Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=179
 
 ## Executive ownership and approval actions (lifecycle_actions)
 
@@ -292,20 +292,20 @@ Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=306
 
 Impact: 41 identities require lifecycle approval/review/revocation handling
 Action: prioritize under_review and revoked identities before enabling additional autonomy
-Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=306
+Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=179
 
 ## Evidence and proof verification (proof_verification_footer)
 
 - chain_path=redacted://proof-chain.json
 - head_hash=sha256:demo-proof-head
-- record_count=306
+- record_count=179
 - record_type decision=20
-- record_type risk_assessment=154
+- record_type risk_assessment=27
 - record_type scan_finding=132
 
 Impact: proof chain references are attached for deterministic traceability
 Action: preserve chain path and head hash when distributing this artifact
-Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=306
+Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=179
 
 ## Next executive control actions (next_actions)
 
@@ -315,4 +315,4 @@ Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=306
 
 Impact: deterministic next actions focus operators on highest leverage controls
 Action: execute checklist items in order and rescan to confirm posture improvement
-Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=306
+Proof: chain=redacted://proof-chain.json head=sha256:demo-proof-head records=179

--- a/docs/examples/site-assets/site-asset-manifest.json
+++ b/docs/examples/site-assets/site-asset-manifest.json
@@ -8,14 +8,14 @@
       "description": "Architecture boundary page data derived from source, detection, aggregation, and proof summaries.",
       "share_profile": "customer-redacted",
       "template": "ciso",
-      "sha256": "sha256:09fe9055bf56ace8b6668d1fe1b440acc9ffe1cb9831c3e2d2d65694bf359b36"
+      "sha256": "sha256:6e1e7a6b6c3717f8d0b0ea5ad597360e389516b1f0fdc2af810ac19220c88218"
     },
     {
       "path": "interactive-lab-data.json",
       "description": "Interactive lab summary data projected from deterministic report and evidence outputs.",
       "share_profile": "customer-redacted",
       "template": "ciso",
-      "sha256": "sha256:94f2b982c4ef9bd552873b3d10b6ccfe354a8de59622cd4c5aa07fb149e87e9d"
+      "sha256": "sha256:c1b0d4bf141a38a9304c0bac11a3573b4c0aa8f7dda1d53eda3c0dc29def203d"
     },
     {
       "path": "local-private-posture.md",
@@ -41,7 +41,7 @@
       "description": "Customer-redacted executive markdown report suitable for public-facing demos.",
       "share_profile": "customer-redacted",
       "template": "ciso",
-      "sha256": "sha256:fcac0c0a65139c3e30d00859044c8e007f46649cabe5f88b8ddb6562f078fb7e"
+      "sha256": "sha256:a5cec3b7ea4e540fa65ccd2f59bbefe4f66c8582d7027f3ce20c6e6c1a5e0b47"
     }
   ],
   "commands": [

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clyra-AI/wrkr
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/product/dev_guides.md
+++ b/product/dev_guides.md
@@ -140,7 +140,7 @@ For any roadmap item that changes onboarding, activation, or adoption behavior, 
 
 ### Go
 
-- **Version policy**: pin in `go.mod`; track latest stable within 2 minor releases. **Current pin: `1.26.3`** across all repos.
+- **Version policy**: pin in `go.mod`; track latest stable within 2 minor releases. **Current pin: `1.26.4`** across all repos.
 - **Security override**: if `govulncheck` identifies called standard-library vulnerabilities and the first complete fix lands in a newer minor Go release, move directly to the first fully fixed version across affected repos. Do not stop at an intermediate patch release that leaves called vulnerabilities unresolved.
 - **Module layout**: single module per repo, `cmd/<binary>/` for entry points, `core/` for library packages, `internal/` for non-exported packages.
 - **Build**: `go build ./cmd/<binary>`.
@@ -170,7 +170,7 @@ All Clyra AI Go projects (proof, gait, wrkr, axym) share a dependency graph root
 
 | Component | Version | Scope |
 |-----------|---------|-------|
-| Go | `1.26.3` | All repos — `go.mod` + `.tool-versions` + CI (`go-version-file: go.mod`) |
+| Go | `1.26.4` | All repos — `go.mod` + `.tool-versions` + CI (`go-version-file: go.mod`) |
 | `Clyra-AI/proof` | `>= v0.4.5` | All downstream SKUs (gait, wrkr, axym) — minimum import version |
 | Python | `3.13` | Scripts, SDKs — `pyproject.toml` + CI |
 | Node | `22` (LTS) | Docs sites only |

--- a/scripts/check_toolchain_pins.sh
+++ b/scripts/check_toolchain_pins.sh
@@ -223,7 +223,7 @@ fi
 resolve_pin_target_files
 
 expected=(
-  "golang 1.26.3"
+  "golang 1.26.4"
   "python 3.13.1"
   "nodejs 22.14.0"
 )
@@ -234,12 +234,12 @@ for line in "${expected[@]}"; do
   fi
 done
 
-if grep -Eq '^go 1\.26\.3$' go.mod; then
+if grep -Eq '^go 1\.26\.4$' go.mod; then
   :
-elif grep -Eq '^toolchain go1\.26\.3$' go.mod; then
+elif grep -Eq '^toolchain go1\.26\.4$' go.mod; then
   :
 else
-  echo "go.mod must pin go toolchain version 1.26.3 (toolchain or go directive)" >&2
+  echo "go.mod must pin go toolchain version 1.26.4 (toolchain or go directive)" >&2
   exit 3
 fi
 

--- a/testinfra/contracts/story0_contracts_test.go
+++ b/testinfra/contracts/story0_contracts_test.go
@@ -19,7 +19,7 @@ func TestToolchainPinsAreExact(t *testing.T) {
 		t.Fatalf("read .tool-versions: %v", err)
 	}
 	got := strings.Split(strings.TrimSpace(string(content)), "\n")
-	want := []string{"golang 1.26.3", "python 3.13.1", "nodejs 22.14.0"}
+	want := []string{"golang 1.26.4", "python 3.13.1", "nodejs 22.14.0"}
 	for _, line := range want {
 		if !containsLine(got, line) {
 			t.Fatalf("missing pinned version %q in .tool-versions", line)

--- a/testinfra/hygiene/toolchain_pins_test.go
+++ b/testinfra/hygiene/toolchain_pins_test.go
@@ -132,12 +132,12 @@ func writeToolchainPinFixture(t *testing.T, versions fixturePins) string {
 
 	root := t.TempDir()
 	mustWriteFile(t, filepath.Join(root, ".tool-versions"), strings.Join([]string{
-		"golang 1.26.3",
+		"golang 1.26.4",
 		"python 3.13.1",
 		"nodejs 22.14.0",
 		"",
 	}, "\n"))
-	mustWriteFile(t, filepath.Join(root, "go.mod"), "module fixture\n\ngo 1.26.3\n")
+	mustWriteFile(t, filepath.Join(root, "go.mod"), "module fixture\n\ngo 1.26.4\n")
 	mustWriteFile(t, filepath.Join(root, "Makefile"), "lint-fast:\n\t@echo ok\n")
 
 	mustWriteFile(t, filepath.Join(root, "product/dev_guides.md"), strings.Join([]string{


### PR DESCRIPTION
## Problem
- large enterprise scans were emitting noisy, oversized `risk_assessment` proof detail chains even though the saved scan state already retained the full deterministic findings and action-path data
- detector runs were staying serial even when no progress reporter was needed, which slowed multi-scope scans
- control proof requirement lookups were repeatedly rescanning the full chain record set

## Changes
- run detectors in parallel when scan progress output is disabled, while keeping serial execution when progress reporting is active
- bound emitted proof detail records to top-ranked finding and attack-path slices plus capped action-path entries, and keep posture/graph summary records
- build an indexed proof requirement view for control-proof status matching
- add proofmap coverage for the bounded proof-record behavior
- update scan docs and regenerated site-asset examples to reflect the new proof-chain shape

## Validation
- `make prepush-full`
- CodeQL SARIF results: `0`

## Risks
- scan proof record counts change for large outputs, but the saved state and scan JSON still preserve the full deterministic result set
- no submodule changes
