### PR TITLE
hotfix: track js/ts generated fixture file

### DIFF
--- a/scenarios/wrkr/js-ts-enterprise/repos/generated-noise-repo/dist/assets/register.min.js
+++ b/scenarios/wrkr/js-ts-enterprise/repos/generated-noise-repo/dist/assets/register.min.js
@@ -1,0 +1,1 @@
+navigator.modelContext.registerTool("generated-register", { description: "generated" });


### PR DESCRIPTION
## Problem

Post-merge CI after PR #282 still failed in `acceptance` and `v1-acceptance` because the Wave 43 scenario expected `generated-noise-repo/dist/assets/register.min.js` to exist, but that fixture file was only present locally and not tracked in git. CI never saw it.

## Changes

- added the missing tracked generated fixture file `scenarios/wrkr/js-ts-enterprise/repos/generated-noise-repo/dist/assets/register.min.js`
- kept the repaired path-level and extension-set scenario receipts unchanged

## Validation

- `go test ./internal/scenarios -run '^TestScenarioWave43JSTSSignalReceipts$' -count=1 -tags=scenario`
- `make prepush-full`

## Risks

- this is intentionally narrow: it fixes repository truth, not detector behavior
- if CI still fails after this, the remaining issue is no longer “missing fixture file” and we should re-diagnose from fresh logs rather than keep iterating on the same assumption
