### PR TITLE
hotfix: stabilize interrupted org progress dispatch

### DIFF
--- a/core/source/org/materialized.go
+++ b/core/source/org/materialized.go
@@ -120,12 +120,22 @@ func AcquireMaterialized(
 
 	jobs := make(chan materializeJob)
 	results := make(chan materializeResult, len(pendingJobs))
+	ready := make(chan struct{}, workerCount)
 	var wg sync.WaitGroup
 	for i := 0; i < workerCount; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for job := range jobs {
+			for {
+				select {
+				case ready <- struct{}{}:
+				case <-ctx.Done():
+					return
+				}
+				job, ok := <-jobs
+				if !ok {
+					return
+				}
 				select {
 				case <-ctx.Done():
 					results <- materializeResult{fatalErr: ctx.Err(), repo: job.repo}
@@ -163,6 +173,11 @@ func AcquireMaterialized(
 			}
 			job := pendingJob
 			job.start = make(chan struct{})
+			select {
+			case <-ctx.Done():
+				return
+			case <-ready:
+			}
 			select {
 			case <-ctx.Done():
 				return


### PR DESCRIPTION
## Problem
- the merged `main` workflow for commit `868632ce5b083c3aec71792d0a46eadaf1410b6a` failed in `core-matrix-windows-latest`
- `TestScanProgressFooterIncludesResumeHintForInterruptedOrgScan` timed out before the plain progress output printed `materializing acme/a`
- the org materialization dispatcher emitted repo-start progress only after an unbuffered worker handoff, so under Windows scheduling pressure the progress line could arrive too late

## Changes
- add a worker-ready handshake in `core/source/org.AcquireMaterialized`
- keep repo materialization progress emission paired with dispatch order, but avoid blocking that emission on initial worker startup timing
- preserve the existing start gate so repo work still begins only after the progress update has been emitted

## Validation
- `go test ./core/cli -run TestScanProgressFooterIncludesResumeHintForInterruptedOrgScan -count=20`
- `go test ./core/source/org -count=1`
- `make prepush-full`
- CodeQL SARIF results: `0`

## Risks
- changes are limited to org hosted-source dispatch sequencing
- no schema, proof, or CLI contract changes
