### PR TITLE
fix: finalize evidence bundle redaction projections

### DIFF
--- a/core/cli/report_pdf.go
+++ b/core/cli/report_pdf.go
@@ -57,7 +57,8 @@ func renderSimplePDF(lines []string) []byte {
 
 	out := bytes.Buffer{}
 	out.WriteString("%PDF-1.4\n")
-	offsets := make([]int, len(objects)+1)
+	offsets := []int{0}
+	offsets = append(offsets, make([]int, len(objects))...)
 	for i, object := range objects {
 		offsets[i+1] = out.Len()
 		_, _ = fmt.Fprintf(&out, "%d 0 obj\n%s\nendobj\n", i+1, object)

--- a/core/evidence/evidence.go
+++ b/core/evidence/evidence.go
@@ -202,6 +202,7 @@ func Build(in BuildInput) (BuildResult, error) {
 	if err := validateSnapshot(snapshot); err != nil {
 		return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 	}
+	bundleSnapshot := state.FinalizeSnapshotForOutput(snapshot)
 	complianceSummary, err := compliance.BuildRollupSummary(snapshot.Findings, chain)
 	if err != nil {
 		return BuildResult{}, classifyErrorf(ErrorClassRuntimeFailure, "build compliance summary: %w", err)
@@ -240,32 +241,32 @@ func Build(in BuildInput) (BuildResult, error) {
 		generatedAt = generatedAt.UTC().Truncate(time.Second)
 	}
 
-	if err := writeJSON(filepath.Join(outputDir, "inventory.json"), snapshot.Inventory); err != nil {
+	if err := writeJSON(filepath.Join(outputDir, "inventory.json"), bundleSnapshot.Inventory); err != nil {
 		return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 	}
-	if err := writeYAML(filepath.Join(outputDir, "inventory.yaml"), snapshot.Inventory); err != nil {
+	if err := writeYAML(filepath.Join(outputDir, "inventory.yaml"), bundleSnapshot.Inventory); err != nil {
 		return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 	}
-	if err := writeJSON(filepath.Join(outputDir, "inventory-snapshot.json"), snapshot.Inventory); err != nil {
+	if err := writeJSON(filepath.Join(outputDir, "inventory-snapshot.json"), bundleSnapshot.Inventory); err != nil {
 		return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 	}
 	if snapshot.Target.Mode == "my_setup" {
 		if err := writeJSON(filepath.Join(outputDir, "personal-inventory-snapshot.json"), map[string]any{
-			"target":    snapshot.Target,
-			"inventory": snapshot.Inventory,
+			"target":    bundleSnapshot.Target,
+			"inventory": bundleSnapshot.Inventory,
 		}); err != nil {
 			return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 		}
 	}
-	if err := writeJSON(filepath.Join(outputDir, "risk-report.json"), snapshot.RiskReport); err != nil {
+	if err := writeJSON(filepath.Join(outputDir, "risk-report.json"), bundleSnapshot.RiskReport); err != nil {
 		return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 	}
-	if snapshot.RiskReport != nil {
-		if err := writeJSON(filepath.Join(outputDir, "attack-paths.json"), snapshot.RiskReport.AttackPaths); err != nil {
+	if bundleSnapshot.RiskReport != nil {
+		if err := writeJSON(filepath.Join(outputDir, "attack-paths.json"), bundleSnapshot.RiskReport.AttackPaths); err != nil {
 			return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 		}
 	}
-	if err := writeJSON(filepath.Join(outputDir, "profile-compliance.json"), snapshot.Profile); err != nil {
+	if err := writeJSON(filepath.Join(outputDir, "profile-compliance.json"), bundleSnapshot.Profile); err != nil {
 		return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 	}
 	if err := writeJSON(filepath.Join(outputDir, "compliance-summary.json"), complianceSummary); err != nil {
@@ -311,7 +312,7 @@ func Build(in BuildInput) (BuildResult, error) {
 			return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 		}
 	}
-	if err := writeJSON(filepath.Join(outputDir, "posture-score.json"), snapshot.PostureScore); err != nil {
+	if err := writeJSON(filepath.Join(outputDir, "posture-score.json"), bundleSnapshot.PostureScore); err != nil {
 		return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 	}
 	if err := writeJSON(filepath.Join(outputDir, "scan-metadata.json"), map[string]any{
@@ -324,9 +325,20 @@ func Build(in BuildInput) (BuildResult, error) {
 		return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 	}
 	reportArtifacts := []string{}
+	loadReportSnapshot := func() (state.Snapshot, error) {
+		reportSnapshot, loadErr := state.Load(resolvedStatePath)
+		if loadErr != nil {
+			return state.Snapshot{}, loadErr
+		}
+		return reportSnapshot, nil
+	}
+	internalReportSnapshot, err := loadReportSnapshot()
+	if err != nil {
+		return BuildResult{}, classifyErrorf(ErrorClassRuntimeFailure, "load deterministic report snapshot: %w", err)
+	}
 	summary, err := reportcore.BuildSummary(reportcore.BuildInput{
 		StatePath:    resolvedStatePath,
-		Snapshot:     snapshot,
+		Snapshot:     internalReportSnapshot,
 		Top:          5,
 		Template:     reportcore.TemplateAudit,
 		ShareProfile: reportcore.ShareProfileInternal,
@@ -335,9 +347,13 @@ func Build(in BuildInput) (BuildResult, error) {
 		return BuildResult{}, classifyErrorf(ErrorClassRuntimeFailure, "build deterministic report summary: %w", err)
 	}
 	summary = reportcore.FinalizeSummaryForShareProfile(summary)
+	redactedReportSnapshot, err := loadReportSnapshot()
+	if err != nil {
+		return BuildResult{}, classifyErrorf(ErrorClassRuntimeFailure, "load customer-redacted report snapshot: %w", err)
+	}
 	redactedSummary, err := reportcore.BuildSummary(reportcore.BuildInput{
 		StatePath:    resolvedStatePath,
-		Snapshot:     snapshot,
+		Snapshot:     redactedReportSnapshot,
 		Top:          5,
 		Template:     reportcore.TemplateAudit,
 		ShareProfile: reportcore.ShareProfileCustomerRedacted,
@@ -528,7 +544,7 @@ func Build(in BuildInput) (BuildResult, error) {
 		RuntimeSessions:      runtimeSessions,
 		RuntimeEvidence:      runtimeEvidence,
 		EvidencePackets:      evidencePackets,
-		AgentActionBOM:       summary.AgentActionBOM,
+		AgentActionBOM:       redactedSummary.AgentActionBOM,
 		GovernedUsageMetrics: summary.GovernedUsageMetrics,
 	}, nil
 }

--- a/core/evidence/evidence.go
+++ b/core/evidence/evidence.go
@@ -325,43 +325,10 @@ func Build(in BuildInput) (BuildResult, error) {
 		return BuildResult{}, classifyError(ErrorClassRuntimeFailure, err)
 	}
 	reportArtifacts := []string{}
-	loadReportSnapshot := func() (state.Snapshot, error) {
-		reportSnapshot, loadErr := state.Load(resolvedStatePath)
-		if loadErr != nil {
-			return state.Snapshot{}, loadErr
-		}
-		return reportSnapshot, nil
-	}
-	internalReportSnapshot, err := loadReportSnapshot()
+	summary, redactedSummary, err := buildReportSummaries(resolvedStatePath, snapshot)
 	if err != nil {
-		return BuildResult{}, classifyErrorf(ErrorClassRuntimeFailure, "load deterministic report snapshot: %w", err)
+		return BuildResult{}, err
 	}
-	summary, err := reportcore.BuildSummary(reportcore.BuildInput{
-		StatePath:    resolvedStatePath,
-		Snapshot:     internalReportSnapshot,
-		Top:          5,
-		Template:     reportcore.TemplateAudit,
-		ShareProfile: reportcore.ShareProfileInternal,
-	})
-	if err != nil {
-		return BuildResult{}, classifyErrorf(ErrorClassRuntimeFailure, "build deterministic report summary: %w", err)
-	}
-	summary = reportcore.FinalizeSummaryForShareProfile(summary)
-	redactedReportSnapshot, err := loadReportSnapshot()
-	if err != nil {
-		return BuildResult{}, classifyErrorf(ErrorClassRuntimeFailure, "load customer-redacted report snapshot: %w", err)
-	}
-	redactedSummary, err := reportcore.BuildSummary(reportcore.BuildInput{
-		StatePath:    resolvedStatePath,
-		Snapshot:     redactedReportSnapshot,
-		Top:          5,
-		Template:     reportcore.TemplateAudit,
-		ShareProfile: reportcore.ShareProfileCustomerRedacted,
-	})
-	if err != nil {
-		return BuildResult{}, classifyErrorf(ErrorClassRuntimeFailure, "build customer-redacted report summary: %w", err)
-	}
-	redactedSummary = reportcore.FinalizeSummaryForShareProfile(redactedSummary)
 	pairID := reportcore.BuildPairID(summary, reportcore.ShareProfileCustomerRedacted)
 	privateJoinMapPath := filepath.Join(filepath.Dir(targetOutputDir), "."+filepath.Base(targetOutputDir)+"-"+pairID+"-private-join-map.json")
 	summary.ArtifactMetadata = reportcore.BuildArtifactMetadata(summary, []string{resolvedStatePath}, reportcore.ArtifactVariantInternal, pairID, privateJoinMapPath)
@@ -600,6 +567,53 @@ func buildEvidencePackets(snapshot state.Snapshot, statePath string) (*ingest.Ev
 	merged := ingest.MergeEvidencePacketBundles(bundle, ingest.ProjectSessionsToEvidencePacketBundle(sessionBundle))
 	summary := ingest.CorrelateEvidencePackets(snapshot, firstNonEmptyValue(artifactPath, sessionArtifactPath), merged)
 	return &summary, merged, true, nil
+}
+
+func buildReportSummaries(statePath string, snapshot state.Snapshot) (reportcore.Summary, reportcore.Summary, error) {
+	internalReportSnapshot, err := cloneReportSnapshot(snapshot)
+	if err != nil {
+		return reportcore.Summary{}, reportcore.Summary{}, classifyErrorf(ErrorClassRuntimeFailure, "clone deterministic report snapshot: %w", err)
+	}
+	summary, err := reportcore.BuildSummary(reportcore.BuildInput{
+		StatePath:    statePath,
+		Snapshot:     internalReportSnapshot,
+		Top:          5,
+		Template:     reportcore.TemplateAudit,
+		ShareProfile: reportcore.ShareProfileInternal,
+	})
+	if err != nil {
+		return reportcore.Summary{}, reportcore.Summary{}, classifyErrorf(ErrorClassRuntimeFailure, "build deterministic report summary: %w", err)
+	}
+	summary = reportcore.FinalizeSummaryForShareProfile(summary)
+
+	redactedReportSnapshot, err := cloneReportSnapshot(snapshot)
+	if err != nil {
+		return reportcore.Summary{}, reportcore.Summary{}, classifyErrorf(ErrorClassRuntimeFailure, "clone customer-redacted report snapshot: %w", err)
+	}
+	redactedSummary, err := reportcore.BuildSummary(reportcore.BuildInput{
+		StatePath:    statePath,
+		Snapshot:     redactedReportSnapshot,
+		Top:          5,
+		Template:     reportcore.TemplateAudit,
+		ShareProfile: reportcore.ShareProfileCustomerRedacted,
+	})
+	if err != nil {
+		return reportcore.Summary{}, reportcore.Summary{}, classifyErrorf(ErrorClassRuntimeFailure, "build customer-redacted report summary: %w", err)
+	}
+	redactedSummary = reportcore.FinalizeSummaryForShareProfile(redactedSummary)
+	return summary, redactedSummary, nil
+}
+
+func cloneReportSnapshot(snapshot state.Snapshot) (state.Snapshot, error) {
+	payload, err := json.Marshal(snapshot)
+	if err != nil {
+		return state.Snapshot{}, fmt.Errorf("marshal snapshot clone: %w", err)
+	}
+	var cloned state.Snapshot
+	if err := json.Unmarshal(payload, &cloned); err != nil {
+		return state.Snapshot{}, fmt.Errorf("unmarshal snapshot clone: %w", err)
+	}
+	return cloned, nil
 }
 
 func defaultCoverageNote() CoverageNote {

--- a/core/evidence/evidence_test.go
+++ b/core/evidence/evidence_test.go
@@ -308,6 +308,67 @@ func TestBuildEvidenceBundleFinalizesCanonicalProjectionSidecars(t *testing.T) {
 	assertNoEmbeddedEvidenceCanonicalClonesOutsideStores(t, "top-level evidence JSON BOM", bomPayload, nil)
 }
 
+func TestBuildReportSummariesStayOnValidatedSnapshot(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+
+	buildSnapshot := func(repo, severity string) state.Snapshot {
+		findings := []model.Finding{{
+			FindingType: "skill_policy_conflict",
+			Severity:    severity,
+			ToolType:    "skill",
+			Location:    ".claude/skills/deploy/SKILL.md",
+			Repo:        repo,
+			Org:         "acme",
+		}}
+		report := risk.Score(findings, 5, now)
+		profile := profileeval.Result{ProfileName: "standard", CompliancePercent: 88.2, Status: "pass"}
+		posture := score.Result{Score: 81.0, Grade: "B", Weights: scoremodel.DefaultWeights()}
+		return state.Snapshot{
+			Version:      state.SnapshotVersion,
+			Target:       source.Target{Mode: "repo", Value: "acme/" + repo},
+			Findings:     findings,
+			Inventory:    &agginventory.Inventory{InventoryVersion: "v1", GeneratedAt: now.Format(time.RFC3339)},
+			RiskReport:   &report,
+			Profile:      &profile,
+			PostureScore: &posture,
+		}
+	}
+
+	validatedSnapshot := buildSnapshot("validated-repo", model.SeverityHigh)
+	if err := state.Save(statePath, validatedSnapshot); err != nil {
+		t.Fatalf("save validated state: %v", err)
+	}
+	if _, err := proofemit.EmitScan(statePath, now, validatedSnapshot.Findings, nil, *validatedSnapshot.RiskReport, *validatedSnapshot.Profile, *validatedSnapshot.PostureScore, nil); err != nil {
+		t.Fatalf("emit validated scan records: %v", err)
+	}
+
+	overwrittenSnapshot := buildSnapshot("overwritten-repo", model.SeverityMedium)
+	if err := state.Save(statePath, overwrittenSnapshot); err != nil {
+		t.Fatalf("overwrite state after proof emission: %v", err)
+	}
+
+	summary, redactedSummary, err := buildReportSummaries(statePath, validatedSnapshot)
+	if err != nil {
+		t.Fatalf("build report summaries: %v", err)
+	}
+	if len(summary.TopRisks) == 0 {
+		t.Fatal("expected internal summary top risks")
+	}
+	if got := summary.TopRisks[0].Repo; got != "validated-repo" {
+		t.Fatalf("expected internal summary to stay on validated snapshot repo, got %q", got)
+	}
+	if len(redactedSummary.TopRisks) == 0 {
+		t.Fatal("expected redacted summary top risks")
+	}
+	if got := redactedSummary.TopRisks[0].Severity; got != model.SeverityHigh {
+		t.Fatalf("expected redacted summary to keep validated snapshot severity, got %q", got)
+	}
+}
+
 func TestBuildEvidenceBundleIncludesRuntimeEvidenceCorrelation(t *testing.T) {
 	t.Parallel()
 

--- a/core/evidence/evidence_test.go
+++ b/core/evidence/evidence_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -156,6 +157,155 @@ func TestBuildEvidenceBundle(t *testing.T) {
 	if len(traceLines) != 1 {
 		t.Fatalf("expected one decision trace record, got %d: %s", len(traceLines), tracePayload)
 	}
+}
+
+func TestBuildEvidenceBundleFinalizesCanonicalProjectionSidecars(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "state.json")
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	endpoint := agginventory.MutableEndpointSemantic{
+		Semantic:     agginventory.EndpointSemanticDeploy,
+		Confidence:   "high",
+		Surface:      "workflow",
+		Operation:    "deploy release",
+		EvidenceRefs: []string{".github/workflows/release.yml"},
+	}
+	authority := &agginventory.CredentialAuthority{
+		CredentialPresent:              true,
+		CredentialReferencedByWorkflow: true,
+		CredentialUsableByPath:         true,
+		CredentialKind:                 agginventory.CredentialKindGitHubWorkflowToken,
+		AccessType:                     agginventory.CredentialAccessTypeStanding,
+		StandingAccess:                 true,
+		TargetSystem:                   "github",
+		ScopeConfidence:                "high",
+		CredentialSource:               agginventory.CredentialSourceWorkflowBuiltin,
+		Confidence:                     "high",
+		ReasonCodes:                    []string{"workflow_token"},
+	}
+	binding := &agginventory.AuthorityBinding{
+		Kind:         agginventory.AuthorityBindingDeploymentPath,
+		Provider:     "github",
+		Subject:      "release-token",
+		TargetSystem: "github-actions",
+		AccessLevel:  agginventory.AuthorityAccessWrite,
+		Production:   true,
+		Confidence:   "high",
+		EvidenceRefs: []string{".github/workflows/release.yml"},
+	}
+	findings := []model.Finding{{
+		FindingType: "ci_autonomy",
+		Severity:    model.SeverityHigh,
+		ToolType:    "ci_agent",
+		Location:    ".github/workflows/release.yml",
+		Repo:        "payments",
+		Org:         "acme",
+	}}
+	report := risk.Score(findings, 5, now)
+	report.ActionPaths = []risk.ActionPath{risk.ProjectActionPath(risk.ActionPath{
+		PathID:                   "apc-evidence-canonical",
+		AgentID:                  "wrkr:ci-agent:acme",
+		Org:                      "acme",
+		Repo:                     "payments",
+		ToolType:                 "ci_agent",
+		Location:                 ".github/workflows/release.yml",
+		WriteCapable:             true,
+		DeployWrite:              true,
+		ProductionWrite:          true,
+		CredentialAccess:         true,
+		OperationalOwner:         "@acme/platform",
+		OwnerSource:              "customer_owner_map",
+		OwnershipStatus:          "explicit",
+		OwnershipState:           "explicit_owner",
+		MutableEndpointSemantics: []agginventory.MutableEndpointSemantic{endpoint},
+		CredentialAuthority:      authority,
+		AuthorityBindings:        []*agginventory.AuthorityBinding{binding},
+	})}
+	report.ActionPathToControlFirst = risk.BuildActionPathChoice(report.ActionPaths)
+	inventory := &agginventory.Inventory{
+		InventoryVersion: "v1",
+		GeneratedAt:      now.Format(time.RFC3339),
+		Org:              "acme",
+		Tools: []agginventory.Tool{{
+			ToolID:                   "tool-release",
+			AgentID:                  "wrkr:ci-agent:acme",
+			DiscoveryMethod:          "static",
+			ToolType:                 "ci_agent",
+			ToolCategory:             "ci_automation",
+			Org:                      "acme",
+			Repos:                    []string{"payments"},
+			Locations:                []agginventory.ToolLocation{{Repo: "payments", Location: ".github/workflows/release.yml", Owner: "@acme/platform"}},
+			MutableEndpointSemantics: []agginventory.MutableEndpointSemantic{endpoint},
+		}},
+		AgentPrivilegeMap: []agginventory.AgentPrivilegeMapEntry{{
+			AgentID:                  "wrkr:ci-agent:acme",
+			ToolID:                   "tool-release",
+			ToolType:                 "ci_agent",
+			Org:                      "acme",
+			Repos:                    []string{"payments"},
+			Permissions:              []string{"contents.write"},
+			WriteCapable:             true,
+			CredentialAccess:         true,
+			MutableEndpointSemantics: []agginventory.MutableEndpointSemantic{endpoint},
+			CredentialAuthority:      authority,
+			AuthorityBindings:        []*agginventory.AuthorityBinding{binding},
+			OperationalOwner:         "@acme/platform",
+			OwnerSource:              "customer_owner_map",
+			OwnershipStatus:          "explicit",
+			OwnershipState:           "explicit_owner",
+		}},
+	}
+	profile := profileeval.Result{ProfileName: "standard", CompliancePercent: 88.2, Status: "pass"}
+	posture := score.Result{Score: 81.0, Grade: "B", Weights: scoremodel.DefaultWeights()}
+	snapshot := state.Snapshot{
+		Version:      state.SnapshotVersion,
+		Target:       source.Target{Mode: "repo", Value: "acme/payments"},
+		Findings:     findings,
+		Inventory:    inventory,
+		RiskReport:   &report,
+		Profile:      &profile,
+		PostureScore: &posture,
+	}
+	if err := state.Save(statePath, snapshot); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	if _, err := proofemit.EmitScan(statePath, now, findings, inventory, report, profile, posture, nil); err != nil {
+		t.Fatalf("emit scan records: %v", err)
+	}
+
+	outputDir := filepath.Join(tmp, "wrkr-evidence")
+	result, err := Build(BuildInput{StatePath: statePath, Frameworks: []string{"soc2"}, OutputDir: outputDir, GeneratedAt: now.Add(time.Hour)})
+	if err != nil {
+		t.Fatalf("build evidence bundle: %v", err)
+	}
+	for _, relative := range []string{
+		"inventory.json",
+		"inventory-snapshot.json",
+		"risk-report.json",
+		"attack-paths.json",
+	} {
+		assertNoEmbeddedEvidenceCanonicalClonesOutsideStores(t, relative, readEvidenceJSONAny(t, filepath.Join(outputDir, relative)), nil)
+	}
+	if result.AgentActionBOM == nil {
+		t.Fatal("expected top-level evidence JSON BOM projection")
+	}
+	if result.AgentActionBOM.ShareProfile != "customer-redacted" {
+		t.Fatalf("expected top-level evidence JSON BOM to be customer-redacted, got %q", result.AgentActionBOM.ShareProfile)
+	}
+	encodedBOM, err := json.Marshal(result.AgentActionBOM)
+	if err != nil {
+		t.Fatalf("marshal result BOM: %v", err)
+	}
+	if strings.Contains(string(encodedBOM), "@acme/platform") {
+		t.Fatalf("expected top-level evidence JSON BOM to redact owner handle, got %s", encodedBOM)
+	}
+	var bomPayload any
+	if err := json.Unmarshal(encodedBOM, &bomPayload); err != nil {
+		t.Fatalf("parse result BOM: %v", err)
+	}
+	assertNoEmbeddedEvidenceCanonicalClonesOutsideStores(t, "top-level evidence JSON BOM", bomPayload, nil)
 }
 
 func TestBuildEvidenceBundleIncludesRuntimeEvidenceCorrelation(t *testing.T) {
@@ -1284,6 +1434,53 @@ func createEvidenceStateWithProof(t *testing.T, tmp string) string {
 		t.Fatalf("emit scan records: %v", err)
 	}
 	return statePath
+}
+
+func readEvidenceJSONAny(t *testing.T, path string) any {
+	t.Helper()
+
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var parsed any
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return parsed
+}
+
+func assertNoEmbeddedEvidenceCanonicalClonesOutsideStores(t *testing.T, label string, value any, path []string) {
+	t.Helper()
+
+	pathString := strings.Join(path, ".")
+	if strings.Contains(pathString, "canonical_stores") {
+		return
+	}
+
+	switch typed := value.(type) {
+	case map[string]any:
+		if ref, ok := typed["credential_authority_ref"].(string); ok && strings.TrimSpace(ref) != "" && typed["credential_authority"] != nil {
+			t.Fatalf("expected %s to omit credential_authority at %s when credential_authority_ref is present: %+v", label, pathString, typed)
+		}
+		if refs, ok := typed["authority_binding_refs"].([]any); ok && len(refs) > 0 {
+			if bindings, ok := typed["authority_bindings"].([]any); ok && len(bindings) > 0 {
+				t.Fatalf("expected %s to omit authority_bindings at %s when authority_binding_refs are present: %+v", label, pathString, typed)
+			}
+		}
+		if refs, ok := typed["mutable_endpoint_semantic_refs"].([]any); ok && len(refs) > 0 {
+			if semantics, ok := typed["mutable_endpoint_semantics"].([]any); ok && len(semantics) > 0 {
+				t.Fatalf("expected %s to omit mutable_endpoint_semantics at %s when mutable_endpoint_semantic_refs are present: %+v", label, pathString, typed)
+			}
+		}
+		for key, nested := range typed {
+			assertNoEmbeddedEvidenceCanonicalClonesOutsideStores(t, label, nested, append(path, key))
+		}
+	case []any:
+		for idx, nested := range typed {
+			assertNoEmbeddedEvidenceCanonicalClonesOutsideStores(t, label, nested, append(path, "["+strconv.Itoa(idx)+"]"))
+		}
+	}
 }
 
 func snapshotBundleTree(t *testing.T, root string) map[string]string {

--- a/core/proofmap/proofmap.go
+++ b/core/proofmap/proofmap.go
@@ -173,7 +173,7 @@ func MapRisk(report risk.Report, posture score.Result, profile profileeval.Resul
 	attackPathRecords := boundedAttackPaths(report)
 	actionPathRecords := boundedActionPaths(report.ActionPaths, maxActionPathProofRecords)
 
-	records := make([]MappedRecord, 0, len(findingRiskRecords)+len(attackPathRecords)+len(actionPathRecords)+2)
+	records := make([]MappedRecord, 0, len(findingRiskRecords))
 	for idx, item := range findingRiskRecords {
 		event := map[string]any{
 			"assessment_type": "finding_risk",

--- a/core/report/build.go
+++ b/core/report/build.go
@@ -1441,7 +1441,7 @@ func buildAttackPathFacts(report risk.Report) []string {
 	if len(report.TopAttackPaths) == 0 {
 		return []string{"attack paths: none generated from current findings"}
 	}
-	facts := make([]string, 0, len(report.TopAttackPaths)+1)
+	facts := make([]string, 0, len(report.TopAttackPaths))
 	facts = append(facts, fmt.Sprintf("attack paths total=%d", len(report.AttackPaths)))
 	for idx, path := range report.TopAttackPaths {
 		facts = append(facts, fmt.Sprintf("attack_path #%d score=%.2f id=%s", idx+1, path.PathScore, path.PathID))

--- a/core/risk/action_paths.go
+++ b/core/risk/action_paths.go
@@ -1131,7 +1131,7 @@ func assessmentSegments(value string) []string {
 		return r == '/' || r == '\\'
 	})
 	seen := map[string]struct{}{}
-	out := make([]string, 0, len(segments)*4)
+	out := make([]string, 0, len(segments))
 	for _, segment := range segments {
 		for _, candidate := range assessmentSegmentCandidates(segment) {
 			if _, ok := seen[candidate]; ok {

--- a/internal/acceptance/agent_action_bom_acceptance_test.go
+++ b/internal/acceptance/agent_action_bom_acceptance_test.go
@@ -105,11 +105,16 @@ func TestAgentActionBOMAcceptanceStaticToRuntimeEvidence(t *testing.T) {
 		t.Fatalf("expected report/evidence runtime_evidence counts to agree, report=%v evidence=%v", reportRuntimeEvidence, evidenceRuntimeEvidence)
 	}
 	evidenceBOM := requireObject(t, evidencePayload, "agent_action_bom")
-	if !reflect.DeepEqual(requireObject(t, afterBOM, "summary"), requireObject(t, evidenceBOM, "summary")) {
-		t.Fatalf("expected report/evidence BOM summaries to agree\nreport=%v\nevidence=%v", afterBOM["summary"], evidenceBOM["summary"])
+	if evidenceBOM["share_profile"] != "customer-redacted" {
+		t.Fatalf("expected evidence BOM share profile to be customer-redacted, got %v", evidenceBOM["share_profile"])
 	}
-	if afterTopItem["proof_coverage"] != requireObjectItem(t, requireArrayFromObject(t, evidenceBOM, "items")[0])["proof_coverage"] {
-		t.Fatalf("expected report/evidence top BOM proof_coverage to agree, report=%v evidence=%v", afterTopItem["proof_coverage"], requireObjectItem(t, requireArrayFromObject(t, evidenceBOM, "items")[0])["proof_coverage"])
+	bundleRedactedBOM := loadAcceptanceJSONFile(t, filepath.Join(outputDir, "reports", "agent-action-bom-customer-redacted.json"))
+	if !reflect.DeepEqual(bundleRedactedBOM, evidenceBOM) {
+		t.Fatalf("expected evidence JSON BOM to match customer-redacted bundle artifact\nartifact=%v\nevidence=%v", bundleRedactedBOM, evidenceBOM)
+	}
+	evidenceTopItem := requireObjectItem(t, requireArrayFromObject(t, evidenceBOM, "items")[0])
+	if afterTopItem["proof_coverage"] != evidenceTopItem["proof_coverage"] {
+		t.Fatalf("expected report/evidence top BOM proof_coverage to agree, report=%v evidence=%v", afterTopItem["proof_coverage"], evidenceTopItem["proof_coverage"])
 	}
 	if _, err := os.Stat(filepath.Join(outputDir, "reports", "agent-action-bom.json")); err != nil {
 		t.Fatalf("expected BOM report artifact in evidence bundle: %v", err)

--- a/internal/acceptance/wave31_buyer_projection_parity_acceptance_test.go
+++ b/internal/acceptance/wave31_buyer_projection_parity_acceptance_test.go
@@ -18,7 +18,7 @@ func TestWave31BuyerProjectionParityAcrossConsumers(t *testing.T) {
 
 	runJSONOK(t, "scan", "--path", afterScanRoot, "--state", statePath, "--json")
 	runJSONOK(t, "ingest", "--state", statePath, "--input", runtimeEvidencePath, "--json")
-	reportPayload := runJSONOK(t, "report", "--state", statePath, "--template", "agent-action-bom", "--share-profile", "internal", "--md", "--md-path", reportMDPath, "--json")
+	reportPayload := runJSONOK(t, "report", "--state", statePath, "--template", "agent-action-bom", "--share-profile", "customer-redacted", "--md", "--md-path", reportMDPath, "--json")
 	evidencePayload := runJSONOK(t, "evidence", "--frameworks", "soc2", "--state", statePath, "--output", filepath.Join(t.TempDir(), "bundle"), "--json")
 
 	reportSummary := requireObject(t, reportPayload, "summary")


### PR DESCRIPTION
## Problem

Evidence bundle sidecars and the top-level evidence JSON BOM were still using non-finalized snapshot projections and could diverge from the customer-redacted report artifact.

## Changes

- finalize bundle sidecar outputs from the canonicalized snapshot projection before writing inventory, risk, profile, and posture artifacts
- rebuild report summaries from deterministic state loads for both internal and customer-redacted share profiles
- publish the top-level evidence JSON BOM from the customer-redacted summary
- add focused evidence and acceptance coverage for canonical clone stripping and report/evidence parity

## Validation

- make prepush-full

## Risks

- changes evidence/report share-profile behavior for the top-level BOM projection, so downstream consumers now receive the customer-redacted artifact shape by default

## Submodule Notes

- `factory` submodule pointer unchanged
