### PR TITLE
fix: hotfix release linux Homebrew userns fallback for v1.7.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,8 @@ jobs:
           scripts/run_docs_smoke.sh
 
       - name: Run v1 acceptance release gate
+        env:
+          HOMEBREW_NO_SANDBOX_LINUX: 1
         run: scripts/run_v1_acceptance.sh --mode=release
 
       - name: Upload v1 acceptance scorecard
@@ -107,6 +109,7 @@ jobs:
 
       - name: Run pre-publish install-path UAT smoke
         env:
+          HOMEBREW_NO_SANDBOX_LINUX: 1
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
         run: |
           set -euo pipefail
@@ -281,6 +284,8 @@ jobs:
 
       - name: Run published install-path parity (README/docs commands)
         if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          HOMEBREW_NO_SANDBOX_LINUX: 1
         run: |
           set -euo pipefail
           mkdir -p .tmp/release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- (none yet)
+- [semver:patch] Fixed Linux release-only Homebrew UAT to disable the Homebrew sandbox on hosted runners where rootless user namespaces are unavailable, so release acceptance and published install-path parity can complete on GitHub Actions.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- [semver:patch] Fixed Linux release-only Homebrew UAT to disable the Homebrew sandbox on hosted runners where rootless user namespaces are unavailable, so release acceptance and published install-path parity can complete on GitHub Actions.
+- (none yet)
 
 ### Security
 
@@ -37,6 +37,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 3. Validate the prepared release changelog with `python3 scripts/validate_release_changelog.py --release-version vX.Y.Z --json` on merged `main` before or during the tag workflow.
 4. Keep entries concise and operator-facing: what changed, why it matters, and any migration/action notes.
 5. Link release notes and tag artifacts to the finalized changelog section.
+
+## [v1.7.2] - 2026-06-12
+<!-- release-semver: patch -->
+
+### Fixed
+
+- Fixed Linux release-only Homebrew UAT to disable the Homebrew sandbox on hosted runners where rootless user namespaces are unavailable, so release acceptance and published install-path parity can complete on GitHub Actions.
 
 ## [v1.7.1] - 2026-06-11
 <!-- release-semver: patch -->

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ brew install Clyra-AI/tap/wrkr
 ### Go install (Pinned/reproducible)
 
 ```bash
-WRKR_VERSION="v1.7.1"
+WRKR_VERSION="v1.7.2"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -4,7 +4,7 @@ Install with Homebrew or the pinned Go path first, then verify the installed CLI
 
 ```bash
 brew install Clyra-AI/tap/wrkr
-WRKR_VERSION="v1.7.1"
+WRKR_VERSION="v1.7.2"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 wrkr version --json
 

--- a/docs/commands/action.md
+++ b/docs/commands/action.md
@@ -21,7 +21,7 @@ Any packaged GitHub Action surface must wrap these CLI contracts rather than dup
 Wrkr now ships a repo-root `action.yml` composite action that wraps the same CLI contracts through `scripts/action_entrypoint.sh`.
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.7.1
+- uses: Clyra-AI/wrkr@v1.7.2
   with:
     mode: scheduled
     remediation_mode: summary_only
@@ -65,7 +65,7 @@ wrkr action pr-comment --changed-paths ".codex/config.toml" --risk-delta 2.8 --c
 ```
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.7.1
+- uses: Clyra-AI/wrkr@v1.7.2
   with:
     mode: scheduled
     target_mode: repo

--- a/docs/install/minimal-dependencies.md
+++ b/docs/install/minimal-dependencies.md
@@ -7,7 +7,7 @@ The main README landing page surfaces Homebrew, the pinned Go install path below
 ## Go-only pinned install
 
 ```bash
-WRKR_VERSION="v1.7.1"
+WRKR_VERSION="v1.7.2"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 
@@ -56,6 +56,6 @@ Install commands above are validated by release UAT together with the public `wr
 
 ```bash
 scripts/test_uat_local.sh --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.7.1 --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.7.1 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.7.2 --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.7.2 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
 ```

--- a/docs/trust/release-integrity.md
+++ b/docs/trust/release-integrity.md
@@ -89,7 +89,7 @@ scripts/test_uat_local.sh
 scripts/test_uat_local.sh --skip-global-gates
 
 # Validate exact public install commands (brew + pinned go install) for a published tag
-scripts/test_uat_local.sh --release-version v1.7.1 --brew-formula Clyra-AI/tap/wrkr
+scripts/test_uat_local.sh --release-version v1.7.2 --brew-formula Clyra-AI/tap/wrkr
 ```
 
 ## Changelog finalization


### PR DESCRIPTION
## Problem
- the `v1.7.1` tag release still failed in the hosted `release` workflow during `Run v1 acceptance release gate`
- `bubblewrap` was installed, but GitHub's Linux runner still could not create a rootless Homebrew sandbox because unprivileged user namespaces were unavailable

## Changes
- set `HOMEBREW_NO_SANDBOX_LINUX=1` only for the Linux release-workflow steps that execute Homebrew-backed install-path UAT
- bump pinned public install/docs references to `v1.7.2`
- finalize the changelog for the `v1.7.2` hotfix release

## Validation
- `python3 factory/scripts/finalize_release_changelog.py --repo-root . --release-version v1.7.2 --json`
- `python3 factory/scripts/validate_release_changelog.py --repo-root . --release-version v1.7.2 --json`
- `make prepush-full`

## Risks
- Linux Homebrew UAT in the hosted release workflow now relies on the documented no-sandbox fallback for CI-only release validation
- the release workflow itself remains the final environment proof for this fix
