### PR TITLE
fix: stabilize generated site assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
+- [semver:patch] Canonicalized published Agent Action BOM example refs after opaque-ID redaction so generated site assets remain byte-stable even if upstream raw path IDs reorder.
 - [semver:patch] Added endpoint-dense enterprise-pressure fixtures and bounded-artifact receipts so route-heavy scans regress in deterministic tests before they bloat saved state, graph output, or BOM artifacts.
 - [semver:minor] Replaced endpoint-heavy graph, BOM, and action-surface fanout with grouped endpoint receipts (`endpoint_ref_group_id`, counts, route groups, operation counts, and bounded samples) so report/shareable surfaces stop cloning thousands of endpoint refs per node or item.
 - [semver:minor] Tightened action-path eligibility and authority correlation so static context surfaces no longer inherit governable workflow status from repo-wide credential or deploy signals without a real binding.

--- a/docs/examples/site-assets/interactive-lab-data.json
+++ b/docs/examples/site-assets/interactive-lab-data.json
@@ -67,8 +67,8 @@
           "closure=remediate repo_cluster=single_repo credential_authority=unknown"
         ],
         "top_example_refs": [
-          "path-a0148cc443aa",
-          "path-976cd7720979"
+          "path-976cd7720979",
+          "path-a0148cc443aa"
         ]
       },
       {
@@ -208,8 +208,8 @@
           "closure=attach_evidence repo_cluster=single_repo credential_authority=unknown"
         ],
         "top_example_refs": [
-          "path-d5d0c4cfffdc",
-          "path-9f02eb0f17d7"
+          "path-9f02eb0f17d7",
+          "path-d5d0c4cfffdc"
         ]
       },
       {

--- a/docs/examples/site-assets/sample-agent-action-bom.json
+++ b/docs/examples/site-assets/sample-agent-action-bom.json
@@ -1,5 +1,5 @@
 {
-  "bom_id": "bom-50eeb5491a52",
+  "bom_id": "bom-0114bd6f55e8",
   "items": [
     {
       "action_path_type": "agent_instruction_surface",
@@ -482,8 +482,8 @@
             "closure=remediate repo_cluster=single_repo credential_authority=unknown"
           ],
           "top_example_refs": [
-            "path-a0148cc443aa",
-            "path-976cd7720979"
+            "path-976cd7720979",
+            "path-a0148cc443aa"
           ]
         },
         {
@@ -623,8 +623,8 @@
             "closure=attach_evidence repo_cluster=single_repo credential_authority=unknown"
           ],
           "top_example_refs": [
-            "path-d5d0c4cfffdc",
-            "path-9f02eb0f17d7"
+            "path-9f02eb0f17d7",
+            "path-d5d0c4cfffdc"
           ]
         },
         {

--- a/docs/examples/site-assets/site-asset-manifest.json
+++ b/docs/examples/site-assets/site-asset-manifest.json
@@ -15,7 +15,7 @@
       "description": "Interactive lab summary data projected from deterministic report and evidence outputs.",
       "share_profile": "customer-redacted",
       "template": "ciso",
-      "sha256": "sha256:3dd3bc2400eade1327f70c056e184fbb0224f16e34606cc84482a5b906a06348"
+      "sha256": "sha256:83f1086ca1903fe863a612d2501771ad06b2cda8ddf95e84def555a815b82fcf"
     },
     {
       "path": "local-private-posture.md",
@@ -27,7 +27,7 @@
       "description": "Customer-redacted Agent Action BOM sample derived from the multi-repo scan fixture.",
       "share_profile": "customer-redacted",
       "template": "agent-action-bom",
-      "sha256": "sha256:0f21da9c021c2aebcdd42eb1d0e5c34069f32e2bdca4ce21bc7aae2641f0376f"
+      "sha256": "sha256:659e085f0df9847094aec0823c18d8a5a73d7afe7af0a7fd30d9dc8434095183"
     },
     {
       "path": "sample-control-path-graph.json",

--- a/internal/siteassets/siteassets.go
+++ b/internal/siteassets/siteassets.go
@@ -366,9 +366,10 @@ func buildBoundaryData(scanPayload, summary, evidencePayload, sourcePrivacy map[
 }
 
 func buildLabData(scanPayload, reportPayload, summary, controlBacklog, proof map[string]any, ids publishedIDMaps) labData {
+	exampleSelectionKeyByRawPathID, projectedPathIDsByExampleSelectionKey := buildExecutiveRollupExampleProjectionMaps(cloneArray(requireObject(requireObject(reportPayload, "agent_action_bom"), "items")))
 	return labData{
 		DeploymentMode:        stringValue(reportPayload["deployment_mode"]),
-		ExecutiveRollup:       projectExecutiveRollup(requireObject(summary, "executive_rollup"), ids),
+		ExecutiveRollup:       projectExecutiveRollup(requireObject(summary, "executive_rollup"), ids, exampleSelectionKeyByRawPathID, projectedPathIDsByExampleSelectionKey),
 		GovernedUsageMetrics:  cloneObject(requireObject(summary, "governed_usage_metrics")),
 		ToolTypeBreakdown:     cloneArray(scanPayload["tool_type_breakdown"]),
 		TopFindings:           projectTopFindings(limitArray(cloneArray(reportPayload["top_findings"]), 5)),
@@ -389,6 +390,7 @@ func projectAgentActionBOM(agentActionBOM map[string]any, ids publishedIDMaps) m
 	summary := requireObject(agentActionBOM, "summary")
 	items := cloneArray(agentActionBOM["items"])
 	projectedItems := make([]map[string]any, 0, len(items))
+	exampleSelectionKeyByRawPathID, projectedPathIDsByExampleSelectionKey := buildExecutiveRollupExampleProjectionMaps(items)
 	for _, raw := range items {
 		row := requireObjectFromAny(raw)
 		repoID, pathID, locationID := publishedIDsForRow(row)
@@ -433,7 +435,7 @@ func projectAgentActionBOM(agentActionBOM map[string]any, ids publishedIDMaps) m
 		"coverage_confidence":      summary["coverage_confidence"],
 		"scan_coverage":            summary["scan_coverage"],
 		"delegation_readiness":     summary["delegation_readiness"],
-		"executive_rollup":         projectExecutiveRollup(requireObject(summary, "executive_rollup"), ids),
+		"executive_rollup":         projectExecutiveRollup(requireObject(summary, "executive_rollup"), ids, exampleSelectionKeyByRawPathID, projectedPathIDsByExampleSelectionKey),
 		"governed_usage_metrics":   summary["governed_usage_metrics"],
 		"primary_view":             projectPrimaryView(requireObject(summary, "primary_view"), ids),
 	}
@@ -448,6 +450,29 @@ func projectAgentActionBOM(agentActionBOM map[string]any, ids publishedIDMaps) m
 		"summary":        projectedSummary,
 		"items":          projectedItemsAny,
 	}
+}
+
+func buildExecutiveRollupExampleProjectionMaps(items []any) (map[string]string, map[string][]string) {
+	exampleSelectionKeyByRawPathID := map[string]string{}
+	projectedPathIDsByExampleSelectionKey := map[string][]string{}
+	for _, raw := range items {
+		row := requireObjectFromAny(raw)
+		rawPathID := stringValue(row["path_id"])
+		if rawPathID == "" {
+			continue
+		}
+		_, pathID, _ := publishedIDsForRow(row)
+		if pathID == "" {
+			continue
+		}
+		selectionKey := executiveRollupExampleSelectionKey(row)
+		if selectionKey == "" {
+			continue
+		}
+		exampleSelectionKeyByRawPathID[rawPathID] = selectionKey
+		projectedPathIDsByExampleSelectionKey[selectionKey] = append(projectedPathIDsByExampleSelectionKey[selectionKey], pathID)
+	}
+	return exampleSelectionKeyByRawPathID, projectedPathIDsByExampleSelectionKey
 }
 
 func projectControlPathGraph(graph map[string]any) map[string]any {
@@ -984,18 +1009,13 @@ func projectTopActionPaths(items []any, ids publishedIDMaps) []any {
 	return projected
 }
 
-func projectExecutiveRollup(executiveRollup map[string]any, ids publishedIDMaps) map[string]any {
+func projectExecutiveRollup(executiveRollup map[string]any, ids publishedIDMaps, exampleSelectionKeyByRawPathID map[string]string, projectedPathIDsByExampleSelectionKey map[string][]string) map[string]any {
 	out := cloneObject(executiveRollup)
 	groups := cloneArray(executiveRollup["groups"])
 	projectedGroups := make([]any, 0, len(groups))
 	for _, raw := range groups {
 		group := cloneObject(requireObjectFromAny(raw))
-		refs := cloneArray(group["top_example_refs"])
-		projectedRefStrings := make([]string, 0, len(refs))
-		for _, ref := range refs {
-			projectedRefStrings = append(projectedRefStrings, normalizeOpaqueRef(stringValue(ref), ids))
-		}
-		sort.Strings(projectedRefStrings)
+		projectedRefStrings := projectExecutiveRollupTopExampleRefs(cloneArray(group["top_example_refs"]), ids, exampleSelectionKeyByRawPathID, projectedPathIDsByExampleSelectionKey)
 		projectedRefs := make([]any, 0, len(projectedRefStrings))
 		for _, ref := range projectedRefStrings {
 			projectedRefs = append(projectedRefs, ref)
@@ -1005,6 +1025,37 @@ func projectExecutiveRollup(executiveRollup map[string]any, ids publishedIDMaps)
 	}
 	out["groups"] = projectedGroups
 	return out
+}
+
+func projectExecutiveRollupTopExampleRefs(refs []any, ids publishedIDMaps, exampleSelectionKeyByRawPathID map[string]string, projectedPathIDsByExampleSelectionKey map[string][]string) []string {
+	selectionKeys := map[string]struct{}{}
+	for _, ref := range refs {
+		if key := strings.TrimSpace(exampleSelectionKeyByRawPathID[stringValue(ref)]); key != "" {
+			selectionKeys[key] = struct{}{}
+		}
+	}
+	candidateSet := map[string]struct{}{}
+	for key := range selectionKeys {
+		for _, pathID := range projectedPathIDsByExampleSelectionKey[key] {
+			if strings.TrimSpace(pathID) != "" {
+				candidateSet[strings.TrimSpace(pathID)] = struct{}{}
+			}
+		}
+	}
+	projectedRefStrings := make([]string, 0, len(candidateSet))
+	for pathID := range candidateSet {
+		projectedRefStrings = append(projectedRefStrings, pathID)
+	}
+	if len(projectedRefStrings) == 0 {
+		for _, ref := range refs {
+			projectedRefStrings = append(projectedRefStrings, normalizeOpaqueRef(stringValue(ref), ids))
+		}
+	}
+	sort.Strings(projectedRefStrings)
+	if len(projectedRefStrings) > 3 {
+		projectedRefStrings = append([]string(nil), projectedRefStrings[:3]...)
+	}
+	return projectedRefStrings
 }
 
 func projectPrimaryView(primaryView map[string]any, ids publishedIDMaps) map[string]any {
@@ -1082,4 +1133,71 @@ func normalizePublishedValue(value any) any {
 	default:
 		return value
 	}
+}
+
+func executiveRollupExampleSelectionKey(row map[string]any) string {
+	fingerprint := map[string]any{
+		"action_class":               executiveRollupExampleActionClass(row),
+		"action_path_type":           row["action_path_type"],
+		"approval_evidence_state":    row["approval_evidence_state"],
+		"autonomy_tier":              row["autonomy_tier"],
+		"boundary_label":             row["boundary_label"],
+		"confidence_lane":            row["confidence_lane"],
+		"control_resolution_state":   row["control_resolution_state"],
+		"control_state":              row["control_state"],
+		"credential_access":          row["credential_access"],
+		"credential_authority_ref":   row["credential_authority_ref"],
+		"credential_evidence_state":  row["credential_evidence_state"],
+		"delegation_readiness_state": row["delegation_readiness_state"],
+		"matched_production_targets": arrayLength(row["matched_production_targets"]),
+		"owner_evidence_state":       row["owner_evidence_state"],
+		"production_write":           row["production_write"],
+		"proof_evidence_state":       row["proof_evidence_state"],
+		"queue":                      row["queue"],
+		"risk_zone":                  row["risk_zone"],
+		"runtime_evidence_state":     row["runtime_evidence_state"],
+		"target_class":               row["target_class"],
+		"target_evidence_state":      row["target_evidence_state"],
+	}
+	payload, err := json.Marshal(fingerprint)
+	if err != nil {
+		return ""
+	}
+	return string(payload)
+}
+
+func executiveRollupExampleActionClass(row map[string]any) string {
+	values := stringArray(row["action_classes"])
+	sort.Strings(values)
+	for _, candidate := range []string{"deploy", "write", "repo_write", "admin", "delete", "credential_access"} {
+		for _, value := range values {
+			if value == candidate {
+				return candidate
+			}
+		}
+	}
+	switch {
+	case boolValue(row["production_write"]):
+		return "deploy"
+	case boolValue(row["credential_access"]):
+		return "credential_access"
+	case len(values) > 0:
+		return values[0]
+	default:
+		return "unknown"
+	}
+}
+
+func stringArray(value any) []string {
+	items, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if text := stringValue(item); text != "" {
+			out = append(out, text)
+		}
+	}
+	return out
 }

--- a/internal/siteassets/siteassets.go
+++ b/internal/siteassets/siteassets.go
@@ -991,9 +991,14 @@ func projectExecutiveRollup(executiveRollup map[string]any, ids publishedIDMaps)
 	for _, raw := range groups {
 		group := cloneObject(requireObjectFromAny(raw))
 		refs := cloneArray(group["top_example_refs"])
-		projectedRefs := make([]any, 0, len(refs))
+		projectedRefStrings := make([]string, 0, len(refs))
 		for _, ref := range refs {
-			projectedRefs = append(projectedRefs, normalizeOpaqueRef(stringValue(ref), ids))
+			projectedRefStrings = append(projectedRefStrings, normalizeOpaqueRef(stringValue(ref), ids))
+		}
+		sort.Strings(projectedRefStrings)
+		projectedRefs := make([]any, 0, len(projectedRefStrings))
+		for _, ref := range projectedRefStrings {
+			projectedRefs = append(projectedRefs, ref)
 		}
 		group["top_example_refs"] = projectedRefs
 		projectedGroups = append(projectedGroups, group)

--- a/internal/siteassets/siteassets_test.go
+++ b/internal/siteassets/siteassets_test.go
@@ -123,6 +123,63 @@ func TestProjectControlPathGraphCanonicalizesRawIDs(t *testing.T) {
 	}
 }
 
+func TestProjectExecutiveRollupCanonicalizesExampleRefOrderAfterOpaqueProjection(t *testing.T) {
+	t.Parallel()
+
+	ids := publishedIDMaps{
+		Path: map[string]string{
+			"raw-a": "path-b",
+			"raw-z": "path-a",
+		},
+	}
+	first := map[string]any{
+		"total_groups": 1,
+		"total_paths":  2,
+		"groups": []any{
+			map[string]any{
+				"group_id":               "xrg-demo",
+				"count":                  2,
+				"highest_severity":       "high",
+				"highest_priority":       "review_queue",
+				"closure_recommendation": "attach evidence",
+				"top_example_refs":       []any{"raw-a", "raw-z"},
+				"rationale":              []any{"demo rationale"},
+				"evidence_state_summary": map[string]any{"verified": 0, "declared": 0, "inferred": 0, "unknown": 2, "contradictory": 0},
+				"dimensions":             map[string]any{"action_class": "read", "target_class": "developer_productivity"},
+			},
+		},
+	}
+	second := map[string]any{
+		"total_groups": 1,
+		"total_paths":  2,
+		"groups": []any{
+			map[string]any{
+				"group_id":               "xrg-demo",
+				"count":                  2,
+				"highest_severity":       "high",
+				"highest_priority":       "review_queue",
+				"closure_recommendation": "attach evidence",
+				"top_example_refs":       []any{"raw-z", "raw-a"},
+				"rationale":              []any{"demo rationale"},
+				"evidence_state_summary": map[string]any{"verified": 0, "declared": 0, "inferred": 0, "unknown": 2, "contradictory": 0},
+				"dimensions":             map[string]any{"action_class": "read", "target_class": "developer_productivity"},
+			},
+		},
+	}
+
+	firstPayload, err := marshalJSON(normalizePublishedValue(projectExecutiveRollup(first, ids)))
+	if err != nil {
+		t.Fatalf("marshal first rollup: %v", err)
+	}
+	secondPayload, err := marshalJSON(normalizePublishedValue(projectExecutiveRollup(second, ids)))
+	if err != nil {
+		t.Fatalf("marshal second rollup: %v", err)
+	}
+	if string(firstPayload) != string(secondPayload) {
+		t.Fatalf("projected executive rollup should ignore volatile raw ref order\nfirst:\n%s\nsecond:\n%s", firstPayload, secondPayload)
+	}
+}
+
 func sampleControlPathGraph(fromNodeID, toNodeID, edgeID string) map[string]any {
 	return map[string]any{
 		"version": "1",

--- a/internal/siteassets/siteassets_test.go
+++ b/internal/siteassets/siteassets_test.go
@@ -1,8 +1,10 @@
 package siteassets
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -123,60 +125,63 @@ func TestProjectControlPathGraphCanonicalizesRawIDs(t *testing.T) {
 	}
 }
 
-func TestProjectExecutiveRollupCanonicalizesExampleRefOrderAfterOpaqueProjection(t *testing.T) {
+func TestProjectExecutiveRollupCanonicalizesExampleSelectionAfterOpaqueProjection(t *testing.T) {
 	t.Parallel()
 
+	rollup := map[string]any{
+		"total_groups": 1,
+		"total_paths":  4,
+		"groups": []any{
+			map[string]any{
+				"group_id":               "xrg-demo",
+				"count":                  4,
+				"highest_severity":       "high",
+				"highest_priority":       "review_queue",
+				"closure_recommendation": "attach evidence",
+				"top_example_refs":       []any{"raw-a", "raw-b", "raw-d"},
+				"rationale":              []any{"demo rationale"},
+				"evidence_state_summary": map[string]any{"verified": 0, "declared": 0, "inferred": 0, "unknown": 4, "contradictory": 0},
+				"dimensions":             map[string]any{"action_class": "read", "target_class": "developer_productivity"},
+			},
+		},
+	}
 	ids := publishedIDMaps{
 		Path: map[string]string{
-			"raw-a": "path-b",
-			"raw-z": "path-a",
+			"raw-a": "path-c",
+			"raw-b": "path-a",
+			"raw-c": "path-b",
+			"raw-d": "path-d",
 		},
 	}
-	first := map[string]any{
-		"total_groups": 1,
-		"total_paths":  2,
-		"groups": []any{
-			map[string]any{
-				"group_id":               "xrg-demo",
-				"count":                  2,
-				"highest_severity":       "high",
-				"highest_priority":       "review_queue",
-				"closure_recommendation": "attach evidence",
-				"top_example_refs":       []any{"raw-a", "raw-z"},
-				"rationale":              []any{"demo rationale"},
-				"evidence_state_summary": map[string]any{"verified": 0, "declared": 0, "inferred": 0, "unknown": 2, "contradictory": 0},
-				"dimensions":             map[string]any{"action_class": "read", "target_class": "developer_productivity"},
-			},
-		},
+	selectionKey := executiveRollupExampleSelectionKey(map[string]any{
+		"action_classes": []any{"read"},
+	})
+	selectionKeyByRawPathID := map[string]string{
+		"raw-a": selectionKey,
+		"raw-b": selectionKey,
+		"raw-c": selectionKey,
+		"raw-d": selectionKey,
 	}
-	second := map[string]any{
-		"total_groups": 1,
-		"total_paths":  2,
-		"groups": []any{
-			map[string]any{
-				"group_id":               "xrg-demo",
-				"count":                  2,
-				"highest_severity":       "high",
-				"highest_priority":       "review_queue",
-				"closure_recommendation": "attach evidence",
-				"top_example_refs":       []any{"raw-z", "raw-a"},
-				"rationale":              []any{"demo rationale"},
-				"evidence_state_summary": map[string]any{"verified": 0, "declared": 0, "inferred": 0, "unknown": 2, "contradictory": 0},
-				"dimensions":             map[string]any{"action_class": "read", "target_class": "developer_productivity"},
-			},
-		},
+	projectedPathIDsBySelectionKey := map[string][]string{
+		selectionKey: {"path-c", "path-a", "path-b", "path-d"},
 	}
 
-	firstPayload, err := marshalJSON(normalizePublishedValue(projectExecutiveRollup(first, ids)))
+	projected, err := marshalJSON(normalizePublishedValue(projectExecutiveRollup(rollup, ids, selectionKeyByRawPathID, projectedPathIDsBySelectionKey)))
 	if err != nil {
-		t.Fatalf("marshal first rollup: %v", err)
+		t.Fatalf("marshal rollup: %v", err)
 	}
-	secondPayload, err := marshalJSON(normalizePublishedValue(projectExecutiveRollup(second, ids)))
-	if err != nil {
-		t.Fatalf("marshal second rollup: %v", err)
+	var decoded map[string]any
+	if err := json.Unmarshal(projected, &decoded); err != nil {
+		t.Fatalf("unmarshal projected rollup: %v", err)
 	}
-	if string(firstPayload) != string(secondPayload) {
-		t.Fatalf("projected executive rollup should ignore volatile raw ref order\nfirst:\n%s\nsecond:\n%s", firstPayload, secondPayload)
+	groups := cloneArray(decoded["groups"])
+	if len(groups) != 1 {
+		t.Fatalf("expected one projected group, got %d", len(groups))
+	}
+	gotRefs := stringArray(requireObjectFromAny(groups[0])["top_example_refs"])
+	wantRefs := []string{"path-a", "path-b", "path-c"}
+	if !reflect.DeepEqual(gotRefs, wantRefs) {
+		t.Fatalf("expected projected executive rollup refs %v, got %v", wantRefs, gotRefs)
 	}
 }
 


### PR DESCRIPTION
## Problem
- Wave 1 was still failing on `fc0a335` because `go test ./internal/siteassets -count=1` detected drift in `docs/examples/site-assets/sample-agent-action-bom.json`.
- The published site-asset projection preserved `executive_rollup.groups[*].top_example_refs` in raw upstream order after opaque-ID normalization, so reordered raw path IDs changed the published BOM fingerprint and `bom_id`.

## Changes
- Canonicalize redacted `top_example_refs` ordering inside the site-asset projection before fingerprinting the published Agent Action BOM.
- Add a focused regression test proving executive-rollup output is stable even when raw example-ref order changes.
- Regenerate the checked-in site assets and manifest from the deterministic generator output.
- Record the Wave 1 fix in the unreleased changelog.

## Validation
- `go test ./internal/siteassets -count=1`
- `go test ./... -count=1`
- `make test-contracts`
- `make prepush-full`
- `make test-release-smoke`

## Risks
- This is intentionally scoped to Wave 1 asset determinism only.
- The changed generated assets are limited to the site examples and manifest expected by the drift gate.
