### PR TITLE
ci: align nightly race timeout budget

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,8 @@ jobs:
         run: go test ./internal/integration/interop -count=1
 
       - name: Run race lane
-        run: go test -race ./... -count=1
+        # Keep race-lane package timeouts aligned with the repo's standard Go test budget.
+        run: go test -race ./... -count=1 -timeout=20m
 
       - name: Run vulnerability scan
         run: |


### PR DESCRIPTION
## Problem
- the scheduled `nightly` workflow on `main` failed on June 26, 2026 in the `Run race lane` step
- the failure was not a product regression or race report; the job hit Go's default 10 minute package timeout while `internal/acceptance` was still running under `-race`

## Changes
- align the nightly race-lane invocation with the repository's standard Go test timeout budget
- add `-timeout=20m` to `go test -race ./... -count=1` in `.github/workflows/nightly.yml`

## Validation
- `make prepush-full`
- `go test -race ./internal/acceptance -count=1 -timeout=15m`
- observed `internal/acceptance` pass under `-race` in `797.170s`, which explains the old nightly timeout failure

## Risk
- low; this changes only CI timeout budgeting for the nightly race lane
- no product, schema, or runtime behavior changes
