### PR TITLE
chore: finalize changelog for v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Added
 
-- [semver:minor] Added stable `resolution_key` action-path, BOM, report, and regress-baseline joins plus selector-fallback match metadata so reviewed paths can survive harmless `path_id` churn across reruns.
-- [semver:minor] Added review disposition declarations in `wrkr-control-declarations.yaml` / `.wrkr/control-declarations.yaml` for controlled, accepted-risk, not-applicable, false-positive, runtime-evidence-needed, and confirmed paths.
-- [semver:minor] Added expiry, contradiction, disappeared-import, credential-family, and target-escalation reopen tracking for reviewed action paths in reports and regress baselines.
-- [semver:minor] Added provider-control evidence correlation for local PR review, branch protection, required-check, environment approval, workflow permission, merge metadata, and owner evidence exports, including direct `resolution_key` joins.
-- [semver:minor] Added path-specific closure actions plus deterministic declaration snippet export for reviewed BOM and backlog items, including repo-local and governance-repo declaration modes.
-- [semver:minor] Added synthetic enterprise review-loop fixtures that gate closure actions, lifecycle reopen behavior, governed-CI ranking, and share-safe declaration/report wording.
+- (none yet)
 
 ### Changed
 
-- [semver:minor] Changed reviewed action-path handling so declared, imported, accepted-risk, not-applicable, and false-positive paths move to auditable appendix visibility with explicit lifecycle and reopen metadata instead of remaining in unresolved top output.
-- [semver:minor] Changed top action recommendations to account for credential authority confidence, static caller context, and governed CI control evidence before suggesting stronger credential remediation.
+- (none yet)
 
 ### Deprecated
 
@@ -30,7 +24,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- [semver:patch] Fixed paired internal and customer-redacted artifact handling so local join maps preserve stable `resolution_key` and evidence joins while staying excluded from shareable bundles by default.
+- (none yet)
 
 ### Security
 
@@ -44,6 +38,27 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 4. Keep entries concise and operator-facing: what changed, why it matters, and any migration/action notes.
 5. Link release notes and tag artifacts to the finalized changelog section.
 6. The Sprint 0 v1.7.3 clarification workflow item must record measured artifact-size deltas, redaction test names, and fixture coverage before release notes claim size, privacy, redaction, customer-safe, or readability hardening.
+
+## [v1.11.0] - 2026-06-26
+<!-- release-semver: minor -->
+
+### Added
+
+- Added stable `resolution_key` action-path, BOM, report, and regress-baseline joins plus selector-fallback match metadata so reviewed paths can survive harmless `path_id` churn across reruns.
+- Added review disposition declarations in `wrkr-control-declarations.yaml` / `.wrkr/control-declarations.yaml` for controlled, accepted-risk, not-applicable, false-positive, runtime-evidence-needed, and confirmed paths.
+- Added expiry, contradiction, disappeared-import, credential-family, and target-escalation reopen tracking for reviewed action paths in reports and regress baselines.
+- Added provider-control evidence correlation for local PR review, branch protection, required-check, environment approval, workflow permission, merge metadata, and owner evidence exports, including direct `resolution_key` joins.
+- Added path-specific closure actions plus deterministic declaration snippet export for reviewed BOM and backlog items, including repo-local and governance-repo declaration modes.
+- Added synthetic enterprise review-loop fixtures that gate closure actions, lifecycle reopen behavior, governed-CI ranking, and share-safe declaration/report wording.
+
+### Changed
+
+- Changed reviewed action-path handling so declared, imported, accepted-risk, not-applicable, and false-positive paths move to auditable appendix visibility with explicit lifecycle and reopen metadata instead of remaining in unresolved top output.
+- Changed top action recommendations to account for credential authority confidence, static caller context, and governed CI control evidence before suggesting stronger credential remediation.
+
+### Fixed
+
+- Fixed paired internal and customer-redacted artifact handling so local join maps preserve stable `resolution_key` and evidence joins while staying excluded from shareable bundles by default.
 
 ## [v1.10.0] - 2026-06-23
 <!-- release-semver: minor -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Added expiry, contradiction, disappeared-import, credential-family, and target-escalation reopen tracking for reviewed action paths in reports and regress baselines.
 - Added provider-control evidence correlation for local PR review, branch protection, required-check, environment approval, workflow permission, merge metadata, and owner evidence exports, including direct `resolution_key` joins.
 - Added path-specific closure actions plus deterministic declaration snippet export for reviewed BOM and backlog items, including repo-local and governance-repo declaration modes.
-- Added synthetic enterprise review-loop fixtures that gate closure actions, lifecycle reopen behavior, governed-CI ranking, and share-safe declaration/report wording.
+- Added synthetic enterprise review-loop fixtures that gate closure actions, lifecycle reopen behavior, governed-CI ranking, and declaration/report wording.
 
 ### Changed
 
@@ -58,7 +58,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- Fixed paired internal and customer-redacted artifact handling so local join maps preserve stable `resolution_key` and evidence joins while staying excluded from shareable bundles by default.
+- Fixed paired artifact join handling so local outputs preserve stable `resolution_key` and evidence joins across related artifacts.
 
 ## [v1.10.0] - 2026-06-23
 <!-- release-semver: minor -->

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ brew install Clyra-AI/tap/wrkr
 ### Go install (Pinned/reproducible)
 
 ```bash
-WRKR_VERSION="v1.10.0"
+WRKR_VERSION="v1.11.0"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -4,7 +4,7 @@ Install with Homebrew or the pinned Go path first, then verify the installed CLI
 
 ```bash
 brew install Clyra-AI/tap/wrkr
-WRKR_VERSION="v1.10.0"
+WRKR_VERSION="v1.11.0"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 wrkr version --json
 

--- a/docs/commands/action.md
+++ b/docs/commands/action.md
@@ -21,7 +21,7 @@ Any packaged GitHub Action surface must wrap these CLI contracts rather than dup
 Wrkr now ships a repo-root `action.yml` composite action that wraps the same CLI contracts through `scripts/action_entrypoint.sh`.
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.10.0
+- uses: Clyra-AI/wrkr@v1.11.0
   with:
     mode: scheduled
     remediation_mode: summary_only
@@ -65,7 +65,7 @@ wrkr action pr-comment --changed-paths ".codex/config.toml" --risk-delta 2.8 --c
 ```
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.10.0
+- uses: Clyra-AI/wrkr@v1.11.0
   with:
     mode: scheduled
     target_mode: repo

--- a/docs/install/minimal-dependencies.md
+++ b/docs/install/minimal-dependencies.md
@@ -7,7 +7,7 @@ The main README landing page surfaces Homebrew, the pinned Go install path below
 ## Go-only pinned install
 
 ```bash
-WRKR_VERSION="v1.10.0"
+WRKR_VERSION="v1.11.0"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 
@@ -56,6 +56,6 @@ Install commands above are validated by release UAT together with the public `wr
 
 ```bash
 scripts/test_uat_local.sh --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.10.0 --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.10.0 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.11.0 --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.11.0 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
 ```

--- a/docs/trust/release-integrity.md
+++ b/docs/trust/release-integrity.md
@@ -92,7 +92,7 @@ scripts/test_uat_local.sh
 scripts/test_uat_local.sh --skip-global-gates
 
 # Validate exact public install commands (brew + pinned go install) for a published tag
-scripts/test_uat_local.sh --release-version v1.10.0 --brew-formula Clyra-AI/tap/wrkr
+scripts/test_uat_local.sh --release-version v1.11.0 --brew-formula Clyra-AI/tap/wrkr
 ```
 
 ## Changelog finalization


### PR DESCRIPTION
## Summary
- finalize `CHANGELOG.md` for `v1.11.0`
- promote the current `Unreleased` entries into the dated release section
- reset `Unreleased` to the canonical empty section layout

## Validation
- `python3 scripts/resolve_release_version.py --repo-root . --json`
- `python3 scripts/finalize_release_changelog.py --repo-root . --release-version v1.11.0 --json`
- `python3 scripts/validate_release_changelog.py --repo-root . --release-version v1.11.0 --json`
