### PR TITLE
test: add Sprint 0 size and freeze gate receipts

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,6 +30,7 @@ Additional scoped commands:
 
 - [ ] Acceptance lane evidence included when behavior is operator-facing.
 - [ ] Cross-platform/path behavior reviewed for touched surfaces.
+- [ ] Release-note or changelog claims about size, privacy, redaction, customer-safe sharing, or readability include measured artifact-size deltas, redaction test names, and fixture coverage below.
 
 ## Docs and Source of Truth
 
@@ -40,6 +41,7 @@ Additional scoped commands:
 
 - [ ] Any new detector, report mode, graph field, platform surface, or docs claim explains its impact on focused BOM clarity, repeat use, or evidence quality.
 - [ ] Output-size / finding-noise / markdown-budget impact is documented below when buyer-facing surfaces change.
+- [ ] Sprint 0 temporary freeze gate: any new scan/report field, sidecar, detector expansion, report section, or context dimension is directly required by Stories 1.1 through 4.2 or the size, redaction, and readability gates are green.
 
 Surface-area notes:
 
@@ -47,6 +49,10 @@ Surface-area notes:
 - Repeat-use impact:
 - Evidence-quality impact:
 - Budget impact:
+- Sprint 0 gate justification:
+- Measured artifact-size deltas:
+- Redaction test names:
+- Fixture coverage:
 
 ## Risks and Follow-ups
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,8 @@ Determinism requirements:
 - Keep terminology consistent with Wrkr domain language: discovery, posture, risk, identity lifecycle, proof records, regression.
 - New detectors, report modes, graph fields, platform surfaces, or buyer-facing docs claims must state how they improve focused BOM clarity, repeat use, or evidence quality before they land.
 - Output-size, markdown-length, and finding-noise budget regressions are release blockers for buyer-facing surfaces.
+- Sprint 0 subtractive fixes keep a temporary freeze gate in place: do not add new scan/report surface area unless it is directly required by Stories 1.1 through 4.2 or the size, redaction, and readability gates are green.
+- Changelog and release-note claims about size, privacy, redaction, customer-safe sharing, or readability require measured artifact-size deltas, redaction test names, and fixture coverage receipts in the same PR.
 
 ## 12) Pull Request Checklist (Agent and Human)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed
 
-- (none yet)
+- [semver:patch] Required measured receipts for size, redaction, privacy, and customer-safe release claims, and added a Sprint 0 temporary freeze gate for new scan/report surface expansion until the size, redaction, and readability gates are green.
 
 ### Deprecated
 
@@ -24,7 +24,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- (none yet)
+- [semver:patch] Added real-scan-shaped size, signal, redaction, and BOM readability regression fixtures to block artifact bloat and shareable-output leaks before release.
 
 ### Security
 
@@ -37,6 +37,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 3. Validate the prepared release changelog with `python3 scripts/validate_release_changelog.py --release-version vX.Y.Z --json` on merged `main` before or during the tag workflow.
 4. Keep entries concise and operator-facing: what changed, why it matters, and any migration/action notes.
 5. Link release notes and tag artifacts to the finalized changelog section.
+6. The Sprint 0 v1.7.3 clarification workflow item must record measured artifact-size deltas, redaction test names, and fixture coverage before release notes claim size, privacy, redaction, customer-safe, or readability hardening.
 
 ## [v1.7.2] - 2026-06-12
 <!-- release-semver: patch -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,7 @@ These commands do not replace `make test-fast`, `make prepush`, contract lanes, 
 1. Keep scope tight and mapped to one story/contract change when possible.
 2. Run required local commands for your touched surfaces (at minimum fast + core lane anchors).
    `make test-focused-docs` or `make test-focused-scan` are acceptable as the first local pass for narrow changes, but they are additive helpers only and do not satisfy merge or release gates by themselves.
+   During Sprint 0 subtractive fixes, the temporary freeze gate blocks new scan/report fields, sidecars, detector breadth, report sections, and context dimensions unless they are directly required by Stories 1.1 through 4.2 or the size, redaction, and readability gates are green.
 3. If workflow refs change, rerun the affected workflow class on your branch and inspect it for the absence of the prior deprecation warning:
    - `gh workflow run pr.yml --ref <branch>`
    - `gh workflow run nightly.yml --ref <branch>`
@@ -95,11 +96,17 @@ These commands do not replace `make test-fast`, `make prepush`, contract lanes, 
    - schema/output changed?
    - docs updated in same change for user-visible behavior?
 5. Include command evidence in PR description (commands and pass/fail).
+   Claims about artifact size, privacy, redaction, customer-safe sharing, or readability must include measured artifact-size deltas, redaction test names, and fixture coverage in the PR description or release-prep notes.
 6. If docs are touched, follow [`docs/map.md`](docs/map.md) and run docs validation bundle.
 7. For user-visible changes, update [`CHANGELOG.md`](CHANGELOG.md) under `Unreleased`.
    Public contract wording changes in `README.md`, command help, `docs/`, `product/`, or docs-site projections count even when JSON, exit codes, and schemas stay unchanged.
    Maintainers finalize `Unreleased` into a versioned section immediately before tagging with `python3 scripts/finalize_release_changelog.py --json`, publish that change through a short-lived release-prep PR, merge it to `main`, and only then create the tag from merged `main`.
 8. For `product/` or `.agents/skills/` changes, confirm policy conformance per [`docs/governance/content-visibility.md`](docs/governance/content-visibility.md).
+
+## Sprint 0 Receipt Rules
+
+- Release-note or changelog hardening claims about size, privacy, redaction, customer-safe sharing, or readability require measured artifact-size deltas, named redaction tests, and fixture coverage.
+- The v1.7.3 clarification workflow item must record actual before/after artifact sizes plus the exact redaction tests and fixtures used before release notes claim Sprint 0 hardening.
 
 Issue/PR templates:
 

--- a/core/cli/sprint0_report_contract_test.go
+++ b/core/cli/sprint0_report_contract_test.go
@@ -107,11 +107,7 @@ func TestSprint0LargeScanSizeSignalBudget(t *testing.T) {
 		t.Fatalf("expected primary workflow BOM section, got %q", string(markdownBytes))
 	}
 
-	sanitizedSummary, err := json.Marshal(summary)
-	if err != nil {
-		t.Fatalf("marshal sanitized summary: %v", err)
-	}
-	combined := string(sanitizedSummary) + "\n" + string(evidenceBytes) + "\n" + string(markdownBytes)
+	combined := reportOut.String() + "\n" + string(evidenceBytes) + "\n" + string(markdownBytes)
 	for _, forbidden := range []string{
 		"release-bot",
 		"triage-bot",

--- a/core/cli/sprint0_report_contract_test.go
+++ b/core/cli/sprint0_report_contract_test.go
@@ -1,0 +1,255 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/internal/enterprisepressure"
+)
+
+const (
+	sprint0CLILargeScanRepoCount   = 32
+	sprint0CLIStateByteBudget      = 5 << 20
+	sprint0CLIEvidenceByteBudget   = 2 << 20
+	sprint0CLIMarkdownLineBudget   = 1500
+	sprint0CLIExpectedShareProfile = "customer-redacted"
+)
+
+func TestSprint0LargeScanSizeSignalBudget(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	scanRoot := filepath.Join(tmp, "enterprise-pressure")
+	if err := enterprisepressure.MaterializeCount(scanRoot, enterprisepressure.VariantBaseline, sprint0CLILargeScanRepoCount); err != nil {
+		t.Fatalf("materialize enterprise fixture: %v", err)
+	}
+
+	statePath := filepath.Join(tmp, "last-scan.json")
+	var scanOut bytes.Buffer
+	var scanErr bytes.Buffer
+	if code := Run([]string{"scan", "--path", scanRoot, "--state", statePath, "--quiet", "--json"}, &scanOut, &scanErr); code != 0 {
+		t.Fatalf("scan failed: %d %s", code, scanErr.String())
+	}
+
+	var scanPayload map[string]any
+	if err := json.Unmarshal(scanOut.Bytes(), &scanPayload); err != nil {
+		t.Fatalf("parse scan payload: %v", err)
+	}
+	requirePositiveCLISuppressedCount(t, scanPayload, "findings")
+	requirePositiveCLISuppressedCount(t, scanPayload, "inventory_agents")
+	requireGroupedCLIPolicyOutcome(t, scanPayload)
+
+	stateBytes, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if len(stateBytes) > sprint0CLIStateByteBudget {
+		t.Fatalf("expected %s under %d bytes, got %d", filepath.Base(statePath), sprint0CLIStateByteBudget, len(stateBytes))
+	}
+
+	mdPath := filepath.Join(tmp, "agent-action-bom.md")
+	evidencePath := filepath.Join(tmp, "agent-action-bom-evidence.json")
+	var reportOut bytes.Buffer
+	var reportErr bytes.Buffer
+	if code := Run([]string{
+		"report",
+		"--state", statePath,
+		"--template", "agent-action-bom",
+		"--share-profile", sprint0CLIExpectedShareProfile,
+		"--md",
+		"--md-path", mdPath,
+		"--evidence-json",
+		"--evidence-json-path", evidencePath,
+		"--json",
+	}, &reportOut, &reportErr); code != 0 {
+		t.Fatalf("report failed: %d %s", code, reportErr.String())
+	}
+
+	var reportPayload map[string]any
+	if err := json.Unmarshal(reportOut.Bytes(), &reportPayload); err != nil {
+		t.Fatalf("parse report payload: %v", err)
+	}
+	summary, ok := reportPayload["summary"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected summary object, got %T", reportPayload["summary"])
+	}
+	if summary["share_profile"] != sprint0CLIExpectedShareProfile {
+		t.Fatalf("expected share profile %q, got %v", sprint0CLIExpectedShareProfile, summary["share_profile"])
+	}
+	metadata, ok := summary["share_profile_metadata"].(map[string]any)
+	if !ok || metadata["redaction_applied"] != true {
+		t.Fatalf("expected redaction metadata on shareable summary, got %v", summary["share_profile_metadata"])
+	}
+	requireGroupedCLIPolicyOutcome(t, summary)
+	requireReportContainsCanonicalRefs(t, reportPayload)
+
+	evidenceBytes, err := os.ReadFile(evidencePath)
+	if err != nil {
+		t.Fatalf("read evidence artifact: %v", err)
+	}
+	if len(evidenceBytes) > sprint0CLIEvidenceByteBudget {
+		t.Fatalf("expected %s under %d bytes, got %d", filepath.Base(evidencePath), sprint0CLIEvidenceByteBudget, len(evidenceBytes))
+	}
+
+	markdownBytes, err := os.ReadFile(mdPath)
+	if err != nil {
+		t.Fatalf("read markdown artifact: %v", err)
+	}
+	markdownLines := strings.Split(strings.TrimRight(string(markdownBytes), "\n"), "\n")
+	if len(markdownLines) > sprint0CLIMarkdownLineBudget+2 {
+		t.Fatalf("expected markdown under %d lines plus truncation note, got %d", sprint0CLIMarkdownLineBudget+2, len(markdownLines))
+	}
+	if !strings.Contains(string(markdownBytes), "## Primary Workflow BOM") {
+		t.Fatalf("expected primary workflow BOM section, got %q", string(markdownBytes))
+	}
+
+	sanitizedSummary, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal sanitized summary: %v", err)
+	}
+	combined := string(sanitizedSummary) + "\n" + string(evidenceBytes) + "\n" + string(markdownBytes)
+	for _, forbidden := range []string{
+		"release-bot",
+		"triage-bot",
+		"github.example.com/acme/enterprise-001/pull/108",
+		"/Users/",
+		enterprisepressure.RepoName(1),
+	} {
+		if strings.Contains(combined, forbidden) {
+			t.Fatalf("expected shareable artifacts to redact %q, got %q", forbidden, combined)
+		}
+	}
+	assertShareableOwnerFieldsRedacted(t, reportPayload)
+}
+
+func TestShareableArtifactsDoNotLeakOwners(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	scanRoot := filepath.Join(tmp, "enterprise-shareable")
+	if err := enterprisepressure.MaterializeCount(scanRoot, enterprisepressure.VariantBaseline, 16); err != nil {
+		t.Fatalf("materialize enterprise fixture: %v", err)
+	}
+
+	statePath := filepath.Join(tmp, "state.json")
+	if code := Run([]string{"scan", "--path", scanRoot, "--state", statePath, "--quiet", "--json"}, &bytes.Buffer{}, &bytes.Buffer{}); code != 0 {
+		t.Fatalf("scan failed with code %d", code)
+	}
+
+	var reportOut bytes.Buffer
+	var reportErr bytes.Buffer
+	if code := Run([]string{
+		"report",
+		"--state", statePath,
+		"--template", "agent-action-bom",
+		"--share-profile", sprint0CLIExpectedShareProfile,
+		"--json",
+	}, &reportOut, &reportErr); code != 0 {
+		t.Fatalf("report failed: %d %s", code, reportErr.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(reportOut.Bytes(), &payload); err != nil {
+		t.Fatalf("parse report payload: %v", err)
+	}
+	assertShareableOwnerFieldsRedacted(t, payload)
+}
+
+func requirePositiveCLISuppressedCount(t *testing.T, payload map[string]any, key string) {
+	t.Helper()
+
+	counts, ok := payload["suppressed_counts"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected suppressed_counts map, got %T", payload["suppressed_counts"])
+	}
+	value, ok := counts[key]
+	if !ok {
+		t.Fatalf("expected suppressed_counts[%q], got %v", key, counts)
+	}
+	number, ok := value.(float64)
+	if !ok || number <= 0 {
+		t.Fatalf("expected suppressed_counts[%q] > 0, got %v", key, value)
+	}
+}
+
+func requireGroupedCLIPolicyOutcome(t *testing.T, payload map[string]any) {
+	t.Helper()
+
+	outcomes, ok := payload["policy_outcomes"].([]any)
+	if !ok || len(outcomes) == 0 {
+		t.Fatalf("expected grouped policy_outcomes, got %T (%v)", payload["policy_outcomes"], payload["policy_outcomes"])
+	}
+	for _, raw := range outcomes {
+		outcome, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		suppressed, _ := outcome["suppressed_count"].(float64)
+		repos, _ := outcome["top_repo_refs"].([]any)
+		if suppressed > 0 && len(repos) > 0 {
+			return
+		}
+	}
+	t.Fatalf("expected at least one grouped policy outcome with bounded repo examples, got %v", outcomes)
+}
+
+func requireReportContainsCanonicalRefs(t *testing.T, payload map[string]any) {
+	t.Helper()
+
+	bom, ok := payload["agent_action_bom"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected agent_action_bom object, got %T", payload["agent_action_bom"])
+	}
+	items, ok := bom["items"].([]any)
+	if !ok || len(items) == 0 {
+		t.Fatalf("expected agent_action_bom.items, got %T (%v)", bom["items"], bom["items"])
+	}
+	hasCredentialAuthorityRef := false
+	hasAuthorityBindingRefs := false
+	hasEndpointRefs := false
+	for _, raw := range items {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if item["credential_authority_ref"] != nil {
+			hasCredentialAuthorityRef = true
+		}
+		if refs, ok := item["authority_binding_refs"].([]any); ok && len(refs) > 0 {
+			hasAuthorityBindingRefs = true
+		}
+		if endpointRefs, ok := item["mutable_endpoint_semantic_refs"].([]any); ok && len(endpointRefs) > 0 {
+			hasEndpointRefs = true
+		}
+	}
+	if !hasCredentialAuthorityRef && !hasAuthorityBindingRefs && !hasEndpointRefs {
+		t.Fatalf("expected canonical ref joins in BOM items, got %v", items)
+	}
+}
+
+func assertShareableOwnerFieldsRedacted(t *testing.T, payload map[string]any) {
+	t.Helper()
+
+	bom, ok := payload["agent_action_bom"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected agent_action_bom object, got %T", payload["agent_action_bom"])
+	}
+	items, ok := bom["items"].([]any)
+	if !ok || len(items) == 0 {
+		t.Fatalf("expected agent_action_bom.items, got %T (%v)", bom["items"], bom["items"])
+	}
+	for _, raw := range items {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		owner, _ := item["owner"].(string)
+		if strings.HasPrefix(owner, "@acme/") {
+			t.Fatalf("expected shareable owner field to be redacted, got %q", owner)
+		}
+	}
+}

--- a/core/report/sprint0_signal_test.go
+++ b/core/report/sprint0_signal_test.go
@@ -1,0 +1,107 @@
+package report
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/model"
+	"github.com/Clyra-AI/wrkr/core/risk"
+)
+
+func TestAgentActionBOMPrimaryViewLineBudget(t *testing.T) {
+	t.Parallel()
+
+	items := make([]AgentActionBOMItem, 0, 400)
+	for idx := 0; idx < 400; idx++ {
+		items = append(items, AgentActionBOMItem{
+			PathID:                   fmt.Sprintf("apc-%03d", idx),
+			Org:                      "acme",
+			Repo:                     fmt.Sprintf("enterprise-%03d", idx),
+			ToolType:                 "compiled_action",
+			Location:                 fmt.Sprintf(".github/workflows/release-%03d.yml", idx),
+			ControlState:             "block_recommended",
+			RiskZone:                 "high",
+			ReviewBurden:             "high",
+			ConfidenceLane:           risk.ConfidenceLaneConfirmedActionPath,
+			DelegationReadinessState: risk.DelegationReadinessApprovalRequired,
+			RecommendedControl:       risk.RecommendedControlApprovalRequired,
+			Remediation:              "Attach owner-approved evidence, verify the release path, and rescan.",
+			ProofCoverage:            "missing",
+		})
+	}
+
+	summary := Summary{
+		GeneratedAt:  "2026-06-12T12:00:00Z",
+		Template:     string(TemplateAgentActionBOM),
+		ShareProfile: string(ShareProfileInternal),
+		AgentActionBOM: &AgentActionBOM{
+			BOMID:         "bom-sprint0",
+			SchemaVersion: AgentActionBOMSchemaVersion,
+			Summary: AgentActionBOMSummary{
+				TotalItems:        len(items),
+				ControlFirstItems: len(items),
+				PrimaryView: &AgentActionBOMPrimaryView{
+					PathID:                   "apc-000",
+					SelectionReason:          AgentActionBOMPrimarySelectionDefaultTopPath,
+					AutonomyTier:             risk.AutonomyTier4ProdPrivilegedCustomerImpact,
+					DelegationReadinessState: risk.DelegationReadinessApprovalRequired,
+					RecommendedControl:       risk.RecommendedControlApprovalRequired,
+					PathMap: AgentActionBOMPrimaryPathMap{
+						Tool:       "codex",
+						RepoPR:     "enterprise-000 / pr/108",
+						Workflow:   ".github/workflows/release-000.yml",
+						Credential: "github_actions_prod_deployer",
+						Action:     "deploy",
+						Target:     "production_impacting",
+					},
+					DecisionTraceRefs: []string{"decision_trace:trace-000"},
+					AppendixRefs:      []string{"bom_items", "graph_refs", "proof_refs"},
+				},
+			},
+			Items: items,
+		},
+	}
+
+	markdown := RenderMarkdown(summary)
+	lines := strings.Split(strings.TrimRight(markdown, "\n"), "\n")
+	if len(lines) > defaultMarkdownLineCap {
+		t.Fatalf("expected markdown under the %d-line budget, got %d", defaultMarkdownLineCap, len(lines))
+	}
+	if !strings.Contains(markdown, "## Primary Workflow BOM") || !strings.Contains(markdown, "## Workflow BOM Appendix") {
+		t.Fatalf("expected primary-view and appendix sections in markdown, got %q", markdown)
+	}
+}
+
+func TestPolicyOutcomeSuppressedCounts(t *testing.T) {
+	t.Parallel()
+
+	findings := make([]model.Finding, 0, 5)
+	for idx := 0; idx < 5; idx++ {
+		findings = append(findings, model.Finding{
+			FindingType: "policy_violation",
+			RuleID:      "WRKR-016",
+			CheckResult: "fail",
+			Severity:    "high",
+			Org:         "acme",
+			Repo:        fmt.Sprintf("enterprise-%03d", idx),
+		})
+	}
+
+	outcomes := BuildPolicyOutcomes(findings)
+	if len(outcomes) != 1 {
+		t.Fatalf("expected one grouped policy outcome, got %+v", outcomes)
+	}
+	if outcomes[0].OccurrenceCount != 5 {
+		t.Fatalf("expected occurrence count 5, got %+v", outcomes[0])
+	}
+	if outcomes[0].AffectedRepoCount != 5 {
+		t.Fatalf("expected affected repo count 5, got %+v", outcomes[0])
+	}
+	if len(outcomes[0].TopRepoRefs) != 3 {
+		t.Fatalf("expected bounded repo refs, got %+v", outcomes[0])
+	}
+	if outcomes[0].SuppressedCount != 2 {
+		t.Fatalf("expected suppressed repo examples, got %+v", outcomes[0])
+	}
+}

--- a/internal/acceptance/sprint0_size_signal_acceptance_test.go
+++ b/internal/acceptance/sprint0_size_signal_acceptance_test.go
@@ -1,0 +1,173 @@
+package acceptance
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/internal/enterprisepressure"
+)
+
+const (
+	sprint0AcceptanceRepoCount       = 96
+	sprint0AcceptanceStateByteBudget = 16 << 20
+	sprint0AcceptanceEvidenceBudget  = 2 << 20
+	sprint0AcceptanceMarkdownLineCap = 1500
+)
+
+func TestSprint0AgentActionBOMArtifactsStayBoundedAndRedacted(t *testing.T) {
+	tmp := t.TempDir()
+	scanRoot := filepath.Join(tmp, "enterprise-pressure")
+	if err := enterprisepressure.MaterializeCount(scanRoot, enterprisepressure.VariantBaseline, sprint0AcceptanceRepoCount); err != nil {
+		t.Fatalf("materialize enterprise fixture: %v", err)
+	}
+
+	statePath := filepath.Join(tmp, "last-scan.json")
+	scanPayload := runJSONOK(t, "scan", "--path", scanRoot, "--state", statePath, "--quiet", "--json")
+	requirePositiveAcceptanceSuppressedCount(t, scanPayload, "findings")
+	requirePositiveAcceptanceSuppressedCount(t, scanPayload, "inventory_agents")
+	requireAcceptancePolicyOutcomeGrouping(t, scanPayload)
+
+	stateBytes, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if len(stateBytes) > sprint0AcceptanceStateByteBudget {
+		t.Fatalf("expected last-scan.json under %d bytes, got %d", sprint0AcceptanceStateByteBudget, len(stateBytes))
+	}
+
+	mdPath := filepath.Join(tmp, "agent-action-bom.md")
+	evidencePath := filepath.Join(tmp, "agent-action-bom-evidence.json")
+	reportPayload := runJSONOK(
+		t,
+		"report",
+		"--state", statePath,
+		"--template", "agent-action-bom",
+		"--share-profile", "customer-redacted",
+		"--md", "--md-path", mdPath,
+		"--evidence-json", "--evidence-json-path", evidencePath,
+		"--json",
+	)
+
+	summary := requireObject(t, reportPayload, "summary")
+	if summary["share_profile"] != "customer-redacted" {
+		t.Fatalf("expected customer-redacted share profile, got %v", summary["share_profile"])
+	}
+	metadata := requireObject(t, summary, "share_profile_metadata")
+	if metadata["redaction_applied"] != true {
+		t.Fatalf("expected redaction metadata, got %v", metadata)
+	}
+	requireAcceptancePolicyOutcomeGrouping(t, summary)
+	requireAcceptanceCanonicalRefs(t, reportPayload)
+
+	evidenceBytes, err := os.ReadFile(evidencePath)
+	if err != nil {
+		t.Fatalf("read evidence artifact: %v", err)
+	}
+	if len(evidenceBytes) > sprint0AcceptanceEvidenceBudget {
+		t.Fatalf("expected agent-action-bom-evidence.json under %d bytes, got %d", sprint0AcceptanceEvidenceBudget, len(evidenceBytes))
+	}
+
+	markdownBytes, err := os.ReadFile(mdPath)
+	if err != nil {
+		t.Fatalf("read markdown artifact: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(markdownBytes), "\n"), "\n")
+	if len(lines) > sprint0AcceptanceMarkdownLineCap+2 {
+		t.Fatalf("expected markdown under %d lines plus truncation note, got %d", sprint0AcceptanceMarkdownLineCap+2, len(lines))
+	}
+
+	summaryBytes, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal report summary: %v", err)
+	}
+	combined := string(summaryBytes) + "\n" + string(evidenceBytes) + "\n" + string(markdownBytes)
+	for _, forbidden := range []string{
+		"release-bot",
+		"triage-bot",
+		"github.example.com/acme/enterprise-001/pull/108",
+		"/Users/",
+		enterprisepressure.RepoName(1),
+	} {
+		if strings.Contains(combined, forbidden) {
+			t.Fatalf("expected shareable artifacts to redact %q", forbidden)
+		}
+	}
+	requireAcceptanceOwnerFieldsRedacted(t, reportPayload)
+}
+
+func requirePositiveAcceptanceSuppressedCount(t *testing.T, payload map[string]any, key string) {
+	t.Helper()
+
+	counts, ok := payload["suppressed_counts"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected suppressed_counts, got %T", payload["suppressed_counts"])
+	}
+	value, ok := counts[key]
+	if !ok {
+		t.Fatalf("expected suppressed_counts[%q], got %v", key, counts)
+	}
+	number, ok := value.(float64)
+	if !ok || number <= 0 {
+		t.Fatalf("expected suppressed_counts[%q] > 0, got %v", key, value)
+	}
+}
+
+func requireAcceptancePolicyOutcomeGrouping(t *testing.T, payload map[string]any) {
+	t.Helper()
+
+	outcomes, ok := payload["policy_outcomes"].([]any)
+	if !ok || len(outcomes) == 0 {
+		t.Fatalf("expected policy_outcomes, got %T (%v)", payload["policy_outcomes"], payload["policy_outcomes"])
+	}
+	for _, raw := range outcomes {
+		outcome := requireObjectItem(t, raw)
+		suppressed, _ := outcome["suppressed_count"].(float64)
+		repos, _ := outcome["top_repo_refs"].([]any)
+		if suppressed > 0 && len(repos) > 0 {
+			return
+		}
+	}
+	t.Fatalf("expected grouped policy outcomes with bounded repo examples, got %v", outcomes)
+}
+
+func requireAcceptanceCanonicalRefs(t *testing.T, reportPayload map[string]any) {
+	t.Helper()
+
+	bom := requireObject(t, reportPayload, "agent_action_bom")
+	items := requireArrayFromObject(t, bom, "items")
+	hasCredentialAuthorityRef := false
+	hasAuthorityBindingRefs := false
+	hasEndpointRefs := false
+	for _, raw := range items {
+		item := requireObjectItem(t, raw)
+		if item["credential_authority_ref"] != nil {
+			hasCredentialAuthorityRef = true
+		}
+		if refs, ok := item["authority_binding_refs"].([]any); ok && len(refs) > 0 {
+			hasAuthorityBindingRefs = true
+		}
+		if endpointRefs, ok := item["mutable_endpoint_semantic_refs"].([]any); ok && len(endpointRefs) > 0 {
+			hasEndpointRefs = true
+		}
+	}
+	if !hasCredentialAuthorityRef && !hasAuthorityBindingRefs && !hasEndpointRefs {
+		t.Fatalf("expected canonical ref joins in BOM items, got %v", items)
+	}
+}
+
+func requireAcceptanceOwnerFieldsRedacted(t *testing.T, reportPayload map[string]any) {
+	t.Helper()
+
+	bom := requireObject(t, reportPayload, "agent_action_bom")
+	items := requireArrayFromObject(t, bom, "items")
+	for _, raw := range items {
+		item := requireObjectItem(t, raw)
+		owner, _ := item["owner"].(string)
+		if strings.HasPrefix(owner, "@acme/") {
+			t.Fatalf("expected shareable owner field to be redacted, got %q", owner)
+		}
+	}
+}

--- a/internal/acceptance/sprint0_size_signal_acceptance_test.go
+++ b/internal/acceptance/sprint0_size_signal_acceptance_test.go
@@ -79,11 +79,11 @@ func TestSprint0AgentActionBOMArtifactsStayBoundedAndRedacted(t *testing.T) {
 		t.Fatalf("expected markdown under %d lines plus truncation note, got %d", sprint0AcceptanceMarkdownLineCap+2, len(lines))
 	}
 
-	summaryBytes, err := json.Marshal(summary)
+	reportBytes, err := json.Marshal(reportPayload)
 	if err != nil {
-		t.Fatalf("marshal report summary: %v", err)
+		t.Fatalf("marshal report payload: %v", err)
 	}
-	combined := string(summaryBytes) + "\n" + string(evidenceBytes) + "\n" + string(markdownBytes)
+	combined := string(reportBytes) + "\n" + string(evidenceBytes) + "\n" + string(markdownBytes)
 	for _, forbidden := range []string{
 		"release-bot",
 		"triage-bot",

--- a/internal/scenarios/sprint0_size_signal_scenario_test.go
+++ b/internal/scenarios/sprint0_size_signal_scenario_test.go
@@ -1,0 +1,167 @@
+//go:build scenario
+
+package scenarios
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/internal/enterprisepressure"
+)
+
+const (
+	sprint0ScenarioRepoCount       = 96
+	sprint0ScenarioStateByteBudget = 16 << 20
+	sprint0ScenarioEvidenceBudget  = 2 << 20
+	sprint0ScenarioMarkdownCap     = 1500
+)
+
+func TestScenarioSprint0LargeScanBudgetContract(t *testing.T) {
+	repoRoot := mustFindRepoRoot(t)
+	_ = repoRoot
+
+	tmp := t.TempDir()
+	scanRoot := filepath.Join(tmp, "enterprise-pressure")
+	if err := enterprisepressure.MaterializeCount(scanRoot, enterprisepressure.VariantBaseline, sprint0ScenarioRepoCount); err != nil {
+		t.Fatalf("materialize enterprise fixture: %v", err)
+	}
+
+	statePath := filepath.Join(tmp, "last-scan.json")
+	scanPayload := runScenarioCommandJSON(t, []string{"scan", "--path", scanRoot, "--state", statePath, "--quiet", "--json"})
+	requirePositiveScenarioSuppressedCount(t, scanPayload, "findings")
+	requirePositiveScenarioSuppressedCount(t, scanPayload, "inventory_agents")
+	requireScenarioPolicyOutcomeGrouping(t, scanPayload)
+
+	stateBytes, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if len(stateBytes) > sprint0ScenarioStateByteBudget {
+		t.Fatalf("expected last-scan.json under %d bytes, got %d", sprint0ScenarioStateByteBudget, len(stateBytes))
+	}
+
+	mdPath := filepath.Join(tmp, "agent-action-bom.md")
+	evidencePath := filepath.Join(tmp, "agent-action-bom-evidence.json")
+	reportPayload := runScenarioCommandJSON(t, []string{
+		"report",
+		"--state", statePath,
+		"--template", "agent-action-bom",
+		"--share-profile", "customer-redacted",
+		"--md", "--md-path", mdPath,
+		"--evidence-json", "--evidence-json-path", evidencePath,
+		"--json",
+	})
+
+	summary := requireScenarioObject(t, reportPayload, "summary")
+	if stringValue(summary["share_profile"]) != "customer-redacted" {
+		t.Fatalf("expected customer-redacted share profile, got %v", summary["share_profile"])
+	}
+	requireScenarioPolicyOutcomeGrouping(t, summary)
+	requireScenarioCanonicalRefs(t, reportPayload)
+
+	evidenceBytes, err := os.ReadFile(evidencePath)
+	if err != nil {
+		t.Fatalf("read evidence artifact: %v", err)
+	}
+	if len(evidenceBytes) > sprint0ScenarioEvidenceBudget {
+		t.Fatalf("expected agent-action-bom-evidence.json under %d bytes, got %d", sprint0ScenarioEvidenceBudget, len(evidenceBytes))
+	}
+
+	markdownBytes, err := os.ReadFile(mdPath)
+	if err != nil {
+		t.Fatalf("read markdown artifact: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(markdownBytes), "\n"), "\n")
+	if len(lines) > sprint0ScenarioMarkdownCap+2 {
+		t.Fatalf("expected markdown under %d lines plus truncation note, got %d", sprint0ScenarioMarkdownCap+2, len(lines))
+	}
+
+	summaryBytes, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+	combined := string(summaryBytes) + "\n" + string(evidenceBytes) + "\n" + string(markdownBytes)
+	for _, forbidden := range []string{
+		"release-bot",
+		"triage-bot",
+		"github.example.com/acme/enterprise-001/pull/108",
+		"/Users/",
+		enterprisepressure.RepoName(1),
+	} {
+		if strings.Contains(combined, forbidden) {
+			t.Fatalf("expected shareable artifacts to redact %q", forbidden)
+		}
+	}
+	requireScenarioOwnerFieldsRedacted(t, reportPayload)
+}
+
+func requirePositiveScenarioSuppressedCount(t *testing.T, payload map[string]any, key string) {
+	t.Helper()
+
+	counts := requireScenarioObject(t, payload, "suppressed_counts")
+	value, ok := counts[key]
+	if !ok {
+		t.Fatalf("expected suppressed_counts[%q], got %v", key, counts)
+	}
+	number, ok := value.(float64)
+	if !ok || number <= 0 {
+		t.Fatalf("expected suppressed_counts[%q] > 0, got %v", key, value)
+	}
+}
+
+func requireScenarioPolicyOutcomeGrouping(t *testing.T, payload map[string]any) {
+	t.Helper()
+
+	outcomes := requireArray(t, payload, "policy_outcomes")
+	for _, raw := range outcomes {
+		outcome := requireObjectItem(t, raw)
+		suppressed, _ := outcome["suppressed_count"].(float64)
+		repos, _ := outcome["top_repo_refs"].([]any)
+		if suppressed > 0 && len(repos) > 0 {
+			return
+		}
+	}
+	t.Fatalf("expected grouped policy outcomes with suppressed repo examples, got %v", outcomes)
+}
+
+func requireScenarioCanonicalRefs(t *testing.T, payload map[string]any) {
+	t.Helper()
+
+	bom := requireScenarioObject(t, payload, "agent_action_bom")
+	items := requireArrayFromObject(t, bom, "items")
+	hasCredentialAuthorityRef := false
+	hasAuthorityBindingRefs := false
+	hasEndpointRefs := false
+	for _, raw := range items {
+		item := requireObjectItem(t, raw)
+		if item["credential_authority_ref"] != nil {
+			hasCredentialAuthorityRef = true
+		}
+		if refs, ok := item["authority_binding_refs"].([]any); ok && len(refs) > 0 {
+			hasAuthorityBindingRefs = true
+		}
+		if endpointRefs, ok := item["mutable_endpoint_semantic_refs"].([]any); ok && len(endpointRefs) > 0 {
+			hasEndpointRefs = true
+		}
+	}
+	if !hasCredentialAuthorityRef && !hasAuthorityBindingRefs && !hasEndpointRefs {
+		t.Fatalf("expected canonical ref joins in BOM items, got %v", items)
+	}
+}
+
+func requireScenarioOwnerFieldsRedacted(t *testing.T, payload map[string]any) {
+	t.Helper()
+
+	bom := requireScenarioObject(t, payload, "agent_action_bom")
+	items := requireArrayFromObject(t, bom, "items")
+	for _, raw := range items {
+		item := requireObjectItem(t, raw)
+		owner := stringValue(item["owner"])
+		if strings.HasPrefix(owner, "@acme/") {
+			t.Fatalf("expected shareable owner field to be redacted, got %q", owner)
+		}
+	}
+}

--- a/internal/scenarios/sprint0_size_signal_scenario_test.go
+++ b/internal/scenarios/sprint0_size_signal_scenario_test.go
@@ -79,11 +79,11 @@ func TestScenarioSprint0LargeScanBudgetContract(t *testing.T) {
 		t.Fatalf("expected markdown under %d lines plus truncation note, got %d", sprint0ScenarioMarkdownCap+2, len(lines))
 	}
 
-	summaryBytes, err := json.Marshal(summary)
+	reportBytes, err := json.Marshal(reportPayload)
 	if err != nil {
-		t.Fatalf("marshal summary: %v", err)
+		t.Fatalf("marshal report payload: %v", err)
 	}
-	combined := string(summaryBytes) + "\n" + string(evidenceBytes) + "\n" + string(markdownBytes)
+	combined := string(reportBytes) + "\n" + string(evidenceBytes) + "\n" + string(markdownBytes)
 	for _, forbidden := range []string{
 		"release-bot",
 		"triage-bot",

--- a/testinfra/hygiene/wave31_focus_and_gate_test.go
+++ b/testinfra/hygiene/wave31_focus_and_gate_test.go
@@ -61,3 +61,52 @@ func TestWave31SurfaceAreaGateDocsRemainPresent(t *testing.T) {
 		t.Fatal("pull request template missing budget impact prompt")
 	}
 }
+
+func TestWave31FreezeBlocksNewSurfaceBeforeSprint0Gates(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	agents := mustReadFile(t, filepath.Join(repoRoot, "AGENTS.md"))
+	contributing := mustReadFile(t, filepath.Join(repoRoot, "CONTRIBUTING.md"))
+	prTemplate := mustReadFile(t, filepath.Join(repoRoot, ".github/pull_request_template.md"))
+	changelog := mustReadFile(t, filepath.Join(repoRoot, "CHANGELOG.md"))
+
+	for _, content := range []string{agents, contributing, prTemplate, changelog} {
+		for _, required := range []string{
+			"Sprint 0",
+			"temporary freeze gate",
+			"size, redaction, and readability gates are green",
+		} {
+			if !strings.Contains(content, required) {
+				t.Fatalf("Sprint 0 freeze gate docs missing %q", required)
+			}
+		}
+	}
+	if !strings.Contains(prTemplate, "Stories 1.1 through 4.2") {
+		t.Fatal("pull request template must require explicit Sprint 0 gate justification")
+	}
+}
+
+func TestChangelogPrivacyClaimsRequireMeasuredReceipts(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	contributing := mustReadFile(t, filepath.Join(repoRoot, "CONTRIBUTING.md"))
+	prTemplate := mustReadFile(t, filepath.Join(repoRoot, ".github/pull_request_template.md"))
+	changelog := mustReadFile(t, filepath.Join(repoRoot, "CHANGELOG.md"))
+
+	for _, content := range []string{contributing, prTemplate, changelog} {
+		for _, required := range []string{
+			"measured artifact-size deltas",
+			"redaction test names",
+			"fixture coverage",
+		} {
+			if !strings.Contains(content, required) {
+				t.Fatalf("receipt governance missing %q", required)
+			}
+		}
+	}
+	if !strings.Contains(changelog, "v1.7.3 clarification workflow item") {
+		t.Fatal("CHANGELOG must record the v1.7.3 clarification workflow item")
+	}
+}


### PR DESCRIPTION
## Problem

Wave 1 of the Sprint 0 subtractive-fixes plan needed executable receipts for size, signal, and governance regressions before later subtractive changes land.

## Changes

- add Sprint 0 size/signal regression coverage in CLI, report, acceptance, and scenario test layers
- add BOM markdown budget and grouped policy-outcome receipts
- add hygiene coverage for measured changelog/privacy receipts and the temporary Sprint 0 freeze gate
- update governance docs and changelog guidance to require measured artifact deltas, named redaction tests, and fixture coverage

## Validation

- make lint-fast
- make test-fast
- go test ./core/cli -run 'Test.*ReportContract|Test.*SizeSignal|Test.*AgentActionBOM' -count=1
- go test ./core/report -run 'Test.*PrimaryView|Test.*LineBudget|Test.*Redaction|Test.*PolicyOutcome' -count=1
- go test ./internal/acceptance -run 'Test.*Sprint0|Test.*AgentActionBOM' -count=1
- go test ./internal/scenarios -run 'Test.*Sprint0|Test.*SizeSignal|Test.*LargeScan' -count=1 -tags=scenario
- go test ./testinfra/hygiene -run 'Test.*Wave31|Test.*Freeze|Test.*LaunchTruth|Test.*Changelog' -count=1
- make test-contracts
- make prepush-full

## Risks

- Wave 1 intentionally measures canonical-ref presence and direct owner-field redaction without claiming the fuller Wave 2 clone-removal and reason-text redaction work is already complete.
- The larger acceptance/scenario state budgets are based on measured current artifact size for the synthetic enterprise-shaped fixture, so later subtractive waves should be able to ratchet those budgets down.
