### PR TITLE
chore: finalize changelog for v1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed
 
-- [semver:patch] Agent Action BOM Markdown now groups repeated top action paths in the buyer lead while preserving full detail in appendices and evidence JSON.
-- [semver:patch] First-run Agent Action BOM reports now summarize approval/proof evidence gaps as onboarding context instead of repeating raw unknown evidence fields throughout the lead.
-- [semver:patch] Reports now explain attack-path non-generation when high-impact action paths exist but attack-path graph prerequisites were not available.
+- (none yet)
 
 ### Deprecated
 
@@ -26,11 +24,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- [semver:patch] Report QA now blocks buyer-hostile primary Markdown patterns such as weak blocked-credential remediation, internal token leakage, repeated raw evidence gaps, and oversized lead lines.
+- (none yet)
 
 ### Security
 
-- [semver:patch] Blocked standing-credential report guidance now leads with reducing, replacing, revoking, rotating, or moving authority to JIT/brokered access before any accept-risk option.
+- (none yet)
 
 ## Changelog maintenance process
 
@@ -40,6 +38,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 4. Keep entries concise and operator-facing: what changed, why it matters, and any migration/action notes.
 5. Link release notes and tag artifacts to the finalized changelog section.
 6. The Sprint 0 v1.7.3 clarification workflow item must record measured artifact-size deltas, redaction test names, and fixture coverage before release notes claim size, privacy, redaction, customer-safe, or readability hardening.
+
+## [v1.11.1] - 2026-06-27
+<!-- release-semver: patch -->
+
+### Changed
+
+- Agent Action BOM Markdown now groups repeated top action paths in the buyer lead while preserving full detail in appendices and evidence JSON.
+- First-run Agent Action BOM reports now summarize approval/proof evidence gaps as onboarding context instead of repeating raw unknown evidence fields throughout the lead.
+- Reports now explain attack-path non-generation when high-impact action paths exist but attack-path graph prerequisites were not available.
+
+### Fixed
+
+- Report QA now blocks buyer-hostile primary Markdown patterns such as weak blocked-credential remediation, internal token leakage, repeated raw evidence gaps, and oversized lead lines.
+
+### Security
+
+- Blocked standing-credential report guidance now leads with reducing, replacing, revoking, rotating, or moving authority to JIT/brokered access before any accept-risk option.
 
 ## [v1.11.0] - 2026-06-26
 <!-- release-semver: minor -->

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ brew install Clyra-AI/tap/wrkr
 ### Go install (Pinned/reproducible)
 
 ```bash
-WRKR_VERSION="v1.11.0"
+WRKR_VERSION="v1.11.1"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -4,7 +4,7 @@ Install with Homebrew or the pinned Go path first, then verify the installed CLI
 
 ```bash
 brew install Clyra-AI/tap/wrkr
-WRKR_VERSION="v1.11.0"
+WRKR_VERSION="v1.11.1"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 wrkr version --json
 

--- a/docs/commands/action.md
+++ b/docs/commands/action.md
@@ -21,7 +21,7 @@ Any packaged GitHub Action surface must wrap these CLI contracts rather than dup
 Wrkr now ships a repo-root `action.yml` composite action that wraps the same CLI contracts through `scripts/action_entrypoint.sh`.
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.11.0
+- uses: Clyra-AI/wrkr@v1.11.1
   with:
     mode: scheduled
     remediation_mode: summary_only
@@ -65,7 +65,7 @@ wrkr action pr-comment --changed-paths ".codex/config.toml" --risk-delta 2.8 --c
 ```
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.11.0
+- uses: Clyra-AI/wrkr@v1.11.1
   with:
     mode: scheduled
     target_mode: repo

--- a/docs/install/minimal-dependencies.md
+++ b/docs/install/minimal-dependencies.md
@@ -7,7 +7,7 @@ The main README landing page surfaces Homebrew, the pinned Go install path below
 ## Go-only pinned install
 
 ```bash
-WRKR_VERSION="v1.11.0"
+WRKR_VERSION="v1.11.1"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 
@@ -56,6 +56,6 @@ Install commands above are validated by release UAT together with the public `wr
 
 ```bash
 scripts/test_uat_local.sh --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.11.0 --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.11.0 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.11.1 --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.11.1 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
 ```

--- a/docs/trust/release-integrity.md
+++ b/docs/trust/release-integrity.md
@@ -92,7 +92,7 @@ scripts/test_uat_local.sh
 scripts/test_uat_local.sh --skip-global-gates
 
 # Validate exact public install commands (brew + pinned go install) for a published tag
-scripts/test_uat_local.sh --release-version v1.11.0 --brew-formula Clyra-AI/tap/wrkr
+scripts/test_uat_local.sh --release-version v1.11.1 --brew-formula Clyra-AI/tap/wrkr
 ```
 
 ## Changelog finalization


### PR DESCRIPTION
## Problem
- `v1.11.1` needs a finalized changelog section before the release tag can be cut.
- The release hygiene gate also requires public install/action docs to pin the current supported release version.

## Changes
- finalize `CHANGELOG.md` for `v1.11.1`
- update pinned release references in README, install docs, release integrity docs, quickstart docs, and action docs
- restore full tag ancestry locally so the release changelog helpers continue resolving against `v1.11.0`

## Validation
- `make prepush-full`
- `make test-docs-consistency`
- `go test ./testinfra/hygiene -run 'TestMinimalDependenciesReleaseSmokeVersionIsCurrent|TestInstallDocsPinnedVersionSupportsCurrentReadmeCommands' -count=1`
- `python3 factory/scripts/validate_release_changelog.py --repo-root . --release-version v1.11.1 --json`

## Risks
- release-prep only; no runtime Go code changes
- docs version pins must stay aligned with the tag that lands from this PR
