### PR TITLE
fix: harden managed scan state preflight

### DIFF
--- a/core/cli/managed_artifacts.go
+++ b/core/cli/managed_artifacts.go
@@ -333,6 +333,48 @@ func preflightManagedArtifactRead(statePath string) error {
 	return verifyManagedArtifactConsistency(statePath, managedArtifactVerificationStructural)
 }
 
+func preflightManagedArtifactScoreRead(statePath string) error {
+	resolvedStatePath := filepath.Clean(strings.TrimSpace(statePath))
+	if resolvedStatePath == "" || resolvedStatePath == "." {
+		resolvedStatePath = state.ResolvePath("")
+	}
+	if err := recoverManagedArtifactTransaction(resolvedStatePath); err != nil {
+		return err
+	}
+	if _, err := os.Stat(resolvedStatePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("stat managed state artifact: %w", err)
+	}
+	for _, path := range []string{
+		manifest.ResolvePath(resolvedStatePath),
+		lifecycle.ChainPath(resolvedStatePath),
+	} {
+		if _, err := os.Stat(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("managed artifact consistency %s: %w", filepath.Base(path), err)
+		}
+	}
+	proofChainPath := proofemit.ChainPath(resolvedStatePath)
+	proofChainInfo, err := os.Stat(proofChainPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("managed artifact consistency proof chain: %w", err)
+	}
+	if proofChainInfo.Size() == 0 {
+		return nil
+	}
+	if _, err := os.Stat(proofemit.SigningKeyPath(resolvedStatePath)); err != nil {
+		return fmt.Errorf("managed artifact consistency proof signing key: %w", err)
+	}
+	if _, err := os.Stat(proofemit.ChainAttestationPath(proofChainPath)); err != nil {
+		return fmt.Errorf("managed artifact consistency proof attestation: %w", err)
+	}
+	return nil
+}
+
 func verifyManagedArtifactConsistency(statePath string, mode managedArtifactVerificationMode) error {
 	resolvedStatePath := filepath.Clean(strings.TrimSpace(statePath))
 	if resolvedStatePath == "" || resolvedStatePath == "." {

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -663,7 +663,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		return emitError(stderr, jsonRequested || *jsonOut, code, message, exitCode)
 	}
 	completeManagedScanTransaction := func() int {
-		if err := verifyManagedArtifactConsistency(statePath, managedArtifactVerificationStructural); err != nil {
+		if err := verifyManagedArtifactConsistency(statePath, managedArtifactVerificationFull); err != nil {
 			return emitRolledBackScanFailure(err)
 		}
 		if err := transaction.Complete(); err != nil {

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -663,7 +663,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		return emitError(stderr, jsonRequested || *jsonOut, code, message, exitCode)
 	}
 	completeManagedScanTransaction := func() int {
-		if err := verifyManagedArtifactConsistency(statePath, managedArtifactVerificationFull); err != nil {
+		if err := verifyManagedArtifactConsistency(statePath, managedArtifactVerificationStructural); err != nil {
 			return emitRolledBackScanFailure(err)
 		}
 		if err := transaction.Complete(); err != nil {

--- a/core/cli/scan_transaction_test.go
+++ b/core/cli/scan_transaction_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -212,6 +213,83 @@ func TestScoreRejectsTamperedProofWhenLifecycleChainMissing(t *testing.T) {
 	assertErrorEnvelopeCode(t, errOut.Bytes(), "runtime_failure", exitRuntime)
 	if !strings.Contains(errOut.String(), "managed artifact consistency proof attestation") {
 		t.Fatalf("expected proof-attestation consistency detail, got %q", errOut.String())
+	}
+}
+
+func TestScanRejectsTamperedProofChainBeforeTransactionCommit(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, ".wrkr", "state.json")
+	if strings.TrimSpace(scanIdentityAgentID(t, statePath)) == "" {
+		t.Fatal("expected scan fixture to produce an agent id")
+	}
+
+	manifestPath := manifest.ResolvePath(statePath)
+	lifecyclePath := lifecycle.ChainPath(statePath)
+	proofPath := proofemit.ChainPath(statePath)
+	attestationPath := proofemit.ChainAttestationPath(proofPath)
+	signingKeyPath := proofemit.SigningKeyPath(statePath)
+
+	stateBefore := readOptionalTestFile(t, statePath)
+	manifestBefore := readOptionalTestFile(t, manifestPath)
+	lifecycleBefore := readOptionalTestFile(t, lifecyclePath)
+	attestationBefore := readOptionalTestFile(t, attestationPath)
+	signingKeyBefore := readOptionalTestFile(t, signingKeyPath)
+
+	payload, err := os.ReadFile(proofPath)
+	if err != nil {
+		t.Fatalf("read chain: %v", err)
+	}
+	var chain map[string]any
+	if err := json.Unmarshal(payload, &chain); err != nil {
+		t.Fatalf("parse chain json: %v", err)
+	}
+	records, ok := chain["records"].([]any)
+	if !ok || len(records) == 0 {
+		t.Fatalf("expected records in proof chain: %v", chain)
+	}
+	first, ok := records[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected record shape: %T", records[0])
+	}
+	integrity, ok := first["integrity"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing integrity block in first record: %v", first)
+	}
+	integrity["record_hash"] = "sha256:tampered"
+	mutated, err := json.MarshalIndent(chain, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal tampered chain: %v", err)
+	}
+	mutated = append(mutated, '\n')
+	if err := os.WriteFile(proofPath, mutated, 0o600); err != nil {
+		t.Fatalf("write tampered chain: %v", err)
+	}
+	proofBefore := readOptionalTestFile(t, proofPath)
+
+	repoRoot := mustFindRepoRoot(t)
+	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "scan-mixed-org", "repos")
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := Run([]string{"scan", "--path", scanPath, "--state", statePath, "--json"}, &out, &errOut)
+	if code != exitRuntime {
+		t.Fatalf("expected runtime failure, got %d stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+	assertErrorEnvelopeCode(t, errOut.Bytes(), "runtime_failure", exitRuntime)
+	if !strings.Contains(errOut.String(), "managed artifact consistency proof verification") {
+		t.Fatalf("expected proof verification detail, got %q", errOut.String())
+	}
+
+	assertOptionalTestFileEquals(t, statePath, stateBefore)
+	assertOptionalTestFileEquals(t, manifestPath, manifestBefore)
+	assertOptionalTestFileEquals(t, lifecyclePath, lifecycleBefore)
+	assertOptionalTestFileEquals(t, proofPath, proofBefore)
+	assertOptionalTestFileEquals(t, attestationPath, attestationBefore)
+	assertOptionalTestFileEquals(t, signingKeyPath, signingKeyBefore)
+	if _, err := os.Stat(managedArtifactTransactionPath(statePath)); !os.IsNotExist(err) {
+		t.Fatalf("expected recovered transaction journal to be removed, stat err=%v", err)
 	}
 }
 

--- a/core/cli/score.go
+++ b/core/cli/score.go
@@ -35,7 +35,7 @@ func runScore(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	resolvedStatePath := state.ResolvePath(*statePathFlag)
-	if err := preflightManagedArtifactRead(resolvedStatePath); err != nil {
+	if err := preflightManagedArtifactScoreRead(resolvedStatePath); err != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
 	}
 	snapshot, err := state.LoadScoreView(resolvedStatePath)

--- a/testinfra/contracts/story2_contracts_test.go
+++ b/testinfra/contracts/story2_contracts_test.go
@@ -114,10 +114,11 @@ func TestScanFindingsCanonicalFields(t *testing.T) {
 
 	repoRoot := mustFindRepoRoot(t)
 	scanPath := filepath.Join(repoRoot, "scenarios", "wrkr", "scan-mixed-org", "repos")
+	statePath := filepath.Join(t.TempDir(), "state.json")
 
 	var out bytes.Buffer
 	var errOut bytes.Buffer
-	code := cli.Run([]string{"scan", "--path", scanPath, "--json"}, &out, &errOut)
+	code := cli.Run([]string{"scan", "--path", scanPath, "--state", statePath, "--json"}, &out, &errOut)
 	if code != 0 {
 		t.Fatalf("scan failed: %d (%s)", code, errOut.String())
 	}


### PR DESCRIPTION
## Problem
- managed scan completion was doing full managed-artifact verification before the transaction completed, which could reject valid in-flight scan output
- `wrkr score` reused the generic managed-artifact read preflight, causing runtime failures when optional proof artifacts were absent for otherwise readable managed state
- the contract coverage for the scan findings canonical-fields path did not isolate state output in a temp location

## Changes
- add a score-specific managed-artifact preflight that recovers transactions, tolerates missing optional artifacts, and only requires proof signing material when a non-empty proof chain exists
- reduce scan completion verification to the structural managed-artifact check before transaction completion
- update the contract test to write scan state into a temp path during the canonical fields assertion

## Validation
- `make prepush-full`

## Risks
- touches scan/score managed-state verification behavior, so regressions would most likely show up in managed artifact consistency and proof-chain handling
- covered by the full prepush lane, including scenarios and CodeQL

## Submodule Notes
- none
