### PR TITLE
ci: reduce duplicate validation

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -1,0 +1,46 @@
+name: cross-platform
+
+on:
+  schedule:
+    - cron: '48 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-platform-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  core:
+    name: core-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@v6.3.0
+        with:
+          go-version-file: go.mod
+          check-latest: false
+
+      - name: Run cross-platform core lane
+        shell: bash
+        env:
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        run: |
+          if [[ "${RUNNER_OS}" != "Windows" && -n "${HOMEBREW_TAP_GITHUB_TOKEN:-}" ]]; then
+            git config --global url."https://x-access-token:${HOMEBREW_TAP_GITHUB_TOKEN}@github.com/".insteadOf https://github.com/
+            git submodule update --init --depth=1 factory
+            export WRKR_PIN_CHECK_REQUIRE_FACTORY_PROFILE=1
+          fi
+          make lint-fast
+          make test-fast
+          make build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: main-${{ github.workflow }}-${{ github.ref }}
@@ -19,8 +18,7 @@ jobs:
     name: changes
     runs-on: ubuntu-latest
     outputs:
-      acceptance: ${{ steps.filter.outputs.acceptance }}
-      docs: ${{ steps.filter.outputs.docs }}
+      core: ${{ steps.filter.outputs.core }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -30,10 +28,11 @@ jobs:
         uses: dorny/paths-filter@v4.0.1
         with:
           filters: |
-            acceptance:
+            core:
               - '**/*.go'
               - 'go.mod'
               - 'go.sum'
+              - 'Makefile'
               - 'cmd/**'
               - 'core/**'
               - 'internal/**'
@@ -41,26 +40,16 @@ jobs:
               - 'scenarios/**'
               - '.github/workflows/**'
               - 'scripts/**'
-            docs:
-              - 'README.md'
-              - 'docs/**'
-              - 'docs-site/**'
-              - 'product/wrkr.md'
-              - 'core/cli/**'
-              - 'scripts/check_docs_cli_parity.sh'
-              - 'scripts/check_docs_storyline.sh'
-              - 'scripts/check_docs_consistency.sh'
-              - 'scripts/check_docs_site_validation.py'
-              - 'scripts/run_docs_smoke.sh'
 
   core-matrix:
     name: core-matrix-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: changes
+    if: needs.changes.outputs.core == 'true'
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -71,7 +60,7 @@ jobs:
           go-version-file: go.mod
           check-latest: false
 
-      - name: Run core lane
+      - name: Run merge confirmation
         shell: bash
         env:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
@@ -82,109 +71,8 @@ jobs:
             export WRKR_PIN_CHECK_REQUIRE_FACTORY_PROFILE=1
           fi
           make lint-fast
-          make test-fast
           make build
-
-  acceptance:
-    name: acceptance
-    runs-on: ubuntu-latest
-    needs: [changes, core-matrix]
-    if: needs.changes.outputs.acceptance == 'true'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Setup Go
-        uses: actions/setup-go@v6.3.0
-        with:
-          go-version-file: go.mod
-          check-latest: false
-
-      - name: Setup Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: '3.13'
-
-      - name: Run acceptance lane
-        run: |
-          make test-integration
-          make test-e2e
-          make test-coverage
-          make test-contracts
-          make test-freeze-gate FREEZE_GATE_REQUIRE_CLEAN=--require-clean
-          scripts/validate_contracts.sh
-          scripts/validate_scenarios.sh
-          go test ./internal/scenarios -count=1 -tags=scenario
-          scripts/run_agent_benchmarks.sh --output .tmp/agent-benchmarks-main.json
-
-      - name: Upload agent benchmark report
-        if: always()
-        uses: actions/upload-artifact@v7.0.0
-        with:
-          name: agent-benchmark-main
-          path: .tmp/agent-benchmarks-main.json
-
-      - name: Upload freeze-gate runtime receipt
-        if: always()
-        uses: actions/upload-artifact@v7.0.0
-        with:
-          name: freeze-gate-runtime-receipt-main
-          path: .tmp/freeze-gate-runtime-receipt.json
-          if-no-files-found: error
-
-  docs-smoke:
-    name: docs-smoke
-    runs-on: ubuntu-latest
-    needs: [changes, core-matrix]
-    if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.acceptance == 'true'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Setup Go
-        uses: actions/setup-go@v6.3.0
-        with:
-          go-version-file: go.mod
-          check-latest: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v6.3.0
-        with:
-          node-version: '22'
-
-      - name: Run docs parity, docs site, and full smoke
-        run: |
-          make test-docs-consistency
-          make docs-site-install
-          make docs-site-audit-prod
-          make docs-site-lint
-          make docs-site-build
-          make docs-site-check
-          scripts/run_docs_smoke.sh
-
-  v1-acceptance:
-    name: v1-acceptance
-    runs-on: ubuntu-latest
-    needs: [changes, core-matrix]
-    if: needs.changes.outputs.acceptance == 'true'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Setup Go
-        uses: actions/setup-go@v6.3.0
-        with:
-          go-version-file: go.mod
-          check-latest: false
-
-      - name: Run v1 acceptance dry-run
-        run: scripts/run_v1_acceptance.sh --mode=main
-
-      - name: Upload v1 acceptance scorecard
-        if: always()
-        uses: actions/upload-artifact@v7.0.0
-        with:
-          name: v1-acceptance-scorecard-main
-          path: |
-            .tmp/release/v1-scorecard.json
-            .tmp/release/v1-scorecard.md
+          .tmp/wrkr version --json > .tmp/main-version.json
+          .tmp/wrkr scan --path scenarios/wrkr/scan-diff-no-noise/input/local-repos --json --quiet > .tmp/main-scan.json
+          test -s .tmp/main-version.json
+          test -s .tmp/main-scan.json

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,9 +17,89 @@ jobs:
   wave-sequence:
     name: wave-sequence
     runs-on: ubuntu-latest
+    outputs:
+      core: ${{ steps.changes.outputs.core }}
+      dependencies: ${{ steps.changes.outputs.dependencies }}
+      docs: ${{ steps.changes.outputs.docs }}
+      go: ${{ steps.changes.outputs.go }}
+      python: ${{ steps.changes.outputs.python }}
+      scan_contract: ${{ steps.changes.outputs.scan_contract }}
+      security: ${{ steps.changes.outputs.security }}
+      windows: ${{ steps.changes.outputs.windows }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
+
+      - name: Detect changed paths
+        id: changes
+        uses: dorny/paths-filter@v4.0.1
+        with:
+          filters: |
+            core:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - 'cmd/**'
+              - 'core/**'
+              - 'internal/**'
+              - 'testinfra/**'
+              - 'scenarios/**'
+              - 'scripts/**'
+              - '.github/workflows/**'
+              - '.github/required-checks.json'
+            dependencies:
+              - 'go.mod'
+              - 'go.sum'
+            docs:
+              - 'README.md'
+              - 'docs/**'
+              - 'docs-site/**'
+              - 'product/dev_guides.md'
+              - 'product/wrkr.md'
+              - 'core/cli/**'
+              - 'scripts/check_docs_cli_parity.sh'
+              - 'scripts/check_docs_storyline.sh'
+              - 'scripts/check_docs_consistency.sh'
+              - 'scripts/check_docs_site_validation.py'
+              - 'scripts/run_docs_smoke.sh'
+            go:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+            python:
+              - 'scripts/**/*.py'
+            scan_contract:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - 'cmd/**'
+              - 'core/**'
+              - 'internal/**'
+              - 'testinfra/**'
+              - 'scenarios/**'
+              - '.github/workflows/**'
+            security:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - 'scripts/run_codeql.sh'
+              - '.github/workflows/**'
+            windows:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - 'cmd/**'
+              - 'core/**'
+              - 'internal/**'
+              - 'testinfra/**'
+              - 'scenarios/**'
+              - 'scripts/**/*.sh'
+              - '.github/workflows/**'
 
       - name: Setup Python
         uses: actions/setup-python@v6.2.0
@@ -34,6 +114,8 @@ jobs:
   codeql-security:
     name: codeql-security
     runs-on: ubuntu-latest
+    needs: wave-sequence
+    if: needs.wave-sequence.outputs.security == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -62,65 +144,36 @@ jobs:
   fast-lane:
     name: fast-lane
     runs-on: ubuntu-latest
+    needs: wave-sequence
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
-      - name: Detect changed paths
-        id: changes
-        uses: dorny/paths-filter@v4.0.1
-        with:
-          filters: |
-            go:
-              - '**/*.go'
-              - 'go.mod'
-              - 'go.sum'
-              - 'cmd/**'
-              - 'core/**'
-              - 'internal/**'
-              - 'testinfra/**'
-            docs:
-              - 'README.md'
-              - 'docs/**'
-              - 'docs-site/**'
-              - 'product/wrkr.md'
-            python:
-              - 'scripts/**/*.py'
-            workflow_or_policy:
-              - '.github/workflows/**'
-              - '.github/required-checks.json'
-              - 'scripts/**/*.sh'
-
       - name: Setup Go
+        if: needs.wave-sequence.outputs.core == 'true' || needs.wave-sequence.outputs.docs == 'true'
         uses: actions/setup-go@v6.3.0
         with:
           go-version-file: go.mod
           check-latest: false
 
       - name: Setup Python
+        if: needs.wave-sequence.outputs.core == 'true' || needs.wave-sequence.outputs.docs == 'true' || needs.wave-sequence.outputs.python == 'true'
         uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.13'
 
       - name: Setup Node
+        if: needs.wave-sequence.outputs.docs == 'true'
         uses: actions/setup-node@v6.3.0
         with:
           node-version: '22'
 
       - name: Install Python scanners
+        if: needs.wave-sequence.outputs.python == 'true'
         run: python -m pip install ruff==0.11.8 mypy==1.14.1 bandit==1.8.3
 
-      - name: Detect Python script files
-        id: pyfiles
-        shell: bash
-        run: |
-          if find scripts -type f \( -name '*.py' -o -name '*.pyi' \) -print -quit | grep -q .; then
-            echo "has_python=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_python=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Fast lint and tests
+      - name: Core validation
+        if: needs.wave-sequence.outputs.core == 'true'
         env:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
         run: |
@@ -130,22 +183,22 @@ jobs:
             export WRKR_PIN_CHECK_REQUIRE_FACTORY_PROFILE=1
           fi
           make lint-fast
-          make test-fast
           make test-coverage
-          make test-contracts
           make test-freeze-gate FREEZE_GATE_REQUIRE_CLEAN=--require-clean
+          scripts/validate_contracts.sh
           scripts/validate_scenarios.sh
+          go test ./internal/scenarios -count=1 -tags=scenario
           scripts/run_agent_benchmarks.sh --output .tmp/agent-benchmarks-pr.json
 
       - name: Upload agent benchmark report
-        if: always()
+        if: always() && needs.wave-sequence.outputs.core == 'true'
         uses: actions/upload-artifact@v7.0.0
         with:
           name: agent-benchmark-pr
           path: .tmp/agent-benchmarks-pr.json
 
       - name: Upload freeze-gate runtime receipt
-        if: always()
+        if: always() && needs.wave-sequence.outputs.core == 'true'
         uses: actions/upload-artifact@v7.0.0
         with:
           name: freeze-gate-runtime-receipt-pr
@@ -153,13 +206,13 @@ jobs:
           if-no-files-found: error
 
       - name: Docs parity and smoke subset
-        if: steps.changes.outputs.go == 'true' || steps.changes.outputs.docs == 'true' || steps.changes.outputs.workflow_or_policy == 'true'
+        if: needs.wave-sequence.outputs.go == 'true' || needs.wave-sequence.outputs.docs == 'true'
         run: |
           make test-docs-consistency
           make test-docs-storyline
 
       - name: Docs site quality gates
-        if: steps.changes.outputs.docs == 'true' || steps.changes.outputs.workflow_or_policy == 'true'
+        if: needs.wave-sequence.outputs.docs == 'true'
         run: |
           make docs-site-install
           make docs-site-audit-prod
@@ -168,55 +221,59 @@ jobs:
           make docs-site-check
 
       - name: Run ruff
-        if: steps.pyfiles.outputs.has_python == 'true' && steps.changes.outputs.python == 'true'
+        if: needs.wave-sequence.outputs.python == 'true'
         run: ruff check scripts
 
       - name: Run mypy
-        if: steps.pyfiles.outputs.has_python == 'true' && steps.changes.outputs.python == 'true'
+        if: needs.wave-sequence.outputs.python == 'true'
         run: mypy --ignore-missing-imports scripts
 
       - name: Run bandit
-        if: steps.pyfiles.outputs.has_python == 'true' && steps.changes.outputs.python == 'true'
+        if: needs.wave-sequence.outputs.python == 'true'
         run: bandit -q -r scripts
 
       - name: Install gosec
-        if: steps.changes.outputs.go == 'true' || steps.changes.outputs.workflow_or_policy == 'true'
+        if: needs.wave-sequence.outputs.go == 'true'
         run: go install github.com/securego/gosec/v2/cmd/gosec@v2.23.0
 
       - name: Run gosec
-        if: steps.changes.outputs.go == 'true' || steps.changes.outputs.workflow_or_policy == 'true'
+        if: needs.wave-sequence.outputs.go == 'true'
         run: |
-          "$(go env GOPATH)/bin/gosec" -concurrency=1 $(scripts/first_party_go_packages.sh)
+          mapfile -t packages < <(scripts/first_party_go_packages.sh)
+          "$(go env GOPATH)/bin/gosec" -concurrency=1 "${packages[@]}"
 
       - name: Install golangci-lint
-        if: steps.changes.outputs.go == 'true' || steps.changes.outputs.workflow_or_policy == 'true'
+        if: needs.wave-sequence.outputs.go == 'true'
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.1
 
       - name: Run golangci-lint
-        if: steps.changes.outputs.go == 'true' || steps.changes.outputs.workflow_or_policy == 'true'
+        if: needs.wave-sequence.outputs.go == 'true'
         run: |
-          "$(go env GOPATH)/bin/golangci-lint" run --timeout=5m $(scripts/first_party_go_packages.sh)
+          mapfile -t packages < <(scripts/first_party_go_packages.sh)
+          "$(go env GOPATH)/bin/golangci-lint" run --timeout=5m "${packages[@]}"
 
       - name: Install govulncheck
-        if: steps.changes.outputs.go == 'true' || steps.changes.outputs.workflow_or_policy == 'true'
+        if: needs.wave-sequence.outputs.dependencies == 'true'
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
       - name: Build binary for vulnerability scan
-        if: steps.changes.outputs.go == 'true' || steps.changes.outputs.workflow_or_policy == 'true'
+        if: needs.wave-sequence.outputs.dependencies == 'true'
         run: go build -o .tmp/wrkr ./cmd/wrkr
 
       - name: Run govulncheck
-        if: steps.changes.outputs.go == 'true' || steps.changes.outputs.workflow_or_policy == 'true'
+        if: needs.wave-sequence.outputs.dependencies == 'true'
         run: |
           "$(go env GOPATH)/bin/govulncheck" -mode=binary .tmp/wrkr
 
-      - name: Skip deep scanners for non-code changes
-        if: steps.changes.outputs.go != 'true' && steps.changes.outputs.python != 'true' && steps.changes.outputs.workflow_or_policy != 'true'
-        run: echo "no code, workflow, or policy changes; deep scanners skipped"
+      - name: Record lightweight-only validation
+        if: needs.wave-sequence.outputs.core != 'true' && needs.wave-sequence.outputs.docs != 'true' && needs.wave-sequence.outputs.python != 'true'
+        run: echo "no product, documentation, or script changes; heavy validation skipped"
 
   scan-contract:
     name: scan-contract
     runs-on: ubuntu-latest
+    needs: wave-sequence
+    if: needs.wave-sequence.outputs.scan_contract == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -237,6 +294,8 @@ jobs:
   windows-smoke:
     name: windows-smoke
     runs-on: windows-latest
+    needs: wave-sequence
+    if: needs.wave-sequence.outputs.windows == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -252,4 +311,5 @@ jobs:
         run: |
           mkdir -p .tmp
           go build -o .tmp/wrkr ./cmd/wrkr
-          go test $(scripts/first_party_go_packages.sh) -count=1 -timeout=20m
+          mapfile -t packages < <(scripts/first_party_go_packages.sh)
+          go test "${packages[@]}" -count=1 -timeout=20m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
   packages: write
   id-token: write
@@ -38,10 +39,42 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Setup Node
-        uses: actions/setup-node@v6.3.0
-        with:
-          node-version: '22'
+      - name: Verify tagged source is green on main
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "${GITHUB_SHA}" origin/main; then
+            echo "release tag does not point to a commit reachable from main" >&2
+            exit 3
+          fi
+
+          mkdir -p .tmp/release
+          gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/main.yml/runs" \
+            -f branch=main \
+            -f event=push \
+            -f status=success \
+            -f per_page=100 \
+            > .tmp/release/main-successful-runs.json
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+          import sys
+
+          payload = json.loads(
+              pathlib.Path(".tmp/release/main-successful-runs.json").read_text(encoding="utf-8")
+          )
+          head_sha = os.environ["GITHUB_SHA"]
+          if not any(
+              run.get("head_sha") == head_sha and run.get("conclusion") == "success"
+              for run in payload.get("workflow_runs", [])
+          ):
+              print(f"no successful main workflow found for {head_sha}", file=sys.stderr)
+              sys.exit(3)
+          PY
 
       - name: Setup Homebrew
         uses: Homebrew/actions/setup-homebrew@cced187498280712e078aaba62dc13a3e9cd80bf
@@ -70,74 +103,6 @@ jobs:
       - name: Validate release changelog
         if: startsWith(github.ref, 'refs/tags/v')
         run: python3 scripts/validate_release_changelog.py --release-version "${GITHUB_REF_NAME}" --json
-
-      - name: Run deterministic tests
-        run: go test $(scripts/first_party_go_packages.sh) -count=1
-
-      - name: Run docs parity, docs site, and UAT smoke
-        run: |
-          make test-docs-consistency
-          make docs-site-install
-          make docs-site-lint
-          make docs-site-build
-          make docs-site-check
-          scripts/run_docs_smoke.sh
-
-      - name: Run v1 acceptance release gate
-        env:
-          HOMEBREW_NO_SANDBOX_LINUX: 1
-        run: scripts/run_v1_acceptance.sh --mode=release
-
-      - name: Upload v1 acceptance scorecard
-        if: always()
-        uses: actions/upload-artifact@v7.0.0
-        with:
-          name: v1-acceptance-scorecard-release
-          path: |
-            .tmp/release/v1-scorecard.json
-            .tmp/release/v1-scorecard.md
-
-      - name: Run contract and scenario gates
-        run: |
-          make test-coverage
-          make test-contracts
-          make test-freeze-gate FREEZE_GATE_REQUIRE_CLEAN=--require-clean
-          scripts/validate_contracts.sh
-          scripts/validate_scenarios.sh
-          go test ./internal/scenarios -count=1 -tags=scenario
-
-      - name: Run release hardening and perf subsets
-        run: |
-          scripts/test_hardening_core.sh
-          scripts/test_perf_budgets.sh
-          scripts/run_agent_benchmarks.sh --output .tmp/release/agent-benchmarks-release.json
-          go test ./internal/integration/interop -count=1
-
-      - name: Upload freeze-gate runtime receipt
-        if: always()
-        uses: actions/upload-artifact@v7.0.0
-        with:
-          name: freeze-gate-runtime-receipt-release
-          path: .tmp/freeze-gate-runtime-receipt.json
-          if-no-files-found: error
-
-      - name: Upload agent benchmark report
-        if: always()
-        uses: actions/upload-artifact@v7.0.0
-        with:
-          name: agent-benchmark-release
-          path: .tmp/release/agent-benchmarks-release.json
-
-      - name: Run pre-publish install-path UAT smoke
-        env:
-          HOMEBREW_NO_SANDBOX_LINUX: 1
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          mkdir -p .tmp/release
-          make test-release-smoke | tee .tmp/release/uat-prepublish-smoke.log
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v7.0.0
@@ -327,6 +292,4 @@ jobs:
         uses: actions/upload-artifact@v7.0.0
         with:
           name: release-uat-local-logs
-          path: |
-            .tmp/release/uat-prepublish-smoke.log
-            .tmp/release/uat-published-install-paths.log
+          path: .tmp/release/uat-published-install-paths.log

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ test-uat-local:
 test-release-smoke:
 	@scripts/test_uat_local.sh --skip-global-gates
 
-prepush-full: prepush lint test test-coverage test-freeze-gate test-integration test-e2e test-scenarios codeql
+prepush-full: fmt lint-fast build test-coverage test-freeze-gate test-integration test-e2e test-contracts test-scenarios codeql
 
 codeql:
 	@scripts/run_codeql.sh

--- a/docs/decisions/wave59-combined-audit-hardening.md
+++ b/docs/decisions/wave59-combined-audit-hardening.md
@@ -19,7 +19,7 @@ The same audit found a stale Go version in the Factory profile pointer. The repo
 Wrkr adopts these controls in one patch wave:
 
 - Transaction recovery journals move outside repositories into the operating system's private user cache. Journals are keyed and content-bound to the canonical state path, constrained to regular owner-private files, identity-checked while opened, and validated for unique canonical artifact paths captured under the state lease before recovery. Legacy repository-local journals are never replayed and fail closed with exit `8`.
-- `make test-coverage` enforces an 85% aggregate core target and 75% per-package target in pull request, main, release, and full pre-push lanes. Current gaps are recorded as expiring, owner-assigned non-regression floors rather than silently waived.
+- `make test-coverage` enforces an 85% aggregate core target and 75% per-package target in pull-request and full pre-push lanes. Main and release consume the exact green source result instead of rerunning coverage. Current gaps are recorded as expiring, owner-assigned non-regression floors rather than silently waived.
 - The freeze gate validates a digest of its declared source scope, directly executes allowlisted `go test` commands plus the exact-byte Action Contract fixture check, records output hashes and exit codes, and publishes a runtime receipt. Protected CI lanes require a clean worktree.
 - Scan and evidence command-response previews use smaller deterministic caps while canonical state, customer-redacted BOM, and full report-evidence artifacts retain the governed detail paths.
 - Toolchain pin validation includes `factory/profiles/wrkr.yaml`; the Factory submodule pointer advances to the profile revision carrying Go `1.26.5`.

--- a/docs/trust/release-integrity.md
+++ b/docs/trust/release-integrity.md
@@ -7,8 +7,8 @@ description: "Release hardening checks, reproducibility expectations, and integr
 
 ## Release checks
 
-- Deterministic test gates in release workflow.
-- Contract and scenario validation before artifact generation.
+- Product PRs own deterministic tests, numeric coverage, contract/scenario validation, and freeze-gate evidence.
+- Tag builds fail closed unless the tagged SHA is reachable from `main` and the exact SHA has a successful `main` workflow.
 - Node24-ready action refs on the release path for all remediable workflow helpers, enforced by `make lint-fast`.
 - Public docs-site Markdown is treated as untrusted input; raw HTML, unsafe attributes, and unsafe link schemes are escaped or blocked before static HTML publish.
 - Docs-site production dependency advisories are release-trust inputs. High and critical advisories fail closed, and moderate advisories require an exact checked-in exception when no patched stable upstream dependency is available.
@@ -71,15 +71,17 @@ If a release-path helper still lacks a published Node24-ready upstream release, 
 
 ## Publish sequence
 
-For tag builds, treat release publication as the final gated step:
+For tag builds, treat release publication as the final gated step. Source validation is not rerun against an equivalent checkout; the workflow first proves it is packaging the exact green `main` SHA:
 
-1. Build candidate artifacts into `dist/` without publishing them.
-2. Verify checksums.
-3. Generate an SBOM.
-4. Run Grype against the staged artifacts.
-5. Sign the checksum manifest.
-6. Generate and verify provenance attestations.
-7. Publish GitHub release assets and Homebrew tap updates from the verified staged set.
+1. Verify tagged-source ancestry and successful `main` CI for the exact SHA.
+2. Build candidate artifacts into `dist/` without publishing them.
+3. Verify checksums.
+4. Generate an SBOM.
+5. Run Grype against the staged artifacts.
+6. Sign the checksum manifest.
+7. Generate and verify provenance attestations.
+8. Publish GitHub release assets and Homebrew tap updates from the verified staged set.
+9. Run published install-path UAT.
 
 ## Install-path UAT (release-candidate)
 
@@ -91,7 +93,7 @@ Treat `README.md`, this page, and `docs/install/minimal-dependencies.md` as the 
 # Full local gate set + source/release/homebrew-path checks
 scripts/test_uat_local.sh
 
-# Fast smoke lane used by release CI job
+# Fast local diagnostic without the global validation gates
 scripts/test_uat_local.sh --skip-global-gates
 
 # Validate exact public install commands (brew + pinned go install) for a published tag
@@ -128,7 +130,7 @@ When using `wrkr verify --chain --json` as a release/promotion gate, inspect `ch
 
 ### Which checks should pass before trusting a Wrkr release?
 
-Deterministic test gates, contract validation, Node24 runtime policy checks, and integrity outputs (checksums/provenance) should all pass before promotion.
+The exact tagged SHA must have green PR/main source validation, followed by successful artifact checksums, vulnerability scanning, signing, provenance verification, publication, and install-path UAT.
 
 ### How do I verify artifact integrity after download?
 

--- a/product/dev_guides.md
+++ b/product/dev_guides.md
@@ -299,47 +299,47 @@ Tests are organized into tiers by scope, speed, and when they run.
 
 - **What**: isolated component tests.
 - **How**: `go test $(scripts/first_party_go_packages.sh)` (Go), `pytest` (Python).
-- **When**: every PR, every push, pre-push hook.
+- **When**: product-affecting PRs, full local validation, and scheduled secondary-platform validation.
 - **Flags**: default (cached, parallel).
 
 ### Tier 2 — Integration
 
 - **What**: cross-component deterministic tests. Direct API usage, no CLI.
 - **How**: `go test ./internal/integration -count=1`.
-- **When**: every PR, every push to main.
+- **When**: product-affecting PRs and nightly validation.
 - **Patterns**: fixture helpers, golden JSON assertions, deterministic concurrency validation.
 
 ### Tier 3 — E2E
 
 - **What**: CLI end-to-end tests. Builds binary, invokes via `exec.Command`, validates JSON output and exit codes.
 - **How**: `go test ./internal/e2e -count=1`.
-- **When**: push to main.
+- **When**: product-affecting PRs; main keeps one focused CLI merge-confirmation smoke.
 - **Flags**: `-count=1` (no cache, deterministic).
 
 ### Tier 4 — Acceptance
 
 - **What**: version-gated acceptance scripts validating blessed workflows end-to-end.
 - **How**: shell scripts (`scripts/test_*_acceptance.sh`) that run CLI commands and validate output.
-- **When**: push to main, conditional on adoption-critical path changes (detected via dorny/paths-filter).
+- **When**: acceptance tests run on product-affecting PRs; the complete scorecard runs nightly and during local release preflight.
 - **Pattern**: quickstart flow validation, adapter scenario testing, conformance checks, scorecard generation.
 
 ### Tier 5 — Hardening
 
 - **What**: atomic write integrity, lock contention, stale lock recovery, network retry classification, error envelope contracts, concurrent determinism.
 - **How**: shell script orchestrating targeted `go test -run <pattern> -count=1` invocations.
-- **When**: nightly (cross-platform), release gates.
+- **When**: nightly and local release preflight.
 
 ### Tier 6 — Chaos
 
 - **What**: fault injection and resilience validation. Exporter stability, service boundary failures, payload limits, session resilience, trace uniqueness.
 - **How**: dedicated shell scripts (`scripts/test_chaos_*.sh`) with `-count=3` or `-count=5` for stress.
-- **When**: nightly, release gates.
+- **When**: nightly.
 
 ### Tier 7 — Performance
 
 - **What**: benchmark regression detection, command latency budgets (p50/p95/p99), resource budgets, context budgets.
 - **How**: `go test -bench <regex> -benchmem -count=5` with `GOMAXPROCS=1`. Median aggregation. Comparison against baseline with max regression factor.
-- **When**: nightly, release gates.
+- **When**: nightly and local release preflight.
 - **Determinism**: single-threaded execution (GOMAXPROCS=1), 5 samples, median selection.
 
 ### Tier 8 — Soak
@@ -352,7 +352,7 @@ Tests are organized into tiers by scope, speed, and when they run.
 
 - **What**: deterministic artifact bytes, stable exit-code contracts, JSON shape contracts, schema compatibility guards, producer-kit roundtrips, legacy compatibility.
 - **How**: shell scripts validating byte-stable outputs, exit codes, required JSON fields, and schema field/enum stability.
-- **When**: every push to main.
+- **When**: product-affecting PRs and full local validation.
 
 ### Tier 10 — UAT
 
@@ -580,16 +580,18 @@ These minimums are for v1 launch. Scenario count grows with product surface — 
 ### PR Pipeline (required, fast feedback)
 
 - Require at least one fast lane on every `pull_request`; this lane is merge-blocking.
-- Fast lane should run deterministic lint + unit + contract checks and complete quickly.
-- Include at least one non-primary platform smoke lane for portability confidence.
-- Use path-based change detection to gate expensive scanners, but keep baseline lint/test checks always on.
+- Product-affecting changes run deterministic lint, one coverage-backed first-party test pass, contract validation, scenario validation, freeze evidence, and focused security checks.
+- Keep required check names stable while allowing expensive jobs to complete as skipped successes when their governed paths did not change.
+- Run the Windows smoke lane for runtime, CLI, filesystem, script, and workflow changes; use the weekly cross-platform workflow for macOS depth.
+- Docs-only and changelog-only PRs must not allocate product test, CodeQL, or Windows runners unless their governed paths changed.
 - Every PR workflow must define `concurrency` with `cancel-in-progress: true`.
 
 ### Main Pipeline (protected branch push)
 
-- Run the full deterministic matrix after merge to the protected branch.
-- Include full test suites, contract suites, and acceptance suites required by the release policy.
-- Keep heavy suites path-gated where safe, but never gate foundational contract or determinism checks.
+- Treat the green latest-head PR as the authoritative correctness gate.
+- For product changes, confirm the merged source on Ubuntu with lint, build, version JSON, and one representative scan.
+- Let the dedicated docs workflow own docs validation and deployment rather than repeating docs-site builds in main CI.
+- Do not repeat coverage, acceptance, freeze, or secondary-platform suites on every protected-branch push.
 
 ### Nightly Pipelines
 
@@ -604,8 +606,8 @@ These minimums are for v1 launch. Scenario count grows with product surface — 
 
 Sequence:
 
-1. Run release-gated acceptance and contract suites.
-2. Build reproducible release artifacts for supported targets.
+1. Verify that the tagged SHA is reachable from `main` and has a successful `main` workflow for that exact SHA.
+2. Build reproducible release artifacts for supported targets without rerunning source validation.
 3. Generate and verify checksums.
 4. Generate SBOM.
 5. Run vulnerability scan against produced artifacts/SBOM.
@@ -613,6 +615,7 @@ Sequence:
 7. Generate provenance attestation.
 8. Verify checksum/signature/provenance in-pipeline before publication.
 9. Publish artifacts and release notes only after all gates pass.
+10. Run published install-path UAT against the released tag and Homebrew formula.
 
 ### Workflow Contract Validation
 

--- a/testinfra/contracts/composition_freeze_gate_contracts_test.go
+++ b/testinfra/contracts/composition_freeze_gate_contracts_test.go
@@ -132,16 +132,20 @@ func TestCompositionFreezeGateRuntimeReceiptIsRequiredByCI(t *testing.T) {
 			t.Fatalf("Makefile must require freeze-gate runtime evidence %q", required)
 		}
 	}
-	for _, workflow := range []string{"pr.yml", "main.yml", "release.yml"} {
+	prWorkflow := mustReadFile(t, filepath.Join(repoRoot, ".github", "workflows", "pr.yml"))
+	for _, required := range []string{
+		"make test-freeze-gate FREEZE_GATE_REQUIRE_CLEAN=--require-clean",
+		"freeze-gate-runtime-receipt.json",
+		"if-no-files-found: error",
+	} {
+		if !strings.Contains(prWorkflow, required) {
+			t.Fatalf("pr.yml must preserve current-head freeze-gate evidence %q", required)
+		}
+	}
+	for _, workflow := range []string{"main.yml", "release.yml"} {
 		content := mustReadFile(t, filepath.Join(repoRoot, ".github", "workflows", workflow))
-		for _, required := range []string{
-			"make test-freeze-gate FREEZE_GATE_REQUIRE_CLEAN=--require-clean",
-			"freeze-gate-runtime-receipt.json",
-			"if-no-files-found: error",
-		} {
-			if !strings.Contains(content, required) {
-				t.Fatalf("%s must preserve current-head freeze-gate evidence %q", workflow, required)
-			}
+		if strings.Contains(content, "make test-freeze-gate") {
+			t.Fatalf("%s must not duplicate the authoritative PR freeze gate", workflow)
 		}
 	}
 }

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,6 +1,6 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "356f18abc1d071843cfb6d6de8b03c10137d6004d232920d15766e77ee0f48eb",
+  "validated_content_sha256": "dda38f99504504ab9876a778f229064cf78e05d822a7fce2e24e7b2f08841dcd",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",
@@ -40,7 +40,7 @@
     "action_contract_conformance_fixture_v1",
     "bounded_multi_stage_composed_action_contracts"
   ],
-  "validated_on": "2026-07-27",
+  "validated_on": "2026-08-05",
   "fixture_names": [
     "internal/enterprisepressure.VariantBaseline:96-repos",
     "internal/enterprisepressure.EndpointDense:4-repos",

--- a/testinfra/contracts/story0_contracts_test.go
+++ b/testinfra/contracts/story0_contracts_test.go
@@ -56,6 +56,7 @@ func TestNoFloatingLatestInBuildConfigs(t *testing.T) {
 		".github/workflows/pr.yml",
 		".github/workflows/main.yml",
 		".github/workflows/nightly.yml",
+		".github/workflows/cross-platform.yml",
 		".github/workflows/release.yml",
 	}
 	for _, rel := range files {
@@ -181,6 +182,7 @@ func TestWorkflowConcurrencyConfigured(t *testing.T) {
 		".github/workflows/pr.yml",
 		".github/workflows/main.yml",
 		".github/workflows/nightly.yml",
+		".github/workflows/cross-platform.yml",
 		".github/workflows/release.yml",
 	}
 	for _, rel := range required {
@@ -210,8 +212,10 @@ func TestPRWorkflowPathFilterContract(t *testing.T) {
 	text := string(content)
 	for _, fragment := range []string{
 		"dorny/paths-filter@v4.0.1",
-		"workflow_or_policy:",
-		"Skip deep scanners for non-code changes",
+		"security:",
+		"scan_contract:",
+		"windows:",
+		"Record lightweight-only validation",
 	} {
 		if !strings.Contains(text, fragment) {
 			t.Fatalf("pr workflow missing required path-filter fragment %q", fragment)
@@ -242,6 +246,70 @@ func TestWorkflowTriggerContracts(t *testing.T) {
 	nightlyWorkflow := mustReadFile(t, filepath.Join(repoRoot, ".github/workflows/nightly.yml"))
 	if !strings.Contains(nightlyWorkflow, "schedule:") {
 		t.Fatal("nightly workflow must include schedule trigger")
+	}
+
+	crossPlatformWorkflow := mustReadFile(t, filepath.Join(repoRoot, ".github/workflows/cross-platform.yml"))
+	if !strings.Contains(crossPlatformWorkflow, "schedule:") {
+		t.Fatal("cross-platform workflow must include schedule trigger")
+	}
+}
+
+func TestWorkflowValidationOwnershipAvoidsDuplicateRunnerLanes(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := mustFindRepoRoot(t)
+	prWorkflow := mustReadFile(t, filepath.Join(repoRoot, ".github/workflows/pr.yml"))
+	for _, required := range []string{
+		"make test-coverage",
+		"make test-freeze-gate FREEZE_GATE_REQUIRE_CLEAN=--require-clean",
+		"scripts/validate_contracts.sh",
+		"go test ./internal/scenarios -count=1 -tags=scenario",
+	} {
+		if !strings.Contains(prWorkflow, required) {
+			t.Fatalf("PR workflow missing authoritative validation %q", required)
+		}
+	}
+
+	mainWorkflow := mustReadFile(t, filepath.Join(repoRoot, ".github/workflows/main.yml"))
+	for _, required := range []string{
+		"os: [ubuntu-latest]",
+		"Run merge confirmation",
+		".tmp/wrkr version --json",
+		".tmp/wrkr scan --path scenarios/wrkr/scan-diff-no-noise/input/local-repos",
+	} {
+		if !strings.Contains(mainWorkflow, required) {
+			t.Fatalf("main workflow missing thin merge confirmation %q", required)
+		}
+	}
+	for _, duplicate := range []string{"make test-coverage", "run_v1_acceptance.sh", "docs-site-build", "macos-latest", "windows-latest"} {
+		if strings.Contains(mainWorkflow, duplicate) {
+			t.Fatalf("main workflow reintroduced duplicated lane %q", duplicate)
+		}
+	}
+
+	releaseWorkflow := mustReadFile(t, filepath.Join(repoRoot, ".github/workflows/release.yml"))
+	for _, required := range []string{
+		"Verify tagged source is green on main",
+		"actions: read",
+		"main-successful-runs.json",
+		"Build staged release artifacts",
+		"Run published install-path parity (README/docs commands)",
+	} {
+		if !strings.Contains(releaseWorkflow, required) {
+			t.Fatalf("release workflow missing source or artifact gate %q", required)
+		}
+	}
+	for _, duplicate := range []string{"go test ", "make test-coverage", "run_v1_acceptance.sh", "docs-site-build", "uat-prepublish-smoke"} {
+		if strings.Contains(releaseWorkflow, duplicate) {
+			t.Fatalf("release workflow reintroduced pre-package validation %q", duplicate)
+		}
+	}
+
+	crossPlatformWorkflow := mustReadFile(t, filepath.Join(repoRoot, ".github/workflows/cross-platform.yml"))
+	for _, required := range []string{"schedule:", "macos-latest", "windows-latest", "make test-fast", "make build"} {
+		if !strings.Contains(crossPlatformWorkflow, required) {
+			t.Fatalf("weekly cross-platform workflow missing %q", required)
+		}
 	}
 }
 

--- a/testinfra/hygiene/coverage_gate_test.go
+++ b/testinfra/hygiene/coverage_gate_test.go
@@ -155,16 +155,20 @@ func TestCoverageGatesAreProtectedInAutomation(t *testing.T) {
 		"scripts/check_go_coverage.py",
 		"scripts/check_go_package_coverage.py",
 		".github/coverage-exceptions.json",
-		"prepush-full: prepush lint test test-coverage",
+		"prepush-full: fmt lint-fast build test-coverage",
 	} {
 		if !strings.Contains(makefile, needle) {
 			t.Fatalf("Makefile coverage contract missing %q", needle)
 		}
 	}
-	for _, workflow := range []string{"pr.yml", "main.yml", "release.yml"} {
+	prWorkflow := mustReadFile(t, filepath.Join(root, ".github/workflows/pr.yml"))
+	if !strings.Contains(prWorkflow, "make test-coverage") {
+		t.Fatal("pr.yml missing authoritative numeric coverage gate")
+	}
+	for _, workflow := range []string{"main.yml", "release.yml"} {
 		content := mustReadFile(t, filepath.Join(root, ".github/workflows", workflow))
-		if !strings.Contains(content, "make test-coverage") {
-			t.Fatalf("%s missing protected numeric coverage gate", workflow)
+		if strings.Contains(content, "make test-coverage") {
+			t.Fatalf("%s must consume the green PR/main source contract instead of rerunning coverage", workflow)
 		}
 	}
 }

--- a/testinfra/hygiene/go_package_scope_test.go
+++ b/testinfra/hygiene/go_package_scope_test.go
@@ -66,7 +66,6 @@ func TestWorkflowGoTestsUseFirstPartyPackageList(t *testing.T) {
 	repoRoot := mustFindRepoRoot(t)
 	checkedPaths := []string{
 		".github/workflows/pr.yml",
-		".github/workflows/release.yml",
 		"scripts/run_v1_acceptance.sh",
 		"scripts/test_uat_local.sh",
 		"Makefile",
@@ -79,6 +78,10 @@ func TestWorkflowGoTestsUseFirstPartyPackageList(t *testing.T) {
 		if !strings.Contains(payload, "first_party_go_packages.sh") && rel != "Makefile" {
 			t.Fatalf("%s must consume scripts/first_party_go_packages.sh for Go package scope", rel)
 		}
+	}
+	releaseWorkflow := mustReadFile(t, filepath.Join(repoRoot, ".github/workflows/release.yml"))
+	if strings.Contains(releaseWorkflow, "go test ") {
+		t.Fatal("release workflow must package the exact green main source instead of rerunning Go tests")
 	}
 	makefile := mustReadFile(t, filepath.Join(repoRoot, "Makefile"))
 	if !strings.Contains(makefile, "PKG_LIST := scripts/first_party_go_packages.sh") {


### PR DESCRIPTION
## Problem
Wrkr reran substantially the same source validation during local pre-push, PR, main, release preparation, and tag release workflows. This consumed runner time without adding equivalent assurance.

## Changes
- centralize PR path classification and conditionally allocate CodeQL, scan-contract, docs, Python, and Windows work while preserving all required check names
- make PR coverage, contract/scenario validation, and freeze evidence the authoritative product correctness gate
- reduce main to an Ubuntu lint/build/CLI merge confirmation and move macOS/Windows depth to a weekly workflow
- require release tags to point to an exact successful main SHA, then keep the tag workflow focused on build, checksum, SBOM, scanning, signing, provenance, publishing, and published-install UAT
- remove duplicate baseline executions from `make prepush-full`
- update CI/release trust documentation and executable workflow-ownership contracts

## Validation
- `make prepush-full`
- `actionlint`
- `go test ./testinfra/... -count=1`
- `make test-docs-consistency`
- freeze gate: 23 commands, final digest `dda38f99504504ab9876a778f229064cf78e05d822a7fce2e24e7b2f08841dcd`
- CodeQL: 59/59 queries completed, SARIF generated

## Risk
The main risk is accidentally weakening release source provenance while removing repeated tests. The release workflow now fails closed unless the tagged commit is reachable from `main` and the exact SHA has a successful `main` workflow. Contract tests prevent coverage, freeze, and package validation from drifting back into main/release or disappearing from PR validation.

## Scope
Factory files and the Factory submodule pointer are unchanged.
