### PR TITLE
fix: tighten static target authority correlation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - [semver:patch] Added endpoint-dense enterprise-pressure fixtures and bounded-artifact receipts so route-heavy scans regress in deterministic tests before they bloat saved state, graph output, or BOM artifacts.
 - [semver:minor] Replaced endpoint-heavy graph, BOM, and action-surface fanout with grouped endpoint receipts (`endpoint_ref_group_id`, counts, route groups, operation counts, and bounded samples) so report/shareable surfaces stop cloning thousands of endpoint refs per node or item.
 - [semver:minor] Tightened action-path eligibility and authority correlation so static context surfaces no longer inherit governable workflow status from repo-wide credential or deploy signals without a real binding.
+- [semver:patch] Tightened OpenAPI and route authority correlation so static target context no longer inherits unrelated repo-wide workflow credentials or broad repo-derived binding metadata as governable action-path proof.
 - [semver:patch] Kept parse-limited JS/TS WebMCP surfaces in scan-quality coverage receipts instead of surfacing them as scan findings or govern-first action paths.
 
 ### Security

--- a/core/aggregate/privilegebudget/budget.go
+++ b/core/aggregate/privilegebudget/budget.go
@@ -818,10 +818,7 @@ func buildSignalsByRepo(findings []model.Finding) map[string]findingSignals {
 }
 
 func matchingSignalsForTool(tool agginventory.Tool, signalsByAgent map[string]findingSignals, signalsByRepoLocation map[string]findingSignals, signalsByRepo map[string]findingSignals) findingSignals {
-	repoWide := findingSignals{}
-	if repoWideEligibleToolType(tool.ToolType) {
-		repoWide = repoWideSignalsForRepos(tool.Org, tool.Repos, signalsByRepo)
-	}
+	repoWide := repoWideSignalsForTool(tool.ToolType, tool.Org, tool.Repos, signalsByRepo)
 	if signal := signalsByAgent[strings.TrimSpace(tool.AgentID)]; !isEmptyFindingSignals(signal) {
 		return mergeFindingSignalSets(signal, repoWide)
 	}
@@ -862,7 +859,7 @@ func matchingSignalsForAgent(agent agginventory.Agent, tool agginventory.Tool, s
 		return mergeFindingSignalSets(
 			merged,
 			filteredRepoLocationSignals(signalsByRepoLocation[repoLocationSignalKey(agent.Org, "", location)]),
-			repoWideSignalsForRepos(agent.Org, repos, signalsByRepo),
+			repoWideSignalsForTool(firstNonEmptyString(tool.ToolType, agent.Framework), agent.Org, repos, signalsByRepo),
 		)
 	}
 	return mergeFindingSignalSets(merged, filteredRepoLocationSignals(signalsByRepoLocation[repoLocationSignalKey(agent.Org, "", location)]))
@@ -934,6 +931,65 @@ func repoWideSignalsForRepos(org string, repos []string, signalsByRepo map[strin
 		merged = mergeFindingSignalSets(merged, filteredRepoLocationSignals(signalsByRepo[key]))
 	}
 	return merged
+}
+
+func repoWideSignalsForTool(toolType, org string, repos []string, signalsByRepo map[string]findingSignals) findingSignals {
+	if !repoWideEligibleToolType(toolType) {
+		return findingSignals{}
+	}
+	merged := repoWideSignalsForRepos(org, repos, signalsByRepo)
+	if !targetContextAuthorityFilteringRequired(toolType) {
+		return merged
+	}
+	return stripRepoWideAuthoritySignals(merged)
+}
+
+func targetContextAuthorityFilteringRequired(toolType string) bool {
+	switch normalizeToken(toolType) {
+	case "openapi", "route":
+		return true
+	default:
+		return false
+	}
+}
+
+func stripRepoWideAuthoritySignals(signal findingSignals) findingSignals {
+	if isEmptyFindingSignals(signal) {
+		return findingSignals{}
+	}
+	blockedKeys := map[string]struct{}{
+		"workflow_secret_refs":        {},
+		"credential_keys":             {},
+		"credential_provenance_type":  {},
+		"credential_subject":          {},
+		"credential_scope":            {},
+		"credential_confidence":       {},
+		"workflow_builtin_token":      {},
+		"workflow_token_permission":   {},
+		"identity_type":               {},
+		"subject":                     {},
+		"authority_binding":           {},
+		"credential_target_system":    {},
+		"credential_likely_scope":     {},
+		"credential_scope_confidence": {},
+	}
+	out := findingSignals{
+		Repos:      append([]string(nil), signal.Repos...),
+		Locations:  append([]string(nil), signal.Locations...),
+		Values:     []string{},
+		EvidenceKV: map[string][]string{},
+	}
+	for key, values := range signal.EvidenceKV {
+		if _, blocked := blockedKeys[key]; blocked {
+			continue
+		}
+		out.EvidenceKV[key] = append([]string(nil), values...)
+		out.Values = append(out.Values, key)
+		out.Values = append(out.Values, values...)
+	}
+	out.Values = append(out.Values, out.Repos...)
+	out.Values = append(out.Values, out.Locations...)
+	return normalizeFindingSignals(out)
 }
 
 func repoWideEligibleToolType(toolType string) bool {

--- a/core/aggregate/privilegebudget/budget.go
+++ b/core/aggregate/privilegebudget/budget.go
@@ -871,7 +871,6 @@ func filteredRepoLocationSignals(signal findingSignals) findingSignals {
 	}
 	out := findingSignals{
 		Repos:      append([]string(nil), signal.Repos...),
-		Locations:  append([]string(nil), signal.Locations...),
 		Values:     []string{},
 		EvidenceKV: map[string][]string{},
 	}
@@ -920,7 +919,6 @@ func filteredRepoLocationSignals(signal findingSignals) findingSignals {
 		out.Values = append(out.Values, values...)
 	}
 	out.Values = append(out.Values, out.Repos...)
-	out.Values = append(out.Values, out.Locations...)
 	return normalizeFindingSignals(out)
 }
 

--- a/core/aggregate/privilegebudget/budget_test.go
+++ b/core/aggregate/privilegebudget/budget_test.go
@@ -1053,3 +1053,112 @@ func TestBuildCorrelatesRepoWideAuthorityBindingsIntoWorkflowEntry(t *testing.T)
 		t.Fatalf("expected aws provider on authority binding, got %+v", entries[0].AuthorityBindings)
 	}
 }
+
+func TestOpenAPIRouteAuthorityRequiresDirectCorrelation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name          string
+		toolType      string
+		location      string
+		useAgentMatch bool
+	}{
+		{
+			name:     "openapi tool match",
+			toolType: "openapi",
+			location: "openapi/payments.yaml",
+		},
+		{
+			name:     "route tool match",
+			toolType: "route",
+			location: "api/routes/payments.ts",
+		},
+		{
+			name:          "openapi agent match",
+			toolType:      "openapi",
+			location:      "openapi/payments.yaml",
+			useAgentMatch: true,
+		},
+		{
+			name:          "route agent match",
+			toolType:      "route",
+			location:      "api/routes/payments.ts",
+			useAgentMatch: true,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			findings := []model.Finding{
+				{
+					FindingType: "compiled_action",
+					ToolType:    "compiled_action",
+					Location:    ".github/workflows/release.yml",
+					Repo:        "acme/payments",
+					Org:         "acme",
+					Evidence: []model.Evidence{
+						{Key: "workflow_secret_refs", Value: "PROD_DEPLOY_PAT"},
+						{Key: "credential_subject", Value: "PROD_DEPLOY_PAT"},
+						{Key: "credential_provenance_type", Value: "static_secret"},
+						{Key: "credential_scope", Value: agginventory.CredentialScopeWorkflow},
+						{Key: "credential_confidence", Value: "high"},
+						{Key: "workflow_environment", Value: "production"},
+					},
+				},
+				{
+					FindingType: tc.toolType + "_surface",
+					ToolType:    tc.toolType,
+					Location:    tc.location,
+					Repo:        "acme/payments",
+					Org:         "acme",
+					Evidence: []model.Evidence{
+						{Key: "mutable_endpoint_semantic", Value: "payment|high|" + tc.toolType + "|POST /v1/payments"},
+					},
+				},
+			}
+
+			signalsByAgent := buildSignalsByAgent(findings)
+			signalsByRepoLocation := buildSignalsByRepoLocation(findings)
+			signalsByRepo := buildSignalsByRepo(findings)
+			tool := agginventory.Tool{
+				ToolID:    tc.toolType + "-tool",
+				AgentID:   "wrkr:" + tc.toolType + ":acme",
+				ToolType:  tc.toolType,
+				Org:       "acme",
+				Repos:     []string{"acme/payments"},
+				Locations: []agginventory.ToolLocation{{Repo: "acme/payments", Location: tc.location}},
+			}
+
+			var signal findingSignals
+			if tc.useAgentMatch {
+				signal = matchingSignalsForAgent(
+					agginventory.Agent{
+						AgentID:  tc.toolType + "-instance",
+						Org:      "acme",
+						Repo:     "acme/payments",
+						Location: tc.location,
+					},
+					tool,
+					signalsByRepoLocation,
+					signalsByRepo,
+				)
+			} else {
+				signal = matchingSignalsForTool(tool, signalsByAgent, signalsByRepoLocation, signalsByRepo)
+			}
+
+			if got := signal.EvidenceKV["workflow_secret_refs"]; len(got) > 0 {
+				t.Fatalf("expected repo-wide workflow secrets to stay off %s target context, got %v", tc.toolType, got)
+			}
+			if got := signal.EvidenceKV["credential_subject"]; len(got) > 0 {
+				t.Fatalf("expected repo-wide credential subjects to stay off %s target context, got %v", tc.toolType, got)
+			}
+			if got := signal.EvidenceKV["credential_provenance_type"]; len(got) > 0 {
+				t.Fatalf("expected repo-wide credential provenance to stay off %s target context, got %v", tc.toolType, got)
+			}
+			if got := signal.EvidenceKV["workflow_environment"]; len(got) == 0 || got[0] != "production" {
+				t.Fatalf("expected non-authority production context to remain available, got %v", got)
+			}
+		})
+	}
+}

--- a/core/aggregate/privilegebudget/budget_test.go
+++ b/core/aggregate/privilegebudget/budget_test.go
@@ -1162,3 +1162,54 @@ func TestOpenAPIRouteAuthorityRequiresDirectCorrelation(t *testing.T) {
 		})
 	}
 }
+
+func TestOpenAPIDirectAuthorityKeepsTargetLocationWhenRepoHasUnrelatedWorkflow(t *testing.T) {
+	t.Parallel()
+
+	findings := []model.Finding{
+		{
+			FindingType: "compiled_action",
+			ToolType:    "compiled_action",
+			Location:    ".github/workflows/release.yml",
+			Repo:        "acme/payments",
+			Org:         "acme",
+			Evidence: []model.Evidence{
+				{Key: "workflow_environment", Value: "production"},
+				{Key: "workflow_secret_refs", Value: "PROD_DEPLOY_PAT"},
+			},
+		},
+		{
+			FindingType: "openapi_surface",
+			ToolType:    "openapi",
+			Location:    "openapi/payments.yaml",
+			Repo:        "acme/payments",
+			Org:         "acme",
+			Evidence: []model.Evidence{
+				{Key: "credential_subject", Value: "PAYMENTS_SERVICE_TOKEN"},
+				{Key: "credential_provenance_type", Value: "static_secret"},
+				{Key: "credential_scope", Value: agginventory.CredentialScopeTool},
+				{Key: "credential_confidence", Value: "high"},
+			},
+		},
+	}
+
+	signalsByAgent := buildSignalsByAgent(findings)
+	signalsByRepoLocation := buildSignalsByRepoLocation(findings)
+	signalsByRepo := buildSignalsByRepo(findings)
+	tool := agginventory.Tool{
+		ToolID:    "openapi-tool",
+		AgentID:   "wrkr:openapi:acme",
+		ToolType:  "openapi",
+		Org:       "acme",
+		Repos:     []string{"acme/payments"},
+		Locations: []agginventory.ToolLocation{{Repo: "acme/payments", Location: "openapi/payments.yaml"}},
+	}
+
+	signal := matchingSignalsForTool(tool, signalsByAgent, signalsByRepoLocation, signalsByRepo)
+	if got := credentialEvidenceLocation(signal); got != "openapi/payments.yaml" {
+		t.Fatalf("expected direct openapi credential evidence to keep target location, got %q from %+v", got, signal)
+	}
+	if len(signal.Locations) != 1 || signal.Locations[0] != "openapi/payments.yaml" {
+		t.Fatalf("expected filtered repo-wide signals to avoid unrelated workflow locations, got %+v", signal.Locations)
+	}
+}

--- a/core/risk/action_binding.go
+++ b/core/risk/action_binding.go
@@ -1,6 +1,7 @@
 package risk
 
 import (
+	pathpkg "path"
 	"strings"
 
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
@@ -81,6 +82,7 @@ func pathHasGovernableBinding(path ActionPath) bool {
 }
 
 func pathHasContextSurfaceCorrelation(path ActionPath) bool {
+	targetContext := pathTargetsCorrelationContext(path)
 	if pathHasExecutableBinding(path) {
 		return true
 	}
@@ -93,17 +95,23 @@ func pathHasContextSurfaceCorrelation(path ActionPath) bool {
 			return true
 		}
 	}
-	if path.DeployWrite || strings.EqualFold(strings.TrimSpace(path.DeploymentStatus), "deployed") || hasOperationalTargetCorrelation(path.MatchedProductionTargets) {
+	if !targetContext && (path.DeployWrite || strings.EqualFold(strings.TrimSpace(path.DeploymentStatus), "deployed") || hasOperationalTargetCorrelation(path.MatchedProductionTargets)) {
 		return true
 	}
-	if actionPathHasStrongIdentity(path) {
+	if !targetContext && actionPathHasStrongIdentity(path) {
 		return true
 	}
 	if hasRuntimeCorrelationEvidence(path) {
 		return true
 	}
+	if !targetContext && (len(path.DeliveryHarnesses) > 0 || len(path.ResolverRefs) > 0 || len(path.EvalConfigRefs) > 0 || len(path.WorkflowChainRefs) > 0) {
+		return true
+	}
 	if path.IntroducedBy != nil && (strings.TrimSpace(path.IntroducedBy.Reference) != "" || strings.TrimSpace(path.IntroducedBy.Timestamp) != "") {
 		return true
+	}
+	if targetContext {
+		return pathHasPathScopedAuthorityEvidence(path)
 	}
 	for _, binding := range agginventory.NormalizeAuthorityBindings(path.AuthorityBindings) {
 		if binding == nil {
@@ -119,6 +127,54 @@ func pathHasContextSurfaceCorrelation(path ActionPath) bool {
 		}
 	}
 	return false
+}
+
+func pathHasPathScopedAuthorityEvidence(path ActionPath) bool {
+	location := normalizeCorrelationLocation(path.Location)
+	if location == "" {
+		return false
+	}
+	for _, credential := range agginventory.NormalizeCredentialProvenances(path.Credentials) {
+		if credential == nil {
+			continue
+		}
+		if evidenceLocationMatchesPath(credential.EvidenceLocation, location) {
+			return true
+		}
+	}
+	if provenance := agginventory.NormalizeCredentialProvenance(path.CredentialProvenance); provenance != nil {
+		if evidenceLocationMatchesPath(provenance.EvidenceLocation, location) {
+			return true
+		}
+	}
+	for _, binding := range agginventory.NormalizeAuthorityBindings(path.AuthorityBindings) {
+		if binding == nil {
+			continue
+		}
+		for _, ref := range binding.EvidenceRefs {
+			if evidenceLocationMatchesPath(ref, location) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func evidenceLocationMatchesPath(ref, location string) bool {
+	normalized := normalizeCorrelationLocation(ref)
+	if normalized == "" || location == "" {
+		return false
+	}
+	return normalized == location || strings.HasSuffix(normalized, "/"+location)
+}
+
+func normalizeCorrelationLocation(value string) string {
+	value = strings.TrimSpace(strings.ReplaceAll(strings.ToLower(value), "\\", "/"))
+	value = strings.TrimPrefix(value, "./")
+	if value == "" {
+		return ""
+	}
+	return pathpkg.Clean(value)
 }
 
 func hasOperationalTargetCorrelation(targets []string) bool {

--- a/core/risk/action_paths_test.go
+++ b/core/risk/action_paths_test.go
@@ -1056,6 +1056,110 @@ func TestOpenAPIWithoutAuthorityCorrelationStaysAppendixOnlyProductionContext(t 
 	}
 }
 
+func TestTargetContextSurfacesStripUncorrelatedAuthority(t *testing.T) {
+	t.Parallel()
+
+	unrelatedCredential := &agginventory.CredentialProvenance{
+		Type:             agginventory.CredentialProvenanceStaticSecret,
+		Subject:          "PROD_DEPLOY_PAT",
+		Scope:            agginventory.CredentialScopeWorkflow,
+		Confidence:       "high",
+		CredentialKind:   agginventory.CredentialKindGitHubPAT,
+		AccessType:       agginventory.CredentialAccessTypeStanding,
+		StandingAccess:   true,
+		EvidenceLocation: ".github/workflows/release.yml",
+	}
+	unrelatedAuthority := &agginventory.CredentialAuthority{
+		CredentialPresent:      true,
+		CredentialUsableByPath: true,
+		CredentialKind:         agginventory.CredentialKindGitHubPAT,
+		AccessType:             agginventory.CredentialAccessTypeStanding,
+		StandingAccess:         true,
+		Confidence:             "high",
+		ReasonCodes:            []string{"credential_present:true"},
+	}
+	unrelatedBindings := []*agginventory.AuthorityBinding{{
+		Kind:         agginventory.AuthorityBindingSaaSToken,
+		Provider:     "github",
+		TargetSystem: "source_control",
+		LikelyScope:  "source_control_write",
+		AccessLevel:  agginventory.AuthorityAccessWrite,
+		Confidence:   "high",
+		EvidenceRefs: []string{".github/workflows/release.yml"},
+	}}
+
+	for _, tc := range []struct {
+		name        string
+		toolType    string
+		location    string
+		pathContext *agginventory.PathContext
+	}{
+		{
+			name:     "openapi",
+			toolType: "openapi",
+			location: "openapi/payments.yaml",
+		},
+		{
+			name:     "route",
+			toolType: "route",
+			location: "api/routes/payments.ts",
+		},
+		{
+			name:        "generated client",
+			toolType:    "openapi",
+			location:    "generated/client/payments_client.go",
+			pathContext: &agginventory.PathContext{Kind: agginventory.PathContextGeneratedCode, Confidence: "high"},
+		},
+		{
+			name:        "docs",
+			toolType:    "openapi",
+			location:    "docs/openapi/payments.md",
+			pathContext: &agginventory.PathContext{Kind: agginventory.PathContextDocs, Confidence: "high"},
+		},
+		{
+			name:     "dependency",
+			toolType: "dependency",
+			location: "package-lock.json",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			paths := ProjectActionPaths([]ActionPath{{
+				PathID:               "target-context-" + tc.name,
+				Org:                  "acme",
+				Repo:                 "acme/payments",
+				ToolType:             tc.toolType,
+				Location:             tc.location,
+				PathContext:          tc.pathContext,
+				CredentialAccess:     true,
+				Credentials:          []*agginventory.CredentialProvenance{agginventory.CloneCredentialProvenance(unrelatedCredential)},
+				CredentialProvenance: agginventory.CloneCredentialProvenance(unrelatedCredential),
+				CredentialAuthority:  agginventory.CloneCredentialAuthority(unrelatedAuthority),
+				AuthorityBindings:    agginventory.CloneAuthorityBindings(unrelatedBindings),
+				StandingPrivilege:    true,
+			}})
+
+			if len(paths) != 1 {
+				t.Fatalf("expected one projected path, got %+v", paths)
+			}
+			if paths[0].ActionPathEligible {
+				t.Fatalf("expected %s target context to remain ineligible without direct correlation, got %+v", tc.name, paths[0])
+			}
+			if paths[0].ActionBindingState != ActionBindingStateUnboundContext {
+				t.Fatalf("expected %s binding_state=unbound_context, got %+v", tc.name, paths[0])
+			}
+			if paths[0].CredentialAccess {
+				t.Fatalf("expected %s to drop unrelated credential_access, got %+v", tc.name, paths[0])
+			}
+			if paths[0].CredentialProvenance != nil || paths[0].CredentialAuthority != nil || len(paths[0].AuthorityBindings) > 0 {
+				t.Fatalf("expected %s to strip unrelated authority payloads, got %+v", tc.name, paths[0])
+			}
+		})
+	}
+}
+
 func TestCodexConfigProjectsAsInstructionSurfaceWithToolBinding(t *testing.T) {
 	t.Parallel()
 

--- a/docs/decisions/wave51-static-target-authority-correlation.md
+++ b/docs/decisions/wave51-static-target-authority-correlation.md
@@ -1,0 +1,81 @@
+# ADR: Wave 51 Static Target Authority Correlation
+
+Date: 2026-06-16
+Status: accepted
+
+## Context
+
+Wave 2 of the site-assets, OpenAPI authority, and BOM hardening plan found that
+Wrkr still let static target surfaces inherit governable posture from unrelated
+repo-wide workflow evidence. In practice, a repo that contained:
+
+1. an OpenAPI or route surface
+2. an unrelated workflow secret or release workflow elsewhere in the repo
+
+could project the static target as a partially bound action path instead of
+plain target context. That overclaimed authority, crowded Top Action Paths, and
+blurred the difference between:
+
+1. static target context that needs caller correlation
+2. path-scoped authority evidence
+3. real workflow or runtime execution evidence
+
+## Decision
+
+1. Strip repo-wide credential and authority signals before they are merged into
+   `openapi` and `route` target surfaces during privilege-budget aggregation.
+2. Keep repo-wide context that is still useful for buyer-readable production
+   framing, but do not treat that context as enough to promote static target
+   surfaces into governable action paths.
+3. Require path-scoped authority evidence before target-context surfaces can use
+   credential or authority metadata as correlation proof.
+4. Preserve the existing distinction between production context and action-path
+   eligibility: static targets may remain production-adjacent context without
+   automatically becoming governable action paths.
+
+## Alternatives Considered
+
+1. Remove all repo-wide context from OpenAPI and route surfaces.
+   Rejected because it would also erase useful production-adjacent context that
+   still helps buyers understand why the surface matters.
+2. Leave aggregation unchanged and only rewrite markdown or readiness copy.
+   Rejected because JSON, scenario, and govern-first consumers would still see
+   false action-path eligibility.
+3. Treat any workflow, delivery-harness, or matched-target metadata as direct
+   correlation for static targets.
+   Rejected because the unrelated-credential failure class would remain fail-open.
+
+## Tradeoffs
+
+- The model is more conservative, so some static target surfaces move out of Top
+  Action Paths and back into Target Surface Context until stronger evidence is
+  present.
+- Direct path-scoped evidence is now more important than broad repo adjacency,
+  which is a better fit for Wrkr's deterministic, explainable posture model.
+
+## Rollback Plan
+
+1. Revert the repo-wide authority filtering for `openapi` and `route` surfaces.
+2. Restore the old target-context correlation gate that accepted repo-derived
+   authority metadata as sufficient binding evidence.
+3. Re-run the focused privilege-budget, risk, scenario, contract, and final
+   lanes to confirm the old semantics are fully restored.
+
+## Validation Plan
+
+- `go test ./core/aggregate/privilegebudget -run 'Test.*OpenAPI|Test.*Swagger|Test.*Route|Test.*Authority|Test.*Credential' -count=1`
+- `go test ./core/risk -run 'Test.*ActionBinding|Test.*OpenAPI|Test.*TargetSurface|Test.*Authority' -count=1`
+- `go test ./internal/scenarios -run 'TestWave3ActionPathSemanticScenario|TestSwaggerWithUnrelatedWorkflowCredentialStaysTargetContext|TestWave4HighStakesAuthorityScenario' -count=1 -tags=scenario`
+- `scripts/validate_scenarios.sh`
+- `make test-contracts`
+- `make test-hardening`
+- `make prepush-full`
+
+Acceptance criteria:
+
+- static OpenAPI and route surfaces stay in Target Surface Context when the only
+  evidence is an unrelated workflow secret or workflow elsewhere in the repo
+- target-context surfaces strip uncorrelated authority payloads instead of
+  treating them as binding proof
+- production-adjacent context can remain visible without promoting the static
+  surface into a governable action path

--- a/internal/scenarios/coverage_map.json
+++ b/internal/scenarios/coverage_map.json
@@ -151,7 +151,8 @@
     "TestWave4DriftReviewSchemasDeclareCategoryContracts"
   ],
   "W2-target-classification": [
-    "TestTargetClassificationScenario"
+    "TestTargetClassificationScenario",
+    "TestSwaggerWithUnrelatedWorkflowCredentialStaysTargetContext"
   ],
   "W4-high-stakes-authority": [
     "TestWave4HighStakesAuthorityScenario"

--- a/internal/scenarios/wave3_action_path_semantics_scenario_test.go
+++ b/internal/scenarios/wave3_action_path_semantics_scenario_test.go
@@ -48,6 +48,55 @@ paths:
 	}
 }
 
+func TestSwaggerWithUnrelatedWorkflowCredentialStaysTargetContext(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeWave3ScenarioFile(t, root, ".github/workflows/release.yml", `name: release
+on: workflow_dispatch
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./release.sh
+        env:
+          PROD_DEPLOY_PAT: ${{ secrets.PROD_DEPLOY_PAT }}
+`)
+	writeWave3ScenarioFile(t, root, "openapi/swagger.yaml", `openapi: 3.0.0
+paths:
+  /v1/payments:
+    post:
+      summary: Create payment
+      operationId: createPayment
+`)
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	scanPayload := runScenarioCommandJSON(t, []string{"scan", "--path", root, "--state", statePath, "--json"})
+	actionPaths := requireArray(t, scanPayload, "action_paths")
+	swaggerPath := findActionPathByLocation(t, actionPaths, "openapi/swagger.yaml")
+	if value, ok := swaggerPath["action_path_eligible"]; ok && value != false {
+		t.Fatalf("expected swagger target context to stay ineligible when only an unrelated workflow secret exists, got %v", swaggerPath)
+	}
+	if swaggerPath["action_binding_state"] != "unbound_context" {
+		t.Fatalf("expected swagger binding_state=unbound_context, got %v", swaggerPath)
+	}
+	if credentialAccess, ok := swaggerPath["credential_access"].(bool); ok && credentialAccess {
+		t.Fatalf("expected swagger target context to drop unrelated credential_access, got %v", swaggerPath)
+	}
+	if _, ok := swaggerPath["credential_authority_ref"]; ok {
+		t.Fatalf("expected swagger target context to omit credential_authority_ref, got %v", swaggerPath)
+	}
+	if _, ok := swaggerPath["credential_authority"]; ok {
+		t.Fatalf("expected swagger target context to omit embedded credential_authority, got %v", swaggerPath)
+	}
+	if refs, ok := swaggerPath["authority_binding_refs"].([]any); ok && len(refs) > 0 {
+		t.Fatalf("expected swagger target context to omit authority_binding_refs, got %v", swaggerPath)
+	}
+	if bindings, ok := swaggerPath["authority_bindings"].([]any); ok && len(bindings) > 0 {
+		t.Fatalf("expected swagger target context to omit embedded authority_bindings, got %v", swaggerPath)
+	}
+}
+
 func writeWave3ScenarioFile(t *testing.T, root, rel, content string) {
 	t.Helper()
 	path := filepath.Join(root, filepath.FromSlash(rel))

--- a/scenarios/wrkr/buyer-action-registry-hardening/expected/design-partner-lines.txt
+++ b/scenarios/wrkr/buyer-action-registry-hardening/expected/design-partner-lines.txt
@@ -1,6 +1,6 @@
 # Wrkr Design Partner Summary
 
-- Generated at: 2026-06-15T16:41:58Z
+- Generated at: 2026-06-16T22:20:38Z
 - Template: design-partner-summary
 - Share profile: design-partner
 - Boundary: static posture from saved scan state only; no live runtime observation, endpoint probing, or control-layer enforcement
@@ -14,15 +14,15 @@ Problem: This path can change production-adjacent state and is missing enough go
 Likely explanation: config=loc-dd191250
 Threat: risk_zone=production_data, risk_tier=critical, production_target_status=configured, mutable_endpoint=production_mutation x6,refund x4,write x3
 Recommended control: Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.
-Confidence lane: confirmed action path
+Confidence lane: likely action path
 Proof gap: proof=path-specific proof not found, policy=none, runtime=runtime evidence not collected, approval=approval evidence not found
 Credential authority: no credential authority was linked to this path
-High-stakes: credential_bearing_automation (credential_authority:present); mutable_endpoint (mutable_endpoint:present); payment_flow (payment_surface:detected); production_path (production_path:detected); regulated_customer_workflow (customer_or_regulated_surface:detected)
+High-stakes: mutable_endpoint (mutable_endpoint:present); payment_flow (payment_surface:detected); production_path (production_path:detected); regulated_customer_workflow (customer_or_regulated_surface:detected)
 Mutable endpoint: 20 grouped endpoint semantics; 4 route groups; production_mutation x6, refund x4, write x3, data_export x2; samples=endpoint-8be61507 | endpoint-dc74895a | endpoint-d66e2561 | endpoint-c43f7237 | endpoint-0d2751ad | endpoint-0315367e | endpoint-412970ad
-Production context: status=correlated, surface=label-dd191250, credential=standing credential, target=production_impacting, deployment=unknown, operations=label-8be61507,label-c43f7237,label-dc74895a,label-d66e2561,label-0d2751ad,label-0315367e,label-412970ad
+Production context: status=correlated, surface=label-dd191250, credential=no credential evidence, target=production_impacting, deployment=unknown, operations=label-8be61507,label-c43f7237,label-dc74895a,label-d66e2561,label-0d2751ad,label-0315367e,label-412970ad
 Owner: owner-c6dd827f
 Purpose: purpose not confirmed
-Lineage: label-9431ef09 -> label-119136f6 -> label-3cd2637d -> label-d236d5a6 -> label-9614be72 -> label-dd191250 -> label-dd191250 -> label-880ec2e1 -> label-190c1a6b -> label-f82078a0 -> label-eb24c1ad -> label-c6dd827f -> label-05227691 (missing) -> label-a6769766 -> label-eb24c1ad -> label-dcf46005 -> label-2575fc52 (missing) -> label-78aef3a3
+Lineage: label-9431ef09 -> label-119136f6 -> label-3cd2637d -> label-d236d5a6 -> label-9614be72 -> label-dd191250 -> label-dd191250 -> label-880ec2e1 -> label-190c1a6b -> label-b23a6a84 -> label-eb24c1ad -> label-c6dd827f -> label-05227691 (missing) -> label-a6769766 -> label-eb24c1ad -> label-dcf46005 -> label-2575fc52 (missing) -> label-78aef3a3
 
 2. repo-d236d5 in loc-d5d3368a
 Problem: This path can change production-adjacent state and is missing enough governance evidence.
@@ -47,12 +47,12 @@ Recommended control: Review the declared mutable endpoint scope, require owner a
 Confidence lane: likely action path
 Proof gap: proof=path-specific proof not found, policy=none, runtime=runtime evidence not collected, approval=approval evidence not found
 Credential authority: no credential authority was linked to this path
-High-stakes: credential_bearing_automation (credential_authority:present); external_egress (external_egress:detected); mutable_endpoint (mutable_endpoint:present); payment_flow (payment_surface:detected); production_path (production_path:detected); regulated_customer_workflow (customer_or_regulated_surface:detected)
+High-stakes: external_egress (external_egress:detected); mutable_endpoint (mutable_endpoint:present); payment_flow (payment_surface:detected); production_path (production_path:detected); regulated_customer_workflow (customer_or_regulated_surface:detected)
 Mutable endpoint: 19 grouped endpoint semantics; 4 route groups; production_mutation x5, refund x4, data_export x3, write x3; samples=endpoint-dc74895a | endpoint-73437816 | endpoint-d66e2561 | endpoint-0d2751ad | endpoint-fed73031 | endpoint-0315367e | endpoint-412970ad
-Production context: status=correlated, surface=label-6dd0f3ed, credential=standing credential, target=production_impacting, deployment=unknown, operations=label-73437816,label-fed73031,label-dc74895a,label-d66e2561,label-0d2751ad,label-0315367e,label-412970ad
+Production context: status=correlated, surface=label-6dd0f3ed, credential=no credential evidence, target=production_impacting, deployment=unknown, operations=label-73437816,label-fed73031,label-dc74895a,label-d66e2561,label-0d2751ad,label-0315367e,label-412970ad
 Owner: owner-ab37caea
 Purpose: purpose not confirmed
-Lineage: label-9431ef09 -> label-119136f6 -> label-3cd2637d -> label-d236d5a6 -> label-9614be72 -> label-6dd0f3ed -> label-6dd0f3ed -> label-837b932d -> label-44b4c4e4 -> label-f82078a0 -> label-eb24c1ad -> label-ab37caea -> label-05227691 (missing) -> label-a6769766 -> label-eb24c1ad -> label-dcf46005 -> label-2575fc52 (missing) -> label-78aef3a3
+Lineage: label-9431ef09 -> label-119136f6 -> label-3cd2637d -> label-d236d5a6 -> label-9614be72 -> label-6dd0f3ed -> label-6dd0f3ed -> label-837b932d -> label-44b4c4e4 -> credential (missing) -> label-eb24c1ad -> label-ab37caea -> label-05227691 (missing) -> label-a6769766 -> label-eb24c1ad -> label-dcf46005 -> label-2575fc52 (missing) -> label-3ebe56d9
 
 4. repo-d236d5 in loc-d5d3368a
 Problem: This path can change production-adjacent state and is missing enough governance evidence.
@@ -101,7 +101,7 @@ Lineage: label-9431ef09 -> label-119136f6 -> label-3cd2637d -> label-d236d5a6 ->
 
 ## Registry Highlights
 
-- label-8a84e406 surface=route_file owner=owner-c6dd827f purpose=purpose not confirmed confidence=confirmed_action_path remediation=Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.
+- label-8a84e406 surface=route_file owner=owner-c6dd827f purpose=purpose not confirmed confidence=likely_action_path remediation=Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.
 - label-625a4c05 surface=server owner=owner-f9ae3305 purpose=mcp integration confidence=likely_action_path remediation=Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.
 - label-2d676fe1 surface=api_schema owner=owner-ab37caea purpose=purpose not confirmed confidence=likely_action_path remediation=Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.
 - label-625a4c05 surface=surface owner=owner-f9ae3305 purpose=mcp integration confidence=likely_action_path remediation=Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.

--- a/scenarios/wrkr/buyer-action-registry-hardening/expected/design-partner-lines.txt
+++ b/scenarios/wrkr/buyer-action-registry-hardening/expected/design-partner-lines.txt
@@ -1,6 +1,6 @@
 # Wrkr Design Partner Summary
 
-- Generated at: 2026-06-16T22:20:38Z
+- Generated at: 2026-06-16T23:36:48Z
 - Template: design-partner-summary
 - Share profile: design-partner
 - Boundary: static posture from saved scan state only; no live runtime observation, endpoint probing, or control-layer enforcement
@@ -22,7 +22,7 @@ Mutable endpoint: 20 grouped endpoint semantics; 4 route groups; production_muta
 Production context: status=correlated, surface=label-dd191250, credential=no credential evidence, target=production_impacting, deployment=unknown, operations=label-8be61507,label-c43f7237,label-dc74895a,label-d66e2561,label-0d2751ad,label-0315367e,label-412970ad
 Owner: owner-c6dd827f
 Purpose: purpose not confirmed
-Lineage: label-9431ef09 -> label-119136f6 -> label-3cd2637d -> label-d236d5a6 -> label-9614be72 -> label-dd191250 -> label-dd191250 -> label-880ec2e1 -> label-190c1a6b -> label-b23a6a84 -> label-eb24c1ad -> label-c6dd827f -> label-05227691 (missing) -> label-a6769766 -> label-eb24c1ad -> label-dcf46005 -> label-2575fc52 (missing) -> label-78aef3a3
+Lineage: label-9431ef09 -> label-119136f6 -> label-3cd2637d -> label-d236d5a6 -> label-9614be72 -> label-dd191250 -> label-dd191250 -> label-880ec2e1 -> label-190c1a6b -> label-b23a6a84 (missing) -> label-eb24c1ad -> label-c6dd827f -> label-05227691 (missing) -> label-a6769766 -> label-eb24c1ad -> label-dcf46005 -> label-2575fc52 (missing) -> label-78aef3a3
 
 2. repo-d236d5 in loc-d5d3368a
 Problem: This path can change production-adjacent state and is missing enough governance evidence.

--- a/scenarios/wrkr/buyer-action-registry-hardening/expected/evidence-design-partner-summary.json
+++ b/scenarios/wrkr/buyer-action-registry-hardening/expected/evidence-design-partner-summary.json
@@ -1,13 +1,13 @@
 {
   "bom_count": 7,
   "first_bom": {
-    "confidence_lane": "confirmed_action_path",
+    "confidence_lane": "likely_action_path",
     "location": "loc-dd191250",
     "remediation": "Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.",
     "repo": "repo-d236d5"
   },
   "first_registry": {
-    "confidence_lane": "confirmed_action_path",
+    "confidence_lane": "likely_action_path",
     "remediation": "Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.",
     "surface_type": "route_file"
   },

--- a/scenarios/wrkr/buyer-action-registry-hardening/expected/report-internal-summary.json
+++ b/scenarios/wrkr/buyer-action-registry-hardening/expected/report-internal-summary.json
@@ -7,18 +7,18 @@
       "credential_present": true,
       "credential_referenced_by_workflow": true,
       "credential_source": "workflow_secret_ref",
-      "credential_usable_by_path": false,
+      "credential_usable_by_path": true,
       "rotation_evidence_status": "missing",
       "standing_access": true
     },
     "lineage_statuses": [
       {
         "kind": "intent",
-        "status": "unknown"
+        "status": "declared"
       },
       {
         "kind": "task",
-        "status": "unknown"
+        "status": "declared"
       },
       {
         "kind": "human",
@@ -50,11 +50,11 @@
       },
       {
         "kind": "credential",
-        "status": "referenced_only"
+        "status": "present"
       },
       {
         "kind": "target",
-        "status": "present"
+        "status": "missing"
       },
       {
         "kind": "owner",
@@ -70,7 +70,7 @@
       },
       {
         "kind": "deployment",
-        "status": "unknown"
+        "status": "missing"
       },
       {
         "kind": "outcome",
@@ -82,19 +82,19 @@
       },
       {
         "kind": "evidence",
-        "status": "verified"
+        "status": "unknown"
       }
     ],
-    "location": "server/refund_routes.js",
+    "location": ".github/workflows/refund-agent.yml",
     "policy_status": "none",
     "proof_coverage": "missing",
-    "remediation": "Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.",
+    "remediation": "Replace the standing credential with brokered or JIT access where possible, attach rotation evidence, and rescan to confirm the reduced blast radius.",
     "repo": "payments-private"
   },
   "lane_counts": {
-    "confirmed_action_path": 2,
+    "confirmed_action_path": 1,
     "context_only": 1,
-    "likely_action_path": 3,
+    "likely_action_path": 4,
     "semantic_review_candidate": 1
   },
   "registry_count": 7,

--- a/scenarios/wrkr/buyer-action-registry-hardening/expected/scan-summary.json
+++ b/scenarios/wrkr/buyer-action-registry-hardening/expected/scan-summary.json
@@ -2,13 +2,13 @@
   "action_path_count": 7,
   "confirmed_path": {
     "confidence_lane": "confirmed_action_path",
-    "location": "server/refund_routes.js",
+    "location": ".github/workflows/refund-agent.yml",
     "repo": "payments-private"
   },
   "lane_counts": {
-    "confirmed_action_path": 2,
+    "confirmed_action_path": 1,
     "context_only": 1,
-    "likely_action_path": 3,
+    "likely_action_path": 4,
     "semantic_review_candidate": 1
   },
   "mutable_surface_path": {
@@ -32,7 +32,7 @@
       "proof",
       "evidence"
     ],
-    "confidence_lane": "confirmed_action_path",
+    "confidence_lane": "likely_action_path",
     "config_fingerprint": "cfg-25ce41dafe7a",
     "location": "server/refund_routes.js",
     "repo": "payments-private",


### PR DESCRIPTION
## Problem
- static OpenAPI and route surfaces could inherit unrelated repo-wide workflow credential or broad repo-derived binding metadata
- that let target-context surfaces present as governable action paths instead of staying in Target Surface Context until direct correlation existed
- the buyer-action-registry scenario expectations also needed to move to the more conservative ranking this change introduces

## Changes
- filter repo-wide authority and credential signals before merging them into `openapi` and `route` target surfaces in privilege-budget aggregation
- require path-scoped authority evidence before target-context surfaces can use authority metadata as correlation proof
- add focused unit and scenario regressions for Swagger/OpenAPI plus unrelated workflow credential cases
- add ADR `wave51-static-target-authority-correlation`
- refresh buyer-action-registry scenario goldens to match the tightened semantics

## Validation
- `make prepush-full`
- `scripts/validate_scenarios.sh`
- `make test-contracts`
- `make test-hardening`
- `make test-scenarios`
- focused Wave 2 test commands from the plan were run before the full gates

## Risks
- ranking is intentionally more conservative for static target surfaces, so some paths move from confirmed or likely governable lanes back into context-only / correlation-needed treatment until direct evidence exists
- buyer-facing scenario goldens changed accordingly and were revalidated in the full scenario lane

## Submodule Notes
- no submodule pointer changes
