### PR TITLE
fix: pin pages artifact action to node24

### DIFF
--- a/.github/action-ref-exceptions.yaml
+++ b/.github/action-ref-exceptions.yaml
@@ -69,10 +69,3 @@ exceptions:
     scope: docs-site Node setup only
     expires: 2026-08-31
     review_command: scripts/check_actions_runtime.sh
-  - workflow: .github/workflows/docs.yml
-    action: actions/upload-pages-artifact@v4.0.0
-    owner: docs-platform
-    reason: audited Node24-ready Pages artifact action kept on upstream release tag until SHA pin refresh automation lands
-    scope: docs-site static artifact upload only
-    expires: 2026-08-31
-    review_command: scripts/check_actions_runtime.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,7 @@ jobs:
           NODE_ENV: production
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: docs-site/out
 

--- a/docs/trust/release-integrity.md
+++ b/docs/trust/release-integrity.md
@@ -17,6 +17,7 @@ description: "Release hardening checks, reproducibility expectations, and integr
 - `CHANGELOG.md` release-note entries finalized before tag publication with `scripts/finalize_release_changelog.py`, and tag builds verify them with `scripts/validate_release_changelog.py`.
 - Broad major aliases on the release/docs scanner and GitHub Pages helper path are removed. These helpers are pinned to immutable commit refs:
   - `actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d`
+  - `actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9`
   - `actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128`
   - `anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610`
   - `anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2`


### PR DESCRIPTION
## Problem

The post-merge docs workflow for PR #285 passed, but GitHub still emitted a Node20 runtime warning from the Pages artifact upload path. The remaining `actions/upload-pages-artifact@v4.0.0` tag delegates to `actions/upload-artifact@v4.6.2`, which still declares the deprecated Node20 runtime.

## Changes

- Pins `actions/upload-pages-artifact` to the immutable v5.0.0 commit that delegates to Node24-ready `actions/upload-artifact@v7.0.0`.
- Removes the stale moving-ref exception for the old Pages artifact tag.
- Records the pinned Pages artifact helper in `docs/trust/release-integrity.md`.

## Validation

- `scripts/check_actions_runtime.sh`
- `git diff --check`
- `make prepush-full`

## Risk

Low. This only updates the docs artifact upload helper to a newer GitHub-published Pages artifact action and narrows the exception registry.
