### PR TITLE
fix: bump Go toolchain to 1.26.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang 1.26.4
+golang 1.26.5
 python 3.13.1
 nodejs 22.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Security
 
-- (none yet)
+- Raised the pinned Go toolchain to `1.26.5` to clear standard-library advisory `GO-2026-5856` in binary `govulncheck` CI lanes.
 
 ## Changelog maintenance process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Wrkr is a deterministic, offline-first OSS CLI for AI tooling discovery, risk sc
 
 ## Required Toolchain
 
-- Go `1.26.4`
+- Go `1.26.5`
 - Git
 - Make
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clyra-AI/wrkr
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/product/dev_guides.md
+++ b/product/dev_guides.md
@@ -141,7 +141,7 @@ For any roadmap item that changes onboarding, activation, or adoption behavior, 
 
 ### Go
 
-- **Version policy**: pin in `go.mod`; track latest stable within 2 minor releases. **Current pin: `1.26.4`** across all repos.
+- **Version policy**: pin in `go.mod`; track latest stable within 2 minor releases. **Current pin: `1.26.5`** across all repos.
 - **Security override**: if `govulncheck` identifies called standard-library vulnerabilities and the first complete fix lands in a newer minor Go release, move directly to the first fully fixed version across affected repos. Do not stop at an intermediate patch release that leaves called vulnerabilities unresolved.
 - **Module layout**: single module per repo, `cmd/<binary>/` for entry points, `core/` for library packages, `internal/` for non-exported packages.
 - **Build**: `go build ./cmd/<binary>`.
@@ -171,7 +171,7 @@ All Clyra AI Go projects (proof, gait, wrkr, axym) share a dependency graph root
 
 | Component | Version | Scope |
 |-----------|---------|-------|
-| Go | `1.26.4` | All repos — `go.mod` + `.tool-versions` + CI (`go-version-file: go.mod`) |
+| Go | `1.26.5` | All repos — `go.mod` + `.tool-versions` + CI (`go-version-file: go.mod`) |
 | `Clyra-AI/proof` | `>= v0.4.5` | All downstream SKUs (gait, wrkr, axym) — minimum import version |
 | Python | `3.13` | Scripts, SDKs — `pyproject.toml` + CI |
 | Node | `22` (LTS) | Docs sites only |

--- a/scripts/check_toolchain_pins.sh
+++ b/scripts/check_toolchain_pins.sh
@@ -223,7 +223,7 @@ fi
 resolve_pin_target_files
 
 expected=(
-  "golang 1.26.4"
+  "golang 1.26.5"
   "python 3.13.1"
   "nodejs 22.14.0"
 )
@@ -234,12 +234,12 @@ for line in "${expected[@]}"; do
   fi
 done
 
-if grep -Eq '^go 1\.26\.4$' go.mod; then
+if grep -Eq '^go 1\.26\.5$' go.mod; then
   :
-elif grep -Eq '^toolchain go1\.26\.4$' go.mod; then
+elif grep -Eq '^toolchain go1\.26\.5$' go.mod; then
   :
 else
-  echo "go.mod must pin go toolchain version 1.26.4 (toolchain or go directive)" >&2
+  echo "go.mod must pin go toolchain version 1.26.5 (toolchain or go directive)" >&2
   exit 3
 fi
 

--- a/testinfra/contracts/story0_contracts_test.go
+++ b/testinfra/contracts/story0_contracts_test.go
@@ -19,7 +19,7 @@ func TestToolchainPinsAreExact(t *testing.T) {
 		t.Fatalf("read .tool-versions: %v", err)
 	}
 	got := strings.Split(strings.TrimSpace(string(content)), "\n")
-	want := []string{"golang 1.26.4", "python 3.13.1", "nodejs 22.14.0"}
+	want := []string{"golang 1.26.5", "python 3.13.1", "nodejs 22.14.0"}
 	for _, line := range want {
 		if !containsLine(got, line) {
 			t.Fatalf("missing pinned version %q in .tool-versions", line)

--- a/testinfra/hygiene/toolchain_pins_test.go
+++ b/testinfra/hygiene/toolchain_pins_test.go
@@ -132,12 +132,12 @@ func writeToolchainPinFixture(t *testing.T, versions fixturePins) string {
 
 	root := t.TempDir()
 	mustWriteFile(t, filepath.Join(root, ".tool-versions"), strings.Join([]string{
-		"golang 1.26.4",
+		"golang 1.26.5",
 		"python 3.13.1",
 		"nodejs 22.14.0",
 		"",
 	}, "\n"))
-	mustWriteFile(t, filepath.Join(root, "go.mod"), "module fixture\n\ngo 1.26.4\n")
+	mustWriteFile(t, filepath.Join(root, "go.mod"), "module fixture\n\ngo 1.26.5\n")
 	mustWriteFile(t, filepath.Join(root, "Makefile"), "lint-fast:\n\t@echo ok\n")
 
 	mustWriteFile(t, filepath.Join(root, "product/dev_guides.md"), strings.Join([]string{


### PR DESCRIPTION
## Problem
- nightly Actions run `29002846942` failed in `risk-lane` on July 9, 2026
- the `Run vulnerability scan` step built Wrkr with Go `1.26.4`
- `govulncheck` flagged standard-library advisory `GO-2026-5856` in `crypto/tls`, fixed in Go `1.26.5`

## Changes
- bump the repo Go pin from `1.26.4` to `1.26.5` in `go.mod` and `.tool-versions`
- align toolchain policy docs and contributor docs with the new pin
- update toolchain pin enforcement and contract tests
- record the security fix in the unreleased changelog

## Validation
- `make prepush-full`
- `govulncheck -mode=binary .tmp/wrkr` via `go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 -mode=binary .tmp/wrkr`

## Risks
- low risk and repo-wide: this is a patch-level Go toolchain bump with matching contract and docs updates
- no workflow semantics changed beyond using the fixed Go patch version already sourced from `go.mod`
