### PR TITLE
fix: automate docs-site audit expiry follow-up

### DIFF
--- a/.github/workflows/docs-site-audit-watch.yml
+++ b/.github/workflows/docs-site-audit-watch.yml
@@ -1,0 +1,82 @@
+name: docs-site-audit-watch
+
+on:
+  schedule:
+    - cron: '42 10 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: docs-site-audit-watch
+  cancel-in-progress: true
+
+jobs:
+  exception-watch:
+    name: exception-watch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v6.3.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: docs-site/package-lock.json
+
+      - name: Setup Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.13'
+
+      - name: Run docs-site audit exception watch
+        id: audit
+        shell: bash
+        env:
+          NPM_CONFIG_CACHE: ${{ github.workspace }}/.tmp/npm-cache
+        run: |
+          mkdir -p .tmp/docs-site-audit "$NPM_CONFIG_CACHE"
+          set +e
+          python3 scripts/validate_docs_site_audit.py \
+            --repo-root . \
+            --json \
+            --warn-expiring-within-days 14 > .tmp/docs-site-audit/result.json
+          audit_exit=$?
+          set -e
+          python3 scripts/prepare_docs_site_audit_issue.py \
+            --result .tmp/docs-site-audit/result.json \
+            --output-body .tmp/docs-site-audit/issue.md \
+            --github-output "$GITHUB_OUTPUT"
+          echo "audit_exit=$audit_exit" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update docs-site audit issue
+        if: steps.audit.outputs.has_notice == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: ${{ steps.audit.outputs.issue_title }}
+        run: |
+          issue_number="$(gh issue list --state open --search "$ISSUE_TITLE in:title" --json number --jq '.[0].number // ""')"
+          if [[ -n "$issue_number" ]]; then
+            gh issue edit "$issue_number" --title "$ISSUE_TITLE" --body-file .tmp/docs-site-audit/issue.md
+          else
+            gh issue create --title "$ISSUE_TITLE" --body-file .tmp/docs-site-audit/issue.md
+          fi
+
+      - name: Close resolved docs-site audit issue
+        if: steps.audit.outputs.has_notice == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: ${{ steps.audit.outputs.issue_title }}
+        run: |
+          issue_number="$(gh issue list --state open --search "$ISSUE_TITLE in:title" --json number --jq '.[0].number // ""')"
+          if [[ -n "$issue_number" ]]; then
+            gh issue close "$issue_number" --comment "Docs-site audit exceptions are current; closing this watch issue."
+          fi
+
+      - name: Fail on docs-site audit violation
+        if: steps.audit.outputs.audit_status == 'fail'
+        run: exit 1

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -63,6 +63,8 @@ make docs-site-audit-prod
 
 `make docs-site-audit-prod` validates live `npm audit --omit=dev` output against [`docs-site/security-advisory-exceptions.json`](security-advisory-exceptions.json). Exceptions are owner-scoped, expiring, and pinned to the exact advisory, affected node path, direct dependency, and locked version so the gate fails closed when upstream fixes land or the lockfile drifts.
 
+The audit validator also supports deterministic date injection for tests with `--today YYYY-MM-DD` and non-failing lead-time warnings with `--warn-expiring-within-days N`. The weekly `docs-site-audit-watch` workflow uses the warning mode to open or update a GitHub issue before an exception expires.
+
 The `/scan` route is a thin bootstrap shell only. It prepares an equivalent handoff, points back to existing Wrkr org scan contracts, and projects returned machine-readable summaries without introducing dashboard persistence.
 
 ## SEO and AEO Assets

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -4848,9 +4848,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",

--- a/docs-site/security-advisory-exceptions.json
+++ b/docs-site/security-advisory-exceptions.json
@@ -1,19 +1,5 @@
 {
   "schema_id": "wrkr.docs_site.audit_exceptions",
   "schema_version": "1.0.0",
-  "exceptions": [
-    {
-      "package": "js-yaml",
-      "advisory": "GHSA-h67p-54hq-rp68",
-      "severity": "moderate",
-      "affected_node": "node_modules/gray-matter/node_modules/js-yaml",
-      "direct_dependency": "gray-matter",
-      "current_version": "4.0.3",
-      "owner": "docs-platform",
-      "scope": "docs-site production dependencies",
-      "rationale": "The latest stable gray-matter release still vendors js-yaml 3.14.2, so the docs-site audit gate needs a temporary pinned exception until upstream ships a fixed production dependency chain.",
-      "expires_on": "2026-06-30",
-      "upgrade_trigger": "Remove this exception as soon as gray-matter ships a stable release that no longer vendors vulnerable js-yaml and npm audit --omit=dev stops reporting GHSA-h67p-54hq-rp68 for docs-site production dependencies."
-    }
-  ]
+  "exceptions": []
 }

--- a/docs/trust/release-integrity.md
+++ b/docs/trust/release-integrity.md
@@ -28,6 +28,7 @@ description: "Release hardening checks, reproducibility expectations, and integr
 ```bash
 make lint-fast
 python3 scripts/validate_docs_site_audit.py --repo-root . --json
+python3 scripts/validate_docs_site_audit.py --repo-root . --json --warn-expiring-within-days 14
 python3 scripts/resolve_release_version.py --json
 python3 scripts/finalize_release_changelog.py --json
 python3 scripts/validate_release_changelog.py --release-version vX.Y.Z --json
@@ -49,6 +50,8 @@ make test-release-smoke
 - removable as soon as a patched stable upstream release clears the advisory
 
 If an advisory disappears, the node path changes, the direct dependency version drifts, or the exception expires, the gate fails closed instead of silently approving the docs site.
+
+For deterministic tests, the validator accepts `--today YYYY-MM-DD` so fixture expiry checks do not depend on the wall clock. The weekly `docs-site-audit-watch` workflow runs the same validator with `--warn-expiring-within-days 14`; it opens or updates one GitHub issue when an exception is approaching expiry and closes that issue once the exception register is current again. Warning mode does not weaken the release gate: expired, stale, mismatched, high, or critical findings still fail.
 
 ## Factory profile trust posture
 

--- a/scripts/prepare_docs_site_audit_issue.py
+++ b/scripts/prepare_docs_site_audit_issue.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_ISSUE_TITLE = "Docs-site audit exception review needed"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Prepare a GitHub issue body from docs-site audit exception warnings."
+    )
+    parser.add_argument("--result", required=True, help="validator JSON result path")
+    parser.add_argument("--output-body", required=True, help="markdown issue body output path")
+    parser.add_argument("--github-output", help="optional GITHUB_OUTPUT path")
+    parser.add_argument("--issue-title", default=DEFAULT_ISSUE_TITLE, help="GitHub issue title")
+    return parser.parse_args()
+
+
+def non_empty_strings(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    return [str(value).strip() for value in values if str(value).strip()]
+
+
+def issue_body(result: dict[str, Any]) -> str:
+    status = str(result.get("status") or "unknown")
+    warnings = non_empty_strings(result.get("warnings"))
+    failures = non_empty_strings(result.get("failures"))
+
+    lines = [
+        "# Docs-site audit exception review needed",
+        "",
+        f"Status: `{status}`",
+        "",
+    ]
+    if failures:
+        lines.extend(["## Failures", ""])
+        lines.extend(f"- {failure}" for failure in failures)
+        lines.append("")
+    if warnings:
+        lines.extend(["## Warnings", ""])
+        lines.extend(f"- {warning}" for warning in warnings)
+        lines.append("")
+    lines.extend(
+        [
+            "## Review",
+            "",
+            "- Prefer dependency remediation when a patched version is available.",
+            "- Remove stale exceptions when the advisory no longer appears in `npm audit --omit=dev`.",
+            "- Renew an exception only with current owner, rationale, expiry, and upgrade trigger evidence.",
+            "",
+            "## Source",
+            "",
+            "- `scripts/validate_docs_site_audit.py --repo-root . --json --warn-expiring-within-days 14`",
+            "- `docs-site/security-advisory-exceptions.json`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def append_github_output(path: Path, values: dict[str, str]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            if "\n" not in value:
+                handle.write(f"{key}={value}\n")
+                continue
+            delimiter = f"EOF_{key}"
+            while delimiter in value:
+                delimiter = f"{delimiter}_X"
+            handle.write(f"{key}<<{delimiter}\n{value}\n{delimiter}\n")
+
+
+def main() -> int:
+    args = parse_args()
+    result_path = Path(args.result)
+    output_body_path = Path(args.output_body)
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+
+    warnings = non_empty_strings(result.get("warnings"))
+    failures = non_empty_strings(result.get("failures"))
+    has_notice = bool(warnings or failures)
+
+    if has_notice:
+        output_body_path.parent.mkdir(parents=True, exist_ok=True)
+        output_body_path.write_text(issue_body(result), encoding="utf-8")
+
+    if args.github_output:
+        append_github_output(
+            Path(args.github_output),
+            {
+                "has_notice": "true" if has_notice else "false",
+                "audit_status": str(result.get("status") or "unknown"),
+                "issue_title": args.issue_title,
+            },
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_docs_site_audit.py
+++ b/scripts/validate_docs_site_audit.py
@@ -55,6 +55,16 @@ def parse_args() -> argparse.Namespace:
         "--audit-report",
         help="optional pre-recorded npm audit JSON file; when omitted the script runs npm audit",
     )
+    parser.add_argument(
+        "--today",
+        help="override today's date as YYYY-MM-DD for deterministic validation tests",
+    )
+    parser.add_argument(
+        "--warn-expiring-within-days",
+        type=int,
+        default=0,
+        help="emit non-failing warnings for matching exceptions expiring within this many days",
+    )
     parser.add_argument("--json", action="store_true", help="emit JSON result")
     return parser.parse_args()
 
@@ -188,7 +198,22 @@ def collect_actionable_advisories(report: dict[str, Any], lockfile: dict[str, An
     )
 
 
-def validate_exception_shape(raw: dict[str, Any], failures: list[str]) -> None:
+def parse_validation_date(raw_today: str | None) -> date:
+    if not raw_today:
+        return date.today()
+    try:
+        return date.fromisoformat(raw_today)
+    except ValueError as exc:
+        raise ValueError(f"invalid --today {raw_today!r}; expected YYYY-MM-DD") from exc
+
+
+def validate_exception_shape(
+    raw: dict[str, Any],
+    failures: list[str],
+    warnings: list[str],
+    today: date,
+    warn_expiring_within_days: int,
+) -> None:
     for field in REQUIRED_EXCEPTION_FIELDS:
         value = raw.get(field)
         if value is None or not str(value).strip():
@@ -207,13 +232,26 @@ def validate_exception_shape(raw: dict[str, Any], failures: list[str]) -> None:
                 f"exception {raw.get('advisory', '<unknown>')!r} has invalid expires_on {expires_on!r}"
             )
             return
-        if expiry < date.today():
+        if expiry < today:
             failures.append(
                 f"exception {raw.get('advisory', '<unknown>')!r} expired on {expires_on}"
             )
+            return
+        days_remaining = (expiry - today).days
+        if warn_expiring_within_days > 0 and days_remaining <= warn_expiring_within_days:
+            warnings.append(
+                f"exception {raw.get('advisory', '<unknown>')!r} expires on {expires_on} "
+                f"({days_remaining} days remaining)"
+            )
 
 
-def load_exceptions(path: Path, failures: list[str]) -> list[dict[str, str]]:
+def load_exceptions(
+    path: Path,
+    failures: list[str],
+    warnings: list[str],
+    today: date,
+    warn_expiring_within_days: int,
+) -> list[dict[str, str]]:
     payload = load_json(path)
     if payload.get("schema_id") != EXCEPTION_SCHEMA_ID:
         failures.append(f"{path}: unexpected schema_id {payload.get('schema_id')!r}")
@@ -230,7 +268,7 @@ def load_exceptions(path: Path, failures: list[str]) -> list[dict[str, str]]:
         if not isinstance(raw, dict):
             failures.append(f"{path}: exception entries must be objects")
             continue
-        validate_exception_shape(raw, failures)
+        validate_exception_shape(raw, failures, warnings, today, warn_expiring_within_days)
         normalized.append({key: str(raw.get(key, "")).strip() for key in REQUIRED_EXCEPTION_FIELDS})
     return normalized
 
@@ -252,8 +290,11 @@ def validate_audit(
     exceptions_path: Path,
     lockfile_path: Path,
     audit_report_path: Path | None,
+    today: date,
+    warn_expiring_within_days: int,
 ) -> dict[str, Any]:
     failures: list[str] = []
+    warnings: list[str] = []
     if not package_dir.exists():
         failures.append(f"package directory does not exist: {package_dir}")
     if not exceptions_path.exists():
@@ -265,11 +306,12 @@ def validate_audit(
     if failures:
         return {
             "status": "fail",
+            "warnings": warnings,
             "failures": failures,
         }
 
     lockfile = load_json(lockfile_path)
-    exceptions = load_exceptions(exceptions_path, failures)
+    exceptions = load_exceptions(exceptions_path, failures, warnings, today, warn_expiring_within_days)
     if audit_report_path is not None:
         audit_report = load_json(audit_report_path)
     else:
@@ -279,6 +321,7 @@ def validate_audit(
             failures.append(str(exc))
             return {
                 "status": "fail",
+                "warnings": warnings,
                 "failures": failures,
             }
 
@@ -344,6 +387,7 @@ def validate_audit(
         "unmatched_advisories": unmatched_advisories,
         "stale_exceptions": stale_exceptions,
         "metadata_vulnerabilities": vulnerability_counts,
+        "warnings": warnings,
         "failures": failures,
     }
 
@@ -357,16 +401,22 @@ def main() -> int:
     audit_report_path = resolve_path(repo_root, args.audit_report) if args.audit_report else None
 
     try:
+        today = parse_validation_date(args.today)
+        if args.warn_expiring_within_days < 0:
+            raise ValueError("--warn-expiring-within-days must be zero or greater")
         result = validate_audit(
             repo_root=repo_root,
             package_dir=package_dir,
             exceptions_path=exceptions_path,
             lockfile_path=lockfile_path,
             audit_report_path=audit_report_path,
+            today=today,
+            warn_expiring_within_days=args.warn_expiring_within_days,
         )
     except (OSError, json.JSONDecodeError, ValueError) as exc:
         result = {
             "status": "fail",
+            "warnings": [],
             "failures": [str(exc)],
         }
 
@@ -375,6 +425,8 @@ def main() -> int:
     else:
         if result["status"] == "pass":
             print("docs-site audit validation passed")
+            for warning in result.get("warnings", []):
+                print(f"warning: {warning}", file=sys.stderr)
         else:
             print("docs-site audit validation failed", file=sys.stderr)
             for failure in result.get("failures", []):

--- a/testinfra/hygiene/docs_site_audit_policy_test.go
+++ b/testinfra/hygiene/docs_site_audit_policy_test.go
@@ -5,9 +5,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
+
+const docsSiteAuditPolicyFixtureToday = "2026-06-15"
 
 func TestDocsSiteAuditPolicyAllowsCurrentModerateException(t *testing.T) {
 	t.Parallel()
@@ -23,6 +26,25 @@ func TestDocsSiteAuditPolicyAllowsCurrentModerateException(t *testing.T) {
 	}
 	if len(result.MatchedExceptions) != 1 {
 		t.Fatalf("expected 1 matched exception, got %d", len(result.MatchedExceptions))
+	}
+}
+
+func TestDocsSiteAuditPolicyWarnsBeforeExceptionExpiry(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := writeDocsSiteAuditFixtureRepo(t, fixtureRepoOptions{})
+	result := runDocsSiteAuditPolicyWithOptions(t, repoRoot, docsSiteAuditRunOptions{
+		WarnExpiringWithinDays: 20,
+	})
+
+	if result.Status != "pass" {
+		t.Fatalf("expected pass, failures=%v", result.Failures)
+	}
+	if len(result.Warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(result.Warnings), result.Warnings)
+	}
+	if !strings.Contains(result.Warnings[0], "expires on 2026-06-30") {
+		t.Fatalf("expected expiry warning, got %q", result.Warnings[0])
 	}
 }
 
@@ -112,9 +134,15 @@ func TestDocsSiteAuditPolicyAllowsEmptyExceptionsWhenAuditIsClean(t *testing.T) 
 
 type docsSiteAuditPolicyResult struct {
 	Status               string              `json:"status"`
+	Warnings             []string            `json:"warnings"`
 	Failures             []string            `json:"failures"`
 	ActionableAdvisories []map[string]string `json:"actionable_advisories"`
 	MatchedExceptions    []map[string]string `json:"matched_exceptions"`
+}
+
+type docsSiteAuditRunOptions struct {
+	Today                  string
+	WarnExpiringWithinDays int
 }
 
 type fixtureRepoOptions struct {
@@ -131,7 +159,17 @@ type fixtureRepoOptions struct {
 func runDocsSiteAuditPolicy(t *testing.T, repoRoot string) docsSiteAuditPolicyResult {
 	t.Helper()
 
-	stdout, stderr, err := runDocsSiteAuditPolicyRaw(t, repoRoot)
+	return runDocsSiteAuditPolicyWithOptions(t, repoRoot, docsSiteAuditRunOptions{})
+}
+
+func runDocsSiteAuditPolicyWithOptions(
+	t *testing.T,
+	repoRoot string,
+	opts docsSiteAuditRunOptions,
+) docsSiteAuditPolicyResult {
+	t.Helper()
+
+	stdout, stderr, err := runDocsSiteAuditPolicyRawWithOptions(t, repoRoot, opts)
 	if err != nil {
 		t.Fatalf("run docs-site audit policy: %v\nstderr=%s", err, stderr)
 	}
@@ -146,6 +184,16 @@ func runDocsSiteAuditPolicy(t *testing.T, repoRoot string) docsSiteAuditPolicyRe
 func runDocsSiteAuditPolicyRaw(t *testing.T, repoRoot string) (string, string, error) {
 	t.Helper()
 
+	return runDocsSiteAuditPolicyRawWithOptions(t, repoRoot, docsSiteAuditRunOptions{})
+}
+
+func runDocsSiteAuditPolicyRawWithOptions(
+	t *testing.T,
+	repoRoot string,
+	opts docsSiteAuditRunOptions,
+) (string, string, error) {
+	t.Helper()
+
 	pythonPath, err := exec.LookPath("python3")
 	if err != nil {
 		t.Skip("python3 not available in test environment")
@@ -155,15 +203,23 @@ func runDocsSiteAuditPolicyRaw(t *testing.T, repoRoot string) (string, string, e
 	auditPath := filepath.Join(repoRoot, "docs-site", "audit.json")
 	exceptionsPath := filepath.Join(repoRoot, "docs-site", "security-advisory-exceptions.json")
 	lockfilePath := filepath.Join(repoRoot, "docs-site", "package-lock.json")
-	cmd := exec.Command(
-		pythonPath,
+	today := opts.Today
+	if today == "" {
+		today = docsSiteAuditPolicyFixtureToday
+	}
+	args := []string{
 		scriptPath,
 		"--repo-root", repoRoot,
 		"--audit-report", auditPath,
 		"--exceptions", exceptionsPath,
 		"--lockfile", lockfilePath,
+		"--today", today,
 		"--json",
-	)
+	}
+	if opts.WarnExpiringWithinDays > 0 {
+		args = append(args, "--warn-expiring-within-days", strconv.Itoa(opts.WarnExpiringWithinDays))
+	}
+	cmd := exec.Command(pythonPath, args...)
 	output, err := cmd.CombinedOutput()
 	text := strings.TrimSpace(string(output))
 	if err != nil {


### PR DESCRIPTION
## Problem

The docs-site audit exception for `js-yaml` expired on 2026-06-30, which would make the gate fail closed even after upstream remediation. We also lacked an automated warning path to catch expiring exceptions before they become release blockers.

## Changes

- add deterministic `--today` and non-failing `--warn-expiring-within-days` support to `scripts/validate_docs_site_audit.py`
- add `scripts/prepare_docs_site_audit_issue.py` plus a weekly `docs-site-audit-watch` workflow to open or update a single GitHub issue for expiring exceptions
- remove the now-stale docs-site audit exception after the lockfile refresh clears the advisory, and document the new watch flow
- extend docs-site audit policy tests to cover warning behavior with fixed dates

## Validation

- `make prepush-full`
- `python3 scripts/validate_docs_site_audit.py --repo-root . --json`
- `python3 scripts/validate_docs_site_audit.py --repo-root . --json --warn-expiring-within-days 14`

## Risks

- the watch workflow reuses issues by title search, so a manually created open issue with the same title would be updated
- no submodule pointer changes
