### PR TITLE
chore: finalize changelog for v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- [semver:patch] Hardened large-org Agent Action BOM scan/report output by grouping endpoint-derived graph targets, demoting static API-spec context from primary Top Action Paths, bounding repeated endpoint/evidence projections in saved state and reports, adding stale scan-status diagnostics, and adding source artifact SHA-256 digests to report metadata. Validation receipts include a 40-repo endpoint-heavy mock scan reducing saved state from ~142 MB to ~38 MB, `TestScanStatusFlagsStaleRunningSidecarAsLikelyInterrupted`, `TestBuildArtifactMetadataIncludesSourceArtifactDigests`, endpoint graph cap tests, and primary-view static-context tests.
+- (none yet)
 
 ### Security
 
@@ -38,6 +38,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 4. Keep entries concise and operator-facing: what changed, why it matters, and any migration/action notes.
 5. Link release notes and tag artifacts to the finalized changelog section.
 6. The Sprint 0 v1.7.3 clarification workflow item must record measured artifact-size deltas, redaction test names, and fixture coverage before release notes claim size, privacy, redaction, customer-safe, or readability hardening.
+
+## [v1.9.1] - 2026-06-22
+<!-- release-semver: patch -->
+
+### Fixed
+
+- Hardened large-org Agent Action BOM scan/report output by grouping endpoint-derived graph targets, demoting static API-spec context from primary Top Action Paths, bounding repeated endpoint/evidence projections in saved state and reports, adding stale scan-status diagnostics, and adding source artifact SHA-256 digests to report metadata. Validation receipts include a 40-repo endpoint-heavy mock scan reducing saved state from ~142 MB to ~38 MB, `TestScanStatusFlagsStaleRunningSidecarAsLikelyInterrupted`, `TestBuildArtifactMetadataIncludesSourceArtifactDigests`, endpoint graph cap tests, and primary-view static-context tests.
 
 ## [v1.9.0] - 2026-06-18
 <!-- release-semver: minor -->

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ brew install Clyra-AI/tap/wrkr
 ### Go install (Pinned/reproducible)
 
 ```bash
-WRKR_VERSION="v1.9.0"
+WRKR_VERSION="v1.9.1"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -4,7 +4,7 @@ Install with Homebrew or the pinned Go path first, then verify the installed CLI
 
 ```bash
 brew install Clyra-AI/tap/wrkr
-WRKR_VERSION="v1.9.0"
+WRKR_VERSION="v1.9.1"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 wrkr version --json
 

--- a/docs/commands/action.md
+++ b/docs/commands/action.md
@@ -21,7 +21,7 @@ Any packaged GitHub Action surface must wrap these CLI contracts rather than dup
 Wrkr now ships a repo-root `action.yml` composite action that wraps the same CLI contracts through `scripts/action_entrypoint.sh`.
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.9.0
+- uses: Clyra-AI/wrkr@v1.9.1
   with:
     mode: scheduled
     remediation_mode: summary_only
@@ -65,7 +65,7 @@ wrkr action pr-comment --changed-paths ".codex/config.toml" --risk-delta 2.8 --c
 ```
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.9.0
+- uses: Clyra-AI/wrkr@v1.9.1
   with:
     mode: scheduled
     target_mode: repo

--- a/docs/install/minimal-dependencies.md
+++ b/docs/install/minimal-dependencies.md
@@ -7,7 +7,7 @@ The main README landing page surfaces Homebrew, the pinned Go install path below
 ## Go-only pinned install
 
 ```bash
-WRKR_VERSION="v1.9.0"
+WRKR_VERSION="v1.9.1"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 
@@ -56,6 +56,6 @@ Install commands above are validated by release UAT together with the public `wr
 
 ```bash
 scripts/test_uat_local.sh --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.9.0 --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.9.0 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.9.1 --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.9.1 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
 ```

--- a/docs/trust/release-integrity.md
+++ b/docs/trust/release-integrity.md
@@ -92,7 +92,7 @@ scripts/test_uat_local.sh
 scripts/test_uat_local.sh --skip-global-gates
 
 # Validate exact public install commands (brew + pinned go install) for a published tag
-scripts/test_uat_local.sh --release-version v1.9.0 --brew-formula Clyra-AI/tap/wrkr
+scripts/test_uat_local.sh --release-version v1.9.1 --brew-formula Clyra-AI/tap/wrkr
 ```
 
 ## Changelog finalization


### PR DESCRIPTION
## Problem
- the v1.9.1 release needs a finalized changelog section on `main` before tagging
- the repo's release docs contracts still pinned `v1.9.0`, which breaks the release-prep validation lane once the changelog resolves to `v1.9.1`

## Changes
- finalize `CHANGELOG.md` for `v1.9.1`
- sync pinned release/install references in README, install docs, action docs, trust docs, and the LLM quickstart to `v1.9.1`

## Validation
- `make prepush-full`

## Risks
- low: docs-only and changelog-only release prep changes
