### PR TITLE
hotfix: skip Windows Factory checkout in main CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,11 +75,11 @@ jobs:
         shell: bash
         env:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-          WRKR_PIN_CHECK_REQUIRE_FACTORY_PROFILE: "1"
         run: |
-          if [[ -n "${HOMEBREW_TAP_GITHUB_TOKEN:-}" ]]; then
+          if [[ "${RUNNER_OS}" != "Windows" && -n "${HOMEBREW_TAP_GITHUB_TOKEN:-}" ]]; then
             git config --global url."https://x-access-token:${HOMEBREW_TAP_GITHUB_TOKEN}@github.com/".insteadOf https://github.com/
             git submodule update --init --depth=1 factory
+            export WRKR_PIN_CHECK_REQUIRE_FACTORY_PROFILE=1
           fi
           make lint-fast
           make test-fast

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,6 +1,6 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "0a8c03d1177d1ff51a5443d6c0ff22c5911a3eaf29137c938c73862882de7e8b",
+  "validated_content_sha256": "b6edaf6ab4900b8f4340bf53c7abe7408c2da45b25e90d82b76e9a6ba4fbc7df",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",

--- a/testinfra/contracts/story0_contracts_test.go
+++ b/testinfra/contracts/story0_contracts_test.go
@@ -296,8 +296,14 @@ func TestPRMainAndReleaseWorkflowsAvoidFactorySubmoduleCheckoutByDefault(t *test
 	if !strings.Contains(mainWorkflow, "HOMEBREW_TAP_GITHUB_TOKEN") || !strings.Contains(mainWorkflow, "git submodule update --init --depth=1 factory") {
 		t.Fatal("main core lane must initialize the Factory submodule when the existing homebrew token secret is available")
 	}
-	if !strings.Contains(mainWorkflow, `WRKR_PIN_CHECK_REQUIRE_FACTORY_PROFILE: "1"`) {
-		t.Fatal("main core lane must require the authoritative Factory profile when running protected toolchain-pin enforcement")
+	if !strings.Contains(mainWorkflow, `if [[ "${RUNNER_OS}" != "Windows" && -n "${HOMEBREW_TAP_GITHUB_TOKEN:-}" ]]; then`) {
+		t.Fatal("main core lane must skip Windows-unsafe Factory checkout and require the authoritative Factory profile only after non-Windows submodule initialization succeeds")
+	}
+	if !strings.Contains(mainWorkflow, "export WRKR_PIN_CHECK_REQUIRE_FACTORY_PROFILE=1") {
+		t.Fatal("main core lane must require the authoritative Factory profile only after the non-Windows token-backed Factory submodule checkout succeeds")
+	}
+	if strings.Contains(mainWorkflow, `WRKR_PIN_CHECK_REQUIRE_FACTORY_PROFILE: "1"`) {
+		t.Fatal("main core lane must not require the authoritative Factory profile before the Windows-unsafe Factory checkout guard runs")
 	}
 	if strings.Contains(mainWorkflow, "WRKR_PIN_CHECK_ALLOW_MISSING_FACTORY_PROFILE") {
 		t.Fatal("main core lane must not skip Factory toolchain-pin enforcement when the snapshot contract is available")


### PR DESCRIPTION
## Problem
- the `main` workflow fails on `windows-latest` after the merge of commit `96fdb9598bc205f8d35a3481e81f3f23b12b36eb`
- the failure occurs in the token-backed `factory` submodule checkout path
- the current `factory` repo contains a Windows-invalid path (`REQ:1/...`), so the `main` core lane cannot materialize the authoritative submodule worktree on Windows

## Changes
- guard the `main` workflow's Factory submodule initialization so it runs only on non-Windows runners
- require the authoritative Factory profile only after non-Windows token-backed submodule initialization succeeds
- update the workflow contract test to enforce the Windows guard and export-based requirement behavior
- refresh the freeze-gate receipt digest for the workflow and contract change

## Validation
- `go test ./testinfra/contracts -run 'TestPRMainAndReleaseWorkflowsAvoidFactorySubmoduleCheckoutByDefault' -count=1`
- `python3 scripts/run_freeze_gate.py --repo-root . --receipt testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json --metadata-only`
- `make prepush-full`

## Risk
- Linux and macOS protected lanes still validate the authoritative Factory profile when the token-backed submodule checkout succeeds
- Windows now falls back to the committed snapshot instead of attempting a checkout Git cannot materialize on that platform
