### PR TITLE
hotfix: stabilize Windows scan progress interruption test

### DIFF
--- a/core/cli/scan_progress_contract_test.go
+++ b/core/cli/scan_progress_contract_test.go
@@ -452,11 +452,16 @@ func TestScanProgressFooterIncludesResumeHintForInterruptedOrgScan(t *testing.T)
 	t.Parallel()
 
 	releaseRepo := make(chan struct{})
+	repoRequested := make(chan struct{}, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/orgs/acme/repos":
 			_, _ = fmt.Fprint(w, `[{"full_name":"acme/a"}]`)
 		case "/repos/acme/a":
+			select {
+			case repoRequested <- struct{}{}:
+			default:
+			}
 			select {
 			case <-r.Context().Done():
 				return
@@ -484,8 +489,10 @@ func TestScanProgressFooterIncludesResumeHintForInterruptedOrgScan(t *testing.T)
 		}, &out, errOut)
 	}()
 
-	if !errOut.waitFor("materializing acme/a", 2*time.Second) {
-		t.Fatalf("expected source progress before interruption, got %q", errOut.String())
+	select {
+	case <-repoRequested:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("expected repo materialization request before interruption, got %q", errOut.String())
 	}
 	cancel()
 	if code := <-done; code != exitRuntime {


### PR DESCRIPTION
## Problem

Post-merge monitoring for PR #325 caught a failure in the `main` workflow on `core-matrix-windows-latest`:

- `TestScanProgressFooterIncludesResumeHintForInterruptedOrgScan`
- The test waited for the stderr progress text `materializing acme/a` before interrupting the scan.
- On Windows CI, the repository request had started, but the progress text had not necessarily flushed before cancellation, making the assertion timing-sensitive.

## Fix

Stabilize the interruption point by waiting on the test HTTP server observing the `/repos/acme/a` materialization request instead of waiting for the incidental progress log text.

This keeps the test contract focused on the behavior under test: interrupt after source acquisition has moved into repo materialization, then require the resume hint footer.

## Validation

- `go test ./core/cli -run TestScanProgressFooterIncludesResumeHintForInterruptedOrgScan -count=1`
- `make prepush-full`
  - Full local lane passed.
  - CodeQL completed successfully; the slow `CWE-190/AllocationSizeOverflow.ql` query took `63m47s` in this run.

## Notes

- Follow-up hotfix for post-merge failure after PR #325.
- No submodule changes.
