### PR TITLE
chore: finalize changelog for v1.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Security
 
-- Raised the pinned Go toolchain to `1.26.5` to clear standard-library advisory `GO-2026-5856` in binary `govulncheck` CI lanes.
+- (none yet)
 
 ## Changelog maintenance process
 
@@ -38,6 +38,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 4. Keep entries concise and operator-facing: what changed, why it matters, and any migration/action notes.
 5. Link release notes and tag artifacts to the finalized changelog section.
 6. The Sprint 0 v1.7.3 clarification workflow item must record measured artifact-size deltas, redaction test names, and fixture coverage before release notes claim size, privacy, redaction, customer-safe, or readability hardening.
+
+## [v1.11.2] - 2026-07-10
+<!-- release-semver: patch -->
+
+### Security
+
+- Raised the pinned Go toolchain to `1.26.5` to clear standard-library advisory `GO-2026-5856` in binary `govulncheck` CI lanes.
 
 ## [v1.11.1] - 2026-06-27
 <!-- release-semver: patch -->

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ brew install Clyra-AI/tap/wrkr
 ### Go install (Pinned/reproducible)
 
 ```bash
-WRKR_VERSION="v1.11.1"
+WRKR_VERSION="v1.11.2"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -4,7 +4,7 @@ Install with Homebrew or the pinned Go path first, then verify the installed CLI
 
 ```bash
 brew install Clyra-AI/tap/wrkr
-WRKR_VERSION="v1.11.1"
+WRKR_VERSION="v1.11.2"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 wrkr version --json
 

--- a/docs/commands/action.md
+++ b/docs/commands/action.md
@@ -21,7 +21,7 @@ Any packaged GitHub Action surface must wrap these CLI contracts rather than dup
 Wrkr now ships a repo-root `action.yml` composite action that wraps the same CLI contracts through `scripts/action_entrypoint.sh`.
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.11.1
+- uses: Clyra-AI/wrkr@v1.11.2
   with:
     mode: scheduled
     remediation_mode: summary_only
@@ -65,7 +65,7 @@ wrkr action pr-comment --changed-paths ".codex/config.toml" --risk-delta 2.8 --c
 ```
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.11.1
+- uses: Clyra-AI/wrkr@v1.11.2
   with:
     mode: scheduled
     target_mode: repo

--- a/docs/install/minimal-dependencies.md
+++ b/docs/install/minimal-dependencies.md
@@ -7,7 +7,7 @@ The main README landing page surfaces Homebrew, the pinned Go install path below
 ## Go-only pinned install
 
 ```bash
-WRKR_VERSION="v1.11.1"
+WRKR_VERSION="v1.11.2"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 
@@ -56,6 +56,6 @@ Install commands above are validated by release UAT together with the public `wr
 
 ```bash
 scripts/test_uat_local.sh --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.11.1 --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.11.1 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.11.2 --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.11.2 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
 ```

--- a/docs/trust/release-integrity.md
+++ b/docs/trust/release-integrity.md
@@ -95,7 +95,7 @@ scripts/test_uat_local.sh
 scripts/test_uat_local.sh --skip-global-gates
 
 # Validate exact public install commands (brew + pinned go install) for a published tag
-scripts/test_uat_local.sh --release-version v1.11.1 --brew-formula Clyra-AI/tap/wrkr
+scripts/test_uat_local.sh --release-version v1.11.2 --brew-formula Clyra-AI/tap/wrkr
 ```
 
 ## Changelog finalization


### PR DESCRIPTION
## Summary
- Finalize CHANGELOG.md for v1.11.2.
- Promote the pending Unreleased security entry into a dated v1.11.2 section.
- Reset Unreleased sections to `(none yet)`.

## Release Resolution
- Resolved version: v1.11.2
- Bump: patch
- Base tag: v1.11.1
- Source: changelog
- Reason: CHANGELOG.md Unreleased has patch-level Security entries.

## Validation
- `python3 factory/scripts/resolve_release_version.py --repo-root . --json`
- `python3 factory/scripts/finalize_release_changelog.py --repo-root . --release-version v1.11.2 --json`
- `python3 factory/scripts/validate_release_changelog.py --repo-root . --release-version v1.11.2 --json`

## Risk
- Changelog-only release-prep change.
- No submodule pointer changes.
