### PR TITLE
fix: hotfix release linux Homebrew UAT for v1.7.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,13 @@ jobs:
       - name: Setup Homebrew
         uses: Homebrew/actions/setup-homebrew@cced187498280712e078aaba62dc13a3e9cd80bf
 
+      - name: Install bubblewrap for Linux Homebrew sandbox
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap
+          command -v bwrap
+
       - name: Download dependencies
         run: go mod download
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- [semver:patch] Fixed the Linux release runner to install `bubblewrap` before Homebrew-backed acceptance and pre-publish install-path UAT, so tag workflows no longer fail before artifact publication.
+- (none yet)
 
 ### Security
 
@@ -37,6 +37,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 3. Validate the prepared release changelog with `python3 scripts/validate_release_changelog.py --release-version vX.Y.Z --json` on merged `main` before or during the tag workflow.
 4. Keep entries concise and operator-facing: what changed, why it matters, and any migration/action notes.
 5. Link release notes and tag artifacts to the finalized changelog section.
+
+## [v1.7.1] - 2026-06-11
+<!-- release-semver: patch -->
+
+### Fixed
+
+- Fixed the Linux release runner to install `bubblewrap` before Homebrew-backed acceptance and pre-publish install-path UAT, so tag workflows no longer fail before artifact publication.
 
 ## [v1.7.0] - 2026-06-11
 <!-- release-semver: minor -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- (none yet)
+- [semver:patch] Fixed the Linux release runner to install `bubblewrap` before Homebrew-backed acceptance and pre-publish install-path UAT, so tag workflows no longer fail before artifact publication.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ brew install Clyra-AI/tap/wrkr
 ### Go install (Pinned/reproducible)
 
 ```bash
-WRKR_VERSION="v1.7.0"
+WRKR_VERSION="v1.7.1"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -4,7 +4,7 @@ Install with Homebrew or the pinned Go path first, then verify the installed CLI
 
 ```bash
 brew install Clyra-AI/tap/wrkr
-WRKR_VERSION="v1.7.0"
+WRKR_VERSION="v1.7.1"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 wrkr version --json
 

--- a/docs/commands/action.md
+++ b/docs/commands/action.md
@@ -21,7 +21,7 @@ Any packaged GitHub Action surface must wrap these CLI contracts rather than dup
 Wrkr now ships a repo-root `action.yml` composite action that wraps the same CLI contracts through `scripts/action_entrypoint.sh`.
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.7.0
+- uses: Clyra-AI/wrkr@v1.7.1
   with:
     mode: scheduled
     remediation_mode: summary_only
@@ -65,7 +65,7 @@ wrkr action pr-comment --changed-paths ".codex/config.toml" --risk-delta 2.8 --c
 ```
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.7.0
+- uses: Clyra-AI/wrkr@v1.7.1
   with:
     mode: scheduled
     target_mode: repo

--- a/docs/install/minimal-dependencies.md
+++ b/docs/install/minimal-dependencies.md
@@ -7,7 +7,7 @@ The main README landing page surfaces Homebrew, the pinned Go install path below
 ## Go-only pinned install
 
 ```bash
-WRKR_VERSION="v1.7.0"
+WRKR_VERSION="v1.7.1"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 
@@ -56,6 +56,6 @@ Install commands above are validated by release UAT together with the public `wr
 
 ```bash
 scripts/test_uat_local.sh --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.7.0 --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.7.0 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.7.1 --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.7.1 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
 ```

--- a/docs/trust/release-integrity.md
+++ b/docs/trust/release-integrity.md
@@ -89,7 +89,7 @@ scripts/test_uat_local.sh
 scripts/test_uat_local.sh --skip-global-gates
 
 # Validate exact public install commands (brew + pinned go install) for a published tag
-scripts/test_uat_local.sh --release-version v1.7.0 --brew-formula Clyra-AI/tap/wrkr
+scripts/test_uat_local.sh --release-version v1.7.1 --brew-formula Clyra-AI/tap/wrkr
 ```
 
 ## Changelog finalization


### PR DESCRIPTION
## Problem
- the `v1.7.0` tag release failed in the hosted `release` workflow before artifact publication
- the `Run v1 acceptance release gate` step reached `make test-release-smoke`, then Homebrew UAT on Linux failed because `bwrap` was unavailable for the Linux sandbox

## Changes
- provision `bubblewrap` on Linux in `.github/workflows/release.yml` before Homebrew-backed release UAT runs
- bump the pinned public install/docs references to `v1.7.1`
- finalize the changelog for the `v1.7.1` hotfix release

## Validation
- `python3 factory/scripts/finalize_release_changelog.py --repo-root . --release-version v1.7.1 --json`
- `python3 factory/scripts/validate_release_changelog.py --repo-root . --release-version v1.7.1 --json`
- `make prepush-full`

## Risks
- this depends on Ubuntu package installation for `bubblewrap` on the hosted release runner
- the release workflow itself is the environment that must prove the fix
