### PR TITLE
fix: harden BOM buyer view and manual docs handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - [semver:minor] Unified report and evidence serialization metadata with shared suppression and artifact-budget hints so shareable/default outputs advertise caps, appendix availability, and focused/detail handoff paths consistently.
 - [semver:minor] Updated Agent Action BOM and control-backlog closure guidance so OpenAPI, route, instruction, MCP config, dependency, CI, and release workflow surfaces use path-type-specific remediation language.
 - [semver:minor] Reworked Agent Action BOM Markdown to lead with buyer-facing inspect-first diagnostics, keep appendix-heavy refs later, and promote recent PR review into a named workflow instead of appendix-style output.
+- [semver:minor] Reworked the default Agent Action BOM buyer view to start with inspect-first cards, keep the primary path plus top five eligible paths on the first page, and move machine-heavy BOM metadata into appendices and evidence artifacts.
+- [semver:patch] Clarified scan, report, evidence, assess, README, and docs-site guidance so manual large-scan workflows center `--state` plus durable artifacts while `--json` examples stay explicitly labeled for automation and CI.
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ review the top workflow/action path before widening to org-scale inventory.
 ### Focused Repo Review (Recommended first path)
 
 ```bash
-wrkr scan --path ./your-repo --profile assessment --json
-wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --json
-wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/focused-agent-action-bom.md --json
+wrkr scan --path ./your-repo --profile assessment --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/focused-agent-action-bom.md
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --evidence-json --evidence-json-path ./.tmp/focused-agent-action-bom-evidence.json
 ```
 
 Use this when you want the shortest route from "what can this workflow change?"
@@ -68,7 +68,15 @@ over time, initialize a baseline and rerun the bounded assess flow:
 
 ```bash
 wrkr regress init --baseline ./.wrkr/last-scan.json --output ./.wrkr/wrkr-regress-baseline.json --json
-wrkr assess --path ./your-repo --baseline ./.wrkr/wrkr-regress-baseline.json --template design-partner-summary --share-profile design-partner --ticket-format jira --json
+wrkr assess --path ./your-repo --output-dir ./.wrkr/design-partner-assessment --baseline ./.wrkr/wrkr-regress-baseline.json --template design-partner-summary --share-profile design-partner --ticket-format jira
+```
+
+Automation / CI equivalent:
+
+```bash
+wrkr scan --path ./your-repo --profile assessment --state ./.wrkr/last-scan.json --json --json-path ./.wrkr/scan.json
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --json
+wrkr assess --path ./your-repo --output-dir ./.wrkr/assessment --json
 ```
 
 Choose one explicit first-value path:
@@ -91,14 +99,14 @@ Hosted prerequisites for this path:
 - large-org runbook: [`docs/examples/security-team.md`](docs/examples/security-team.md)
 
 ```bash
-wrkr init --non-interactive --org acme --github-api https://api.github.com --json
-wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --timeout 30m --profile assessment --json --json-path ./.wrkr/scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
-wrkr report --state ./.wrkr/last-scan.json --template design-partner-summary --share-profile design-partner --md --md-path ./.wrkr/design-partner-summary.md --evidence-json --evidence-json-path ./.wrkr/design-partner-evidence.json --json
-wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence --json
-wrkr verify --chain --state ./.wrkr/last-scan.json --json
+wrkr init --non-interactive --org acme --github-api https://api.github.com
+wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --timeout 30m --profile assessment --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
+wrkr report --state ./.wrkr/last-scan.json --template design-partner-summary --share-profile design-partner --md --md-path ./.wrkr/design-partner-summary.md --evidence-json --evidence-json-path ./.wrkr/design-partner-evidence.json
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence
+wrkr verify --chain --state ./.wrkr/last-scan.json
 ```
 
-`--json` keeps stdout reserved for the final bounded machine-readable scan summary. Full findings, inventory, risk, action paths, and control backlog detail are written to `--state` for report, evidence, verify, and regress handoff; stdout includes previews and `suppressed_counts` when full-detail sections exceed the inline budget. `--progress auto` preserves stderr-only structured progress by default for `--json` scans, while interactive human scans can render a live bar and non-TTY runs degrade to plain newline progress on stderr. Use `--progress events` for deterministic machine-readable liveness, `--progress none` for CI-stable quiet stderr, or `--quiet` to suppress progress output entirely. `--json-path` adds a byte-identical copy of the bounded JSON stdout artifact on disk, and `--resume` reuses durable org-scan checkpoint state under the scan-state directory when an earlier hosted scan was interrupted. Hosted GitHub materialization is sparse by default, fetching detector-relevant files instead of every repository blob. `--json-path`, `--report-md-path`, and `--sarif-path` must each stay unique and must not alias `--state` or Wrkr-managed sibling artifacts; collisions now fail closed with `invalid_input` before any scan state is mutated. `--profile assessment` narrows the govern-first readout for customer-style scans without changing raw findings, proof chains, or exit codes.
+For human/manual large scans, `--state` plus the generated markdown, evidence, and verify artifacts are the durable handoff. `--json` keeps stdout reserved for the final bounded machine-readable scan summary when automation or CI needs it. Full findings, inventory, risk, action paths, and control backlog detail are written to `--state` for report, evidence, verify, and regress handoff; stdout includes previews and `suppressed_counts` when full-detail sections exceed the inline budget. `--progress auto` preserves stderr-only structured progress by default for `--json` scans, while interactive human scans can render a live bar and non-TTY runs degrade to plain newline progress on stderr. Use `--progress events` for deterministic machine-readable liveness, `--progress none` for CI-stable quiet stderr, or `--quiet` to suppress progress output entirely. `--json-path` adds a byte-identical copy of the bounded JSON stdout artifact on disk, and `--resume` reuses durable org-scan checkpoint state under the scan-state directory when an earlier hosted scan was interrupted. Hosted GitHub materialization is sparse by default, fetching detector-relevant files instead of every repository blob. `--json-path`, `--report-md-path`, and `--sarif-path` must each stay unique and must not alias `--state` or Wrkr-managed sibling artifacts; collisions now fail closed with `invalid_input` before any scan state is mutated. `--profile assessment` narrows the govern-first readout for customer-style scans without changing raw findings, proof chains, or exit codes.
 `wrkr init` can now persist the hosted GitHub API base together with the default org target, so the follow-on `wrkr scan --config ...` path stays copy-pasteable without repeating `--github-api` on every run.
 If a hosted org scan is interrupted, rerun the same target with `--resume`. Treat `partial_result`, `source_errors`, or `source_degraded` as incomplete posture output and rerun after rate limits, permission issues, or upstream failures are resolved. Saved state now preserves those completeness markers, and report, evidence, export, and regress handoff commands reject incomplete saved scans with `invalid_input` instead of producing downstream artifacts.
 `wrkr evidence` now requires the saved scan state to be complete and the saved proof chain to be intact before it stages or publishes a bundle, and `wrkr verify --chain` remains the explicit operator/CI integrity gate. `--resume` also revalidates checkpoint files and reused materialized repo roots so symlink-swapped entries fail closed instead of being treated as trusted scan roots.
@@ -120,11 +128,12 @@ Use the curated scenario bundle when you want a clean evaluator-safe pass throug
 This bundle is intentionally risky by design. A low posture score or low first-run framework coverage is expected here and demonstrates that Wrkr is surfacing real control and evidence gaps, not that the product is failing.
 
 ```bash
-wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json
-wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/wrkr-scenario-evidence --json
-wrkr verify --chain --state ./.wrkr/last-scan.json --json
+wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scenario-summary.md
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/evaluator-bom.md
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/wrkr-scenario-evidence
+wrkr verify --chain --state ./.wrkr/last-scan.json
 wrkr regress init --baseline ./.wrkr/last-scan.json --output ./.tmp/wrkr-regress-baseline.json --json
-wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/last-scan.json --json
+wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/last-scan.json
 ```
 
 This curated path is the recommended fallback and demo workflow when hosted prerequisites are not ready yet or when you want to show the shipped wedge without repo-root fixture noise from Wrkr's own scenario, docs, and test fixtures.
@@ -134,8 +143,8 @@ Low or zero first-run `framework_coverage` in this evaluator path is still an ev
 If hosted prerequisites are still not ready yet after the evaluator-safe scenario, start with one of these deterministic local fallback paths:
 
 ```bash
-wrkr scan --path ./your-repo --json
-wrkr scan --my-setup --json
+wrkr scan --path ./your-repo --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md
+wrkr scan --my-setup --state ./.wrkr/last-scan.json
 ```
 
 Use `./your-repo` when the selected directory itself is the repo root. Use a bundle root like `./scenarios/wrkr/scan-mixed-org/repos` when the selected directory is intentionally a set of immediate child repos.

--- a/core/report/primary_view_test.go
+++ b/core/report/primary_view_test.go
@@ -214,10 +214,14 @@ func TestRenderMarkdownAgentActionBOMLeadsWithPrimaryWorkflowPath(t *testing.T) 
 	}
 
 	markdown := RenderMarkdown(summary)
+	inspectFirstIdx := strings.Index(markdown, "## What To Look At First")
 	primaryIdx := strings.Index(markdown, "## Primary Workflow BOM")
 	topPathsIdx := strings.Index(markdown, "## Top Action Paths")
 	contextIdx := strings.Index(markdown, "## Report Context Appendix")
 	appendixIdx := strings.Index(markdown, "## Workflow BOM Appendix")
+	if inspectFirstIdx < 0 {
+		t.Fatalf("expected inspect-first lead section, got %q", markdown)
+	}
 	if primaryIdx < 0 {
 		t.Fatalf("expected primary workflow section, got %q", markdown)
 	}
@@ -230,11 +234,17 @@ func TestRenderMarkdownAgentActionBOMLeadsWithPrimaryWorkflowPath(t *testing.T) 
 	if appendixIdx < 0 {
 		t.Fatalf("expected workflow appendix section, got %q", markdown)
 	}
+	if inspectFirstIdx > primaryIdx {
+		t.Fatalf("expected inspect-first cards to lead before primary workflow BOM, got %q", markdown)
+	}
 	if primaryIdx > appendixIdx {
 		t.Fatalf("expected primary workflow BOM to lead before appendix, got %q", markdown)
 	}
 	if !strings.Contains(markdown, "Workflow: codex in acme/release / pr/108 via .github/workflows/release.yml.") {
 		t.Fatalf("expected human-readable workflow line in markdown, got %q", markdown)
+	}
+	if !strings.Contains(markdown, "Visible controls:") {
+		t.Fatalf("expected visible controls lead line in markdown, got %q", markdown)
 	}
 	if !strings.Contains(markdown, "Coverage status: complete.") {
 		t.Fatalf("expected coverage status in primary workflow section, got %q", markdown)
@@ -251,7 +261,119 @@ func TestRenderMarkdownAgentActionBOMLeadsWithPrimaryWorkflowPath(t *testing.T) 
 	}
 }
 
-func TestAgentActionBOMPrimaryViewFitsLineBudget(t *testing.T) {
+func TestAgentActionBOMStartsWithInspectFirstCards(t *testing.T) {
+	t.Parallel()
+
+	items := []AgentActionBOMItem{}
+	highlights := []WorkflowHighlight{}
+	for idx := 0; idx < 6; idx++ {
+		pathID := "apc-card-" + string(rune('0'+idx))
+		repo := "acme/repo-" + string(rune('0'+idx))
+		workflow := ".github/workflows/workflow-" + string(rune('0'+idx)) + ".yml"
+		items = append(items, AgentActionBOMItem{
+			PathID:                   pathID,
+			Org:                      "acme",
+			Repo:                     repo,
+			ToolType:                 "compiled_action",
+			Location:                 workflow,
+			ConfidenceLane:           risk.ConfidenceLaneConfirmedActionPath,
+			ActionPathType:           risk.ActionPathTypeCICDWorkflow,
+			DelegationReadinessState: risk.DelegationReadinessApprovalRequired,
+			RecommendedControl:       risk.RecommendedControlApprovalRequired,
+			TargetClass:              risk.TargetClassProductionImpacting,
+			ApprovalGap:              true,
+			CredentialAccess:         true,
+			ControlResolutionState:   risk.ControlResolutionStateNoVisibleControl,
+			ApprovalEvidenceState:    risk.EvidenceStateUnknown,
+			ProofEvidenceState:       risk.EvidenceStateUnknown,
+			RuntimeEvidenceState:     risk.EvidenceStateUnknown,
+		})
+		highlights = append(highlights, WorkflowHighlight{
+			PathID:              pathID,
+			PathType:            "workflow path",
+			Repo:                repo,
+			Workflow:            workflow,
+			TargetClass:         risk.TargetClassProductionImpacting,
+			DelegationReadiness: risk.DelegationReadinessApprovalRequired,
+			Authority:           "credential access declared",
+			EvidenceSummary:     "control=no visible control",
+			ApprovalPath:        "approval evidence unknown",
+			ProofStatus:         "proof evidence unknown",
+			RuntimeStatus:       "runtime evidence unknown",
+			Recommendation:      "Attach approval evidence for this exact workflow path",
+		})
+	}
+
+	summary := Summary{
+		GeneratedAt:  "2026-06-17T12:00:00Z",
+		Template:     string(TemplateAgentActionBOM),
+		ShareProfile: string(ShareProfileCustomerRedacted),
+		AgentActionBOM: &AgentActionBOM{
+			BOMID:         "bom-cards",
+			SchemaVersion: AgentActionBOMSchemaVersion,
+			Summary: AgentActionBOMSummary{
+				TotalItems:        len(items),
+				ControlFirstItems: len(items),
+				PrimaryView: &AgentActionBOMPrimaryView{
+					PathID:                   "apc-card-0",
+					SelectionReason:          AgentActionBOMPrimarySelectionDefaultTopPath,
+					BoundaryLabel:            BoundaryLabelReportOnly,
+					AutonomyTier:             risk.AutonomyTier4ProdPrivilegedCustomerImpact,
+					DelegationReadinessState: risk.DelegationReadinessApprovalRequired,
+					RecommendedControl:       risk.RecommendedControlApprovalRequired,
+					RiskTier:                 "critical",
+					PathMap: AgentActionBOMPrimaryPathMap{
+						Tool:       "codex",
+						RepoPR:     "acme/repo-0 / pr/108",
+						Workflow:   ".github/workflows/workflow-0.yml",
+						Credential: "prod-deployer",
+						Action:     "deploy",
+						Target:     "production_impacting",
+					},
+					ControlResolutionState: risk.ControlResolutionStateNoVisibleControl,
+					ApprovalEvidenceState:  risk.EvidenceStateUnknown,
+					ProofEvidenceState:     risk.EvidenceStateUnknown,
+					RuntimeEvidenceState:   risk.EvidenceStateUnknown,
+					UnresolvedEvidence:     []string{"approval", "proof"},
+					RecommendedNextActions: []string{
+						"Attach approval evidence for this exact workflow path",
+						"Attach path-specific proof before promotion",
+					},
+				},
+			},
+			Items: items,
+		},
+		WorkflowHighlights: &WorkflowHighlights{
+			TotalItems: len(highlights),
+			Highlights: highlights,
+		},
+	}
+
+	markdown := RenderMarkdown(summary)
+	inspectFirstIdx := strings.Index(markdown, "## What To Look At First")
+	primaryIdx := strings.Index(markdown, "## Primary Workflow BOM")
+	topPathsIdx := strings.Index(markdown, "## Top Action Paths")
+	contextIdx := strings.Index(markdown, "## Report Context Appendix")
+	if inspectFirstIdx < 0 || primaryIdx < 0 || topPathsIdx < 0 || contextIdx < 0 {
+		t.Fatalf("expected inspect-first, primary, top-path, and appendix sections, got %q", markdown)
+	}
+	leadCards := markdown[inspectFirstIdx:primaryIdx]
+	if strings.Contains(leadCards, "BOM id:") {
+		t.Fatalf("expected machine-heavy BOM metadata to stay out of the lead cards, got %q", leadCards)
+	}
+	if strings.Contains(leadCards, "apc-card-") {
+		t.Fatalf("expected opaque path ids to stay out of the lead cards, got %q", leadCards)
+	}
+	if count := strings.Count(leadCards, "- Inspect "); count != 5 {
+		t.Fatalf("expected five inspect-first cards when enough eligible paths exist, got %d in %q", count, leadCards)
+	}
+	topPaths := markdown[topPathsIdx:contextIdx]
+	if count := strings.Count(topPaths, "\n- "); count != 5 {
+		t.Fatalf("expected five compact top action paths before appendices, got %d in %q", count, topPaths)
+	}
+}
+
+func TestDefaultAgentActionBOMOnePageBudget(t *testing.T) {
 	t.Parallel()
 
 	summary := Summary{

--- a/core/report/render_markdown.go
+++ b/core/report/render_markdown.go
@@ -19,10 +19,12 @@ func RenderMarkdown(summary Summary) string {
 
 	var builder strings.Builder
 	builder.WriteString("# Wrkr Deterministic Report\n\n")
-	builder.WriteString(fmt.Sprintf("- Generated at: %s\n", summary.GeneratedAt))
-	builder.WriteString(fmt.Sprintf("- Template: %s\n", summary.Template))
-	builder.WriteString(fmt.Sprintf("- Share profile: %s\n\n", summary.ShareProfile))
-	renderExecutiveRollupSection(&builder, templatespkg.Resolve(summary.Template).ExecutiveRollupTitle, resolveExecutiveRollup(summary))
+	if !isAgentActionBOMTemplate {
+		builder.WriteString(fmt.Sprintf("- Generated at: %s\n", summary.GeneratedAt))
+		builder.WriteString(fmt.Sprintf("- Template: %s\n", summary.Template))
+		builder.WriteString(fmt.Sprintf("- Share profile: %s\n\n", summary.ShareProfile))
+		renderExecutiveRollupSection(&builder, templatespkg.Resolve(summary.Template).ExecutiveRollupTitle, resolveExecutiveRollup(summary))
+	}
 
 	agentActionBOMLeadHandledEmptyState := false
 	if summary.AgentActionBOM != nil && isAgentActionBOMTemplate {
@@ -31,6 +33,9 @@ func RenderMarkdown(summary Summary) string {
 		}
 		agentActionBOMLeadHandledEmptyState = renderAgentActionBOMLeadSection(&builder, summary)
 		renderAgentActionBOMContextAppendix(&builder, summary)
+		renderExecutiveRollupSection(&builder, "Executive Rollup Appendix", resolveExecutiveRollup(summary))
+		renderSurfaceContextSection(&builder, "Target Surface Context Appendix", targetSurfaceContextItems(summary.AgentActionBOM.Items))
+		renderSurfaceContextSection(&builder, "Instruction Control Surfaces Appendix", instructionControlSurfaceItems(summary.AgentActionBOM.Items))
 
 		emptyStateStatus := strings.TrimSpace(summary.AgentActionBOM.Summary.EmptyStateStatus)
 		emptyStateReasons := summary.AgentActionBOM.Summary.EmptyStateReasons
@@ -530,15 +535,7 @@ func renderAgentActionBOMLeadSection(builder *strings.Builder, summary Summary) 
 		return false
 	}
 	bom := summary.AgentActionBOM
-	builder.WriteString("## Agent Action BOM\n\n")
-	fmt.Fprintf(builder, "- BOM id: %s\n", bom.BOMID)
-	fmt.Fprintf(builder, "- Lead summary: %d governable paths, %d control-first, %d blocked, %d review required, coverage %s.\n",
-		bom.Summary.TotalItems,
-		bom.Summary.ControlFirstItems,
-		bom.Summary.DelegationReadiness.Blocked,
-		bom.Summary.DelegationReadiness.ReviewRequired,
-		firstNonEmptyValue(strings.TrimSpace(bom.Summary.CoverageConfidence), scanquality.AbsenceStatusNotScanned),
-	)
+	builder.WriteString("## What To Look At First\n\n")
 	renderBuyerDiagnosticCards(builder, summary)
 	builder.WriteString("\n")
 
@@ -555,15 +552,11 @@ func renderAgentActionBOMLeadSection(builder *strings.Builder, summary Summary) 
 			bom.Summary.CoverageConfidence,
 			reasons,
 		)
-		renderSurfaceContextSection(builder, "Target Surface Context", targetSurfaceContextItems(bom.Items))
-		renderSurfaceContextSection(builder, "Instruction Control Surfaces", instructionControlSurfaceItems(bom.Items))
 		return true
 	}
 
 	renderPrimaryWorkflowBOMSection(builder, bom.Summary.PrimaryView)
 	renderCompactTopActionPathsSection(builder, summary.WorkflowHighlights)
-	renderSurfaceContextSection(builder, "Target Surface Context", targetSurfaceContextItems(bom.Items))
-	renderSurfaceContextSection(builder, "Instruction Control Surfaces", instructionControlSurfaceItems(bom.Items))
 	return false
 }
 
@@ -605,7 +598,7 @@ func buildBuyerDiagnosticCards(summary Summary) []buyerDiagnosticCard {
 		itemsByPath[strings.TrimSpace(item.PathID)] = item
 	}
 
-	cards := make([]buyerDiagnosticCard, 0, 2)
+	cards := make([]buyerDiagnosticCard, 0, defaultBOMInspectCards)
 	primaryView := summary.AgentActionBOM.Summary.PrimaryView
 	primaryPathID := strings.TrimSpace(primaryView.PathID)
 	seen := map[string]struct{}{}
@@ -616,23 +609,40 @@ func buildBuyerDiagnosticCards(summary Summary) []buyerDiagnosticCard {
 		cards = append(cards, diagnosticCardFromPrimaryView(primaryView))
 	}
 
-	if summary.WorkflowHighlights == nil {
+	if summary.WorkflowHighlights != nil {
+		for _, highlight := range summary.WorkflowHighlights.Highlights {
+			pathID := strings.TrimSpace(highlight.PathID)
+			if pathID == "" {
+				continue
+			}
+			if _, ok := seen[pathID]; ok {
+				continue
+			}
+			item, ok := itemsByPath[pathID]
+			if !ok {
+				continue
+			}
+			cards = append(cards, diagnosticCardFromHighlight(highlight, item))
+			seen[pathID] = struct{}{}
+			if len(cards) >= defaultBOMInspectCards {
+				break
+			}
+		}
+	}
+	if len(cards) >= defaultBOMInspectCards {
 		return cards
 	}
-	for _, highlight := range summary.WorkflowHighlights.Highlights {
-		pathID := strings.TrimSpace(highlight.PathID)
+	for _, item := range eligibleWorkflowHighlightItems(summary.AgentActionBOM) {
+		pathID := strings.TrimSpace(item.PathID)
 		if pathID == "" {
 			continue
 		}
 		if _, ok := seen[pathID]; ok {
 			continue
 		}
-		item, ok := itemsByPath[pathID]
-		if !ok {
-			continue
-		}
-		cards = append(cards, diagnosticCardFromHighlight(highlight, item))
-		if len(cards) >= 2 {
+		cards = append(cards, diagnosticCardFromHighlight(workflowHighlightFromItem(item), item))
+		seen[pathID] = struct{}{}
+		if len(cards) >= defaultBOMInspectCards {
 			break
 		}
 	}
@@ -743,6 +753,17 @@ func renderAgentActionBOMContextAppendix(builder *strings.Builder, summary Summa
 		return
 	}
 	builder.WriteString("## Report Context Appendix\n\n")
+	fmt.Fprintf(builder, "- Generated at: %s\n", summary.GeneratedAt)
+	fmt.Fprintf(builder, "- Template: %s\n", summary.Template)
+	fmt.Fprintf(builder, "- Share profile: %s\n", summary.ShareProfile)
+	fmt.Fprintf(builder, "- BOM id: %s\n", summary.AgentActionBOM.BOMID)
+	fmt.Fprintf(builder, "- Lead summary: %d governable paths, %d control-first, %d blocked, %d review required, coverage %s.\n",
+		summary.AgentActionBOM.Summary.TotalItems,
+		summary.AgentActionBOM.Summary.ControlFirstItems,
+		summary.AgentActionBOM.Summary.DelegationReadiness.Blocked,
+		summary.AgentActionBOM.Summary.DelegationReadiness.ReviewRequired,
+		firstNonEmptyValue(strings.TrimSpace(summary.AgentActionBOM.Summary.CoverageConfidence), scanquality.AbsenceStatusNotScanned),
+	)
 	if summary.ScanScope != nil {
 		fmt.Fprintf(builder, "- Scanned scope: %s mode=%s repos=%d targets=%d boundary=%s\n",
 			summary.ScanScope.ScopeLabel,
@@ -846,27 +867,24 @@ func renderPrimaryWorkflowBOMSection(builder *strings.Builder, view *AgentAction
 		return
 	}
 	builder.WriteString("## Primary Workflow BOM\n\n")
-	fmt.Fprintf(builder, "- Selection: %s inside the %s boundary.\n",
-		humanizeEnum(view.SelectionReason),
-		humanizeEnum(firstNonEmptyValue(view.BoundaryLabel, BoundaryLabelReportOnly)),
-	)
 	fmt.Fprintf(builder, "- Workflow: %s in %s via %s.\n",
 		firstNonEmptyValue(view.PathMap.Tool, "unknown tool"),
 		firstNonEmptyValue(view.PathMap.RepoPR, "unknown repo"),
 		firstNonEmptyValue(view.PathMap.Workflow, "unknown workflow"),
+	)
+	fmt.Fprintf(builder, "- Why it leads: %s inside the %s boundary with %s readiness, %s risk, and %s autonomy.\n",
+		humanizeEnum(firstNonEmptyValue(view.PathMap.Target, "unknown target")),
+		humanizeEnum(firstNonEmptyValue(view.BoundaryLabel, BoundaryLabelReportOnly)),
+		risk.BuyerDelegationReadinessLabel(view.DelegationReadinessState),
+		firstNonEmptyValue(strings.TrimSpace(view.RiskTier), "unknown"),
+		risk.BuyerAutonomyTierShortLabel(view.AutonomyTier),
 	)
 	fmt.Fprintf(builder, "- Authority and target: %s can %s against %s.\n",
 		firstNonEmptyValue(view.PathMap.Credential, "no visible credential"),
 		firstNonEmptyValue(view.PathMap.Action, "unknown action"),
 		firstNonEmptyValue(view.PathMap.Target, "unknown target"),
 	)
-	fmt.Fprintf(builder, "- Posture: risk=%s autonomy=%s readiness=%s recommended_control=%s.\n",
-		firstNonEmptyValue(strings.TrimSpace(view.RiskTier), "unknown"),
-		risk.BuyerAutonomyTierShortLabel(view.AutonomyTier),
-		risk.BuyerDelegationReadinessLabel(view.DelegationReadinessState),
-		risk.BuyerRecommendedControlLabel(view.RecommendedControl),
-	)
-	fmt.Fprintf(builder, "- Control coverage: control=%s approval=%s owner=%s proof=%s runtime=%s target=%s credential=%s evidence=%s(%d).\n",
+	fmt.Fprintf(builder, "- Visible controls: control=%s approval=%s owner=%s proof=%s runtime=%s target=%s credential=%s evidence=%s(%d) recommended_control=%s.\n",
 		risk.BuyerControlResolutionLabel(view.ControlResolutionState),
 		risk.BuyerEvidenceStateLabel("approval", view.ApprovalEvidenceState),
 		risk.BuyerEvidenceStateLabel("owner", view.OwnerEvidenceState),
@@ -876,9 +894,13 @@ func renderPrimaryWorkflowBOMSection(builder *strings.Builder, view *AgentAction
 		risk.BuyerEvidenceStateLabel("credential", view.CredentialEvidenceState),
 		markdownPrimaryViewEvidenceCompleteness(view),
 		view.EvidenceCompletenessScore,
+		risk.BuyerRecommendedControlLabel(view.RecommendedControl),
 	)
 	if len(view.UnresolvedEvidence) > 0 {
 		fmt.Fprintf(builder, "- Unresolved evidence: %s.\n", strings.Join(view.UnresolvedEvidence, ", "))
+	}
+	if contract := strings.TrimSpace(markdownActionContract(view.RecommendedActionContract)); contract != "" {
+		fmt.Fprintf(builder, "- Recommended action contract: %s.\n", contract)
 	}
 	if strings.TrimSpace(view.CoverageStatus) != "" {
 		fmt.Fprintf(builder, "- Coverage status: %s.\n", humanizeEnum(view.CoverageStatus))
@@ -889,6 +911,7 @@ func renderPrimaryWorkflowBOMSection(builder *strings.Builder, view *AgentAction
 	if len(view.RecommendedNextActions) > 0 {
 		fmt.Fprintf(builder, "- Next actions: %s.\n", strings.Join(view.RecommendedNextActions, " | "))
 	}
+	fmt.Fprintf(builder, "- Appendix handoff: full graph refs, policy diagnostics, and proof detail remain in the appendices and evidence JSON.\n")
 	builder.WriteString("\n")
 }
 

--- a/core/report/render_markdown.go
+++ b/core/report/render_markdown.go
@@ -16,10 +16,11 @@ func RenderMarkdown(summary Summary) string {
 		return renderDesignPartnerMarkdown(summary)
 	}
 	isAgentActionBOMTemplate := summary.Template == string(TemplateAgentActionBOM)
+	usesAgentActionBOMLead := isAgentActionBOMTemplate && summary.AgentActionBOM != nil
 
 	var builder strings.Builder
 	builder.WriteString("# Wrkr Deterministic Report\n\n")
-	if !isAgentActionBOMTemplate {
+	if !usesAgentActionBOMLead {
 		builder.WriteString(fmt.Sprintf("- Generated at: %s\n", summary.GeneratedAt))
 		builder.WriteString(fmt.Sprintf("- Template: %s\n", summary.Template))
 		builder.WriteString(fmt.Sprintf("- Share profile: %s\n\n", summary.ShareProfile))

--- a/core/report/report_test.go
+++ b/core/report/report_test.go
@@ -1807,6 +1807,30 @@ func TestAgentActionBOMMarkdownLeadsWithBuyerSummary(t *testing.T) {
 	}
 }
 
+func TestAgentActionBOMWithoutBOMStillRendersGenericContext(t *testing.T) {
+	t.Parallel()
+
+	markdown := RenderMarkdown(Summary{
+		GeneratedAt:  "2026-06-17T16:00:00Z",
+		Template:     string(TemplateAgentActionBOM),
+		ShareProfile: string(ShareProfileCustomerRedacted),
+	})
+
+	for _, required := range []string{
+		"# Wrkr Deterministic Report",
+		"- Generated at: 2026-06-17T16:00:00Z",
+		"- Template: agent-action-bom",
+		"- Share profile: customer-redacted",
+	} {
+		if !strings.Contains(markdown, required) {
+			t.Fatalf("expected generic context %q in markdown, got %q", required, markdown)
+		}
+	}
+	if strings.Contains(markdown, "## What To Look At First") {
+		t.Fatalf("did not expect inspect-first BOM lead without an AgentActionBOM payload, got %q", markdown)
+	}
+}
+
 func TestMarkdownApprovalUnknownUsesEvidenceNotFound(t *testing.T) {
 	t.Parallel()
 

--- a/core/report/report_test.go
+++ b/core/report/report_test.go
@@ -1745,13 +1745,13 @@ func TestAgentActionBOMTemplateLeadsWithBOMSections(t *testing.T) {
 		t.Fatalf("expected agent_action_bom on summary, got %+v", summary)
 	}
 	markdown := RenderMarkdown(summary)
-	bomIdx := strings.Index(markdown, "## Agent Action BOM")
+	leadIdx := strings.Index(markdown, "## What To Look At First")
 	topRiskIdx := strings.Index(markdown, "Top risky agent action BOM items")
-	if bomIdx < 0 {
-		t.Fatalf("expected BOM section in markdown, got %q", markdown)
+	if leadIdx < 0 {
+		t.Fatalf("expected inspect-first lead section in markdown, got %q", markdown)
 	}
-	if topRiskIdx >= 0 && bomIdx > topRiskIdx {
-		t.Fatalf("expected BOM section to lead before raw sections, got %q", markdown)
+	if topRiskIdx >= 0 && leadIdx > topRiskIdx {
+		t.Fatalf("expected inspect-first lead to appear before raw sections, got %q", markdown)
 	}
 }
 

--- a/core/report/signal_hardening.go
+++ b/core/report/signal_hardening.go
@@ -20,7 +20,8 @@ const (
 	defaultMarkdownLineCap   = 1500
 	defaultBOMLeadLineCap    = 45
 	defaultBOMLeadSectionCap = 4
-	defaultBOMLeadTopPaths   = 3
+	defaultBOMLeadTopPaths   = 5
+	defaultBOMInspectCards   = 5
 )
 
 func BuildPolicyOutcomes(findings []model.Finding) []PolicyOutcome {

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -17,6 +17,7 @@ For the current public launch, the shortest first path is: scan one repo, render
 the focused Agent Action BOM, and review the top workflow path. Use the hosted
 org posture flow below when you need shared inventory or broader audit handoff.
 When concrete local tool, MCP, or secret signals exist, `scan --my-setup --json` also emits additive `activation.items` so the local-machine path stays concrete without mutating the raw risk ranking.
+For manual large scans, keep `--state` plus the generated markdown/evidence artifacts as the durable handoff and reserve `--json` for automation and CI.
 
 Choose one explicit first-value path:
 
@@ -27,34 +28,43 @@ Choose one explicit first-value path:
 
 ```bash
 # Focused repo review first
-wrkr scan --path ./your-repo --profile assessment --json
-wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --json
-wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/focused-agent-action-bom.md --json
+wrkr scan --path ./your-repo --profile assessment --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/focused-agent-action-bom.md
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --evidence-json --evidence-json-path ./.tmp/focused-agent-action-bom-evidence.json
 wrkr regress init --baseline ./.wrkr/last-scan.json --output ./.wrkr/wrkr-regress-baseline.json --json
-wrkr assess --path ./your-repo --baseline ./.wrkr/wrkr-regress-baseline.json --template design-partner-summary --share-profile design-partner --ticket-format jira --json
+wrkr assess --path ./your-repo --output-dir ./.wrkr/design-partner-assessment --baseline ./.wrkr/wrkr-regress-baseline.json --template design-partner-summary --share-profile design-partner --ticket-format jira
 
 # Hosted org posture first when prerequisites are ready
-wrkr init --non-interactive --org acme --github-api https://api.github.com --json
-wrkr scan --config ~/.wrkr/config.json --json
-wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence --json
-wrkr verify --chain --json
+wrkr init --non-interactive --org acme --github-api https://api.github.com
+wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --timeout 30m --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence
+wrkr verify --chain --state ./.wrkr/last-scan.json
 
 # Low or zero first-run framework_coverage means the current state is evidence sparse, not that parsing is broken
 
 # Evaluator-safe scenario fallback when hosted prerequisites are not ready yet
-wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json
-wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/wrkr-scenario-evidence --json
-wrkr verify --chain --state ./.wrkr/last-scan.json --json
+wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scenario-summary.md
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/wrkr-scenario-evidence
+wrkr verify --chain --state ./.wrkr/last-scan.json
 wrkr regress init --baseline ./.wrkr/last-scan.json --output ./.tmp/wrkr-regress-baseline.json --json
-wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/last-scan.json --json
+wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/last-scan.json
 
 # If hosted prerequisites are still not ready yet, use a deterministic local fallback
-wrkr scan --path ./your-repo --json
-wrkr scan --my-setup --json
+wrkr scan --path ./your-repo --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md
+wrkr scan --my-setup --state ./.wrkr/last-scan.json
 wrkr mcp-list --state ./.wrkr/last-scan.json --json
 cp ./.wrkr/last-scan.json ./.wrkr/inventory-baseline.json
 wrkr inventory --diff --baseline ./.wrkr/inventory-baseline.json --state ./.wrkr/last-scan.json --json
 wrkr inventory approve <agent-id> --owner platform-security --evidence SEC-123 --expires 90d --state ./.wrkr/last-scan.json --json
+```
+
+Automation / CI equivalent:
+
+```bash
+wrkr scan --path ./your-repo --profile assessment --state ./.wrkr/last-scan.json --json --json-path ./.wrkr/scan.json
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --json
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence --json
+wrkr assess --path ./your-repo --output-dir ./.wrkr/assessment --json
 ```
 
 `wrkr evidence` now fails closed when the saved proof chain is malformed or tampered, and `wrkr verify --chain --json` remains the explicit machine gate for integrity.
@@ -65,7 +75,7 @@ paths, owner names, prompts, or private URLs.
 Inventory approval/evidence mutations are local, file-based, and append proof events. Evidence and verify JSON may include additive `control_evidence` so operators can see existing and missing proof for active backlog controls.
 The hosted org path is the primary launch workflow when prerequisites are ready. Use the curated scenario when you want the evaluator-safe fallback because it avoids repo-root fixture noise from Wrkr's own scenarios, docs, and test fixtures. That scenario path is the canonical `repo_set` example for `--path`: Wrkr scans the immediate child repos in the bundle instead of treating the bundle root as one repo.
 The curated scenario is intentionally risky by design, so a low posture score or low first-run `framework_coverage` is expected and useful during evaluation.
-Use `wrkr scan --path ./your-repo --json` when the selected directory itself is the repo root and carries repo-root signals such as `.git`, `go.mod`, `AGENTS.md`, or `.codex/`. Use a bundle root like `./scenarios/wrkr/scan-mixed-org/repos` when you want immediate child repos scanned as a deterministic repo-set.
+Use `wrkr scan --path ./your-repo --state ./.wrkr/last-scan.json` when the selected directory itself is the repo root and carries repo-root signals such as `.git`, `go.mod`, `AGENTS.md`, or `.codex/`. Use a bundle root like `./scenarios/wrkr/scan-mixed-org/repos` when you want immediate child repos scanned as a deterministic repo-set.
 
 Use these next when you want deeper triage:
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -6,20 +6,29 @@
 - https://github.com/Clyra-AI/wrkr
 - https://clyra-ai.github.io/wrkr/
 
-## Core Commands
-- wrkr init --org <org> --github-api <url> --json
+## Human Review Workflows
+- wrkr init --org <org> --github-api <url>
+- wrkr scan --path <dir> --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md
+- wrkr scan --github-org <org> --github-api <url> --state ./.wrkr/last-scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
+- wrkr scan --my-setup --state ./.wrkr/last-scan.json
+- wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/focused-agent-action-bom.md
+- wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence
+- wrkr verify --chain --state ./.wrkr/last-scan.json
+- wrkr assess --path <dir> --output-dir ./.wrkr/assessment
+
+## Automation And CI Workflows
 - wrkr --help
 - wrkr help <command>
-- wrkr scan --my-setup --json
-- wrkr mcp-list --state ./.wrkr/last-scan.json --json
 - wrkr scan --repo <owner/repo> --github-api <url> --json
 - wrkr scan --org <org> --github-api <url> --json
-- wrkr scan --github-org <org> --github-api <url> --json
-- wrkr scan --path <dir> --sarif --json
+- wrkr scan --github-org <org> --github-api <url> --state ./.wrkr/last-scan.json --json --json-path ./.wrkr/scan.json
+- wrkr scan --path <dir> --state ./.wrkr/last-scan.json --json --json-path ./.wrkr/scan.json
+- wrkr scan --my-setup --state ./.wrkr/last-scan.json --json
+- wrkr mcp-list --state ./.wrkr/last-scan.json --json
 - wrkr inventory --diff --baseline ./.wrkr/inventory-baseline.json --state ./.wrkr/last-scan.json --json
 - wrkr inventory approve <agent-id> --owner <team> --evidence <ticket-or-url> --expires 90d --state ./.wrkr/last-scan.json --json
 - wrkr inventory attach-evidence <agent-id> --control <control-id> --url <url> --state ./.wrkr/last-scan.json --json
-- wrkr report --top <n> --json
+- wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --json
 - wrkr score --json
 - wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence --json
 - wrkr verify --chain --json

--- a/docs-site/src/app/page.tsx
+++ b/docs-site/src/app/page.tsx
@@ -12,32 +12,32 @@ export const metadata: Metadata = {
 };
 
 const QUICKSTART = `# Focused repo review first
-wrkr scan --path ./your-repo --profile assessment --json
-wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --json
-wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/focused-agent-action-bom.md --json
+wrkr scan --path ./your-repo --profile assessment --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/focused-agent-action-bom.md
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --evidence-json --evidence-json-path ./.tmp/focused-agent-action-bom-evidence.json
 wrkr regress init --baseline ./.wrkr/last-scan.json --output ./.wrkr/wrkr-regress-baseline.json --json
-wrkr assess --path ./your-repo --baseline ./.wrkr/wrkr-regress-baseline.json --template design-partner-summary --share-profile design-partner --ticket-format jira --json
+wrkr assess --path ./your-repo --output-dir ./.wrkr/design-partner-assessment --baseline ./.wrkr/wrkr-regress-baseline.json --template design-partner-summary --share-profile design-partner --ticket-format jira
 
 # Security and platform teams: use hosted org posture first when prerequisites are ready
-wrkr init --non-interactive --org acme --github-api https://api.github.com --json
-wrkr scan --config ~/.wrkr/config.json --json
-wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence --json
-wrkr verify --chain --state ./.wrkr/last-scan.json --json
+wrkr init --non-interactive --org acme --github-api https://api.github.com
+wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --timeout 30m --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence
+wrkr verify --chain --state ./.wrkr/last-scan.json
 
 # Low or zero first-run framework_coverage means the current state is evidence sparse, not that parsing is broken
 
 # Evaluator-safe scenario fallback when hosted prerequisites are not ready yet
-wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json
-wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/wrkr-scenario-evidence --json
-wrkr verify --chain --state ./.wrkr/last-scan.json --json
+wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scenario-summary.md
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/wrkr-scenario-evidence
+wrkr verify --chain --state ./.wrkr/last-scan.json
 wrkr regress init --baseline ./.wrkr/last-scan.json --output ./.tmp/wrkr-regress-baseline.json --json
-wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/last-scan.json --json
+wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/last-scan.json
 
 # If hosted prerequisites are still not ready yet, use a deterministic local fallback
-wrkr scan --path ./your-repo --json
+wrkr scan --path ./your-repo --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md
 
 # Developers: use the secondary local-machine hygiene path
-wrkr scan --my-setup --json
+wrkr scan --my-setup --state ./.wrkr/last-scan.json
 wrkr mcp-list --state ./.wrkr/last-scan.json --json
 cp ./.wrkr/last-scan.json ./.wrkr/inventory-baseline.json
 wrkr inventory --diff --baseline ./.wrkr/inventory-baseline.json --state ./.wrkr/last-scan.json --json`;

--- a/docs/commands/assess.md
+++ b/docs/commands/assess.md
@@ -31,13 +31,23 @@ wrkr assess [--json] [--json-stdout auto|full] [--quiet] [--explain] [--path <di
 
 ## Example
 
+Human/manual handoff:
+
 ```bash
-wrkr assess --path ./your-repo --baseline ./.wrkr/wrkr-regress-baseline.json --template design-partner-summary --share-profile design-partner --ticket-format jira --json
-wrkr assess --path ./scenarios/wrkr/scan-mixed-org/repos --json
-wrkr assess --path ./scenarios/wrkr/scan-mixed-org/repos --focus release --share-profile customer-redacted --json
-wrkr assess --path ./scenarios/wrkr/scan-mixed-org/repos --runtime-input ./fixtures/runtime-session.json --frameworks soc2,eu-ai-act --json
-wrkr assess --path ./scenarios/wrkr/scan-mixed-org/repos --baseline ./.wrkr/wrkr-regress-baseline.json --focus drift-review --json
-wrkr assess --path ./scenarios/wrkr/scan-mixed-org/repos --paired-share-profile customer-redacted --ticket-format jira --json
+wrkr assess --path ./your-repo --output-dir ./.wrkr/assessment --template agent-action-bom --share-profile customer-redacted
+wrkr assess --path ./your-repo --output-dir ./.wrkr/design-partner-assessment --baseline ./.wrkr/wrkr-regress-baseline.json --template design-partner-summary --share-profile design-partner --ticket-format jira
+wrkr assess --path ./scenarios/wrkr/scan-mixed-org/repos --output-dir ./.tmp/wrkr-evaluator-assessment --focus release --share-profile customer-redacted
+```
+
+Automation / CI workflow:
+
+```bash
+wrkr assess --path ./your-repo --output-dir ./.wrkr/assessment --json
+wrkr assess --path ./scenarios/wrkr/scan-mixed-org/repos --output-dir ./.tmp/wrkr-evaluator-assessment --json
+wrkr assess --path ./scenarios/wrkr/scan-mixed-org/repos --output-dir ./.tmp/wrkr-evaluator-assessment --focus release --share-profile customer-redacted --json
+wrkr assess --path ./scenarios/wrkr/scan-mixed-org/repos --output-dir ./.tmp/wrkr-evaluator-assessment --runtime-input ./fixtures/runtime-session.json --frameworks soc2,eu-ai-act --json
+wrkr assess --path ./scenarios/wrkr/scan-mixed-org/repos --output-dir ./.tmp/wrkr-evaluator-assessment --baseline ./.wrkr/wrkr-regress-baseline.json --focus drift-review --json
+wrkr assess --path ./scenarios/wrkr/scan-mixed-org/repos --output-dir ./.tmp/wrkr-evaluator-assessment --paired-share-profile customer-redacted --ticket-format jira --json
 ```
 
 ## Behavior contract

--- a/docs/commands/evidence.md
+++ b/docs/commands/evidence.md
@@ -47,12 +47,20 @@ Evidence output directories are fail-closed:
 
 Recommended operator actions when coverage is low:
 
-1. Run `wrkr scan --json` against the intended scope and confirm findings were produced.
-2. Review prioritized risk/control gaps with `wrkr report --json`.
+1. Run `wrkr scan` against the intended scope and confirm the saved state and report artifacts were produced.
+2. Review prioritized risk/control gaps with the saved-state `wrkr report` workflow described in [`docs/commands/report.md`](report.md).
 3. Implement/remediate missing controls and approvals.
-4. Re-run `wrkr scan --json`, `wrkr evidence --frameworks ... --json`, and `wrkr report --json` to measure updated evidence state.
+4. Re-run `wrkr scan`, `wrkr evidence --frameworks ... --state ./.wrkr/last-scan.json --output ./.wrkr/evidence`, and the saved-state `wrkr report` handoff to measure updated evidence state.
 
 ## Example
+
+Human/manual handoff:
+
+```bash
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence
+```
+
+Automation / CI workflow:
 
 ```bash
 wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./wrkr-evidence --json
@@ -61,10 +69,10 @@ wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json
 Security-team handoff example:
 
 ```bash
-wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./wrkr-evidence --json
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./wrkr-evidence
 ```
 
-Pair this with the saved-state `wrkr report` and explicit proof-chain verification flow documented in [`docs/examples/security-team.md`](../examples/security-team.md). Design-partner handoff workflows typically pair evidence generation with a design-partner summary report and its deterministic report-evidence bundle.
+Pair this with the saved-state `wrkr report` workflow and the explicit proof-chain verification step documented in [`docs/examples/security-team.md`](../examples/security-team.md). Design-partner handoff workflows typically pair evidence generation with a design-partner summary report and its deterministic report-evidence bundle.
 `wrkr evidence` now requires the saved proof chain to be intact before it will stage or publish a bundle; it does not replace the explicit operator or CI proof-chain verification gate.
 
 Expected JSON keys: `status`, additive `deployment_mode`, `output_dir`, `frameworks`, `manifest_path`, additive `artifact_manifest_path`, `chain_path`, `framework_coverage`, bounded `control_evidence`, additive `coverage_note`, bounded `report_artifacts`, additive `source_privacy`, additive `runtime_sessions`, additive `runtime_evidence`, additive `agent_action_bom`, additive `governed_usage_metrics`, additive `next_steps`, and additive `suppressed_counts`.

--- a/docs/commands/report.md
+++ b/docs/commands/report.md
@@ -37,25 +37,33 @@
 
 ## Example
 
-Use the saved state from a prior `wrkr scan --json` run when you want the
-focused repo review path to continue into the Agent Action BOM.
+Use the saved state from a prior `wrkr scan --state ./.wrkr/last-scan.json`
+run when you want the focused repo review path to continue into the Agent
+Action BOM.
 
 Unless you explicitly pass `--share-profile internal`, `wrkr report` defaults
 to `customer-redacted` for most templates, `public` for `public` and
 `customer-draft`, and `design-partner` for `design-partner-summary`.
 
+Human/manual artifact handoff:
+
+```bash
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/focused-agent-action-bom.md
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --share-profile customer-redacted --md --md-path ./.tmp/customer-bom.md --evidence-json --evidence-json-path ./.tmp/customer-bom.json
+wrkr report --state ./.wrkr/last-scan.json --template design-partner-summary --share-profile design-partner --md --md-path ./.tmp/design-partner.md --evidence-json --evidence-json-path ./.tmp/design-partner-evidence.json
+wrkr report --state ./.wrkr/last-scan.json --template ciso --md --md-path ./.tmp/ciso.md --pdf --pdf-path ./.tmp/ciso.pdf --evidence-json --evidence-json-path ./.tmp/evidence.json --csv-backlog --csv-backlog-path ./.tmp/backlog.csv
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --share-profile internal --paired-share-profile customer-redacted --md --md-path ./.tmp/paired-bom.md --evidence-json --evidence-json-path ./.tmp/paired-bom.json
+```
+
+Automation / CI workflow:
+
 ```bash
 wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --json
-wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/focused-agent-action-bom.md --json
-wrkr report --md --md-path ./.tmp/wrkr-summary.md --template operator --share-profile internal --json
-wrkr report --pdf --pdf-path ./.tmp/wrkr-summary.pdf --template exec --json
-wrkr report --md --md-path ./.tmp/wrkr-summary-public.md --template public --share-profile public --json
-wrkr report --template agent-action-bom --share-profile customer-redacted --md --md-path ./.tmp/customer-bom.md --evidence-json --evidence-json-path ./.tmp/customer-bom.json --json
-wrkr report --template design-partner-summary --share-profile design-partner --md --md-path ./.tmp/design-partner.md --evidence-json --evidence-json-path ./.tmp/design-partner-evidence.json --json
-wrkr report --template agent-action-bom --share-profile internal --redact owners,repos,paths --json
-wrkr report --template agent-action-bom --share-profile internal --paired-share-profile customer-redacted --md --md-path ./.tmp/paired-bom.md --evidence-json --evidence-json-path ./.tmp/paired-bom.json --json
-wrkr report --template ciso --md --md-path ./.tmp/ciso.md --pdf --pdf-path ./.tmp/ciso.pdf --evidence-json --evidence-json-path ./.tmp/evidence.json --csv-backlog --csv-backlog-path ./.tmp/backlog.csv --json
-wrkr report --template agent-action-bom --json --evidence-json --evidence-json-path ./.tmp/agent-action-bom-evidence.json
+wrkr report --state ./.wrkr/last-scan.json --template operator --share-profile internal --json
+wrkr report --state ./.wrkr/last-scan.json --template exec --pdf --pdf-path ./.tmp/wrkr-summary.pdf --json
+wrkr report --state ./.wrkr/last-scan.json --template public --share-profile public --md --md-path ./.tmp/wrkr-summary-public.md --json
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --share-profile internal --redact owners,repos,paths --json
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --evidence-json --evidence-json-path ./.tmp/agent-action-bom-evidence.json --json
 wrkr report --template platform --focus release --json
 wrkr report --template agent-action-bom --focus-path apc-12345678 --md --md-path ./.tmp/focused-agent-action-bom.md --json
 wrkr report --template agent-action-bom --focus write-deploy --focus-path apc-12345678 --json

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -14,21 +14,33 @@ For high-signal JS/TS detector surfaces such as WebMCP, prompt-channel declarati
 
 When imported or declared enterprise evidence is present, `action_paths[*]` may also emit additive `evidence_decisions[]` and `contradictions[]`. These preserve the selected source, freshness state (`fresh`, `stale`, `expired`, `unknown`), rejected candidates, stable reason codes, and contradiction evidence refs instead of flattening everything into one winner string.
 
+For manual large scans, treat `--state` plus generated report/evidence artifacts
+as the durable handoff. Reserve `--json` and `--json-path` for automation, CI,
+or when another tool needs the command-response envelope directly.
+
 Start here with one of these first-value paths:
 
 ```bash
 # Focused repo review first
-wrkr scan --path ./your-repo --profile assessment --json
+wrkr scan --path ./your-repo --profile assessment --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md
 
 # Hosted org posture when prerequisites are ready
 # Initialize the default hosted target first as described in docs/commands/init.md, then run:
-wrkr scan --config ~/.wrkr/config.json --json
+wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --timeout 30m --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
 
 # Evaluator-safe fallback when hosted prerequisites are not ready yet
-wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json
+wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scenario-summary.md
 
 # Developer-machine hygiene
-wrkr scan --my-setup --json
+wrkr scan --my-setup --state ./.wrkr/last-scan.json
+```
+
+Automation / CI workflow:
+
+```bash
+wrkr scan --path ./your-repo --profile assessment --state ./.wrkr/last-scan.json --json --json-path ./.wrkr/scan.json
+wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --timeout 30m --json --json-path ./.wrkr/scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
+wrkr scan --my-setup --state ./.wrkr/last-scan.json --json
 ```
 
 Use either one legacy target source (`--repo`, `--org`, `--github-org`, `--path`, or `--my-setup`) or one or more repeatable `--target <mode>:<value>` flags.
@@ -156,7 +168,7 @@ For the current minimum-now launch posture, security/platform teams should start
 ## Security-team org example
 
 ```bash
-wrkr scan --github-org acme --github-api https://api.github.com --json --json-path ./.wrkr/scan.json
+wrkr scan --github-org acme --github-api https://api.github.com --state ./.wrkr/last-scan.json --timeout 30m --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
 ```
 
 `--github-org` is the additive alias for `--org`. Use it when security or platform teams need the deterministic saved-state input for `wrkr report`, `wrkr evidence`, `wrkr mcp-list`, or `wrkr inventory --diff`.
@@ -164,8 +176,8 @@ Private repos and public API rate-limit avoidance usually require a GitHub token
 If you already configured the hosted source and target with `wrkr init`, you can reuse them:
 
 ```bash
-wrkr init --org acme --github-api https://api.github.com --json
-wrkr scan --config ~/.wrkr/config.json --json
+wrkr init --org acme --github-api https://api.github.com
+wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --timeout 30m --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
 ```
 
 Wrkr's hosted connector currently calls these GitHub REST endpoints:
@@ -181,6 +193,12 @@ Fine-grained PAT guidance for the selected repositories:
 - repository contents: read-only
 
 Opinionated large-org command path:
+
+```bash
+wrkr scan --github-org acme --github-api https://api.github.com --state ./.wrkr/last-scan.json --timeout 30m --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
+```
+
+Automation / CI equivalent:
 
 ```bash
 wrkr scan --github-org acme --github-api https://api.github.com --state ./.wrkr/last-scan.json --timeout 30m --json --json-path ./.wrkr/scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif

--- a/docs/examples/quickstart.md
+++ b/docs/examples/quickstart.md
@@ -9,9 +9,9 @@ Wrkr gives security and platform teams an evidence-ready view of org-wide AI too
 Use this first when you want the shortest path from scan to one workflow BOM:
 
 ```bash
-wrkr scan --path ./your-repo --profile assessment --json
-wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --json
-wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/focused-agent-action-bom.md --json
+wrkr scan --path ./your-repo --profile assessment --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/focused-agent-action-bom.md
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --evidence-json --evidence-json-path ./.tmp/focused-agent-action-bom-evidence.json
 ```
 
 The report leads with `agent_action_bom.summary.primary_view`, which answers the
@@ -22,7 +22,7 @@ baseline and use `assess`:
 
 ```bash
 wrkr regress init --baseline ./.wrkr/last-scan.json --output ./.wrkr/wrkr-regress-baseline.json --json
-wrkr assess --path ./your-repo --baseline ./.wrkr/wrkr-regress-baseline.json --template design-partner-summary --share-profile design-partner --ticket-format jira --json
+wrkr assess --path ./your-repo --output-dir ./.wrkr/design-partner-assessment --baseline ./.wrkr/wrkr-regress-baseline.json --template design-partner-summary --share-profile design-partner --ticket-format jira
 ```
 
 `summary.repeat_usage_signals` and `agent_action_bom.summary.repeat_usage_signals`
@@ -60,12 +60,12 @@ Hosted prerequisites for this path:
 - connector endpoints: `GET /orgs/{org}/repos`, `GET /repos/{owner}/{repo}`, `GET /repos/{owner}/{repo}/git/trees/{default_branch}?recursive=1`, `GET /repos/{owner}/{repo}/git/blobs/{sha}`
 
 ```bash
-wrkr init --non-interactive --org acme --github-api https://api.github.com --json
-wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --timeout 30m --json --json-path ./.wrkr/scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
-wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --json --evidence-json --evidence-json-path ./.tmp/agent-action-bom-evidence.json
+wrkr init --non-interactive --org acme --github-api https://api.github.com
+wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --timeout 30m --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.wrkr/focused-agent-action-bom.md --evidence-json --evidence-json-path ./.tmp/agent-action-bom-evidence.json
 ./scripts/run_agent_action_bom_demo.sh after ./.tmp/agent-action-bom-demo
-wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --output ./.tmp/evidence --json
-wrkr verify --chain --json
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/evidence
+wrkr verify --chain --state ./.wrkr/last-scan.json
 ```
 
 `wrkr evidence` now fails closed when the saved proof chain is malformed or tampered, and `wrkr verify --chain --json` remains the explicit integrity gate for CI and operator workflows.
@@ -91,11 +91,11 @@ Use the curated scenario bundle when hosted prerequisites are not ready yet, or 
 The curated bundle is intentionally risky by design. An `F` posture score or low first-run `framework_coverage` is expected here and shows that Wrkr is surfacing control and evidence gaps in the sample repo-set.
 
 ```bash
-wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json
-wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/wrkr-scenario-evidence --json
-wrkr verify --chain --state ./.wrkr/last-scan.json --json
+wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scenario-summary.md
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/wrkr-scenario-evidence
+wrkr verify --chain --state ./.wrkr/last-scan.json
 wrkr regress init --baseline ./.wrkr/last-scan.json --output ./.tmp/wrkr-regress-baseline.json --json
-wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/last-scan.json --json
+wrkr regress run --baseline ./.tmp/wrkr-regress-baseline.json --state ./.wrkr/last-scan.json
 ```
 
 Use this flow when you want the evaluator-safe fallback. It avoids repo-root fixture noise from Wrkr's own scenarios, docs, and tests while still exercising the shipped wedge.
@@ -105,17 +105,26 @@ Low or zero first-run `framework_coverage` in this path is still an evidence-gap
 ## If hosted prerequisites are not ready yet
 
 ```bash
-wrkr scan --path ./your-repo --json
-wrkr scan --my-setup --json
+wrkr scan --path ./your-repo --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md
+wrkr scan --my-setup --state ./.wrkr/last-scan.json
 ```
 
 Use `--path` when you want repo-local discovery with no hosted setup. When `./your-repo` itself is the repo root and carries repo-root signals such as `.git`, `go.mod`, `AGENTS.md`, or `.codex/`, Wrkr scans that directory as one repo. Use a bundle root like `./scenarios/wrkr/scan-mixed-org/repos` when you want Wrkr to scan immediate child repos as a repo-set. Use `--my-setup` when you want developer-machine hygiene for local configs, MCP posture, and secret-presence signals.
 If you start with `wrkr scan --json` and no target on a clean machine, the JSON error now points back to these same hosted, evaluator-safe, and `--my-setup` entry paths with additive `error.next_steps[]`.
 
+Automation / CI equivalent:
+
+```bash
+wrkr scan --path ./your-repo --profile assessment --state ./.wrkr/last-scan.json --json --json-path ./.wrkr/scan.json
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --json
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence --json
+wrkr assess --path ./your-repo --output-dir ./.wrkr/assessment --json
+```
+
 ## Developer-machine hygiene (secondary path)
 
 ```bash
-wrkr scan --my-setup --json
+wrkr scan --my-setup --state ./.wrkr/last-scan.json
 wrkr mcp-list --state ./.wrkr/last-scan.json --json
 ```
 
@@ -139,8 +148,8 @@ Optional enrich-mode note:
 ## Evidence + verification
 
 ```bash
-wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --output ./.tmp/evidence --json
-wrkr verify --chain --json
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.tmp/evidence
+wrkr verify --chain --state ./.wrkr/last-scan.json
 ```
 
 `wrkr evidence` does not replace `wrkr verify --chain --json`; it now reuses the same proof-chain prerequisite and aborts before publish when saved proof state is malformed or tampered.

--- a/docs/examples/security-team.md
+++ b/docs/examples/security-team.md
@@ -11,15 +11,15 @@ Hosted prerequisites for this path:
 - token resolution order is `--github-token`, config `auth.scan.token`, `WRKR_GITHUB_TOKEN`, then `GITHUB_TOKEN`
 - fine-grained PAT guidance: select only the target repositories and grant read-only repository metadata plus read-only repository contents
 - connector endpoints: `GET /orgs/{org}/repos`, `GET /repos/{owner}/{repo}`, `GET /repos/{owner}/{repo}/git/trees/{default_branch}?recursive=1`, `GET /repos/{owner}/{repo}/git/blobs/{sha}`
-- if hosted prerequisites are not ready yet, start with `wrkr scan --path ./your-repo --json` or `wrkr scan --my-setup --json` first and return to this flow when GitHub access is configured; `--path` scans the selected directory itself when it is the repo root and uses bundle roots like `./scenarios/wrkr/scan-mixed-org/repos` when you want a deterministic repo-set
+- if hosted prerequisites are not ready yet, start with `wrkr scan --path ./your-repo --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md` or `wrkr scan --my-setup --state ./.wrkr/last-scan.json` first and return to this flow when GitHub access is configured; `--path` scans the selected directory itself when it is the repo root and uses bundle roots like `./scenarios/wrkr/scan-mixed-org/repos` when you want a deterministic repo-set
 
 ```bash
-wrkr init --non-interactive --org acme --github-api https://api.github.com --json
-wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --timeout 30m --profile assessment --json --json-path ./.wrkr/scan.json --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
-wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --json --evidence-json --evidence-json-path ./.wrkr/agent-action-bom-evidence.json
-wrkr report --state ./.wrkr/last-scan.json --template ciso --md --md-path ./.wrkr/ciso.md --pdf --pdf-path ./.wrkr/ciso.pdf --evidence-json --evidence-json-path ./.wrkr/report-evidence.json --csv-backlog --csv-backlog-path ./.wrkr/control-backlog.csv --json
-wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./wrkr-evidence --json
-wrkr verify --chain --state ./.wrkr/last-scan.json --json
+wrkr init --non-interactive --org acme --github-api https://api.github.com
+wrkr scan --config ~/.wrkr/config.json --state ./.wrkr/last-scan.json --timeout 30m --profile assessment --report-md --report-md-path ./.wrkr/scan-summary.md --sarif --sarif-path ./.wrkr/wrkr.sarif
+wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.wrkr/agent-action-bom.md --evidence-json --evidence-json-path ./.wrkr/agent-action-bom-evidence.json
+wrkr report --state ./.wrkr/last-scan.json --template ciso --md --md-path ./.wrkr/ciso.md --pdf --pdf-path ./.wrkr/ciso.pdf --evidence-json --evidence-json-path ./.wrkr/report-evidence.json --csv-backlog --csv-backlog-path ./.wrkr/control-backlog.csv
+wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./wrkr-evidence
+wrkr verify --chain --state ./.wrkr/last-scan.json
 ```
 
 `wrkr evidence` now requires the saved proof chain to be intact before it stages or publishes a bundle, and `wrkr verify --chain --json` remains the explicit operator/CI integrity gate.

--- a/scripts/check_docs_storyline.sh
+++ b/scripts/check_docs_storyline.sh
@@ -37,8 +37,11 @@ required_quickstart_tokens=(
   "AI-DSPM"
   "See -> Prove -> Control"
   "Focused repo review first"
+  "wrkr scan --path ./your-repo --profile assessment --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md"
+  "wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/focused-agent-action-bom.md"
+  "Automation / CI equivalent"
   "wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --json"
-  "wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json"
+  "wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scenario-summary.md"
   "wrkr scan"
   "wrkr evidence"
   "wrkr verify"
@@ -55,8 +58,10 @@ done
 
 required_readme_tokens=(
   "Focused Repo Review (Recommended first path)"
+  "wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/focused-agent-action-bom.md"
+  "Automation / CI equivalent"
   "wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --json"
-  "wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json"
+  "wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scenario-summary.md"
   "wrkr evidence --frameworks"
   "wrkr verify --chain"
   "wrkr regress init"
@@ -66,6 +71,62 @@ required_readme_tokens=(
 for token in "${required_readme_tokens[@]}"; do
   if ! grep -Fq "$token" "$readme"; then
     echo "README missing token: $token" >&2
+    exit 3
+  fi
+done
+
+required_scan_tokens=(
+  "For manual large scans"
+  "wrkr scan --path ./your-repo --profile assessment --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md"
+  "Automation / CI workflow:"
+  "wrkr scan --path ./your-repo --profile assessment --state ./.wrkr/last-scan.json --json --json-path ./.wrkr/scan.json"
+)
+
+for token in "${required_scan_tokens[@]}"; do
+  if ! grep -Fq "$token" "docs/commands/scan.md"; then
+    echo "scan command docs missing token: $token" >&2
+    exit 3
+  fi
+done
+
+required_report_tokens=(
+  "Human/manual artifact handoff:"
+  "wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/focused-agent-action-bom.md"
+  "Automation / CI workflow:"
+  "wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --json"
+)
+
+for token in "${required_report_tokens[@]}"; do
+  if ! grep -Fq "$token" "docs/commands/report.md"; then
+    echo "report command docs missing token: $token" >&2
+    exit 3
+  fi
+done
+
+required_evidence_tokens=(
+  "Human/manual handoff:"
+  "wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./.wrkr/evidence"
+  "Automation / CI workflow:"
+  "wrkr evidence --frameworks eu-ai-act,soc2,pci-dss --state ./.wrkr/last-scan.json --output ./wrkr-evidence --json"
+)
+
+for token in "${required_evidence_tokens[@]}"; do
+  if ! grep -Fq "$token" "docs/commands/evidence.md"; then
+    echo "evidence command docs missing token: $token" >&2
+    exit 3
+  fi
+done
+
+required_assess_tokens=(
+  "Human/manual handoff:"
+  "wrkr assess --path ./your-repo --output-dir ./.wrkr/assessment --template agent-action-bom --share-profile customer-redacted"
+  "Automation / CI workflow:"
+  "wrkr assess --path ./your-repo --output-dir ./.wrkr/assessment --json"
+)
+
+for token in "${required_assess_tokens[@]}"; do
+  if ! grep -Fq "$token" "docs/commands/assess.md"; then
+    echo "assess command docs missing token: $token" >&2
     exit 3
   fi
 done

--- a/testinfra/hygiene/launch_truth_test.go
+++ b/testinfra/hygiene/launch_truth_test.go
@@ -11,8 +11,8 @@ func TestLaunchTruthScenarioFirstOnboarding(t *testing.T) {
 	t.Parallel()
 
 	repoRoot := mustFindRepoRoot(t)
-	scenarioCmd := "wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json"
-	repoFallbackCmd := "wrkr scan --path ./your-repo --json"
+	scenarioCmd := "wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scenario-summary.md"
+	repoFallbackCmd := "wrkr scan --path ./your-repo --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md"
 	requiredNoiseText := "repo-root fixture noise"
 
 	cases := []struct {
@@ -51,7 +51,7 @@ func TestLaunchTruthReadmeStartHereLeadsWithShippedWedge(t *testing.T) {
 	}
 
 	for _, required := range []string{
-		"wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --json",
+		"wrkr scan --path ./scenarios/wrkr/scan-mixed-org/repos --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scenario-summary.md",
 		"wrkr evidence --frameworks",
 		"wrkr verify --chain",
 		"wrkr regress init",

--- a/testinfra/hygiene/wave2_docs_contracts_test.go
+++ b/testinfra/hygiene/wave2_docs_contracts_test.go
@@ -158,8 +158,8 @@ func TestLandingReadmeStartHerePersonaAndFallback(t *testing.T) {
 		"Hosted prerequisites for this path:",
 		"`--github-api https://api.github.com`",
 		"If hosted prerequisites are still not ready yet after the evaluator-safe scenario, start with one of these deterministic local fallback paths:",
-		"wrkr scan --path ./your-repo --json",
-		"wrkr scan --my-setup --json",
+		"wrkr scan --path ./your-repo --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md",
+		"wrkr scan --my-setup --state ./.wrkr/last-scan.json",
 		"### Developers (Secondary local hygiene)",
 	} {
 		if !strings.Contains(readme, required) {
@@ -173,8 +173,8 @@ func TestLandingReadmeStartHerePersonaAndFallback(t *testing.T) {
 	for _, required := range []string{
 		"Hosted prerequisites for this path:",
 		"## If hosted prerequisites are not ready yet",
-		"wrkr scan --path ./your-repo --json",
-		"wrkr scan --my-setup --json",
+		"wrkr scan --path ./your-repo --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md",
+		"wrkr scan --my-setup --state ./.wrkr/last-scan.json",
 	} {
 		if !strings.Contains(quickstart, required) {
 			t.Fatalf("quickstart missing persona/fallback requirement %q", required)
@@ -184,7 +184,7 @@ func TestLandingReadmeStartHerePersonaAndFallback(t *testing.T) {
 		t.Fatal("quickstart must foreground the security/platform org posture flow before the evaluator fallback")
 	}
 
-	if !strings.Contains(securityTeam, "if hosted prerequisites are not ready yet, start with `wrkr scan --path ./your-repo --json` or `wrkr scan --my-setup --json` first") {
+	if !strings.Contains(securityTeam, "if hosted prerequisites are not ready yet, start with `wrkr scan --path ./your-repo --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md` or `wrkr scan --my-setup --state ./.wrkr/last-scan.json` first") {
 		t.Fatal("security-team workflow missing explicit hosted-prerequisite fallback")
 	}
 	if !strings.Contains(personalHygiene, "secondary fallback when the hosted org posture prerequisites are not ready yet") {
@@ -200,8 +200,8 @@ func TestDocsSiteQuickstartMirrorInstallAndFallback(t *testing.T) {
 	quickstart := mustReadFile(t, filepath.Join(repoRoot, "docs-site/public/llm/quickstart.md"))
 
 	for _, required := range []string{
-		"wrkr scan --path ./your-repo --json",
-		"wrkr scan --my-setup --json",
+		"wrkr scan --path ./your-repo --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md",
+		"wrkr scan --my-setup --state ./.wrkr/last-scan.json",
 	} {
 		if !strings.Contains(homepage, required) {
 			t.Fatalf("docs-site homepage missing fallback requirement %q", required)
@@ -211,9 +211,9 @@ func TestDocsSiteQuickstartMirrorInstallAndFallback(t *testing.T) {
 		"brew install Clyra-AI/tap/wrkr",
 		"go install github.com/Clyra-AI/wrkr/cmd/wrkr@\"${WRKR_VERSION}\"",
 		"wrkr version --json",
-		"wrkr init --non-interactive --org acme --github-api https://api.github.com --json",
-		"wrkr scan --path ./your-repo --json",
-		"wrkr scan --my-setup --json",
+		"wrkr init --non-interactive --org acme --github-api https://api.github.com",
+		"wrkr scan --path ./your-repo --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md",
+		"wrkr scan --my-setup --state ./.wrkr/last-scan.json",
 	} {
 		if !strings.Contains(quickstart, required) {
 			t.Fatalf("docs-site llm quickstart missing mirrored requirement %q", required)

--- a/testinfra/hygiene/wave31_focus_and_gate_test.go
+++ b/testinfra/hygiene/wave31_focus_and_gate_test.go
@@ -17,8 +17,8 @@ func TestWave31FocusedRepoWorkflowDocsRemainPresent(t *testing.T) {
 
 	for _, content := range []string{readme, quickstart, quickstartLLM} {
 		for _, required := range []string{
-			"wrkr scan --path ./your-repo --profile assessment --json",
-			"wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --json",
+			"wrkr scan --path ./your-repo --profile assessment --state ./.wrkr/last-scan.json --report-md --report-md-path ./.tmp/scan-summary.md",
+			"wrkr report --state ./.wrkr/last-scan.json --template agent-action-bom --md --md-path ./.tmp/focused-agent-action-bom.md",
 			"wrkr regress init --baseline ./.wrkr/last-scan.json --output ./.wrkr/wrkr-regress-baseline.json --json",
 		} {
 			if !strings.Contains(content, required) {


### PR DESCRIPTION
## Problem
- the Agent Action BOM lead was still too machine-heavy for the planned buyer-first wave
- manual large-scan docs still over-taught `--json` instead of durable `--state` plus report/evidence artifacts
- repo docs contracts and public docs-site quickstarts needed to align with the new manual-vs-automation split

## Changes
- reworked Agent Action BOM markdown to lead with inspect-first cards, a tighter primary workflow section, and top-five compact action paths while moving BOM metadata and context surfaces into appendices
- added and updated renderer, CLI, acceptance, site-asset, and hygiene coverage for the new BOM lead and one-page buyer-view budget
- updated command docs, README, quickstarts, docs-site surfaces, and docs-storyline enforcement so human workflows center `--state` and artifact handoff while automation keeps explicit `--json` examples
- added the matching changelog entries for the wave 4 and wave 5 public-surface changes

## Validation
- `make prepush-full`
- `make test-contracts`
- `scripts/run_docs_smoke.sh`
- targeted wave checks:
  - `go test ./core/report -run 'Test.*InspectFirst|Test.*PrimaryView|Test.*AgentActionBOM|Test.*Markdown|Test.*LineBudget|TestDefaultAgentActionBOMOnePageBudget' -count=1`
  - `go test ./core/cli -run 'Test.*ReportContract|Test.*Sprint0|Test.*AgentActionBOM' -count=1`
  - `go test ./internal/acceptance -run 'Test.*AgentActionBOM|Test.*OnePage|Test.*Buyer' -count=1`
  - `go test ./internal/siteassets -count=1`
  - `scripts/check_docs_storyline.sh`
  - `scripts/check_docs_cli_parity.sh`
  - `scripts/check_docs_consistency.sh`
  - `make test-focused-docs`

## Risks
- report markdown changed for the default Agent Action BOM lead, so downstream human readers will see a reordered front page
- docs and docs-contract tests were updated together to keep the new manual-vs-automation wording stable

## Submodule Notes
- no submodule pointer updates
