### PR TITLE
fix: protect proof state and GitHub transport

### DIFF
--- a/core/cli/action.go
+++ b/core/cli/action.go
@@ -11,6 +11,7 @@ import (
 
 	coreaction "github.com/Clyra-AI/wrkr/core/action"
 	"github.com/Clyra-AI/wrkr/core/github/pr"
+	"github.com/Clyra-AI/wrkr/internal/githubendpoint"
 )
 
 const (
@@ -142,6 +143,9 @@ func runActionPRComment(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 	if token == "" {
 		return emitError(stderr, jsonRequested || *jsonOut, "dependency_missing", "github token is required for PR comment publishing", exitDependencyMissing)
+	}
+	if _, err := githubendpoint.Parse(strings.TrimSpace(*githubBaseURL), githubendpoint.Options{}); err != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
 	}
 
 	client := pr.NewGitHubClient(strings.TrimSpace(*githubBaseURL), token, nil)

--- a/core/cli/action.go
+++ b/core/cli/action.go
@@ -144,11 +144,13 @@ func runActionPRComment(args []string, stdout io.Writer, stderr io.Writer) int {
 	if token == "" {
 		return emitError(stderr, jsonRequested || *jsonOut, "dependency_missing", "github token is required for PR comment publishing", exitDependencyMissing)
 	}
-	if _, err := githubendpoint.Parse(strings.TrimSpace(*githubBaseURL), githubendpoint.Options{}); err != nil {
-		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
+	if strings.TrimSpace(*githubBaseURL) != "" {
+		if _, err := githubendpoint.Parse(strings.TrimSpace(*githubBaseURL), githubEndpointOptions()); err != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
+		}
 	}
 
-	client := pr.NewGitHubClient(strings.TrimSpace(*githubBaseURL), token, nil)
+	client := pr.NewGitHubClientWithOptions(strings.TrimSpace(*githubBaseURL), token, nil, pr.GitHubClientOptions{AllowInsecureLoopback: githubEndpointOptions().AllowInsecureLoopback})
 	commentResult, err := pr.UpsertIssueComment(context.Background(), client, pr.UpsertIssueCommentInput{
 		Owner:       strings.TrimSpace(*owner),
 		Repo:        strings.TrimSpace(*repo),

--- a/core/cli/fix.go
+++ b/core/cli/fix.go
@@ -18,6 +18,7 @@ import (
 	githubpr "github.com/Clyra-AI/wrkr/core/github/pr"
 	"github.com/Clyra-AI/wrkr/core/risk"
 	"github.com/Clyra-AI/wrkr/core/state"
+	"github.com/Clyra-AI/wrkr/internal/githubendpoint"
 )
 
 var newGitHubPRClient = func(baseURL, token string) githubpr.API {
@@ -106,6 +107,9 @@ func runFix(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	if *openPR {
+		if _, endpointErr := githubendpoint.Parse(*githubAPI, githubendpoint.Options{}); endpointErr != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", endpointErr.Error(), exitInvalidInput)
+		}
 		publicationPlan := plan
 		if *applyMode {
 			publicationPlan = fix.ApplyCapablePlan(plan)

--- a/core/cli/fix.go
+++ b/core/cli/fix.go
@@ -22,7 +22,7 @@ import (
 )
 
 var newGitHubPRClient = func(baseURL, token string) githubpr.API {
-	return githubpr.NewGitHubClient(baseURL, token, nil)
+	return githubpr.NewGitHubClientWithOptions(baseURL, token, nil, githubpr.GitHubClientOptions{AllowInsecureLoopback: githubEndpointOptions().AllowInsecureLoopback})
 }
 
 const (
@@ -107,9 +107,6 @@ func runFix(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	if *openPR {
-		if _, endpointErr := githubendpoint.Parse(*githubAPI, githubendpoint.Options{}); endpointErr != nil {
-			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", endpointErr.Error(), exitInvalidInput)
-		}
 		publicationPlan := plan
 		if *applyMode {
 			publicationPlan = fix.ApplyCapablePlan(plan)
@@ -136,6 +133,11 @@ func runFix(args []string, stdout io.Writer, stderr io.Writer) int {
 		token, tokenErr := auth.ResolveFixToken(cfg.Auth.Scan.Token, cfg.Auth.Fix.Token, *fixToken)
 		if tokenErr != nil {
 			return emitError(stderr, jsonRequested || *jsonOut, "approval_required", tokenErr.Error(), exitApprovalRequired)
+		}
+		if strings.TrimSpace(*githubAPI) != "" {
+			if _, endpointErr := githubendpoint.Parse(*githubAPI, githubEndpointOptions()); endpointErr != nil {
+				return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", endpointErr.Error(), exitInvalidInput)
+			}
 		}
 
 		title := strings.TrimSpace(*prTitle)

--- a/core/cli/github_endpoint_policy.go
+++ b/core/cli/github_endpoint_policy.go
@@ -15,5 +15,6 @@ func githubEndpointOptions() githubendpoint.Options {
 }
 
 func isDevelopmentTestProcess() bool {
-	return strings.HasSuffix(filepath.Base(os.Args[0]), ".test")
+	name := strings.ToLower(filepath.Base(os.Args[0]))
+	return strings.HasSuffix(name, ".test") || strings.HasSuffix(name, ".test.exe")
 }

--- a/core/cli/github_endpoint_policy.go
+++ b/core/cli/github_endpoint_policy.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Clyra-AI/wrkr/internal/githubendpoint"
+)
+
+const insecureLoopbackGitHubEnv = "WRKR_ALLOW_INSECURE_LOOPBACK_GITHUB"
+
+func githubEndpointOptions() githubendpoint.Options {
+	return githubendpoint.Options{AllowInsecureLoopback: isDevelopmentTestProcess() || strings.TrimSpace(os.Getenv(insecureLoopbackGitHubEnv)) == "1"}
+}
+
+func isDevelopmentTestProcess() bool {
+	return strings.HasSuffix(filepath.Base(os.Args[0]), ".test")
+}

--- a/core/cli/identity.go
+++ b/core/cli/identity.go
@@ -222,6 +222,7 @@ func runIdentityManualTransition(stateName, agentID, approver, scope, reason str
 	if err != nil {
 		return emitStateMutationError(stderr, jsonOut, err)
 	}
+	defer func() { _ = ctx.releaseLease() }()
 	now := time.Now().UTC().Truncate(time.Second)
 	nextManifest, transition, transitionErr := lifecycle.ApplyManualState(ctx.manifest, agentID, stateName, approver, scope, reason, expiresAt, now)
 	if transitionErr != nil {

--- a/core/cli/inventory_mutations.go
+++ b/core/cli/inventory_mutations.go
@@ -97,6 +97,7 @@ func runInventoryMutation(action string, args []string, stdout io.Writer, stderr
 	if err != nil {
 		return emitStateMutationError(stderr, jsonRequested || *jsonOut, err)
 	}
+	defer func() { _ = ctx.releaseLease() }()
 
 	agentID, resolveErr := resolveInventoryMutationAgentID(id, ctx.manifest, ctx.snapshot)
 	if resolveErr != nil {

--- a/core/cli/managed_artifacts.go
+++ b/core/cli/managed_artifacts.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,6 +18,7 @@ import (
 	"github.com/Clyra-AI/wrkr/core/state"
 	verifycore "github.com/Clyra-AI/wrkr/core/verify"
 	"github.com/Clyra-AI/wrkr/internal/atomicwrite"
+	"github.com/Clyra-AI/wrkr/internal/statelock"
 )
 
 const (
@@ -46,6 +48,7 @@ type managedArtifactFile struct {
 type managedArtifactTransaction struct {
 	journalPath string
 	snapshots   []managedArtifactSnapshot
+	lease       *statelock.Lease
 	completed   bool
 }
 
@@ -151,6 +154,27 @@ func recoverManagedArtifactTransaction(statePath string) error {
 }
 
 func beginManagedArtifactTransaction(statePath string, operation string, files []managedArtifactFile) (*managedArtifactTransaction, error) {
+	lease, err := statelock.Acquire(context.Background(), statePath)
+	if err != nil {
+		return nil, err
+	}
+	tx, err := beginManagedArtifactTransactionWithLease(statePath, operation, files, lease)
+	if err != nil {
+		if releaseErr := lease.Release(); releaseErr != nil {
+			return nil, fmt.Errorf("%v (release managed artifact lock: %v)", err, releaseErr)
+		}
+		return nil, err
+	}
+	tx.lease = lease
+	return tx, nil
+}
+
+// beginManagedArtifactTransactionWithLease starts a transaction while the caller
+// holds the state-directory lease for the complete operation.
+func beginManagedArtifactTransactionWithLease(statePath string, operation string, files []managedArtifactFile, lease *statelock.Lease) (*managedArtifactTransaction, error) {
+	if lease == nil {
+		return nil, fmt.Errorf("managed artifact transaction requires a state lease")
+	}
 	if err := recoverManagedArtifactTransaction(statePath); err != nil {
 		return nil, err
 	}
@@ -198,15 +222,28 @@ func (tx *managedArtifactTransaction) Rollback(actionErr error) error {
 		removeErr = nil
 	}
 	tx.completed = true
+	releaseErr := tx.releaseLease()
 
+	if restoreErr != nil && removeErr != nil && releaseErr != nil {
+		return fmt.Errorf("%v (rollback restore failed: %v; transaction cleanup failed: %v; lock release failed: %v)", actionErr, restoreErr, removeErr, releaseErr)
+	}
 	if restoreErr != nil && removeErr != nil {
 		return fmt.Errorf("%v (rollback restore failed: %v; transaction cleanup failed: %v)", actionErr, restoreErr, removeErr)
+	}
+	if restoreErr != nil && releaseErr != nil {
+		return fmt.Errorf("%v (rollback restore failed: %v; lock release failed: %v)", actionErr, restoreErr, releaseErr)
 	}
 	if restoreErr != nil {
 		return fmt.Errorf("%v (rollback restore failed: %v)", actionErr, restoreErr)
 	}
+	if removeErr != nil && releaseErr != nil {
+		return fmt.Errorf("%v (transaction cleanup failed: %v; lock release failed: %v)", actionErr, removeErr, releaseErr)
+	}
 	if removeErr != nil {
 		return fmt.Errorf("%v (transaction cleanup failed: %v)", actionErr, removeErr)
+	}
+	if releaseErr != nil {
+		return fmt.Errorf("%v (lock release failed: %v)", actionErr, releaseErr)
 	}
 	return actionErr
 }
@@ -219,7 +256,16 @@ func (tx *managedArtifactTransaction) Complete() error {
 		return fmt.Errorf("remove managed artifact transaction: %w", err)
 	}
 	tx.completed = true
-	return nil
+	return tx.releaseLease()
+}
+
+func (tx *managedArtifactTransaction) releaseLease() error {
+	if tx == nil || tx.lease == nil {
+		return nil
+	}
+	lease := tx.lease
+	tx.lease = nil
+	return lease.Release()
 }
 
 func managedArtifactTransactionPath(statePath string) string {

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -44,6 +44,8 @@ import (
 	sourceorg "github.com/Clyra-AI/wrkr/core/source/org"
 	"github.com/Clyra-AI/wrkr/core/sourceprivacy"
 	"github.com/Clyra-AI/wrkr/core/state"
+	"github.com/Clyra-AI/wrkr/internal/githubendpoint"
+	"github.com/Clyra-AI/wrkr/internal/statelock"
 )
 
 func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writer, stderr io.Writer) int {
@@ -190,6 +192,11 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 			exitDependencyMissing,
 		)
 	}
+	if strings.TrimSpace(*githubBaseURL) != "" {
+		if _, err := githubendpoint.Parse(*githubBaseURL, githubendpoint.Options{}); err != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
+		}
+	}
 	artifactPreflight, preflightErr := preflightScanArtifacts(
 		state.ResolvePath(*statePathFlag),
 		*jsonPath,
@@ -211,6 +218,17 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", jsonSinkErr.Error(), exitInvalidInput)
 	}
 	statePath := artifactPreflight.StatePath
+	ctx := parentCtx
+	cancel := func() {}
+	if *timeout > 0 {
+		ctx, cancel = context.WithTimeout(parentCtx, *timeout)
+	}
+	defer cancel()
+	lease, leaseErr := statelock.Acquire(ctx, statePath)
+	if leaseErr != nil {
+		return emitScanRuntimeError(stderr, jsonRequested || *jsonOut, leaseErr)
+	}
+	defer func() { _ = lease.Release() }()
 	if recoveryErr := recoverManagedArtifactTransaction(statePath); recoveryErr != nil {
 		return emitScanRuntimeError(stderr, jsonRequested || *jsonOut, recoveryErr)
 	}
@@ -229,12 +247,6 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	sourcePrivacy := sourceprivacy.InitialContract(sourceRetentionMode, materializedRoot != "", allowHostedSourceMaterialization, deploymentMode)
 	sourceCleanupFinalized := false
 
-	ctx := parentCtx
-	cancel := func() {}
-	if *timeout > 0 {
-		ctx, cancel = context.WithTimeout(parentCtx, *timeout)
-	}
-	defer cancel()
 	scanStartedAt := time.Now().UTC().Truncate(time.Second)
 	progressTargetMode, progressTargetValue := scanProgressTargetLabel(targets)
 	artifactPaths := map[string]string{
@@ -642,7 +654,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	}
 	chainPath := artifactPreflight.LifecyclePath
 	proofChainPath := artifactPreflight.ProofChainPath
-	transaction, snapshotErr := beginManagedArtifactTransaction(statePath, "scan", []managedArtifactFile{
+	transaction, snapshotErr := beginManagedArtifactTransactionWithLease(statePath, "scan", []managedArtifactFile{
 		{label: "state", path: statePath},
 		{label: "manifest", path: manifestPath},
 		{label: "lifecycle chain", path: chainPath},
@@ -652,7 +664,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		{label: "report markdown", path: artifactPreflight.ReportPath},
 		{label: "sarif", path: artifactPreflight.SARIFPath},
 		{label: "json output", path: jsonSink.outputPath},
-	})
+	}, lease)
 	if snapshotErr != nil {
 		return emitScanFailure(snapshotErr)
 	}

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -193,7 +193,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		)
 	}
 	if strings.TrimSpace(*githubBaseURL) != "" {
-		if _, err := githubendpoint.Parse(*githubBaseURL, githubendpoint.Options{}); err != nil {
+		if _, err := githubendpoint.Parse(*githubBaseURL, githubEndpointOptions()); err != nil {
 			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
 		}
 	}

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -192,7 +192,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 			exitDependencyMissing,
 		)
 	}
-	if strings.TrimSpace(*githubBaseURL) != "" {
+	if (anyTargetNeedsGitHub(targets) || *enrich) && strings.TrimSpace(*githubBaseURL) != "" {
 		if _, err := githubendpoint.Parse(*githubBaseURL, githubEndpointOptions()); err != nil {
 			return emitError(stderr, jsonRequested || *jsonOut, "invalid_input", err.Error(), exitInvalidInput)
 		}

--- a/core/cli/scan_helpers.go
+++ b/core/cli/scan_helpers.go
@@ -200,7 +200,7 @@ func acquireSources(ctx context.Context, targets []config.Target, githubBaseURL,
 		return source.Manifest{}, nil, fmt.Errorf("at least one scan target is required")
 	}
 
-	connector := github.NewConnector(githubBaseURL, githubToken, nil)
+	connector := github.NewConnectorWithOptions(githubBaseURL, githubToken, nil, github.ConnectorOptions{AllowInsecureLoopback: githubEndpointOptions().AllowInsecureLoopback})
 	connector.SetAllowSourceMaterialization(opts.AllowSourceMaterialization)
 	manifestOut := source.Manifest{
 		Target:           manifestTargetFromTargets(targets),

--- a/core/cli/scan_process_lock_test.go
+++ b/core/cli/scan_process_lock_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/Clyra-AI/wrkr/core/proofemit"
+	verifycore "github.com/Clyra-AI/wrkr/core/verify"
+)
+
+const (
+	scanProcessHelperEnv = "WRKR_SCAN_PROCESS_HELPER"
+	scanProcessRootEnv   = "WRKR_SCAN_PROCESS_ROOT"
+	scanProcessStateEnv  = "WRKR_SCAN_PROCESS_STATE"
+)
+
+func TestScanProcessHelper(t *testing.T) {
+	if os.Getenv(scanProcessHelperEnv) != "1" {
+		return
+	}
+	os.Exit(Run([]string{
+		"scan",
+		"--path", os.Getenv(scanProcessRootEnv),
+		"--state", os.Getenv(scanProcessStateEnv),
+		"--quiet",
+	}, os.Stdout, os.Stderr))
+}
+
+func TestConcurrentScanProcessesPreserveCompleteProofChain(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", "scenarios", "wrkr", "scan-mixed-org", "repos"))
+	if err != nil {
+		t.Fatalf("resolve fixture path: %v", err)
+	}
+
+	sequentialState := filepath.Join(t.TempDir(), "sequential", "state.json")
+	runScanProcess(t, repoRoot, sequentialState)
+	runScanProcess(t, repoRoot, sequentialState)
+	sequentialCount := proofChainRecordCount(t, sequentialState)
+
+	concurrentState := filepath.Join(t.TempDir(), "concurrent", "state.json")
+	first := scanProcessCommand(t, repoRoot, concurrentState)
+	second := scanProcessCommand(t, repoRoot, concurrentState)
+	if err := first.Start(); err != nil {
+		t.Fatalf("start first scan: %v", err)
+	}
+	if err := second.Start(); err != nil {
+		t.Fatalf("start second scan: %v", err)
+	}
+	if err := first.Wait(); err != nil {
+		t.Fatalf("first scan failed: %v\nstderr=%s", err, first.Stderr.(*bytes.Buffer).String())
+	}
+	if err := second.Wait(); err != nil {
+		t.Fatalf("second scan failed: %v\nstderr=%s", err, second.Stderr.(*bytes.Buffer).String())
+	}
+	concurrentCount := proofChainRecordCount(t, concurrentState)
+	if concurrentCount != sequentialCount {
+		t.Fatalf("concurrent proof records = %d, sequential proof records = %d", concurrentCount, sequentialCount)
+	}
+}
+
+func runScanProcess(t *testing.T, repoRoot, statePath string) {
+	t.Helper()
+	command := scanProcessCommand(t, repoRoot, statePath)
+	if err := command.Run(); err != nil {
+		t.Fatalf("scan process failed: %v\nstderr=%s", err, command.Stderr.(*bytes.Buffer).String())
+	}
+}
+
+func scanProcessCommand(t *testing.T, repoRoot, statePath string) *exec.Cmd {
+	t.Helper()
+	command := exec.Command(os.Args[0], "-test.run=^TestScanProcessHelper$") // #nosec G204 -- runs the current test binary with fixed arguments.
+	command.Env = append(os.Environ(),
+		scanProcessHelperEnv+"=1",
+		scanProcessRootEnv+"="+repoRoot,
+		scanProcessStateEnv+"="+statePath,
+	)
+	command.Stdout = &bytes.Buffer{}
+	command.Stderr = &bytes.Buffer{}
+	return command
+}
+
+func proofChainRecordCount(t *testing.T, statePath string) int {
+	t.Helper()
+	chainPath := proofemit.ChainPath(statePath)
+	chain, err := proofemit.LoadChain(chainPath)
+	if err != nil {
+		t.Fatalf("load proof chain: %v", err)
+	}
+	result, err := verifycore.Chain(chainPath)
+	if err != nil {
+		t.Fatalf("verify proof chain: %v", err)
+	}
+	if !result.Intact {
+		t.Fatalf("proof chain is not intact: %+v", result)
+	}
+	return len(chain.Records)
+}

--- a/core/cli/state_mutation.go
+++ b/core/cli/state_mutation.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -41,7 +42,7 @@ func loadStateMutationContext(statePathRaw string) (stateMutationContext, error)
 		}
 		return stateMutationContext{}, unsafeManagedArtifactPathError{err: err}
 	}
-	lease, err := statelock.Acquire(nil, preflight.statePath)
+	lease, err := statelock.Acquire(context.Background(), preflight.statePath)
 	if err != nil {
 		return stateMutationContext{}, err
 	}

--- a/core/cli/state_mutation.go
+++ b/core/cli/state_mutation.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -21,6 +22,7 @@ import (
 	"github.com/Clyra-AI/wrkr/core/score"
 	scoremodel "github.com/Clyra-AI/wrkr/core/score/model"
 	"github.com/Clyra-AI/wrkr/core/state"
+	"github.com/Clyra-AI/wrkr/internal/statelock"
 )
 
 type stateMutationContext struct {
@@ -28,6 +30,7 @@ type stateMutationContext struct {
 	snapshot       state.Snapshot
 	manifest       manifest.Manifest
 	lifecycleChain *proof.Chain
+	lease          *statelock.Lease
 }
 
 func loadStateMutationContext(statePathRaw string) (stateMutationContext, error) {
@@ -38,31 +41,51 @@ func loadStateMutationContext(statePathRaw string) (stateMutationContext, error)
 		}
 		return stateMutationContext{}, unsafeManagedArtifactPathError{err: err}
 	}
-	if err := preflightManagedArtifactRead(preflight.statePath); err != nil {
+	lease, err := statelock.Acquire(nil, preflight.statePath)
+	if err != nil {
 		return stateMutationContext{}, err
+	}
+	releaseOnError := func(err error) (stateMutationContext, error) {
+		if releaseErr := lease.Release(); releaseErr != nil {
+			return stateMutationContext{}, fmt.Errorf("%v (release managed artifact lock: %v)", err, releaseErr)
+		}
+		return stateMutationContext{}, err
+	}
+	if err := preflightManagedArtifactRead(preflight.statePath); err != nil {
+		return releaseOnError(err)
 	}
 	snapshot, err := state.Load(preflight.statePath)
 	if err != nil {
-		return stateMutationContext{}, err
+		return releaseOnError(err)
 	}
 	loadedManifest, err := manifest.Load(preflight.manifestPath)
 	if err != nil {
-		return stateMutationContext{}, err
+		return releaseOnError(err)
 	}
 	loadedManifest.Identities = model.FilterLegacyArtifactIdentityRecords(loadedManifest.Identities)
 	lifecycleChain, err := lifecycle.LoadChain(preflight.lifecyclePath)
 	if err != nil {
-		return stateMutationContext{}, err
+		return releaseOnError(err)
 	}
 	if _, err := proofemit.LoadChain(preflight.proofChainPath); err != nil {
-		return stateMutationContext{}, err
+		return releaseOnError(err)
 	}
 	return stateMutationContext{
 		preflight:      preflight,
 		snapshot:       snapshot,
 		manifest:       loadedManifest,
 		lifecycleChain: lifecycleChain,
+		lease:          lease,
 	}, nil
+}
+
+func (ctx *stateMutationContext) releaseLease() error {
+	if ctx == nil || ctx.lease == nil {
+		return nil
+	}
+	lease := ctx.lease
+	ctx.lease = nil
+	return lease.Release()
 }
 
 func applyStateMutationToSnapshot(snapshot *state.Snapshot, nextManifest manifest.Manifest, transition lifecycle.Transition) error {
@@ -152,14 +175,14 @@ func refreshDerivedMutationSnapshot(snapshot *state.Snapshot) error {
 }
 
 func commitStateMutationContext(ctx stateMutationContext, transition lifecycle.Transition, eventType string) error {
-	transaction, err := beginManagedArtifactTransaction(ctx.preflight.statePath, "state_mutation", []managedArtifactFile{
+	transaction, err := beginManagedArtifactTransactionWithLease(ctx.preflight.statePath, "state_mutation", []managedArtifactFile{
 		{label: "state", path: ctx.preflight.statePath},
 		{label: "manifest", path: ctx.preflight.manifestPath},
 		{label: "lifecycle chain", path: ctx.preflight.lifecyclePath},
 		{label: "proof chain", path: ctx.preflight.proofChainPath},
 		{label: "proof attestation", path: ctx.preflight.proofAttestationPath},
 		{label: "proof signing key", path: ctx.preflight.signingKeyPath},
-	})
+	}, ctx.lease)
 	if err != nil {
 		return unsafeManagedArtifactPathError{err: err}
 	}

--- a/core/cli/verify.go
+++ b/core/cli/verify.go
@@ -44,12 +44,13 @@ func runVerify(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	chainPath, keyLookupPath := resolveVerifyPaths(*statePathFlag, *chainPathFlag)
-	lease, leaseErr := statelock.Acquire(context.Background(), keyLookupPath)
-	if leaseErr != nil {
-		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", leaseErr.Error(), exitRuntime)
-	}
-	defer func() { _ = lease.Release() }()
-	if strings.TrimSpace(*chainPathFlag) == "" || strings.TrimSpace(*statePathFlag) != "" {
+	usesManagedState := strings.TrimSpace(*chainPathFlag) == "" || strings.TrimSpace(*statePathFlag) != ""
+	if usesManagedState {
+		lease, leaseErr := statelock.Acquire(context.Background(), keyLookupPath)
+		if leaseErr != nil {
+			return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", leaseErr.Error(), exitRuntime)
+		}
+		defer func() { _ = lease.Release() }()
 		if err := recoverManagedArtifactTransaction(keyLookupPath); err != nil {
 			return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)
 		}

--- a/core/cli/verify.go
+++ b/core/cli/verify.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Clyra-AI/wrkr/core/proofemit"
 	"github.com/Clyra-AI/wrkr/core/state"
 	verifycore "github.com/Clyra-AI/wrkr/core/verify"
+	"github.com/Clyra-AI/wrkr/internal/statelock"
 )
 
 func runVerify(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -42,6 +43,11 @@ func runVerify(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	chainPath, keyLookupPath := resolveVerifyPaths(*statePathFlag, *chainPathFlag)
+	lease, leaseErr := statelock.Acquire(nil, keyLookupPath)
+	if leaseErr != nil {
+		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", leaseErr.Error(), exitRuntime)
+	}
+	defer func() { _ = lease.Release() }()
 	if strings.TrimSpace(*chainPathFlag) == "" || strings.TrimSpace(*statePathFlag) != "" {
 		if err := recoverManagedArtifactTransaction(keyLookupPath); err != nil {
 			return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", err.Error(), exitRuntime)

--- a/core/cli/verify.go
+++ b/core/cli/verify.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -43,7 +44,7 @@ func runVerify(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	chainPath, keyLookupPath := resolveVerifyPaths(*statePathFlag, *chainPathFlag)
-	lease, leaseErr := statelock.Acquire(nil, keyLookupPath)
+	lease, leaseErr := statelock.Acquire(context.Background(), keyLookupPath)
 	if leaseErr != nil {
 		return emitError(stderr, jsonRequested || *jsonOut, "runtime_failure", leaseErr.Error(), exitRuntime)
 	}

--- a/core/github/pr/github_client.go
+++ b/core/github/pr/github_client.go
@@ -13,6 +13,8 @@ import (
 	"path"
 	"strconv"
 	"strings"
+
+	"github.com/Clyra-AI/wrkr/internal/githubendpoint"
 )
 
 const (
@@ -24,6 +26,12 @@ type GitHubClient struct {
 	baseURL string
 	token   string
 	http    *http.Client
+	options githubendpoint.Options
+}
+
+// GitHubClientOptions controls explicit development-only client behavior.
+type GitHubClientOptions struct {
+	AllowInsecureLoopback bool
 }
 
 type httpStatusError struct {
@@ -38,18 +46,35 @@ func (e *httpStatusError) Error() string {
 }
 
 func NewGitHubClient(baseURL, token string, client *http.Client) *GitHubClient {
+	return NewGitHubClientWithOptions(baseURL, token, client, GitHubClientOptions{})
+}
+
+// NewGitHubClientWithOptions permits loopback HTTP only when explicitly
+// requested for local development or tests. Production callers must use NewGitHubClient.
+func NewGitHubClientWithOptions(baseURL, token string, client *http.Client, options GitHubClientOptions) *GitHubClient {
 	trimmedBase := strings.TrimSpace(baseURL)
 	if trimmedBase == "" {
 		trimmedBase = defaultGitHubAPI
 	}
-	if client == nil {
-		client = http.DefaultClient
-	}
+	endpointOptions := githubendpoint.Options{AllowInsecureLoopback: options.AllowInsecureLoopback}
+	client = newSafeHTTPClient(trimmedBase, endpointOptions, client)
 	return &GitHubClient{
 		baseURL: strings.TrimRight(trimmedBase, "/"),
 		token:   strings.TrimSpace(token),
 		http:    client,
+		options: endpointOptions,
 	}
+}
+
+func newSafeHTTPClient(baseURL string, options githubendpoint.Options, source *http.Client) *http.Client {
+	client := *http.DefaultClient
+	if source != nil {
+		client = *source
+	}
+	if endpoint, err := githubendpoint.Parse(baseURL, options); err == nil {
+		client.CheckRedirect = githubendpoint.RedirectPolicy(endpoint)
+	}
+	return &client
 }
 
 func (c *GitHubClient) ListOpenByHead(ctx context.Context, owner, repo, headBranch, baseBranch string) ([]PullRequest, error) {
@@ -394,9 +419,9 @@ func shouldRetry(statusCode int) bool {
 }
 
 func (c *GitHubClient) repoURL(owner, repo string, parts ...string) (*url.URL, error) {
-	base, err := url.Parse(c.baseURL)
+	base, err := githubendpoint.Parse(c.baseURL, c.options)
 	if err != nil {
-		return nil, fmt.Errorf("parse github base url: %w", err)
+		return nil, err
 	}
 	segments := []string{"repos", owner, repo}
 	segments = append(segments, parts...)

--- a/core/github/pr/github_client_test.go
+++ b/core/github/pr/github_client_test.go
@@ -4,13 +4,38 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	"github.com/Clyra-AI/wrkr/internal/githubendpoint"
 )
+
+func TestGitHubClientRejectsInsecureEndpointBeforeSendingToken(t *testing.T) {
+	t.Parallel()
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("authorization = %q, want no credential delivery", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient(server.URL, "secret-token", server.Client())
+	_, err := client.ListOpenByHead(context.Background(), "acme", "repo", "branch", "main")
+	if !errors.Is(err, githubendpoint.ErrUnsafeEndpoint) {
+		t.Fatalf("ListOpenByHead() error = %v, want unsafe endpoint", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
 
 func TestGitHubClientListCreateUpdateWithRetry(t *testing.T) {
 	t.Parallel()
@@ -43,7 +68,7 @@ func TestGitHubClientListCreateUpdateWithRetry(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewGitHubClient(server.URL, "token", server.Client())
+	client := NewGitHubClientWithOptions(server.URL, "token", server.Client(), GitHubClientOptions{AllowInsecureLoopback: true})
 
 	list, err := client.ListOpenByHead(context.Background(), "acme", "repo", "wrkr-bot/remediation/repo/adhoc/abc", "main")
 	if err != nil {
@@ -86,7 +111,7 @@ func TestGitHubClientRepoURLPreservesBasePathPrefix(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewGitHubClient(server.URL+"/api/v3", "token", server.Client())
+	client := NewGitHubClientWithOptions(server.URL+"/api/v3", "token", server.Client(), GitHubClientOptions{AllowInsecureLoopback: true})
 	if _, err := client.ListOpenByHead(context.Background(), "acme", "repo", "branch", "main"); err != nil {
 		t.Fatalf("list prs: %v", err)
 	}
@@ -116,7 +141,7 @@ func TestGitHubClientEnsureHeadRefCreatesMissingBranchFromBase(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewGitHubClient(server.URL, "token", server.Client())
+	client := NewGitHubClientWithOptions(server.URL, "token", server.Client(), GitHubClientOptions{AllowInsecureLoopback: true})
 	if err := client.EnsureHeadRef(context.Background(), "acme", "repo", "wrkr-bot/remediation/repo/weekly/abc", "main"); err != nil {
 		t.Fatalf("ensure head ref: %v", err)
 	}
@@ -184,7 +209,7 @@ func TestGitHubClientEnsureFileContentCreateUpdateAndNoop(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewGitHubClient(server.URL, "token", server.Client())
+	client := NewGitHubClientWithOptions(server.URL, "token", server.Client(), GitHubClientOptions{AllowInsecureLoopback: true})
 	path := ".wrkr/remediations/abc123/plan.json"
 
 	changed, err := client.EnsureFileContent(context.Background(), "acme", "repo", "main", path, "update remediation plan", []byte("{\"v\":1}\n"))
@@ -234,7 +259,7 @@ func TestGitHubClientEnsureFileContentNormalizesWindowsSeparators(t *testing.T) 
 	}))
 	defer server.Close()
 
-	client := NewGitHubClient(server.URL, "token", server.Client())
+	client := NewGitHubClientWithOptions(server.URL, "token", server.Client(), GitHubClientOptions{AllowInsecureLoopback: true})
 	_, err := client.EnsureFileContent(
 		context.Background(),
 		"acme",
@@ -296,7 +321,7 @@ func TestGitHubClientIssueCommentCRUD(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewGitHubClient(server.URL, "token", server.Client())
+	client := NewGitHubClientWithOptions(server.URL, "token", server.Client(), GitHubClientOptions{AllowInsecureLoopback: true})
 	created, err := client.CreateIssueComment(context.Background(), "acme", "repo", 12, "first comment")
 	if err != nil {
 		t.Fatalf("create issue comment: %v", err)
@@ -354,7 +379,7 @@ func TestGitHubClientListIssueCommentsPaginates(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewGitHubClient(server.URL, "token", server.Client())
+	client := NewGitHubClientWithOptions(server.URL, "token", server.Client(), GitHubClientOptions{AllowInsecureLoopback: true})
 	listed, err := client.ListIssueComments(context.Background(), "acme", "repo", 12)
 	if err != nil {
 		t.Fatalf("list issue comments: %v", err)

--- a/core/source/github/connector.go
+++ b/core/source/github/connector.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/Clyra-AI/wrkr/core/source"
+	"github.com/Clyra-AI/wrkr/internal/githubendpoint"
 	"github.com/Clyra-AI/wrkr/internal/reponame"
 )
 
@@ -40,6 +41,7 @@ type Connector struct {
 	// AllowSourceMaterialization permits broad source-code extension fetching for
 	// explicit deep/debug scans. Default hosted scans keep this false.
 	AllowSourceMaterialization bool
+	endpointOptions            githubendpoint.Options
 
 	mu                  sync.Mutex
 	consecutiveFailures int
@@ -49,6 +51,11 @@ type Connector struct {
 	onRetry             func(RetryEvent)
 	onCooldown          func(CooldownEvent)
 	cooldownErr         error
+}
+
+// ConnectorOptions controls explicit development-only connector behavior.
+type ConnectorOptions struct {
+	AllowInsecureLoopback bool
 }
 
 type RetryEvent struct {
@@ -63,8 +70,17 @@ type CooldownEvent struct {
 }
 
 func NewConnector(baseURL, token string, client HTTPClient) *Connector {
-	if client == nil {
-		client = &http.Client{Timeout: 10 * time.Second}
+	return NewConnectorWithOptions(baseURL, token, client, ConnectorOptions{})
+}
+
+// NewConnectorWithOptions permits loopback HTTP only when explicitly requested
+// for local development or tests. Production callers must use NewConnector.
+func NewConnectorWithOptions(baseURL, token string, client HTTPClient, options ConnectorOptions) *Connector {
+	endpointOptions := githubendpoint.Options{AllowInsecureLoopback: options.AllowInsecureLoopback}
+	if configured, ok := client.(*http.Client); ok {
+		client = newSafeHTTPClient(baseURL, endpointOptions, configured)
+	} else if client == nil {
+		client = newSafeHTTPClient(baseURL, endpointOptions, nil)
 	}
 	return &Connector{
 		BaseURL:          strings.TrimRight(baseURL, "/"),
@@ -75,9 +91,29 @@ func NewConnector(baseURL, token string, client HTTPClient) *Connector {
 		MaxBackoff:       2 * time.Second,
 		FailureThreshold: 3,
 		Cooldown:         10 * time.Second,
+		endpointOptions:  endpointOptions,
 		nowFn:            time.Now,
 		sleepFn:          sleepWithContext,
 	}
+}
+
+func newSafeHTTPClient(baseURL string, options githubendpoint.Options, source *http.Client) *http.Client {
+	client := http.Client{Timeout: 10 * time.Second}
+	if source != nil {
+		client = *source
+	}
+	if endpoint, err := githubendpoint.Parse(baseURL, options); err == nil {
+		client.CheckRedirect = githubendpoint.RedirectPolicy(endpoint)
+	}
+	return &client
+}
+
+func (c *Connector) validateEndpoint() error {
+	if c == nil {
+		return errors.New("github connector is required")
+	}
+	_, err := githubendpoint.Parse(c.BaseURL, c.endpointOptions)
+	return err
 }
 
 func (c *Connector) SetRetryHandler(fn func(RetryEvent)) {
@@ -173,6 +209,9 @@ func (c *Connector) AcquireRepo(ctx context.Context, repo string) (source.RepoMa
 	if c.BaseURL == "" {
 		return source.RepoManifest{}, errors.New("github api base url is required for repository acquisition")
 	}
+	if err := c.validateEndpoint(); err != nil {
+		return source.RepoManifest{}, err
+	}
 
 	meta, err := c.repoMetadata(ctx, repo)
 	if err != nil {
@@ -201,6 +240,9 @@ func (c *Connector) ListOrgRepos(ctx context.Context, org string) ([]string, err
 	}
 	if c.BaseURL == "" {
 		return nil, errors.New("github api base url is required for organization acquisition")
+	}
+	if err := c.validateEndpoint(); err != nil {
+		return nil, err
 	}
 
 	u, err := url.Parse(c.BaseURL)
@@ -269,6 +311,9 @@ func (c *Connector) MaterializeRepo(ctx context.Context, repo string, materializ
 	}
 	if c.BaseURL == "" {
 		return source.RepoManifest{}, errors.New("github api base url is required for repository materialization")
+	}
+	if err := c.validateEndpoint(); err != nil {
+		return source.RepoManifest{}, err
 	}
 
 	meta, err := c.repoMetadata(ctx, repo)

--- a/core/source/github/connector_test.go
+++ b/core/source/github/connector_test.go
@@ -15,7 +15,57 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/Clyra-AI/wrkr/internal/githubendpoint"
 )
+
+func TestConnectorRejectsInsecureEndpointBeforeSendingToken(t *testing.T) {
+	t.Parallel()
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("authorization = %q, want no credential delivery", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	connector := NewConnector(server.URL, "secret-token", server.Client())
+	_, err := connector.ListOrgRepos(context.Background(), "acme")
+	if !errors.Is(err, githubendpoint.ErrUnsafeEndpoint) {
+		t.Fatalf("ListOrgRepos() error = %v, want unsafe endpoint", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
+
+func TestConnectorRejectsRedirectBeforeSendingTokenOffOrigin(t *testing.T) {
+	t.Parallel()
+	redirectedRequests := 0
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests++
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("authorization = %q, want no credential delivery", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer server.Close()
+
+	connector := NewConnector(server.URL, "secret-token", server.Client())
+	_, err := connector.ListOrgRepos(context.Background(), "acme")
+	if !errors.Is(err, githubendpoint.ErrUnsafeEndpoint) {
+		t.Fatalf("ListOrgRepos() error = %v, want unsafe redirect", err)
+	}
+	if redirectedRequests != 0 {
+		t.Fatalf("redirected requests = %d, want 0", redirectedRequests)
+	}
+}
 
 func TestAcquireRepoRequiresBaseURL(t *testing.T) {
 	t.Parallel()
@@ -37,7 +87,7 @@ func TestListOrgReposIntegrationSimulatedAPI(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := NewConnector(server.URL, "test-token", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "test-token", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	repos, err := connector.ListOrgRepos(context.Background(), "acme")
 	if err != nil {
 		t.Fatalf("list org repos: %v", err)
@@ -81,7 +131,7 @@ func TestListOrgReposPaginatesDeterministically(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	repos, err := connector.ListOrgRepos(context.Background(), "acme")
 	if err != nil {
 		t.Fatalf("list org repos: %v", err)
@@ -133,7 +183,7 @@ func TestListOrgReposRetriesTransientPageFailure(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	repos, err := connector.ListOrgRepos(context.Background(), "acme")
 	if err != nil {
 		t.Fatalf("list org repos: %v", err)
@@ -170,7 +220,7 @@ func TestListOrgReposFailsClosedOnLaterPageError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	repos, err := connector.ListOrgRepos(context.Background(), "acme")
 	if err == nil {
 		t.Fatal("expected page error to fail closed")
@@ -195,7 +245,7 @@ func TestAcquireRepoRetriesTransientStatus(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	manifest, err := connector.AcquireRepo(context.Background(), "acme/backend")
 	if err != nil {
 		t.Fatalf("expected retry to recover: %v", err)
@@ -236,7 +286,7 @@ func TestListOrgReposAllowsEmptyResultWithoutSyntheticFallback(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	repos, err := connector.ListOrgRepos(context.Background(), "acme")
 	if err != nil {
 		t.Fatalf("list org repos: %v", err)
@@ -327,7 +377,7 @@ func TestMaterializeRepoWritesRepositoryTree(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	manifest, err := connector.MaterializeRepo(context.Background(), "acme/backend", tmp)
 	if err != nil {
 		t.Fatalf("materialize repo: %v", err)
@@ -444,7 +494,7 @@ func TestMaterializeRepoAllowsGenericSourceWhenExplicitlyEnabled(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	connector.SetAllowSourceMaterialization(true)
 	manifest, err := connector.MaterializeRepo(context.Background(), "acme/backend", tmp)
 	if err != nil {
@@ -480,7 +530,7 @@ func TestMaterializeRepoRejectsPathTraversal(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	if _, err := connector.MaterializeRepo(context.Background(), "acme/backend", tmp); err == nil {
 		t.Fatal("expected traversal path to fail")
 	}
@@ -509,7 +559,7 @@ func TestMaterializeRepoRejectsUnsafeMetadataFullName(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	if _, err := connector.MaterializeRepo(context.Background(), "acme/backend", materializedRoot); err == nil {
 		t.Fatal("expected unsafe metadata full_name to fail")
 	}
@@ -529,7 +579,7 @@ func TestListOrgReposRejectsUnsafeFullName(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	if _, err := connector.ListOrgRepos(context.Background(), "acme"); err == nil {
 		t.Fatal("expected unsafe repo metadata to fail closed")
 	}
@@ -551,7 +601,7 @@ func TestMaterializeRepoFailsClosedOnTruncatedTree(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	_, err := connector.MaterializeRepo(context.Background(), "acme/backend", tmp)
 	if err == nil {
 		t.Fatal("expected truncated tree to fail closed")
@@ -578,7 +628,7 @@ func TestConnectorHonorsRetryAfter429(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	connector.MaxRetries = 2
 	connector.sleepFn = func(_ context.Context, duration time.Duration) error {
 		slept = append(slept, duration)
@@ -613,7 +663,7 @@ func TestConnectorRetriesRecognizedRateLimit403(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	connector.MaxRetries = 2
 	connector.sleepFn = func(_ context.Context, duration time.Duration) error {
 		slept = append(slept, duration)
@@ -642,7 +692,7 @@ func TestConnectorDoesNotRetryNonRateLimit403(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	connector.MaxRetries = 2
 	connector.sleepFn = func(_ context.Context, _ time.Duration) error {
 		t.Fatal("unexpected sleep for non-rate-limit 403")
@@ -674,7 +724,7 @@ func TestConnectorReturnsRateLimitedErrorWhenRetriesExhausted(t *testing.T) {
 	defer server.Close()
 
 	now := time.Unix(1_700_000_000, 0)
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	connector.MaxRetries = 1
 	connector.nowFn = func() time.Time { return now }
 	connector.sleepFn = func(_ context.Context, _ time.Duration) error { return nil }
@@ -713,7 +763,7 @@ func TestConnectorCircuitBreakerCooldown(t *testing.T) {
 	defer server.Close()
 
 	now := time.Unix(1_700_000_000, 0)
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	connector.MaxRetries = 0
 	connector.FailureThreshold = 2
 	connector.Cooldown = 30 * time.Second
@@ -781,7 +831,7 @@ func TestConnectorNonRetryableStatusResetsTransientFailureStreak(t *testing.T) {
 	defer server.Close()
 
 	now := time.Unix(1_700_000_000, 0)
-	connector := NewConnector(server.URL, "", server.Client())
+	connector := NewConnectorWithOptions(server.URL, "", server.Client(), ConnectorOptions{AllowInsecureLoopback: true})
 	connector.MaxRetries = 0
 	connector.FailureThreshold = 2
 	connector.Cooldown = 30 * time.Second

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/Clyra-AI/proof v0.4.6
 	github.com/dop251/goja v0.0.0-20260219130522-0ba9a5494a59
+	github.com/gofrs/flock v0.13.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	golang.org/x/mod v0.35.0
 	golang.org/x/net v0.55.0
@@ -15,5 +16,6 @@ require (
 require (
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/gowebpki/jcs v1.0.1 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/dop251/goja v0.0.0-20260219130522-0ba9a5494a59 h1:r75egwbnoPNxVa/m+g7
 github.com/dop251/goja v0.0.0-20260219130522-0ba9a5494a59/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/gowebpki/jcs v1.0.1 h1:Qjzg8EOkrOTuWP7DqQ1FbYtcpEbeTzUoTN9bptp8FOU=
 github.com/gowebpki/jcs v1.0.1/go.mod h1:CID1cNZ+sHp1CCpAR8mPf6QRtagFBgPJE0FCUQ6+BrI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -19,14 +21,18 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/e2e/github_pr/github_pr_e2e_test.go
+++ b/internal/e2e/github_pr/github_pr_e2e_test.go
@@ -70,7 +70,7 @@ func TestE2EPRUpsertIdempotentWithSimulatedAPI(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := pr.NewGitHubClient(server.URL, "token", server.Client())
+	client := pr.NewGitHubClientWithOptions(server.URL, "token", server.Client(), pr.GitHubClientOptions{AllowInsecureLoopback: true})
 	input := pr.UpsertInput{
 		Owner:       "acme",
 		Repo:        "backend",

--- a/internal/githubendpoint/githubendpoint.go
+++ b/internal/githubendpoint/githubendpoint.go
@@ -1,0 +1,79 @@
+// Package githubendpoint validates token-bearing GitHub API endpoints.
+package githubendpoint
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+var ErrUnsafeEndpoint = errors.New("unsafe GitHub API endpoint")
+
+type Options struct {
+	// AllowInsecureLoopback permits HTTP only for localhost test/development servers.
+	AllowInsecureLoopback bool
+}
+
+func Parse(raw string, options Options) (*url.URL, error) {
+	endpoint, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return nil, fmt.Errorf("%w: parse URL: %v", ErrUnsafeEndpoint, err)
+	}
+	if endpoint.Scheme == "" || endpoint.Host == "" || endpoint.Hostname() == "" {
+		return nil, fmt.Errorf("%w: URL must include scheme and host", ErrUnsafeEndpoint)
+	}
+	if endpoint.User != nil {
+		return nil, fmt.Errorf("%w: userinfo is not allowed", ErrUnsafeEndpoint)
+	}
+	if endpoint.Fragment != "" {
+		return nil, fmt.Errorf("%w: fragments are not allowed", ErrUnsafeEndpoint)
+	}
+	if endpoint.RawQuery != "" {
+		return nil, fmt.Errorf("%w: query parameters are not allowed", ErrUnsafeEndpoint)
+	}
+	switch strings.ToLower(endpoint.Scheme) {
+	case "https":
+		return endpoint, nil
+	case "http":
+		if options.AllowInsecureLoopback && isLoopback(endpoint.Hostname()) {
+			return endpoint, nil
+		}
+		return nil, fmt.Errorf("%w: HTTPS is required", ErrUnsafeEndpoint)
+	default:
+		return nil, fmt.Errorf("%w: unsupported scheme %q", ErrUnsafeEndpoint, endpoint.Scheme)
+	}
+}
+
+func RedirectPolicy(base *url.URL) func(*http.Request, []*http.Request) error {
+	return func(next *http.Request, _ []*http.Request) error {
+		if next == nil || next.URL == nil {
+			return fmt.Errorf("%w: invalid redirect target", ErrUnsafeEndpoint)
+		}
+		if next.URL.Scheme != "https" || next.URL.User != nil || next.URL.Fragment != "" || next.URL.Hostname() == "" {
+			return fmt.Errorf("%w: redirect must remain HTTPS without userinfo or fragments", ErrUnsafeEndpoint)
+		}
+		if !sameOrigin(base, next.URL) {
+			return fmt.Errorf("%w: redirect must remain on the configured GitHub API origin", ErrUnsafeEndpoint)
+		}
+		return nil
+	}
+}
+
+func isLoopback(host string) bool {
+	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func sameOrigin(left, right *url.URL) bool {
+	if left == nil || right == nil {
+		return false
+	}
+	return strings.EqualFold(left.Scheme, right.Scheme) && strings.EqualFold(left.Host, right.Host)
+}

--- a/internal/githubendpoint/githubendpoint_test.go
+++ b/internal/githubendpoint/githubendpoint_test.go
@@ -1,0 +1,56 @@
+package githubendpoint
+
+import (
+	"errors"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseRequiresSafeHTTPSBaseURL(t *testing.T) {
+	t.Parallel()
+
+	endpoint, err := Parse("https://github.example/api/v3", Options{})
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if got, want := endpoint.String(), "https://github.example/api/v3"; got != want {
+		t.Fatalf("endpoint = %q, want %q", got, want)
+	}
+
+	for _, raw := range []string{
+		"http://github.example",
+		"https://token@github.example",
+		"https://github.example#fragment",
+		"https://github.example?token=leak",
+		"github.example",
+	} {
+		if _, err := Parse(raw, Options{}); !errors.Is(err, ErrUnsafeEndpoint) {
+			t.Fatalf("Parse(%q) error = %v, want unsafe endpoint", raw, err)
+		}
+	}
+}
+
+func TestParseAllowsExplicitLoopbackHTTPOnly(t *testing.T) {
+	t.Parallel()
+	if _, err := Parse("http://127.0.0.1:8080", Options{AllowInsecureLoopback: true}); err != nil {
+		t.Fatalf("Parse(loopback) error = %v", err)
+	}
+	if _, err := Parse("http://github.example", Options{AllowInsecureLoopback: true}); !errors.Is(err, ErrUnsafeEndpoint) {
+		t.Fatalf("Parse(external HTTP) error = %v, want unsafe endpoint", err)
+	}
+}
+
+func TestRedirectPolicyRejectsCrossOriginAndDowngrade(t *testing.T) {
+	t.Parallel()
+	base, err := Parse("https://github.example/api/v3", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := RedirectPolicy(base)
+	for _, raw := range []string{"https://other.example/api/v3", "http://github.example/api/v3"} {
+		req := httptest.NewRequest("GET", raw, nil)
+		if err := policy(req, nil); !errors.Is(err, ErrUnsafeEndpoint) {
+			t.Fatalf("policy(%q) error = %v, want unsafe endpoint", raw, err)
+		}
+	}
+}

--- a/internal/integration/source/source_integration_test.go
+++ b/internal/integration/source/source_integration_test.go
@@ -29,7 +29,7 @@ func TestIntegrationOrgAcquireWithSimulatedGitHub(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connector := github.NewConnector(server.URL, "token", server.Client())
+	connector := github.NewConnectorWithOptions(server.URL, "token", server.Client(), github.ConnectorOptions{AllowInsecureLoopback: true})
 	repos, failures, err := org.Acquire(context.Background(), "acme", connector, connector)
 	if err != nil {
 		t.Fatalf("acquire org: %v", err)

--- a/internal/statelock/statelock.go
+++ b/internal/statelock/statelock.go
@@ -1,0 +1,75 @@
+// Package statelock serializes operations that read or update a managed state directory.
+package statelock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+const (
+	fileName       = ".wrkr-managed.lock"
+	defaultTimeout = 30 * time.Second
+	retryDelay     = 25 * time.Millisecond
+)
+
+var ErrBusy = errors.New("managed artifact state is busy")
+
+// Lease is an exclusive, cross-process lock for a managed artifact directory.
+type Lease struct {
+	lock *flock.Flock
+}
+
+func Acquire(ctx context.Context, statePath string) (*Lease, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	dir := filepath.Dir(filepath.Clean(strings.TrimSpace(statePath)))
+	if dir == "" || dir == "." {
+		dir = "."
+	}
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, fmt.Errorf("create managed artifact lock directory: %w", err)
+	}
+
+	lockCtx := ctx
+	cancel := func() {}
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		lockCtx, cancel = context.WithTimeout(ctx, defaultTimeout)
+	}
+	defer cancel()
+
+	lock := flock.New(filepath.Join(dir, fileName))
+	locked, err := lock.TryLockContext(lockCtx, retryDelay)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return nil, fmt.Errorf("%w: %v", ErrBusy, err)
+		}
+		return nil, fmt.Errorf("acquire managed artifact lock: %w", err)
+	}
+	if !locked {
+		if lockCtx.Err() != nil {
+			return nil, fmt.Errorf("%w: %v", ErrBusy, lockCtx.Err())
+		}
+		return nil, ErrBusy
+	}
+	return &Lease{lock: lock}, nil
+}
+
+func (l *Lease) Release() error {
+	if l == nil || l.lock == nil {
+		return nil
+	}
+	err := l.lock.Unlock()
+	l.lock = nil
+	if err != nil {
+		return fmt.Errorf("release managed artifact lock: %w", err)
+	}
+	return nil
+}

--- a/internal/statelock/statelock.go
+++ b/internal/statelock/statelock.go
@@ -49,13 +49,16 @@ func Acquire(ctx context.Context, statePath string) (*Lease, error) {
 	locked, err := lock.TryLockContext(lockCtx, retryDelay)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-			return nil, fmt.Errorf("%w: %w", ErrBusy, err)
+			if ctx.Err() != nil {
+				return nil, fmt.Errorf("acquire managed artifact lock: %w", ctx.Err())
+			}
+			return nil, ErrBusy
 		}
 		return nil, fmt.Errorf("acquire managed artifact lock: %w", err)
 	}
 	if !locked {
-		if lockCtx.Err() != nil {
-			return nil, fmt.Errorf("%w: %w", ErrBusy, lockCtx.Err())
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("acquire managed artifact lock: %w", ctx.Err())
 		}
 		return nil, ErrBusy
 	}

--- a/internal/statelock/statelock.go
+++ b/internal/statelock/statelock.go
@@ -49,13 +49,13 @@ func Acquire(ctx context.Context, statePath string) (*Lease, error) {
 	locked, err := lock.TryLockContext(lockCtx, retryDelay)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-			return nil, fmt.Errorf("%w: %v", ErrBusy, err)
+			return nil, fmt.Errorf("%w: %w", ErrBusy, err)
 		}
 		return nil, fmt.Errorf("acquire managed artifact lock: %w", err)
 	}
 	if !locked {
 		if lockCtx.Err() != nil {
-			return nil, fmt.Errorf("%w: %v", ErrBusy, lockCtx.Err())
+			return nil, fmt.Errorf("%w: %w", ErrBusy, lockCtx.Err())
 		}
 		return nil, ErrBusy
 	}

--- a/internal/statelock/statelock_test.go
+++ b/internal/statelock/statelock_test.go
@@ -1,0 +1,37 @@
+package statelock
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAcquireBlocksOtherProcessLeaseUntilRelease(t *testing.T) {
+	t.Parallel()
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	first, err := Acquire(context.Background(), statePath)
+	if err != nil {
+		t.Fatalf("Acquire(first) error = %v", err)
+	}
+	defer func() { _ = first.Release() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if _, err := Acquire(ctx, statePath); !errors.Is(err, ErrBusy) {
+		t.Fatalf("Acquire(second) error = %v, want ErrBusy", err)
+	}
+
+	if err := first.Release(); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+	first = nil
+	third, err := Acquire(context.Background(), statePath)
+	if err != nil {
+		t.Fatalf("Acquire(after release) error = %v", err)
+	}
+	if err := third.Release(); err != nil {
+		t.Fatalf("Release(third) error = %v", err)
+	}
+}

--- a/internal/statelock/statelock_test.go
+++ b/internal/statelock/statelock_test.go
@@ -19,8 +19,8 @@ func TestAcquireBlocksOtherProcessLeaseUntilRelease(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
-	if _, err := Acquire(ctx, statePath); !errors.Is(err, ErrBusy) {
-		t.Fatalf("Acquire(second) error = %v, want ErrBusy", err)
+	if _, err := Acquire(ctx, statePath); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Acquire(second) error = %v, want context deadline", err)
 	}
 
 	if err := first.Release(); err != nil {


### PR DESCRIPTION
## Problem
Concurrent scans against one state directory could silently overwrite otherwise valid proof records. GitHub scan and PR clients could attach tokens to unsafe configured endpoints.

## Changes
- Add a cross-process managed-state lease covering scan recovery, status writes, proof emission, verification, transaction commit, and state mutations.
- Require safe HTTPS GitHub API endpoints, reject unsafe URL forms, and block cross-origin or downgrade redirects.
- Allow loopback HTTP only through explicit development/test options.

## Validation
- `make prepush-full`
- `go test -count=1 ./...`
- Added two-process concurrent scan coverage comparing proof-chain records with sequential scans.
- Added credential non-delivery coverage for insecure endpoints and redirects.

## Risk
The change intentionally rejects production HTTP GitHub API configuration. No Factory submodule pointer is included.
