### PR TITLE
chore: finalize changelog for v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Added
 
-- Added `wrkr report --evidence-json-scope` so Agent Action BOM evidence can default to a buyer-facing lead bundle while still allowing explicit full graph/workflow evidence export.
-- Added workstation detection for local agentic factory and handoff artifacts such as `.agents/skills`, `factory/skills`, Bob config, local PR provenance, and runtime-session sidecars.
+- (none yet)
 
 ### Changed
 
-- Changed Agent Action BOM markdown and evidence output to keep the lead view focused on the primary path and compact top paths, with appendices/full evidence available through explicit output scope.
-- Changed control guidance for standard CI credential references to request imported PR review, branch protection, deployment, or owner-map evidence instead of implying approval or proof is absent from source alone.
+- (none yet)
 
 ### Deprecated
 
@@ -26,8 +24,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- Fixed standard non-agentic CI credential paths so they remain inventory hygiene unless agentic influence or high-impact release/production evidence makes them control-first.
-- Fixed buyer-facing report labels so approval and runtime gaps render as evidence not observed in the scanned/imported context instead of unsupported missing-control claims.
+- (none yet)
 
 ### Security
 
@@ -41,6 +38,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 4. Keep entries concise and operator-facing: what changed, why it matters, and any migration/action notes.
 5. Link release notes and tag artifacts to the finalized changelog section.
 6. The Sprint 0 v1.7.3 clarification workflow item must record measured artifact-size deltas, redaction test names, and fixture coverage before release notes claim size, privacy, redaction, customer-safe, or readability hardening.
+
+## [v1.10.0] - 2026-06-23
+<!-- release-semver: minor -->
+
+### Added
+
+- Added `wrkr report --evidence-json-scope` so Agent Action BOM evidence can default to a buyer-facing lead bundle while still allowing explicit full graph/workflow evidence export.
+- Added workstation detection for local agentic factory and handoff artifacts such as `.agents/skills`, `factory/skills`, Bob config, local PR provenance, and runtime-session sidecars.
+
+### Changed
+
+- Changed Agent Action BOM markdown and evidence output to keep the lead view focused on the primary path and compact top paths, with appendices/full evidence available through explicit output scope.
+- Changed control guidance for standard CI credential references to request imported PR review, branch protection, deployment, or owner-map evidence instead of implying approval or proof is absent from source alone.
+
+### Fixed
+
+- Fixed standard non-agentic CI credential paths so they remain inventory hygiene unless agentic influence or high-impact release/production evidence makes them control-first.
+- Fixed buyer-facing report labels so approval and runtime gaps render as evidence not observed in the scanned/imported context instead of unsupported missing-control claims.
 
 ## [v1.9.1] - 2026-06-22
 <!-- release-semver: patch -->

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ brew install Clyra-AI/tap/wrkr
 ### Go install (Pinned/reproducible)
 
 ```bash
-WRKR_VERSION="v1.9.1"
+WRKR_VERSION="v1.10.0"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -4,7 +4,7 @@ Install with Homebrew or the pinned Go path first, then verify the installed CLI
 
 ```bash
 brew install Clyra-AI/tap/wrkr
-WRKR_VERSION="v1.9.1"
+WRKR_VERSION="v1.10.0"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 wrkr version --json
 

--- a/docs/commands/action.md
+++ b/docs/commands/action.md
@@ -21,7 +21,7 @@ Any packaged GitHub Action surface must wrap these CLI contracts rather than dup
 Wrkr now ships a repo-root `action.yml` composite action that wraps the same CLI contracts through `scripts/action_entrypoint.sh`.
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.9.1
+- uses: Clyra-AI/wrkr@v1.10.0
   with:
     mode: scheduled
     remediation_mode: summary_only
@@ -65,7 +65,7 @@ wrkr action pr-comment --changed-paths ".codex/config.toml" --risk-delta 2.8 --c
 ```
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.9.1
+- uses: Clyra-AI/wrkr@v1.10.0
   with:
     mode: scheduled
     target_mode: repo

--- a/docs/install/minimal-dependencies.md
+++ b/docs/install/minimal-dependencies.md
@@ -7,7 +7,7 @@ The main README landing page surfaces Homebrew, the pinned Go install path below
 ## Go-only pinned install
 
 ```bash
-WRKR_VERSION="v1.9.1"
+WRKR_VERSION="v1.10.0"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 
@@ -56,6 +56,6 @@ Install commands above are validated by release UAT together with the public `wr
 
 ```bash
 scripts/test_uat_local.sh --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.9.1 --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.9.1 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.10.0 --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.10.0 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
 ```

--- a/docs/trust/release-integrity.md
+++ b/docs/trust/release-integrity.md
@@ -92,7 +92,7 @@ scripts/test_uat_local.sh
 scripts/test_uat_local.sh --skip-global-gates
 
 # Validate exact public install commands (brew + pinned go install) for a published tag
-scripts/test_uat_local.sh --release-version v1.9.1 --brew-formula Clyra-AI/tap/wrkr
+scripts/test_uat_local.sh --release-version v1.10.0 --brew-formula Clyra-AI/tap/wrkr
 ```
 
 ## Changelog finalization


### PR DESCRIPTION
## Problem
- `v1.10.0` needs a finalized changelog section before tag publication.
- Release-prep validation also found public docs still pinned to `v1.9.1`, which would break the current release contract.

## Changes
- Finalized `CHANGELOG.md` for `v1.10.0`.
- Advanced public pinned install references and packaged action examples to `v1.10.0`.
- Updated release-smoke/UAT docs to use the current supported release version.

## Validation
- `make prepush-full`

## Risks
- Release docs and install contract drift if this PR does not land before tagging.
- No submodule pointer changes.
