### PR TITLE
fix: harden scan analysis and docs dependencies

### DIFF
--- a/.github/coverage-exceptions.json
+++ b/.github/coverage-exceptions.json
@@ -75,6 +75,7 @@
     "github.com/Clyra-AI/wrkr/internal/managedmarker": 0.0,
     "github.com/Clyra-AI/wrkr/internal/proofcompat": 69.2,
     "github.com/Clyra-AI/wrkr/internal/reponame": 0.0,
+    "github.com/Clyra-AI/wrkr/internal/statelock": 71.9,
     "github.com/Clyra-AI/wrkr/internal/testutil/detectors": 0.0,
     "github.com/Clyra-AI/wrkr/scenarios/wrkr/webmcp-declarations/repos/route-repo/server": 0.0,
     "github.com/Clyra-AI/wrkr/scripts": 0.0,

--- a/.github/coverage-exceptions.json
+++ b/.github/coverage-exceptions.json
@@ -75,7 +75,6 @@
     "github.com/Clyra-AI/wrkr/internal/managedmarker": 0.0,
     "github.com/Clyra-AI/wrkr/internal/proofcompat": 69.2,
     "github.com/Clyra-AI/wrkr/internal/reponame": 0.0,
-    "github.com/Clyra-AI/wrkr/internal/statelock": 71.9,
     "github.com/Clyra-AI/wrkr/internal/testutil/detectors": 0.0,
     "github.com/Clyra-AI/wrkr/scenarios/wrkr/webmcp-declarations/repos/route-repo/server": 0.0,
     "github.com/Clyra-AI/wrkr/scripts": 0.0,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,6 +46,9 @@ jobs:
               - 'testinfra/**'
               - 'scenarios/**'
               - 'scripts/**'
+              - 'schemas/**'
+              - '.goreleaser.yaml'
+              - '.github/coverage-exceptions.json'
               - '.github/workflows/**'
               - '.github/required-checks.json'
             dependencies:
@@ -80,6 +83,9 @@ jobs:
               - 'internal/**'
               - 'testinfra/**'
               - 'scenarios/**'
+              - 'schemas/**'
+              - '.goreleaser.yaml'
+              - '.github/coverage-exceptions.json'
               - '.github/workflows/**'
             security:
               - '**/*.go'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- (none yet)
+- [semver:patch] Kept endpoint-dense scans bounded by reusing canonical endpoint evidence during analysis, preserving per-operation attribution, and isolating concurrent scan artifacts.
 
 ### Security
 

--- a/core/aggregate/agentresolver/workflow_chain.go
+++ b/core/aggregate/agentresolver/workflow_chain.go
@@ -1,6 +1,7 @@
 package agentresolver
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -106,8 +107,20 @@ type WorkflowChainInput struct {
 }
 
 func BuildWorkflowChains(inputs []WorkflowChainInput) *WorkflowChainArtifact {
+	artifact, _ := BuildWorkflowChainsContext(context.Background(), inputs)
+	return artifact
+}
+
+// BuildWorkflowChainsContext builds the deterministic workflow-chain artifact while honoring cancellation.
+func BuildWorkflowChainsContext(ctx context.Context, inputs []WorkflowChainInput) (*WorkflowChainArtifact, error) {
 	if len(inputs) == 0 {
-		return nil
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	ordered := append([]WorkflowChainInput(nil), inputs...)
@@ -126,6 +139,9 @@ func BuildWorkflowChains(inputs []WorkflowChainInput) *WorkflowChainArtifact {
 
 	byID := map[string]*WorkflowChain{}
 	for _, input := range ordered {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		chain := buildWorkflowChain(input)
 		if current, ok := byID[chain.ChainID]; ok {
 			current.PathIDs = uniqueSortedStrings(append(current.PathIDs, chain.PathIDs...))
@@ -154,17 +170,23 @@ func BuildWorkflowChains(inputs []WorkflowChainInput) *WorkflowChainArtifact {
 
 	chains := make([]WorkflowChain, 0, len(byID))
 	for _, chain := range byID {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		chains = append(chains, cloneWorkflowChain(*chain))
 	}
 	sort.Slice(chains, func(i, j int) bool {
 		return chains[i].ChainID < chains[j].ChainID
 	})
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	return &WorkflowChainArtifact{
 		Version: WorkflowChainVersion,
 		Summary: summarizeWorkflowChains(chains),
 		Chains:  chains,
-	}
+	}, nil
 }
 
 func WorkflowChainRefsByPath(artifact *WorkflowChainArtifact) map[string][]string {

--- a/core/aggregate/attackpath/graph.go
+++ b/core/aggregate/attackpath/graph.go
@@ -628,15 +628,9 @@ func BuildControlPathGraphContext(ctx context.Context, paths []ControlPathInput)
 	}
 
 	ordered := append([]ControlPathInput(nil), paths...)
-	sort.Slice(ordered, func(i, j int) bool {
-		if strings.TrimSpace(ordered[i].Org) != strings.TrimSpace(ordered[j].Org) {
-			return strings.TrimSpace(ordered[i].Org) < strings.TrimSpace(ordered[j].Org)
-		}
-		if strings.TrimSpace(ordered[i].Repo) != strings.TrimSpace(ordered[j].Repo) {
-			return strings.TrimSpace(ordered[i].Repo) < strings.TrimSpace(ordered[j].Repo)
-		}
-		return strings.TrimSpace(ordered[i].PathID) < strings.TrimSpace(ordered[j].PathID)
-	})
+	if err := sortControlPathInputsContext(ctx, ordered); err != nil {
+		return nil, err
+	}
 
 	nodes := make([]ControlPathNode, 0, len(ordered)*8)
 	edges := make([]ControlPathEdge, 0, len(ordered)*8)
@@ -669,28 +663,16 @@ func BuildControlPathGraphContext(ctx context.Context, paths []ControlPathInput)
 		}
 	}
 
-	sort.Slice(nodes, func(i, j int) bool {
-		if nodes[i].PathID != nodes[j].PathID {
-			return nodes[i].PathID < nodes[j].PathID
-		}
-		if nodes[i].Kind != nodes[j].Kind {
-			return nodes[i].Kind < nodes[j].Kind
-		}
-		return nodes[i].NodeID < nodes[j].NodeID
-	})
-	sort.Slice(edges, func(i, j int) bool {
-		if edges[i].PathID != edges[j].PathID {
-			return edges[i].PathID < edges[j].PathID
-		}
-		if edges[i].Kind != edges[j].Kind {
-			return edges[i].Kind < edges[j].Kind
-		}
-		return edges[i].EdgeID < edges[j].EdgeID
-	})
-
+	if err := sortControlPathNodesContext(ctx, nodes); err != nil {
+		return nil, err
+	}
+	if err := sortControlPathEdgesContext(ctx, edges); err != nil {
+		return nil, err
+	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+
 	graph := &ControlPathGraph{
 		Version: ControlPathGraphVersion,
 		Summary: ControlPathGraphSummary{
@@ -706,6 +688,94 @@ func BuildControlPathGraphContext(ctx context.Context, paths []ControlPathInput)
 		Edges: edges,
 	}
 	return StripCanonicalProjectionDetails(BackfillCanonicalProjectionRefs(graph)), nil
+}
+
+func sortControlPathInputsContext(ctx context.Context, values []ControlPathInput) error {
+	return stableSortControlPathValuesContext(ctx, values, func(left, right ControlPathInput) bool {
+		if strings.TrimSpace(left.Org) != strings.TrimSpace(right.Org) {
+			return strings.TrimSpace(left.Org) < strings.TrimSpace(right.Org)
+		}
+		if strings.TrimSpace(left.Repo) != strings.TrimSpace(right.Repo) {
+			return strings.TrimSpace(left.Repo) < strings.TrimSpace(right.Repo)
+		}
+		return strings.TrimSpace(left.PathID) < strings.TrimSpace(right.PathID)
+	})
+}
+
+func sortControlPathNodesContext(ctx context.Context, values []ControlPathNode) error {
+	return stableSortControlPathValuesContext(ctx, values, func(left, right ControlPathNode) bool {
+		if left.PathID != right.PathID {
+			return left.PathID < right.PathID
+		}
+		if left.Kind != right.Kind {
+			return left.Kind < right.Kind
+		}
+		return left.NodeID < right.NodeID
+	})
+}
+
+func sortControlPathEdgesContext(ctx context.Context, values []ControlPathEdge) error {
+	return stableSortControlPathValuesContext(ctx, values, func(left, right ControlPathEdge) bool {
+		if left.PathID != right.PathID {
+			return left.PathID < right.PathID
+		}
+		if left.Kind != right.Kind {
+			return left.Kind < right.Kind
+		}
+		return left.EdgeID < right.EdgeID
+	})
+}
+
+func stableSortControlPathValuesContext[T any](ctx context.Context, values []T, less func(left, right T) bool) error {
+	if len(values) < 2 {
+		return ctx.Err()
+	}
+	scratch := make([]T, len(values))
+	for width := 1; width < len(values); {
+		for start := 0; start < len(values); start += 2 * width {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			middle := min(start+width, len(values))
+			end := min(start+2*width, len(values))
+			left, right, destination := start, middle, start
+			for left < middle && right < end {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				if less(values[right], values[left]) {
+					scratch[destination] = values[right]
+					right++
+				} else {
+					scratch[destination] = values[left]
+					left++
+				}
+				destination++
+			}
+			for left < middle {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				scratch[destination] = values[left]
+				left++
+				destination++
+			}
+			for right < end {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				scratch[destination] = values[right]
+				right++
+				destination++
+			}
+		}
+		copy(values, scratch)
+		if width > len(values)/2 {
+			break
+		}
+		width *= 2
+	}
+	return nil
 }
 
 func buildControlPath(path ControlPathInput) ([]ControlPathNode, []ControlPathEdge) {

--- a/core/aggregate/attackpath/graph.go
+++ b/core/aggregate/attackpath/graph.go
@@ -713,6 +713,7 @@ func buildControlPath(path ControlPathInput) ([]ControlPathNode, []ControlPathEd
 	if pathID == "" {
 		return nil, nil
 	}
+	path = prepareControlPathEndpointMetadata(path)
 	org := fallbackOrg(path.Org)
 	repo := controlValue(path.Repo, "unknown_repo")
 	location := controlValue(path.Location, "unknown_workflow")
@@ -848,6 +849,20 @@ func buildControlPath(path ControlPathInput) ([]ControlPathNode, []ControlPathEd
 	return nodes, edges
 }
 
+func prepareControlPathEndpointMetadata(path ControlPathInput) ControlPathInput {
+	path.EndpointRefGroupProjection = agginventory.BackfillMutableEndpointGroupProjection(
+		path.EndpointRefGroupProjection,
+		path.MutableEndpointSemanticRefs,
+		path.MutableEndpointSemantics,
+	)
+	path.MutableEndpointSemanticRefs = agginventory.BoundedMutableEndpointSemanticRefs(
+		path.MutableEndpointSemanticRefs,
+		path.MutableEndpointSemantics,
+	)
+	path.MutableEndpointSemantics = agginventory.BoundedMutableEndpointSemantics(path.MutableEndpointSemantics)
+	return path
+}
+
 func controlCredentialNode(pathID string, path ControlPathInput, org string, repo string, toolType string, location string) *ControlPathNode {
 	provenance := agginventory.NormalizeCredentialProvenance(path.CredentialProvenance)
 	if provenance == nil && !path.CredentialAccess {
@@ -875,9 +890,9 @@ func controlCredentialNode(pathID string, path ControlPathInput, org string, rep
 	node.CredentialAuthority = agginventory.CloneCredentialAuthority(path.CredentialAuthority)
 	node.AuthorityBindingRefs = append([]string(nil), path.AuthorityBindingRefs...)
 	node.AuthorityBindings = agginventory.CloneAuthorityBindings(path.AuthorityBindings)
-	node.EndpointRefGroupProjection = agginventory.BackfillMutableEndpointGroupProjection(path.EndpointRefGroupProjection, path.MutableEndpointSemanticRefs, path.MutableEndpointSemantics)
-	node.MutableEndpointSemanticRefs = agginventory.BoundedMutableEndpointSemanticRefs(path.MutableEndpointSemanticRefs, path.MutableEndpointSemantics)
-	node.MutableEndpointSemantics = agginventory.BoundedMutableEndpointSemantics(path.MutableEndpointSemantics)
+	node.EndpointRefGroupProjection = path.EndpointRefGroupProjection
+	node.MutableEndpointSemanticRefs = append([]string(nil), path.MutableEndpointSemanticRefs...)
+	node.MutableEndpointSemantics = agginventory.CloneMutableEndpointSemantics(path.MutableEndpointSemantics)
 	return &node
 }
 
@@ -893,9 +908,9 @@ func applyNodeMetadata(node *ControlPathNode, path ControlPathInput, lineageSegm
 	node.VersionSource = strings.TrimSpace(path.VersionSource)
 	node.ConfigFingerprint = strings.TrimSpace(path.ConfigFingerprint)
 	node.ConfigSource = strings.TrimSpace(path.ConfigSource)
-	node.EndpointRefGroupProjection = agginventory.BackfillMutableEndpointGroupProjection(path.EndpointRefGroupProjection, path.MutableEndpointSemanticRefs, path.MutableEndpointSemantics)
-	node.MutableEndpointSemanticRefs = agginventory.BoundedMutableEndpointSemanticRefs(path.MutableEndpointSemanticRefs, path.MutableEndpointSemantics)
-	node.MutableEndpointSemantics = agginventory.BoundedMutableEndpointSemantics(path.MutableEndpointSemantics)
+	node.EndpointRefGroupProjection = path.EndpointRefGroupProjection
+	node.MutableEndpointSemanticRefs = append([]string(nil), path.MutableEndpointSemanticRefs...)
+	node.MutableEndpointSemantics = agginventory.CloneMutableEndpointSemantics(path.MutableEndpointSemantics)
 }
 
 func lineageSegmentForGovernanceControl(control string) string {
@@ -1317,9 +1332,18 @@ func actionCapabilityLabels(path ControlPathInput) []string {
 	if path.ProductionWrite {
 		values = append(values, "production_write")
 	}
-	for _, item := range agginventory.NormalizeMutableEndpointSemantics(path.MutableEndpointSemantics) {
-		if strings.TrimSpace(item.Semantic) != "" {
-			values = append(values, "endpoint_semantic:"+strings.TrimSpace(item.Semantic))
+	projection := agginventory.BackfillMutableEndpointGroupProjection(path.EndpointRefGroupProjection, path.MutableEndpointSemanticRefs, path.MutableEndpointSemantics)
+	if len(projection.EndpointOperationCounts) > 0 {
+		for _, item := range projection.EndpointOperationCounts {
+			if class := strings.TrimSpace(item.Class); class != "" {
+				values = append(values, "endpoint_semantic:"+class)
+			}
+		}
+	} else {
+		for _, item := range agginventory.NormalizeMutableEndpointSemantics(path.MutableEndpointSemantics) {
+			if strings.TrimSpace(item.Semantic) != "" {
+				values = append(values, "endpoint_semantic:"+strings.TrimSpace(item.Semantic))
+			}
 		}
 	}
 	for _, class := range path.WritePathClasses {

--- a/core/aggregate/attackpath/graph.go
+++ b/core/aggregate/attackpath/graph.go
@@ -1,6 +1,7 @@
 package attackpath
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -610,8 +611,20 @@ type ControlPathEdge struct {
 }
 
 func BuildControlPathGraph(paths []ControlPathInput) *ControlPathGraph {
+	graph, _ := BuildControlPathGraphContext(context.Background(), paths)
+	return graph
+}
+
+// BuildControlPathGraphContext builds the deterministic graph while honoring scan cancellation.
+func BuildControlPathGraphContext(ctx context.Context, paths []ControlPathInput) (*ControlPathGraph, error) {
 	if len(paths) == 0 {
-		return nil
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	ordered := append([]ControlPathInput(nil), paths...)
@@ -633,6 +646,9 @@ func BuildControlPathGraph(paths []ControlPathInput) *ControlPathGraph {
 	readinessCounts := map[string]int{}
 	evidenceCounts := map[string]int{}
 	for _, path := range ordered {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		pathNodes, pathEdges := buildControlPath(path)
 		nodes = append(nodes, pathNodes...)
 		edges = append(edges, pathEdges...)
@@ -672,6 +688,9 @@ func BuildControlPathGraph(paths []ControlPathInput) *ControlPathGraph {
 		return edges[i].EdgeID < edges[j].EdgeID
 	})
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	graph := &ControlPathGraph{
 		Version: ControlPathGraphVersion,
 		Summary: ControlPathGraphSummary{
@@ -686,7 +705,7 @@ func BuildControlPathGraph(paths []ControlPathInput) *ControlPathGraph {
 		Nodes: nodes,
 		Edges: edges,
 	}
-	return StripCanonicalProjectionDetails(BackfillCanonicalProjectionRefs(graph))
+	return StripCanonicalProjectionDetails(BackfillCanonicalProjectionRefs(graph)), nil
 }
 
 func buildControlPath(path ControlPathInput) ([]ControlPathNode, []ControlPathEdge) {
@@ -1339,6 +1358,11 @@ func uniqueSortedStrings(values []string) []string {
 	if len(values) == 0 {
 		return nil
 	}
+	if alreadyUniqueSortedStrings(values) {
+		// The graph is an output snapshot. Keep its references independent from
+		// caller-owned input slices even when normalization work can be skipped.
+		return append([]string(nil), values...)
+	}
 	seen := map[string]struct{}{}
 	out := make([]string, 0, len(values))
 	for _, value := range values {
@@ -1357,6 +1381,20 @@ func uniqueSortedStrings(values []string) []string {
 		return nil
 	}
 	return out
+}
+
+func alreadyUniqueSortedStrings(values []string) bool {
+	previous := ""
+	for index, value := range values {
+		if value == "" || strings.TrimSpace(value) != value {
+			return false
+		}
+		if index > 0 && previous >= value {
+			return false
+		}
+		previous = value
+	}
+	return true
 }
 
 func firstNonEmpty(values ...string) string {

--- a/core/aggregate/attackpath/graph_test.go
+++ b/core/aggregate/attackpath/graph_test.go
@@ -327,6 +327,9 @@ func TestUniqueSortedStringsCopiesAlreadyNormalizedInput(t *testing.T) {
 	got := uniqueSortedStrings(input)
 	got[0] = "changed"
 	got = append(got, "attack_path:c")
+	if want := "attack_path:c"; got[2] != want {
+		t.Fatalf("uniqueSortedStrings append = %q, want %q", got[2], want)
+	}
 
 	if want := []string{"attack_path:a", "attack_path:b"}; !reflect.DeepEqual(input, want) {
 		t.Fatalf("uniqueSortedStrings mutated input = %v, want %v", input, want)

--- a/core/aggregate/attackpath/graph_test.go
+++ b/core/aggregate/attackpath/graph_test.go
@@ -1,6 +1,8 @@
 package attackpath
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -320,6 +322,25 @@ func TestControlPathGraphCompositionEvidenceRefsRemainDeterministic(t *testing.T
 	}
 }
 
+func TestControlPathGraphSortsHonorCancellation(t *testing.T) {
+	nodes := make([]ControlPathNode, 128)
+	edges := make([]ControlPathEdge, 128)
+	for index := range nodes {
+		value := fmt.Sprintf("%03d", len(nodes)-index)
+		nodes[index] = ControlPathNode{PathID: "apc-" + value, Kind: ControlPathNodeTool, NodeID: "node-" + value}
+		edges[index] = ControlPathEdge{PathID: "apc-" + value, Kind: "path_uses_tool", EdgeID: "edge-" + value}
+	}
+
+	nodeCtx := &deadlineAfterCallsContext{Context: context.Background(), allowedCalls: 4}
+	if err := sortControlPathNodesContext(nodeCtx, nodes); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("node-sort cancellation error = %v, want deadline exceeded", err)
+	}
+	edgeCtx := &deadlineAfterCallsContext{Context: context.Background(), allowedCalls: 4}
+	if err := sortControlPathEdgesContext(edgeCtx, edges); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("edge-sort cancellation error = %v, want deadline exceeded", err)
+	}
+}
+
 func TestUniqueSortedStringsCopiesAlreadyNormalizedInput(t *testing.T) {
 	input := make([]string, 2, 4)
 	copy(input, []string{"attack_path:a", "attack_path:b"})
@@ -546,4 +567,18 @@ func hasControlPathEdgeKind(edges []ControlPathEdge, want string) bool {
 		}
 	}
 	return false
+}
+
+type deadlineAfterCallsContext struct {
+	context.Context
+	allowedCalls int
+	calls        int
+}
+
+func (c *deadlineAfterCallsContext) Err() error {
+	c.calls++
+	if c.calls > c.allowedCalls {
+		return context.DeadlineExceeded
+	}
+	return nil
 }

--- a/core/aggregate/attackpath/graph_test.go
+++ b/core/aggregate/attackpath/graph_test.go
@@ -320,6 +320,19 @@ func TestControlPathGraphCompositionEvidenceRefsRemainDeterministic(t *testing.T
 	}
 }
 
+func TestUniqueSortedStringsCopiesAlreadyNormalizedInput(t *testing.T) {
+	input := make([]string, 2, 4)
+	copy(input, []string{"attack_path:a", "attack_path:b"})
+
+	got := uniqueSortedStrings(input)
+	got[0] = "changed"
+	got = append(got, "attack_path:c")
+
+	if want := []string{"attack_path:a", "attack_path:b"}; !reflect.DeepEqual(input, want) {
+		t.Fatalf("uniqueSortedStrings mutated input = %v, want %v", input, want)
+	}
+}
+
 func TestControlPathGraphLinksIdentityCredentialToolWorkflowTargetAction(t *testing.T) {
 	t.Parallel()
 

--- a/core/aggregate/privilegebudget/budget.go
+++ b/core/aggregate/privilegebudget/budget.go
@@ -347,7 +347,7 @@ func buildInstanceEntries(
 			approvalClassification = "unapproved"
 		}
 
-		mutableEndpointSemantics := mergeMutableEndpointSemantics(tool.MutableEndpointSemantics, mutableEndpointSemanticsFromSignals(signals))
+		mutableEndpointSemantics := mutableEndpointSemanticsForAgent(tool, scopedSignals, signals)
 		writeCapable := hasAnyPermission(permissions, writeSet)
 		credentialAccess := hasCredentialAccessForSurface(dataClass, permissions, agent.BoundAuthSurfaces)
 		execCapable := hasExecPermission(permissions)
@@ -1224,6 +1224,16 @@ func mutableEndpointSemanticsFromSignals(signals findingSignals) []agginventory.
 		values = append(values, item)
 	}
 	return agginventory.NormalizeMutableEndpointSemantics(values)
+}
+
+func mutableEndpointSemanticsForAgent(tool agginventory.Tool, scopedSignals findingSignals, fallbackSignals findingSignals) []agginventory.MutableEndpointSemantic {
+	if scoped := mutableEndpointSemanticsFromSignals(scopedSignals); len(scoped) > 0 {
+		// Endpoint instance records are precise evidence. Do not widen them with
+		// the aggregate tool or repository surface, which would attribute every
+		// endpoint to every operation in a shared specification.
+		return scoped
+	}
+	return mergeMutableEndpointSemantics(tool.MutableEndpointSemantics, mutableEndpointSemanticsFromSignals(fallbackSignals))
 }
 
 func mergeMutableEndpointSemantics(groups ...[]agginventory.MutableEndpointSemantic) []agginventory.MutableEndpointSemantic {

--- a/core/aggregate/privilegebudget/budget_test.go
+++ b/core/aggregate/privilegebudget/budget_test.go
@@ -1111,6 +1111,77 @@ func TestBuildCreatesSeparateInstanceScopedEntriesForAgentsInSameFile(t *testing
 	}
 }
 
+func TestBuildKeepsOpenAPIEndpointSemanticsInstanceScoped(t *testing.T) {
+	t.Parallel()
+
+	const (
+		org      = "acme"
+		repo     = "acme/payments"
+		location = "openapi/payments.yaml"
+	)
+	endpoint := func(symbol, semantic, operation string) model.Finding {
+		return model.Finding{
+			FindingType: "openapi_endpoint",
+			ToolType:    "openapi",
+			Org:         org,
+			Repo:        repo,
+			Location:    location,
+			Evidence: []model.Evidence{
+				{Key: "operation_id", Value: symbol},
+				{Key: "mutable_endpoint_semantic", Value: semantic + "|high|openapi|" + operation},
+			},
+		}
+	}
+	findings := []model.Finding{
+		endpoint("refundPayment", agginventory.EndpointSemanticRefund, "POST /v1/refunds"),
+		endpoint("capturePayment", agginventory.EndpointSemanticPayment, "POST /v1/payments"),
+	}
+	tools := []agginventory.Tool{{
+		ToolID:    identity.ToolID("openapi", location),
+		ToolType:  "openapi",
+		Org:       org,
+		Repos:     []string{repo},
+		Locations: []agginventory.ToolLocation{{Repo: repo, Location: location}},
+		MutableEndpointSemantics: []agginventory.MutableEndpointSemantic{
+			{Semantic: agginventory.EndpointSemanticRefund, Confidence: "high", Surface: "openapi", Operation: "POST /v1/refunds"},
+			{Semantic: agginventory.EndpointSemanticPayment, Confidence: "high", Surface: "openapi", Operation: "POST /v1/payments"},
+		},
+	}}
+	agents := make([]agginventory.Agent, 0, len(findings))
+	for _, item := range findings {
+		symbol, startLine, endLine := agentIdentityPartsForFinding(item)
+		instanceID := identity.AgentInstanceID(item.ToolType, item.Location, symbol, startLine, endLine)
+		agents = append(agents, agginventory.Agent{
+			AgentID:         identity.AgentID(instanceID, org),
+			AgentInstanceID: instanceID,
+			ToolInstanceID:  identity.ToolInstanceID(item.ToolType, item.Repo, item.Location, symbol, startLine, endLine),
+			Framework:       "openapi",
+			Symbol:          symbol,
+			Org:             org,
+			Repo:            repo,
+			Location:        location,
+		})
+	}
+
+	_, entries := Build(tools, agents, findings, nil)
+	if len(entries) != 2 {
+		t.Fatalf("expected two endpoint entries, got %+v", entries)
+	}
+	wantBySymbol := map[string]string{
+		"refundPayment":  agginventory.EndpointSemanticRefund,
+		"capturePayment": agginventory.EndpointSemanticPayment,
+	}
+	for _, entry := range entries {
+		want, ok := wantBySymbol[entry.Symbol]
+		if !ok {
+			t.Fatalf("unexpected endpoint entry %+v", entry)
+		}
+		if len(entry.MutableEndpointSemantics) != 1 || entry.MutableEndpointSemantics[0].Semantic != want {
+			t.Fatalf("endpoint %s semantics = %+v, want only %q", entry.Symbol, entry.MutableEndpointSemantics, want)
+		}
+	}
+}
+
 func TestCredentialAuthoritySeparatesReferenceFromUsability(t *testing.T) {
 	t.Parallel()
 

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -434,7 +434,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	if err := statusTracker.Phase("analysis_start"); err != nil {
 		return emitScanFailure(err)
 	}
-	progress.PhaseSubstep("analysis", "inventory", 1, 6)
+	progress.PhaseSubstep("analysis", "inventory", 1, 10)
 
 	previousSnapshot, loadPreviousErr := loadPreviousSnapshot(statePath, strings.TrimSpace(*baselinePath))
 	if loadPreviousErr != nil {
@@ -578,7 +578,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	}
 	agginventory.ApplySecurityVisibilityToPrivilegeMap(&inventoryOut)
 	agginventory.ApplyCanonicalStores(&inventoryOut)
-	progress.PhaseSubstep("analysis", "action_paths", 2, 6)
+	progress.PhaseSubstep("analysis", "action_paths", 2, 10)
 	riskReport.ActionPaths, riskReport.ActionPathToControlFirst = risk.BuildActionPaths(riskReport.AttackPaths, &inventoryOut)
 	riskReport.ActionPaths = risk.DecoratePolicyCoverage(riskReport.ActionPaths, analysisFindings)
 	riskReport.ActionPaths = risk.DecorateIntroducedBy(riskReport.ActionPaths, repoAttributionContexts(manifestOut, now))
@@ -623,23 +623,55 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	}
 	artifactFindings := summarizeArtifactFindings(findings, scanMode)
 	riskReport.ActionPaths = risk.DecorateEvidenceContext(riskReport.ActionPaths, &scanQuality)
-	progress.PhaseSubstep("analysis", "control_graph", 3, 6)
-	riskReport.ControlPathGraph = risk.BuildControlPathGraph(riskReport.ActionPaths)
-	progress.PhaseSubstep("analysis", "workflow_chains", 4, 6)
-	riskReport.WorkflowChains = risk.BuildWorkflowChains(riskReport.ActionPaths, riskReport.ControlPathGraph)
-	riskReport.ActionPaths = risk.DecorateWorkflowChainRefs(riskReport.ActionPaths, riskReport.WorkflowChains)
-	riskReport.ActionPaths = risk.DecorateActionLineage(riskReport.ActionPaths, riskReport.ControlPathGraph)
-	riskReport.ActionPaths = risk.ProjectReviewLifecycleTransitions(riskReport.ActionPaths, previousSnapshotActionPaths(previousSnapshot))
-	riskReport.ComposedActionPaths, riskReport.ComposedActionPathToControlFirst = risk.BuildComposedActionPaths(riskReport.ActionPaths, riskReport.WorkflowChains)
-	riskReport.ActionPaths = risk.DecorateActionPathCompositionRefs(riskReport.ActionPaths, riskReport.ComposedActionPaths)
+	progress.PhaseSubstep("analysis", "control_graph", 3, 10)
+	controlGraph, graphErr := risk.BuildControlPathGraphContext(ctx, riskReport.ActionPaths)
+	if graphErr != nil {
+		return emitScanFailure(graphErr)
+	}
+	riskReport.ControlPathGraph = controlGraph
+	progress.PhaseSubstep("analysis", "workflow_chains", 4, 10)
+	workflowChains, workflowErr := risk.BuildWorkflowChainsContext(ctx, riskReport.ActionPaths, riskReport.ControlPathGraph)
+	if workflowErr != nil {
+		return emitScanFailure(workflowErr)
+	}
+	riskReport.WorkflowChains = workflowChains
+	progress.PhaseSubstep("analysis", "action_lineage", 5, 10)
+	pathsWithWorkflowRefs, workflowRefErr := risk.DecorateWorkflowChainRefsContext(ctx, riskReport.ActionPaths, riskReport.WorkflowChains)
+	if workflowRefErr != nil {
+		return emitScanFailure(workflowRefErr)
+	}
+	pathsWithLineage, lineageErr := risk.DecorateActionLineageContext(ctx, pathsWithWorkflowRefs, riskReport.ControlPathGraph)
+	if lineageErr != nil {
+		return emitScanFailure(lineageErr)
+	}
+	riskReport.ActionPaths = pathsWithLineage
+	progress.PhaseSubstep("analysis", "review_lifecycle", 6, 10)
+	pathsWithReviewLifecycle, reviewLifecycleErr := risk.ProjectReviewLifecycleTransitionsContext(ctx, riskReport.ActionPaths, previousSnapshotActionPaths(previousSnapshot))
+	if reviewLifecycleErr != nil {
+		return emitScanFailure(reviewLifecycleErr)
+	}
+	riskReport.ActionPaths = pathsWithReviewLifecycle
+	progress.PhaseSubstep("analysis", "composition", 7, 10)
+	compositions, compositionChoice, compositionErr := risk.BuildComposedActionPathsContext(ctx, riskReport.ActionPaths, riskReport.WorkflowChains)
+	if compositionErr != nil {
+		return emitScanFailure(compositionErr)
+	}
+	riskReport.ComposedActionPaths = compositions
+	riskReport.ComposedActionPathToControlFirst = compositionChoice
+	pathsWithCompositionRefs, compositionRefErr := risk.DecorateActionPathCompositionRefsContext(ctx, riskReport.ActionPaths, riskReport.ComposedActionPaths)
+	if compositionRefErr != nil {
+		return emitScanFailure(compositionRefErr)
+	}
+	riskReport.ActionPaths = pathsWithCompositionRefs
 	riskReport.ActionPathToControlFirst = risk.BuildActionPathChoice(riskReport.ActionPaths)
+	progress.PhaseSubstep("analysis", "lifecycle_queue", 8, 10)
 	lifecycleGaps := lifecycle.DetectGaps(lifecycle.GapInput{
 		Identities:  nextManifest.Identities,
 		Inventory:   &inventoryOut,
 		Transitions: transitions,
 	})
 	inventoryOut.LifecycleQueue = lifecycle.BuildQueue(lifecycleGaps)
-	progress.PhaseSubstep("analysis", "backlog", 5, 6)
+	progress.PhaseSubstep("analysis", "backlog", 9, 10)
 	controlBacklog := controlbacklog.Build(controlbacklog.Input{
 		Mode:             scanMode,
 		GeneratedAt:      now,
@@ -672,7 +704,7 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	if err := checkScanContext(); err != nil {
 		return emitScanFailure(err)
 	}
-	progress.PhaseSubstep("analysis", "state_finalization", 6, 6)
+	progress.PhaseSubstep("analysis", "state_finalization", 10, 10)
 
 	snapshot := state.Snapshot{
 		Version:                    state.SnapshotVersion,

--- a/core/cli/scan.go
+++ b/core/cli/scan.go
@@ -583,7 +583,11 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 	riskReport.ActionPaths = risk.DecoratePolicyCoverage(riskReport.ActionPaths, analysisFindings)
 	riskReport.ActionPaths = risk.DecorateIntroducedBy(riskReport.ActionPaths, repoAttributionContexts(manifestOut, now))
 	riskReport.ActionPaths = risk.DecorateControlMetadata(riskReport.ActionPaths, repoAttributionContexts(manifestOut, now))
-	riskReport.ActionPaths = risk.ProjectActionPaths(riskReport.ActionPaths)
+	projectedActionPaths, projectionErr := risk.ProjectActionPathsContext(ctx, riskReport.ActionPaths)
+	if projectionErr != nil {
+		return emitScanFailure(projectionErr)
+	}
+	riskReport.ActionPaths = projectedActionPaths
 	riskReport.ActionPathToControlFirst = risk.BuildActionPathChoice(riskReport.ActionPaths)
 
 	var previousProfile *profileeval.Result
@@ -592,7 +596,12 @@ func runScanWithContext(parentCtx context.Context, args []string, stdout io.Writ
 		previousProfile = &copyResult
 	}
 	profileResult := profileeval.Evaluate(profileDef, analysisFindings, previousProfile)
-	riskReport.ActionPaths, riskReport.ActionPathToControlFirst = risk.ApplyGovernFirstProfile(profileResult.ProfileName, riskReport.ActionPaths)
+	governedActionPaths, actionPathChoice, governFirstErr := risk.ApplyGovernFirstProfileContext(ctx, profileResult.ProfileName, riskReport.ActionPaths)
+	if governFirstErr != nil {
+		return emitScanFailure(governFirstErr)
+	}
+	riskReport.ActionPaths = governedActionPaths
+	riskReport.ActionPathToControlFirst = actionPathChoice
 	if err := checkScanContext(); err != nil {
 		return emitScanFailure(err)
 	}

--- a/core/cli/scan_process_lock_test.go
+++ b/core/cli/scan_process_lock_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -60,6 +61,38 @@ func TestConcurrentScanProcessesPreserveCompleteProofChain(t *testing.T) {
 	concurrentCount := proofChainRecordCount(t, concurrentState)
 	if concurrentCount != sequentialCount {
 		t.Fatalf("concurrent proof records = %d, sequential proof records = %d", concurrentCount, sequentialCount)
+	}
+}
+
+func TestConcurrentScanProcessesWithSeparateArtifactsDoNotCollide(t *testing.T) {
+	t.Parallel()
+
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", "scenarios", "wrkr", "scan-mixed-org", "repos"))
+	if err != nil {
+		t.Fatalf("resolve fixture path: %v", err)
+	}
+
+	artifactRoot := t.TempDir()
+	commands := make([]*exec.Cmd, 0, 4)
+	states := make([]string, 0, 4)
+	for index := 0; index < 4; index++ {
+		statePath := filepath.Join(artifactRoot, fmt.Sprintf("scan-%d", index), "state.json")
+		states = append(states, statePath)
+		commands = append(commands, scanProcessCommand(t, repoRoot, statePath))
+	}
+
+	for _, command := range commands {
+		if err := command.Start(); err != nil {
+			t.Fatalf("start isolated scan: %v", err)
+		}
+	}
+	for index, command := range commands {
+		if err := command.Wait(); err != nil {
+			t.Fatalf("isolated scan %d failed: %v\nstderr=%s", index, err, command.Stderr.(*bytes.Buffer).String())
+		}
+		if count := proofChainRecordCount(t, states[index]); count == 0 {
+			t.Fatalf("isolated scan %d emitted no proof records", index)
+		}
 	}
 }
 

--- a/core/cli/scan_progress_test.go
+++ b/core/cli/scan_progress_test.go
@@ -581,12 +581,16 @@ func TestScanProgressReportsAnalysisSubphases(t *testing.T) {
 	}
 
 	for _, want := range []string{
-		"event=phase_substep phase=analysis subphase=inventory step=1 step_total=6",
-		"event=phase_substep phase=analysis subphase=action_paths step=2 step_total=6",
-		"event=phase_substep phase=analysis subphase=control_graph step=3 step_total=6",
-		"event=phase_substep phase=analysis subphase=workflow_chains step=4 step_total=6",
-		"event=phase_substep phase=analysis subphase=backlog step=5 step_total=6",
-		"event=phase_substep phase=analysis subphase=state_finalization step=6 step_total=6",
+		"event=phase_substep phase=analysis subphase=inventory step=1 step_total=10",
+		"event=phase_substep phase=analysis subphase=action_paths step=2 step_total=10",
+		"event=phase_substep phase=analysis subphase=control_graph step=3 step_total=10",
+		"event=phase_substep phase=analysis subphase=workflow_chains step=4 step_total=10",
+		"event=phase_substep phase=analysis subphase=action_lineage step=5 step_total=10",
+		"event=phase_substep phase=analysis subphase=review_lifecycle step=6 step_total=10",
+		"event=phase_substep phase=analysis subphase=composition step=7 step_total=10",
+		"event=phase_substep phase=analysis subphase=lifecycle_queue step=8 step_total=10",
+		"event=phase_substep phase=analysis subphase=backlog step=9 step_total=10",
+		"event=phase_substep phase=analysis subphase=state_finalization step=10 step_total=10",
 		"event=phase_substep phase=artifact_commit subphase=artifact_write step=1 step_total=1",
 	} {
 		if !strings.Contains(errOut.String(), want) {

--- a/core/cli/scan_timeout_test.go
+++ b/core/cli/scan_timeout_test.go
@@ -128,7 +128,6 @@ func TestScanTimeoutAfterStateWriteRollsBackManagedArtifacts(t *testing.T) {
 		}
 		return nil
 	})
-	defer restore()
 
 	var out bytes.Buffer
 	var errOut bytes.Buffer
@@ -148,6 +147,19 @@ func TestScanTimeoutAfterStateWriteRollsBackManagedArtifacts(t *testing.T) {
 	assertErrorCode(t, errOut.Bytes(), "scan_timeout")
 	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
 		t.Fatalf("expected timed out scan state to roll back, stat err=%v", err)
+	}
+
+	restore()
+	var retryOut bytes.Buffer
+	var retryErr bytes.Buffer
+	retryCode := Run([]string{
+		"scan",
+		"--path", reposPath,
+		"--state", statePath,
+		"--json",
+	}, &retryOut, &retryErr)
+	if retryCode != exitSuccess {
+		t.Fatalf("expected retry to acquire released state lease, got %d stderr=%s", retryCode, retryErr.String())
 	}
 }
 

--- a/core/risk/action_lineage.go
+++ b/core/risk/action_lineage.go
@@ -1,6 +1,7 @@
 package risk
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"sort"
@@ -45,17 +46,32 @@ func CloneActionLineage(in *ActionLineage) *ActionLineage {
 }
 
 func DecorateActionLineage(paths []ActionPath, graph *aggattack.ControlPathGraph) []ActionPath {
+	decorated, _ := DecorateActionLineageContext(context.Background(), paths, graph)
+	return decorated
+}
+
+// DecorateActionLineageContext projects lineage while allowing a scan timeout to stop the work.
+func DecorateActionLineageContext(ctx context.Context, paths []ActionPath, graph *aggattack.ControlPathGraph) ([]ActionPath, error) {
 	if len(paths) == 0 {
-		return nil
+		return nil, nil
 	}
-	index := newControlPathLineageIndex(graph)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	index, err := newControlPathLineageIndexContext(ctx, graph)
+	if err != nil {
+		return nil, err
+	}
 	out := make([]ActionPath, 0, len(paths))
 	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		copyPath := path
 		copyPath.ActionLineage = buildActionLineage(path, index)
 		out = append(out, copyPath)
 	}
-	return out
+	return out, nil
 }
 
 type controlPathLineageIndex struct {
@@ -64,14 +80,25 @@ type controlPathLineageIndex struct {
 }
 
 func newControlPathLineageIndex(graph *aggattack.ControlPathGraph) controlPathLineageIndex {
+	index, _ := newControlPathLineageIndexContext(context.Background(), graph)
+	return index
+}
+
+func newControlPathLineageIndexContext(ctx context.Context, graph *aggattack.ControlPathGraph) (controlPathLineageIndex, error) {
 	index := controlPathLineageIndex{
 		nodesByPath: map[string][]aggattack.ControlPathNode{},
 		edgesByPath: map[string][]aggattack.ControlPathEdge{},
 	}
 	if graph == nil {
-		return index
+		return index, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	for _, node := range graph.Nodes {
+		if err := ctx.Err(); err != nil {
+			return controlPathLineageIndex{}, err
+		}
 		pathID := strings.TrimSpace(node.PathID)
 		if pathID == "" {
 			continue
@@ -79,13 +106,16 @@ func newControlPathLineageIndex(graph *aggattack.ControlPathGraph) controlPathLi
 		index.nodesByPath[pathID] = append(index.nodesByPath[pathID], node)
 	}
 	for _, edge := range graph.Edges {
+		if err := ctx.Err(); err != nil {
+			return controlPathLineageIndex{}, err
+		}
 		pathID := strings.TrimSpace(edge.PathID)
 		if pathID == "" {
 			continue
 		}
 		index.edgesByPath[pathID] = append(index.edgesByPath[pathID], edge)
 	}
-	return index
+	return index, nil
 }
 
 func buildActionLineage(path ActionPath, index controlPathLineageIndex) *ActionLineage {

--- a/core/risk/action_lineage.go
+++ b/core/risk/action_lineage.go
@@ -79,11 +79,6 @@ type controlPathLineageIndex struct {
 	edgesByPath map[string][]aggattack.ControlPathEdge
 }
 
-func newControlPathLineageIndex(graph *aggattack.ControlPathGraph) controlPathLineageIndex {
-	index, _ := newControlPathLineageIndexContext(context.Background(), graph)
-	return index
-}
-
 func newControlPathLineageIndexContext(ctx context.Context, graph *aggattack.ControlPathGraph) (controlPathLineageIndex, error) {
 	index := controlPathLineageIndex{
 		nodesByPath: map[string][]aggattack.ControlPathNode{},

--- a/core/risk/action_paths.go
+++ b/core/risk/action_paths.go
@@ -1,6 +1,7 @@
 package risk
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -836,11 +837,23 @@ func BuildActionPathChoice(paths []ActionPath) *ActionPathToControlFirst {
 }
 
 func BuildControlPathGraph(paths []ActionPath) *aggattack.ControlPathGraph {
+	graph, _ := BuildControlPathGraphContext(context.Background(), paths)
+	return graph
+}
+
+// BuildControlPathGraphContext builds a bounded control graph and honors scan cancellation.
+func BuildControlPathGraphContext(ctx context.Context, paths []ActionPath) (*aggattack.ControlPathGraph, error) {
 	if len(paths) == 0 {
-		return nil
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	inputs := make([]aggattack.ControlPathInput, 0, len(paths))
 	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		inputs = append(inputs, aggattack.ControlPathInput{
 			PathID:                      strings.TrimSpace(path.PathID),
 			AgentID:                     strings.TrimSpace(path.AgentID),
@@ -886,11 +899,11 @@ func BuildControlPathGraph(paths []ActionPath) *aggattack.ControlPathGraph {
 			RuntimeEvidenceState:        strings.TrimSpace(path.RuntimeEvidenceState),
 			TargetEvidenceState:         strings.TrimSpace(path.TargetEvidenceState),
 			EvidenceCompletenessLabel:   evidenceCompletenessProjectionLabel(path.EvidenceCompleteness),
-			AttackPathRefs:              dedupeSortedStrings(path.AttackPathRefs),
-			SourceFindingKeys:           dedupeSortedStrings(path.SourceFindingKeys),
+			AttackPathRefs:              boundedOutputEvidenceRefs(path.AttackPathRefs),
+			SourceFindingKeys:           boundedOutputEvidenceRefs(path.SourceFindingKeys),
 		})
 	}
-	return aggattack.BuildControlPathGraph(inputs)
+	return aggattack.BuildControlPathGraphContext(ctx, inputs)
 }
 
 func evidenceCompletenessProjectionLabel(in *EvidenceCompleteness) string {

--- a/core/risk/action_paths.go
+++ b/core/risk/action_paths.go
@@ -789,21 +789,36 @@ func actionPathHasCriticalTrustGap(depth *agginventory.TrustDepth) bool {
 }
 
 func ApplyGovernFirstProfile(profileName string, paths []ActionPath) ([]ActionPath, *ActionPathToControlFirst) {
+	filtered, choice, _ := ApplyGovernFirstProfileContext(context.Background(), profileName, paths)
+	return filtered, choice
+}
+
+// ApplyGovernFirstProfileContext filters and projects buyer-facing paths while honoring cancellation.
+func ApplyGovernFirstProfileContext(ctx context.Context, profileName string, paths []ActionPath) ([]ActionPath, *ActionPathToControlFirst, error) {
 	if len(paths) == 0 {
-		return nil, nil
+		return nil, nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	filtered := append([]ActionPath(nil), paths...)
 	if strings.EqualFold(strings.TrimSpace(profileName), "assessment") {
 		filtered = make([]ActionPath, 0, len(paths))
 		for _, path := range paths {
+			if err := ctx.Err(); err != nil {
+				return nil, nil, err
+			}
 			if assessmentSuppressesPath(path) {
 				continue
 			}
 			filtered = append(filtered, path)
 		}
 	}
-	filtered = ProjectActionPaths(filtered)
-	return filtered, buildActionPathChoice(filtered)
+	filtered, err := ProjectActionPathsContext(ctx, filtered)
+	if err != nil {
+		return nil, nil, err
+	}
+	return filtered, buildActionPathChoice(filtered), nil
 }
 
 // ApplyFindingProfile keeps assessment-only fixtures and examples out of buyer

--- a/core/risk/action_paths.go
+++ b/core/risk/action_paths.go
@@ -13,6 +13,7 @@ import (
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/attribution"
 	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
+	"github.com/Clyra-AI/wrkr/core/identity"
 	"github.com/Clyra-AI/wrkr/core/model"
 	"github.com/Clyra-AI/wrkr/core/owners"
 	"github.com/Clyra-AI/wrkr/core/resolution"
@@ -311,6 +312,7 @@ func buildActionPath(
 	credentials := agginventory.NormalizeCredentialProvenances(entry.Credentials)
 	provenance := agginventory.CredentialRollup(credentials, entry.CredentialProvenance)
 	authority := agginventory.NormalizeCredentialAuthority(entry.CredentialAuthority)
+	agentID, toolInstanceID := actionPathIdentityFields(entry)
 	if len(credentials) == 0 && provenance != nil {
 		credentials = agginventory.NormalizeCredentialProvenances([]*agginventory.CredentialProvenance{provenance})
 	}
@@ -323,9 +325,9 @@ func buildActionPath(
 		PathID:                      actionPathID(entry),
 		Org:                         strings.TrimSpace(entry.Org),
 		Repo:                        firstRepoFromEntry(entry),
-		AgentID:                     strings.TrimSpace(entry.AgentID),
+		AgentID:                     agentID,
 		ToolFamilyID:                strings.TrimSpace(entry.ToolFamilyID),
-		ToolInstanceID:              strings.TrimSpace(entry.ToolInstanceID),
+		ToolInstanceID:              toolInstanceID,
 		ToolType:                    actionPathToolType(entry),
 		Location:                    strings.TrimSpace(entry.Location),
 		LocationRange:               cloneLocationRange(entry.LocationRange),
@@ -453,6 +455,16 @@ func actionPathToolType(entry agginventory.AgentPrivilegeMapEntry) string {
 		return strings.TrimSpace(entry.Framework)
 	}
 	return strings.TrimSpace(entry.ToolType)
+}
+
+func actionPathIdentityFields(entry agginventory.AgentPrivilegeMapEntry) (string, string) {
+	if !isEndpointActionPathRepresentation(entry) {
+		return strings.TrimSpace(entry.AgentID), strings.TrimSpace(entry.ToolInstanceID)
+	}
+	toolType := actionPathToolType(entry)
+	location := strings.TrimSpace(entry.Location)
+	return identity.AgentID(identity.ToolID(toolType, location), strings.TrimSpace(entry.Org)),
+		identity.ToolInstanceID(toolType, firstRepoFromEntry(entry), location, "", 0, 0)
 }
 
 func actionPathID(entry agginventory.AgentPrivilegeMapEntry) string {

--- a/core/risk/action_paths.go
+++ b/core/risk/action_paths.go
@@ -469,6 +469,18 @@ func actionPathIdentityKey(entry agginventory.AgentPrivilegeMapEntry) string {
 			strings.TrimSpace(entry.Location),
 		}, "|")
 	}
+	if isEndpointActionPathRepresentation(entry) {
+		// OpenAPI and route findings are emitted per operation. Keep those
+		// operation records exact in the privilege map, but give the buyer-facing
+		// action-path view one bounded, evidence-backed specification roll-up.
+		return strings.Join([]string{
+			strings.TrimSpace(entry.Org),
+			strings.Join(dedupeSortedStrings(entry.Repos), ","),
+			"endpoint_specification",
+			actionPathToolType(entry),
+			strings.TrimSpace(entry.Location),
+		}, "|")
+	}
 	parts := []string{
 		strings.TrimSpace(entry.Org),
 		strings.Join(dedupeSortedStrings(entry.Repos), ","),
@@ -493,6 +505,18 @@ func actionPathOccurrenceRef(entry agginventory.AgentPrivilegeMapEntry) string {
 			strings.TrimSpace(entry.Symbol),
 		}, "|")
 	}
+	if isEndpointActionPathRepresentation(entry) {
+		return strings.Join([]string{
+			strings.TrimSpace(entry.Org),
+			strings.Join(dedupeSortedStrings(entry.Repos), ","),
+			strings.TrimSpace(entry.Location),
+			actionPathToolType(entry),
+			strings.TrimSpace(entry.ToolInstanceID),
+			strings.TrimSpace(entry.AgentInstanceID),
+			strings.TrimSpace(entry.AgentID),
+			strings.TrimSpace(entry.Symbol),
+		}, "|")
+	}
 	parts := []string{
 		strings.TrimSpace(entry.Org),
 		strings.Join(dedupeSortedStrings(entry.Repos), ","),
@@ -508,6 +532,16 @@ func isWorkflowActionPathRepresentation(entry agginventory.AgentPrivilegeMapEntr
 	for _, value := range []string{entry.Framework, entry.ToolType} {
 		switch strings.ToLower(strings.TrimSpace(value)) {
 		case "ci_agent", "compiled_action":
+			return true
+		}
+	}
+	return false
+}
+
+func isEndpointActionPathRepresentation(entry agginventory.AgentPrivilegeMapEntry) bool {
+	for _, value := range []string{entry.Framework, entry.ToolType} {
+		switch strings.ToLower(strings.TrimSpace(value)) {
+		case "openapi", "route":
 			return true
 		}
 	}

--- a/core/risk/action_paths_test.go
+++ b/core/risk/action_paths_test.go
@@ -1,6 +1,8 @@
 package risk
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"reflect"
@@ -1633,6 +1635,17 @@ func TestApplyGovernFirstProfileAssessmentSuppressesAllCandidates(t *testing.T) 
 	}
 	if choice != nil {
 		t.Fatalf("expected no control-first choice when all assessment candidates are suppressed, got %+v", choice)
+	}
+}
+
+func TestApplyGovernFirstProfileContextHonorsCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := ApplyGovernFirstProfileContext(ctx, "assessment", []ActionPath{{PathID: "one", Repo: "acme/service", Location: ".github/workflows/release.yml"}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ApplyGovernFirstProfileContext() error = %v, want context cancellation", err)
 	}
 }
 

--- a/core/risk/action_paths_test.go
+++ b/core/risk/action_paths_test.go
@@ -1870,6 +1870,69 @@ func TestBuildActionPathsGroupsEndpointOperationsBySpecification(t *testing.T) {
 	}
 }
 
+func TestBuildActionPathsBoundsSerializedOccurrenceRefs(t *testing.T) {
+	t.Parallel()
+
+	const occurrenceCount = maxOutputOccurrenceRefs + 256
+	entries := make([]agginventory.AgentPrivilegeMapEntry, 0, occurrenceCount)
+	for index := 0; index < occurrenceCount; index++ {
+		operation := fmt.Sprintf("POST /v1/payments/%03d/capture", index)
+		semantic := agginventory.MutableEndpointSemantic{
+			Semantic:     agginventory.EndpointSemanticPayment,
+			Confidence:   "high",
+			Surface:      "openapi",
+			Operation:    operation,
+			EvidenceRefs: []string{operation},
+		}
+		entries = append(entries, agginventory.AgentPrivilegeMapEntry{
+			AgentID:                     "wrkr:openapi:" + operation,
+			AgentInstanceID:             "instance:" + operation,
+			ToolInstanceID:              "tool:" + operation,
+			ToolID:                      "payments-openapi",
+			ToolType:                    "openapi",
+			Framework:                   "openapi",
+			Org:                         "acme",
+			Repos:                       []string{"acme/payments"},
+			Location:                    "openapi/payments.yaml",
+			MutableEndpointSemantics:    []agginventory.MutableEndpointSemantic{semantic},
+			MutableEndpointSemanticRefs: agginventory.CanonicalMutableEndpointRefs([]agginventory.MutableEndpointSemantic{semantic}),
+		})
+	}
+
+	paths, choice := BuildActionPaths(nil, &agginventory.Inventory{AgentPrivilegeMap: entries})
+	if len(paths) != 1 || choice == nil {
+		t.Fatalf("expected one action path and control-first choice, got paths=%+v choice=%+v", paths, choice)
+	}
+	if got := paths[0].OccurrenceCount; got != occurrenceCount {
+		t.Fatalf("expected exact occurrence count %d, got %d", occurrenceCount, got)
+	}
+	if got := len(paths[0].OccurrenceRefs); got != occurrenceCount {
+		t.Fatalf("expected complete in-memory occurrence attribution %d, got %d", occurrenceCount, got)
+	}
+
+	stripped := StripCanonicalProjectionDetails(paths)
+	if got := stripped[0].OccurrenceCount; got != occurrenceCount {
+		t.Fatalf("expected serialized occurrence count %d, got %d", occurrenceCount, got)
+	}
+	if got := len(stripped[0].OccurrenceRefs); got != maxOutputOccurrenceRefs {
+		t.Fatalf("expected serialized occurrence refs capped at %d, got %d", maxOutputOccurrenceRefs, got)
+	}
+	if got := len(paths[0].OccurrenceRefs); got != occurrenceCount {
+		t.Fatalf("expected source occurrence refs to remain intact, got %d", got)
+	}
+
+	strippedChoice := StripActionPathToControlFirstCanonicalProjectionDetails(choice)
+	if strippedChoice == nil {
+		t.Fatal("expected stripped control-first choice")
+	}
+	if got := strippedChoice.Path.OccurrenceCount; got != occurrenceCount {
+		t.Fatalf("expected control-first occurrence count %d, got %d", occurrenceCount, got)
+	}
+	if got := len(strippedChoice.Path.OccurrenceRefs); got != maxOutputOccurrenceRefs {
+		t.Fatalf("expected control-first occurrence refs capped at %d, got %d", maxOutputOccurrenceRefs, got)
+	}
+}
+
 func sliceToSet(values []string) map[string]struct{} {
 	out := make(map[string]struct{}, len(values))
 	for _, value := range values {

--- a/core/risk/action_paths_test.go
+++ b/core/risk/action_paths_test.go
@@ -1830,6 +1830,46 @@ func TestBuildActionPathsCarriesEndpointGroupProjection(t *testing.T) {
 	}
 }
 
+func TestBuildActionPathsGroupsEndpointOperationsBySpecification(t *testing.T) {
+	t.Parallel()
+
+	entries := []agginventory.AgentPrivilegeMapEntry{}
+	for _, operation := range []string{"POST /v1/payments", "DELETE /v1/payments/{id}"} {
+		semantic := agginventory.MutableEndpointSemantic{
+			Semantic:     agginventory.EndpointSemanticPayment,
+			Confidence:   "high",
+			Surface:      "openapi",
+			Operation:    operation,
+			EvidenceRefs: []string{operation},
+		}
+		entries = append(entries, agginventory.AgentPrivilegeMapEntry{
+			AgentID:                     "wrkr:openapi:" + operation,
+			AgentInstanceID:             "instance:" + operation,
+			ToolInstanceID:              "tool:" + operation,
+			ToolID:                      "payments-openapi",
+			ToolType:                    "openapi",
+			Framework:                   "openapi",
+			Org:                         "acme",
+			Repos:                       []string{"acme/payments"},
+			Location:                    "openapi/payments.yaml",
+			MutableEndpointSemantics:    []agginventory.MutableEndpointSemantic{semantic},
+			MutableEndpointSemanticRefs: agginventory.CanonicalMutableEndpointRefs([]agginventory.MutableEndpointSemantic{semantic}),
+		})
+	}
+
+	paths, _ := BuildActionPaths(nil, &agginventory.Inventory{AgentPrivilegeMap: entries})
+	if len(paths) != 1 {
+		t.Fatalf("expected one OpenAPI specification roll-up, got %+v", paths)
+	}
+	path := paths[0]
+	if path.OccurrenceCount != 2 || path.EndpointRefCount != 2 {
+		t.Fatalf("expected two exact operations in one bounded roll-up, got %+v", path)
+	}
+	if len(path.MutableEndpointSemanticRefs) != 2 || len(path.EndpointRefSamples) != 2 {
+		t.Fatalf("expected both operation references to remain attributable, got %+v", path)
+	}
+}
+
 func sliceToSet(values []string) map[string]struct{} {
 	out := make(map[string]struct{}, len(values))
 	for _, value := range values {

--- a/core/risk/action_paths_test.go
+++ b/core/risk/action_paths_test.go
@@ -11,6 +11,7 @@ import (
 
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
 	"github.com/Clyra-AI/wrkr/core/evidencepolicy"
+	"github.com/Clyra-AI/wrkr/core/identity"
 	"github.com/Clyra-AI/wrkr/core/model"
 	riskattack "github.com/Clyra-AI/wrkr/core/risk/attackpath"
 )
@@ -1867,6 +1868,21 @@ func TestBuildActionPathsGroupsEndpointOperationsBySpecification(t *testing.T) {
 	}
 	if len(path.MutableEndpointSemanticRefs) != 2 || len(path.EndpointRefSamples) != 2 {
 		t.Fatalf("expected both operation references to remain attributable, got %+v", path)
+	}
+	wantAgentID := identity.AgentID(identity.ToolID("openapi", "openapi/payments.yaml"), "acme")
+	if path.AgentID != wantAgentID {
+		t.Fatalf("expected specification-level agent id %q, got %q", wantAgentID, path.AgentID)
+	}
+	wantToolInstanceID := identity.ToolInstanceID("openapi", "acme/payments", "openapi/payments.yaml", "", 0, 0)
+	if path.ToolInstanceID != wantToolInstanceID {
+		t.Fatalf("expected specification-level tool instance id %q, got %q", wantToolInstanceID, path.ToolInstanceID)
+	}
+
+	reversed := append([]agginventory.AgentPrivilegeMapEntry(nil), entries...)
+	reversed[0], reversed[1] = reversed[1], reversed[0]
+	reversedPaths, _ := BuildActionPaths(nil, &agginventory.Inventory{AgentPrivilegeMap: reversed})
+	if len(reversedPaths) != 1 || reversedPaths[0].AgentID != wantAgentID || reversedPaths[0].ToolInstanceID != wantToolInstanceID {
+		t.Fatalf("expected endpoint roll-up identity to be independent of operation order, got %+v", reversedPaths)
 	}
 }
 

--- a/core/risk/action_paths_test.go
+++ b/core/risk/action_paths_test.go
@@ -1940,12 +1940,13 @@ func TestBuildActionPathsBoundsSerializedOccurrenceRefs(t *testing.T) {
 	strippedChoice := StripActionPathToControlFirstCanonicalProjectionDetails(choice)
 	if strippedChoice == nil {
 		t.Fatal("expected stripped control-first choice")
-	}
-	if got := strippedChoice.Path.OccurrenceCount; got != occurrenceCount {
-		t.Fatalf("expected control-first occurrence count %d, got %d", occurrenceCount, got)
-	}
-	if got := len(strippedChoice.Path.OccurrenceRefs); got != maxOutputOccurrenceRefs {
-		t.Fatalf("expected control-first occurrence refs capped at %d, got %d", maxOutputOccurrenceRefs, got)
+	} else {
+		if got := strippedChoice.Path.OccurrenceCount; got != occurrenceCount {
+			t.Fatalf("expected control-first occurrence count %d, got %d", occurrenceCount, got)
+		}
+		if got := len(strippedChoice.Path.OccurrenceRefs); got != maxOutputOccurrenceRefs {
+			t.Fatalf("expected control-first occurrence refs capped at %d, got %d", maxOutputOccurrenceRefs, got)
+		}
 	}
 }
 

--- a/core/risk/buyer_projection.go
+++ b/core/risk/buyer_projection.go
@@ -1,7 +1,7 @@
 package risk
 
 import (
-	"sort"
+	"context"
 	"strings"
 
 	agginventory "github.com/Clyra-AI/wrkr/core/aggregate/inventory"
@@ -88,17 +88,91 @@ func ProjectActionPath(path ActionPath) ActionPath {
 }
 
 func ProjectActionPaths(paths []ActionPath) []ActionPath {
+	projected, _ := ProjectActionPathsContext(context.Background(), paths)
+	return projected
+}
+
+// ProjectActionPathsContext projects and orders action paths while honoring cancellation.
+func ProjectActionPathsContext(ctx context.Context, paths []ActionPath) ([]ActionPath, error) {
 	if len(paths) == 0 {
-		return nil
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 	out := make([]ActionPath, 0, len(paths))
 	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		out = append(out, ProjectActionPath(path))
 	}
-	sort.Slice(out, func(i, j int) bool {
-		return compareActionPaths(out[i], out[j])
-	})
-	return out
+	if err := sortActionPathsContext(ctx, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func sortActionPathsContext(ctx context.Context, paths []ActionPath) error {
+	if len(paths) < 2 {
+		return ctx.Err()
+	}
+	scratch := make([]ActionPath, len(paths))
+	for width := 1; width < len(paths); {
+		for start := 0; start < len(paths); start += 2 * width {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			middle := start + width
+			if middle > len(paths) {
+				middle = len(paths)
+			}
+			end := start + 2*width
+			if end > len(paths) {
+				end = len(paths)
+			}
+
+			left, right, destination := start, middle, start
+			for left < middle && right < end {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				if compareActionPaths(paths[right], paths[left]) {
+					scratch[destination] = paths[right]
+					right++
+				} else {
+					scratch[destination] = paths[left]
+					left++
+				}
+				destination++
+			}
+			for left < middle {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				scratch[destination] = paths[left]
+				left++
+				destination++
+			}
+			for right < end {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				scratch[destination] = paths[right]
+				right++
+				destination++
+			}
+		}
+		copy(paths, scratch)
+		if width > len(paths)/2 {
+			break
+		}
+		width *= 2
+	}
+	return nil
 }
 
 func ProjectBuyerFacingActionPath(path ActionPath) ActionPath {

--- a/core/risk/buyer_projection.go
+++ b/core/risk/buyer_projection.go
@@ -140,7 +140,7 @@ func sortActionPathsContext(ctx context.Context, paths []ActionPath) error {
 				if err := ctx.Err(); err != nil {
 					return err
 				}
-				if compareActionPaths(paths[right], paths[left]) {
+				if compareProjectedActionPaths(paths[right], paths[left]) {
 					scratch[destination] = paths[right]
 					right++
 				} else {

--- a/core/risk/canonical_projection.go
+++ b/core/risk/canonical_projection.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	maxOutputEvidenceRefs       = 64
+	maxOutputOccurrenceRefs     = maxOutputEvidenceRefs
 	maxOutputEndpointOperations = 32
 )
 
@@ -92,6 +93,7 @@ func StripCanonicalProjectionDetails(paths []ActionPath) []ActionPath {
 }
 
 func stripActionPathOutputEvidenceDetails(path ActionPath) ActionPath {
+	path.OccurrenceRefs = boundedOutputStrings(path.OccurrenceRefs, maxOutputOccurrenceRefs)
 	path.ControlEvidenceRefs = boundedOutputEvidenceRefs(path.ControlEvidenceRefs)
 	path.ConstraintEvidenceRefs = boundedOutputEvidenceRefs(path.ConstraintEvidenceRefs)
 	path.TargetClassEvidenceRefs = boundedOutputEvidenceRefs(path.TargetClassEvidenceRefs)

--- a/core/risk/composition.go
+++ b/core/risk/composition.go
@@ -536,7 +536,30 @@ func groupCompositionCandidates(candidates []compositionCandidate) ([]compositio
 }
 
 func compositionCandidateMembershipKey(candidate compositionCandidate) string {
-	return candidate.scope + "\x1e" + candidate.memberKey
+	return strings.Join([]string{
+		candidate.scope,
+		candidate.memberKey,
+		compositionCandidateOutcomeIdentity(candidate),
+	}, "\x1e")
+}
+
+// compositionCandidateOutcomeIdentity keeps only paths that would produce the
+// same target and outcome evidence in one candidate group.
+func compositionCandidateOutcomeIdentity(candidate compositionCandidate) string {
+	endpointSemantics := make([]string, 0, len(candidate.path.MutableEndpointSemantics))
+	for _, item := range candidate.path.MutableEndpointSemantics {
+		endpointSemantics = append(endpointSemantics, strings.Join([]string{
+			"semantic=" + strings.TrimSpace(item.Semantic),
+			"surface=" + strings.TrimSpace(item.Surface),
+			"operation=" + strings.TrimSpace(item.Operation),
+		}, ","))
+	}
+	return strings.Join([]string{
+		"target=" + compositionTargetIdentity(compositionPatternSpec{}, []ActionPath{candidate.path}),
+		"target_class=" + candidate.targetClass,
+		"environment=" + candidate.environment,
+		"endpoint_semantics=" + strings.Join(dedupeSortedStrings(endpointSemantics), "+"),
+	}, "|")
 }
 
 func indexCompositionCandidatesByScope(candidates []compositionCandidate) map[string][]compositionCandidate {

--- a/core/risk/composition.go
+++ b/core/risk/composition.go
@@ -293,8 +293,8 @@ func BuildComposedActionPathsContext(ctx context.Context, paths []ActionPath, wo
 	truncated := map[string]*compositionTruncationState{}
 
 	for _, spec := range specs {
-		sources := filterCompositionCandidates(projected, candidateMetadata, spec.sourceOK)
-		sinks := filterCompositionCandidates(projected, candidateMetadata, spec.sinkOK)
+		sources, sourceMembership := groupCompositionCandidates(filterCompositionCandidates(projected, candidateMetadata, spec.sourceOK))
+		sinks, sinkMembership := groupCompositionCandidates(filterCompositionCandidates(projected, candidateMetadata, spec.sinkOK))
 		sinksByScope := indexCompositionCandidatesByScope(sinks)
 		count := 0
 		evaluated := 0
@@ -320,6 +320,10 @@ func BuildComposedActionPathsContext(ctx context.Context, paths []ActionPath, wo
 					break
 				}
 				composition := buildComposedActionPath(spec, source.path, sink.path, chainRefsByPath)
+				composition = withCompositionMemberPathIDs(composition, append(
+					sourceMembership[compositionCandidateMembershipKey(source)],
+					sinkMembership[compositionCandidateMembershipKey(sink)]...,
+				))
 				if seen {
 					compositionsByKey[compositionID] = mergeComposedActionPathWithoutContract(current, composition)
 					continue
@@ -512,6 +516,29 @@ func filterCompositionCandidates(paths []ActionPath, candidates []compositionCan
 	return out
 }
 
+func groupCompositionCandidates(candidates []compositionCandidate) ([]compositionCandidate, map[string][]string) {
+	grouped := make([]compositionCandidate, 0, len(candidates))
+	memberships := make(map[string][]string, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		key := compositionCandidateMembershipKey(candidate)
+		memberships[key] = append(memberships[key], strings.TrimSpace(candidate.path.PathID))
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		grouped = append(grouped, candidate)
+	}
+	for key, pathIDs := range memberships {
+		memberships[key] = dedupeSortedStrings(pathIDs)
+	}
+	return grouped, memberships
+}
+
+func compositionCandidateMembershipKey(candidate compositionCandidate) string {
+	return candidate.scope + "\x1e" + candidate.memberKey
+}
+
 func indexCompositionCandidatesByScope(candidates []compositionCandidate) map[string][]compositionCandidate {
 	byScope := make(map[string][]compositionCandidate, len(candidates))
 	for _, candidate := range candidates {
@@ -622,6 +649,13 @@ func buildComposedActionPath(spec compositionPatternSpec, source, sink ActionPat
 	applyCompositionDelegationRelationships(&composition, paths)
 	applyCompositionRecommendedControl(&composition, paths)
 	hydrateCompositionTransitions(&composition)
+	return composition
+}
+
+func withCompositionMemberPathIDs(composition ComposedActionPath, pathIDs []string) ComposedActionPath {
+	members := dedupeSortedStrings(append(compositionMemberPathIDs(composition), pathIDs...))
+	composition.memberPathIDs = members
+	composition.PathIDs = boundedOutputEvidenceRefs(members)
 	return composition
 }
 

--- a/core/risk/composition.go
+++ b/core/risk/composition.go
@@ -167,11 +167,12 @@ type CompositionTruncation struct {
 }
 
 type ComposedActionPath struct {
-	CompositionID                     string                         `json:"composition_id"`
-	PatternID                         string                         `json:"pattern_id"`
-	Pattern                           CompositionPattern             `json:"pattern"`
-	ResolutionKey                     string                         `json:"resolution_key,omitempty"`
-	PathIDs                           []string                       `json:"path_ids,omitempty"`
+	CompositionID                     string             `json:"composition_id"`
+	PatternID                         string             `json:"pattern_id"`
+	Pattern                           CompositionPattern `json:"pattern"`
+	ResolutionKey                     string             `json:"resolution_key,omitempty"`
+	PathIDs                           []string           `json:"path_ids,omitempty"`
+	memberPathIDs                     []string
 	WorkflowChainRefs                 []string                       `json:"workflow_chain_refs,omitempty"`
 	Stages                            []CompositionStage             `json:"stages"`
 	Transitions                       []CompositionTransition        `json:"transitions,omitempty"`
@@ -385,7 +386,7 @@ func DecorateActionPathCompositionRefsContext(ctx context.Context, paths []Actio
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		for _, pathID := range composition.PathIDs {
+		for _, pathID := range compositionMemberPathIDs(composition) {
 			trimmed := strings.TrimSpace(pathID)
 			if trimmed == "" {
 				continue
@@ -507,13 +508,6 @@ func filterCompositionCandidates(paths []ActionPath, candidates []compositionCan
 	return out
 }
 
-func compositionCandidatesCompatible(source, sink ActionPath) bool {
-	if strings.TrimSpace(source.Org) != strings.TrimSpace(sink.Org) {
-		return false
-	}
-	return strings.TrimSpace(source.Repo) == strings.TrimSpace(sink.Repo)
-}
-
 func compositionCandidatesCompatibleCandidate(source, sink compositionCandidate) bool {
 	return source.scope == sink.scope
 }
@@ -597,6 +591,7 @@ func buildComposedActionPath(spec compositionPatternSpec, source, sink ActionPat
 		Pattern:                      CompositionPattern{PatternID: spec.id, Description: spec.description, StageRoles: compositionStageRoles(stages), OutcomeClass: spec.outcome},
 		ResolutionKey:                compositionResolutionKey(paths),
 		PathIDs:                      compositionPathIDs(paths),
+		memberPathIDs:                compositionMembershipPathIDs(paths),
 		WorkflowChainRefs:            workflowRefs,
 		Stages:                       stages,
 		Transitions:                  transitions,
@@ -1509,6 +1504,7 @@ func mergeComposedActionPathWithContract(current, incoming ComposedActionPath, b
 	}
 	merged := current
 	merged.PathIDs = boundedOutputEvidenceRefs(append(merged.PathIDs, incoming.PathIDs...))
+	merged.memberPathIDs = dedupeSortedStrings(append(compositionMemberPathIDs(current), compositionMemberPathIDs(incoming)...))
 	merged.WorkflowChainRefs = boundedOutputEvidenceRefs(append(merged.WorkflowChainRefs, incoming.WorkflowChainRefs...))
 	merged.EvidenceRefs = boundedOutputEvidenceRefs(append(merged.EvidenceRefs, incoming.EvidenceRefs...))
 	merged.ProofRefs = boundedOutputEvidenceRefs(append(merged.ProofRefs, incoming.ProofRefs...))
@@ -2040,11 +2036,23 @@ func compositionCandidateKey(path ActionPath) string {
 }
 
 func compositionPathIDs(paths []ActionPath) []string {
+	return boundedOutputEvidenceRefs(compositionMembershipPathIDs(paths))
+}
+
+func compositionMembershipPathIDs(paths []ActionPath) []string {
 	out := []string{}
 	for _, path := range paths {
 		out = append(out, strings.TrimSpace(path.PathID))
 	}
-	return boundedOutputEvidenceRefs(out)
+	return dedupeSortedStrings(out)
+}
+
+func compositionMemberPathIDs(composition ComposedActionPath) []string {
+	if len(composition.memberPathIDs) > 0 {
+		return composition.memberPathIDs
+	}
+	// Compositions restored from persisted state predate the internal index.
+	return composition.PathIDs
 }
 
 func compositionWorkflowRefs(paths []ActionPath, refsByPath map[string][]string) []string {

--- a/core/risk/composition.go
+++ b/core/risk/composition.go
@@ -1,6 +1,7 @@
 package risk
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"sort"
@@ -70,8 +71,10 @@ const (
 	CompositionMaterialityLow      = "low"
 	CompositionMaterialityMaterial = "material"
 
-	maxComposedActionPathCandidates = 128
-	maxEquivalentOutcomeRefs        = 8
+	maxComposedActionPathCandidates           = 128
+	maxComposedActionPathCandidateEvaluations = maxComposedActionPathCandidates * 8
+	maxComposedActionPathTruncatedCandidates  = 16
+	maxEquivalentOutcomeRefs                  = 8
 )
 
 type CompositionPattern struct {
@@ -238,38 +241,100 @@ type compositionPatternSpec struct {
 	sinkOK      func(ActionPath) bool
 }
 
+type compositionTruncationState struct {
+	Candidates         []string
+	ObservedCandidates int
+	OmittedCandidates  int
+	Limit              int
+}
+
+type compositionCandidate struct {
+	path                      ActionPath
+	memberKey                 string
+	scope                     string
+	targetIdentityClass       string
+	orgRepo                   string
+	targetClass               string
+	environment               string
+	hasExplicitTargetIdentity bool
+}
+
 func BuildComposedActionPaths(paths []ActionPath, workflowChains *agentresolver.WorkflowChainArtifact) ([]ComposedActionPath, *ComposedActionPathToControlFirst) {
+	compositions, choice, _ := BuildComposedActionPathsContext(context.Background(), paths, workflowChains)
+	return compositions, choice
+}
+
+// BuildComposedActionPathsContext builds bounded composition evidence while honoring scan cancellation.
+func BuildComposedActionPathsContext(ctx context.Context, paths []ActionPath, workflowChains *agentresolver.WorkflowChainArtifact) ([]ComposedActionPath, *ComposedActionPathToControlFirst, error) {
 	if len(paths) == 0 {
-		return nil, nil
+		return nil, nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
 	}
 	projected := ProjectActionPaths(paths)
+	candidateMetadata := make([]compositionCandidate, len(projected))
+	for index := range projected {
+		candidateMetadata[index] = newCompositionCandidate(projected[index])
+	}
 	chainRefsByPath := agentresolver.WorkflowChainRefsByPath(workflowChains)
 	specs := compositionPatternSpecs()
 	compositionsByKey := map[string]ComposedActionPath{}
-	truncated := map[string][]string{}
+	truncated := map[string]*compositionTruncationState{}
 
 	for _, spec := range specs {
-		sources := filterCompositionCandidates(projected, spec.sourceOK)
-		sinks := filterCompositionCandidates(projected, spec.sinkOK)
+		sources := filterCompositionCandidates(projected, candidateMetadata, spec.sourceOK)
+		sinks := filterCompositionCandidates(projected, candidateMetadata, spec.sinkOK)
 		count := 0
-		for _, source := range sources {
-			for _, sink := range sinks {
-				if !compositionCandidatesCompatible(source, sink) {
+		evaluated := 0
+		truncatedPattern := false
+		for sourceIndex, source := range sources {
+			for sinkIndex, sink := range sinks {
+				if err := ctx.Err(); err != nil {
+					return nil, nil, err
+				}
+				if !compositionCandidatesCompatibleCandidate(source, sink) {
 					continue
 				}
-				composition := buildComposedActionPath(spec, source, sink, chainRefsByPath)
-				if _, seen := compositionsByKey[composition.CompositionID]; !seen {
-					count++
-					if count > maxComposedActionPathCandidates {
-						truncated[spec.id] = append(truncated[spec.id], compositionCandidateKey(source)+"->"+compositionCandidateKey(sink))
-						continue
-					}
+				if evaluated >= maxComposedActionPathCandidateEvaluations {
+					state := truncationStateForPattern(truncated, spec.id, maxComposedActionPathCandidateEvaluations)
+					state.recordBatch(source.memberKey+"->"+sink.memberKey, evaluated, remainingCompatibleCompositionCandidates(sources, sinks, sourceIndex, sinkIndex))
+					truncatedPattern = true
+					break
 				}
-				compositionsByKey[composition.CompositionID] = mergeComposedActionPath(compositionsByKey[composition.CompositionID], composition)
+				evaluated++
+				compositionID := compositionCandidateIDForCandidates(spec, source, sink)
+				current, seen := compositionsByKey[compositionID]
+				if !seen && count >= maxComposedActionPathCandidates {
+					state := truncationStateForPattern(truncated, spec.id, maxComposedActionPathCandidates)
+					state.recordBatch(source.memberKey+"->"+sink.memberKey, evaluated-1, remainingCompatibleCompositionCandidates(sources, sinks, sourceIndex, sinkIndex))
+					truncatedPattern = true
+					break
+				}
+				composition := buildComposedActionPath(spec, source.path, sink.path, chainRefsByPath)
+				if seen {
+					compositionsByKey[compositionID] = mergeComposedActionPathWithoutContract(current, composition)
+					continue
+				}
+				count++
+				compositionsByKey[compositionID] = composition
+			}
+			if truncatedPattern {
+				break
 			}
 		}
 	}
-	for _, composition := range buildMultiStageComposedActionPaths(projected, workflowChains) {
+	multiStage, err := buildMultiStageComposedActionPathsContext(ctx, projected, workflowChains)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, composition := range multiStage {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		if strings.TrimSpace(composition.CompositionID) == "" {
 			continue
 		}
@@ -277,14 +342,18 @@ func BuildComposedActionPaths(paths []ActionPath, workflowChains *agentresolver.
 	}
 
 	if len(compositionsByKey) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	compositions := make([]ComposedActionPath, 0, len(compositionsByKey))
 	for _, composition := range compositionsByKey {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		composition.TruncatedCandidates = dedupeSortedStrings(composition.TruncatedCandidates)
 		composition.Truncations = normalizeCompositionTruncations(composition.Truncations)
 		compositions = append(compositions, composition)
 	}
+	refreshCompositionContracts(compositions)
 	annotateMultiStageAlternateRoutes(compositions)
 	annotateEquivalentOutcomeSignals(compositions)
 	sort.Slice(compositions, func(i, j int) bool {
@@ -295,16 +364,27 @@ func BuildComposedActionPaths(paths []ActionPath, workflowChains *agentresolver.
 	return compositions, &ComposedActionPathToControlFirst{
 		Summary: summary,
 		Path:    compositions[0],
-	}
+	}, nil
 }
 
 func DecorateActionPathCompositionRefs(paths []ActionPath, compositions []ComposedActionPath) []ActionPath {
+	decorated, _ := DecorateActionPathCompositionRefsContext(context.Background(), paths, compositions)
+	return decorated
+}
+
+func DecorateActionPathCompositionRefsContext(ctx context.Context, paths []ActionPath, compositions []ComposedActionPath) ([]ActionPath, error) {
 	if len(paths) == 0 {
-		return nil
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	refsByPath := map[string][]string{}
 	contractRefsByPath := map[string][]string{}
 	for _, composition := range compositions {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		for _, pathID := range composition.PathIDs {
 			trimmed := strings.TrimSpace(pathID)
 			if trimmed == "" {
@@ -316,12 +396,15 @@ func DecorateActionPathCompositionRefs(paths []ActionPath, compositions []Compos
 	}
 	out := make([]ActionPath, 0, len(paths))
 	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		copyPath := path
 		copyPath.CompositionIDs = dedupeSortedStrings(append(copyPath.CompositionIDs, refsByPath[strings.TrimSpace(path.PathID)]...))
 		copyPath.ProposedActionContractRefs = dedupeSortedStrings(append(copyPath.ProposedActionContractRefs, contractRefsByPath[strings.TrimSpace(path.PathID)]...))
 		out = append(out, copyPath)
 	}
-	return out
+	return out, nil
 }
 
 func SummarizeComposedActionPaths(paths []ComposedActionPath) ComposedActionPathSummary {
@@ -411,14 +494,14 @@ func compositionPatternSpecs() []compositionPatternSpec {
 	}
 }
 
-func filterCompositionCandidates(paths []ActionPath, predicate func(ActionPath) bool) []ActionPath {
-	out := []ActionPath{}
-	for _, path := range paths {
+func filterCompositionCandidates(paths []ActionPath, candidates []compositionCandidate, predicate func(ActionPath) bool) []compositionCandidate {
+	out := []compositionCandidate{}
+	for index, path := range paths {
 		if !IsActionPathEligible(path) {
 			continue
 		}
 		if predicate(path) {
-			out = append(out, path)
+			out = append(out, candidates[index])
 		}
 	}
 	return out
@@ -429,6 +512,59 @@ func compositionCandidatesCompatible(source, sink ActionPath) bool {
 		return false
 	}
 	return strings.TrimSpace(source.Repo) == strings.TrimSpace(sink.Repo)
+}
+
+func compositionCandidatesCompatibleCandidate(source, sink compositionCandidate) bool {
+	return source.scope == sink.scope
+}
+
+func remainingCompatibleCompositionCandidates(sources, sinks []compositionCandidate, sourceIndex, sinkIndex int) int {
+	if sourceIndex < 0 || sourceIndex >= len(sources) || sinkIndex < 0 || sinkIndex >= len(sinks) {
+		return 0
+	}
+	remaining := 0
+	for index := sinkIndex; index < len(sinks); index++ {
+		if compositionCandidatesCompatibleCandidate(sources[sourceIndex], sinks[index]) {
+			remaining++
+		}
+	}
+	sinksByScope := map[string]int{}
+	for _, sink := range sinks {
+		sinksByScope[sink.scope]++
+	}
+	for index := sourceIndex + 1; index < len(sources); index++ {
+		remaining += sinksByScope[sources[index].scope]
+	}
+	return remaining
+}
+
+func truncationStateForPattern(truncated map[string]*compositionTruncationState, patternID string, limit int) *compositionTruncationState {
+	key := strings.TrimSpace(patternID)
+	state := truncated[key]
+	if state == nil {
+		state = &compositionTruncationState{Limit: limit}
+		truncated[key] = state
+	}
+	return state
+}
+
+func newCompositionCandidate(path ActionPath) compositionCandidate {
+	candidate := compositionCandidate{
+		path:                      path,
+		memberKey:                 compositionMemberKey(path),
+		scope:                     strings.TrimSpace(path.Org) + "\x1f" + strings.TrimSpace(path.Repo),
+		targetIdentityClass:       strings.TrimSpace(path.TargetClass),
+		orgRepo:                   strings.TrimSpace(path.Org) + "/" + strings.TrimSpace(path.Repo),
+		targetClass:               normalizeTargetClass(path.TargetClass),
+		hasExplicitTargetIdentity: len(path.MatchedProductionTargets) > 0 || strings.TrimSpace(path.EndpointRefGroupID) != "" || len(path.MutableEndpointSemantics) > 0,
+	}
+	switch {
+	case path.ProductionWrite || candidate.targetClass == TargetClassProductionImpacting || len(path.MatchedProductionTargets) > 0:
+		candidate.environment = "production"
+	case strings.TrimSpace(path.RiskZone) == RiskZoneRelease || strings.Contains(strings.ToLower(path.Location), "release"):
+		candidate.environment = "release"
+	}
+	return candidate
 }
 
 func buildComposedActionPath(spec compositionPatternSpec, source, sink ActionPath, chainRefsByPath map[string][]string) ComposedActionPath {
@@ -488,14 +624,165 @@ func buildComposedActionPath(spec compositionPatternSpec, source, sink ActionPat
 	applyCompositionDelegationRelationships(&composition, paths)
 	applyCompositionRecommendedControl(&composition, paths)
 	hydrateCompositionTransitions(&composition)
-	composition.ProposedActionContract = BuildProposedActionContract(composition)
-	if composition.ProposedActionContract != nil {
-		composition.ProposedActionContractRefs = []string{composition.ProposedActionContract.ContractID}
-	}
 	return composition
 }
 
-func attachTruncatedCandidates(compositions []ComposedActionPath, truncated map[string][]string) {
+func compositionCandidateID(spec compositionPatternSpec, source, sink ActionPath) string {
+	return compositionCandidateIDForCandidates(spec, newCompositionCandidate(source), newCompositionCandidate(sink))
+}
+
+func compositionCandidateIDForCandidates(spec compositionPatternSpec, source, sink compositionCandidate) string {
+	sourceRole := strings.TrimSpace(spec.sourceRole)
+	sinkRole := strings.TrimSpace(spec.sinkRole)
+	if compositionStageRoleRank(sourceRole) >= compositionStageRoleRank(sinkRole) {
+		return compositionCandidateIDGeneric(spec, source.path, sink.path)
+	}
+
+	targetIdentity := compositionCandidateTargetIdentity(source, sink)
+	targetClass := compositionCandidateTargetClass(source, sink)
+	environment := compositionCandidateEnvironment(spec, source, sink)
+	outcomeKey := "asset=" + targetIdentity + "|environment=" + environment + "|outcome=" + strings.TrimSpace(spec.outcome) + "|target_class=" + targetClass
+
+	// Normal composition patterns order distinct source and sink roles. Build the
+	// same identity bytes as compositionID without allocating stage maps or slices
+	// for candidates that will be suppressed by the per-pattern cap.
+	var raw strings.Builder
+	sourceMember := source.memberKey
+	sinkMember := sink.memberKey
+	raw.Grow(len(spec.id) + len(sourceRole) + len(sinkRole) + len(sourceMember) + len(sinkMember) + len(targetIdentity) + len(outcomeKey) + 80)
+	raw.WriteString("pattern=")
+	raw.WriteString(strings.TrimSpace(spec.id))
+	raw.WriteString("\x1frole=")
+	raw.WriteString(sourceRole)
+	raw.WriteString(";member=")
+	raw.WriteString(sourceMember)
+	raw.WriteString("\x1frole=")
+	raw.WriteString(sinkRole)
+	raw.WriteString(";member=")
+	raw.WriteString(sinkMember)
+	raw.WriteString("\x1ftarget=")
+	raw.WriteString(targetIdentity)
+	raw.WriteString("\x1foutcome=")
+	raw.WriteString(outcomeKey)
+	return "cap-" + stableCompositionHash(raw.String())
+}
+
+func compositionCandidateIDGeneric(spec compositionPatternSpec, source, sink ActionPath) string {
+	stages := dedupeCompositionStages([]CompositionStage{
+		compositionCandidateStage(spec.sourceRole, source),
+		compositionCandidateStage(spec.sinkRole, sink),
+	})
+	paths := []ActionPath{source, sink}
+	targetIdentity := compositionTargetIdentity(spec, paths)
+	targetClass := compositionTargetClass(paths)
+	outcomeKey := strings.Join(dedupeSortedStrings([]string{
+		"asset=" + targetIdentity,
+		"target_class=" + targetClass,
+		"outcome=" + spec.outcome,
+		"environment=" + compositionEnvironment(spec, paths),
+	}), "|")
+	return compositionID(spec.id, stages, targetIdentity, outcomeKey)
+}
+
+func compositionCandidateTargetIdentity(source, sink compositionCandidate) string {
+	if source.hasExplicitTargetIdentity || sink.hasExplicitTargetIdentity {
+		return compositionTargetIdentity(compositionPatternSpec{}, []ActionPath{source.path, sink.path})
+	}
+	return compositionCandidateFallbackTargetIdentity(source.targetIdentityClass, source.orgRepo, sink.targetIdentityClass, sink.orgRepo)
+}
+
+func compositionCandidateFallbackTargetIdentity(sourceTargetClass, sourceOrgRepo, sinkTargetClass, sinkOrgRepo string) string {
+	values := [4]string{
+		sourceTargetClass,
+		sourceOrgRepo,
+		sinkTargetClass,
+		sinkOrgRepo,
+	}
+	count := 0
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		values[count] = value
+		count++
+	}
+	for index := 1; index < count; index++ {
+		for previous := index; previous > 0 && values[previous] < values[previous-1]; previous-- {
+			values[previous], values[previous-1] = values[previous-1], values[previous]
+		}
+	}
+	length := 0
+	unique := 0
+	for index := 0; index < count; index++ {
+		if index > 0 && values[index] == values[index-1] {
+			continue
+		}
+		length += len(values[index])
+		if unique > 0 {
+			length++
+		}
+		unique++
+	}
+	var out strings.Builder
+	out.Grow(length)
+	for index := 0; index < count; index++ {
+		if index > 0 && values[index] == values[index-1] {
+			continue
+		}
+		if out.Len() > 0 {
+			out.WriteByte('+')
+		}
+		out.WriteString(values[index])
+	}
+	return out.String()
+}
+
+func compositionCandidateTargetClass(source, sink compositionCandidate) string {
+	targetClass := chooseTargetClass(source.targetClass, sink.targetClass)
+	if strings.TrimSpace(targetClass) == "" {
+		return TargetClassUnknown
+	}
+	return targetClass
+}
+
+func compositionCandidateEnvironment(spec compositionPatternSpec, source, sink compositionCandidate) string {
+	if source.environment != "" {
+		return source.environment
+	}
+	if sink.environment != "" {
+		return sink.environment
+	}
+	switch strings.TrimSpace(spec.outcome) {
+	case "data_egress", "network_egress":
+		return "external"
+	default:
+		return "unknown"
+	}
+}
+
+func compositionCandidateStage(role string, path ActionPath) CompositionStage {
+	stage := CompositionStage{
+		Role:          strings.TrimSpace(role),
+		ResolutionKey: compositionMemberKey(path),
+		TargetClass:   strings.TrimSpace(path.TargetClass),
+		EvidenceState: pathConservativeEvidenceState(path),
+	}
+	stage.StageID = compositionStageID(stage.Role, stage.ResolutionKey, stage.TargetClass, stage.EvidenceState)
+	return stage
+}
+
+func (s *compositionTruncationState) recordBatch(candidate string, observed, omitted int) {
+	if s == nil || omitted <= 0 {
+		return
+	}
+	s.OmittedCandidates += omitted
+	s.ObservedCandidates += observed + omitted
+	if len(s.Candidates) < maxComposedActionPathTruncatedCandidates {
+		s.Candidates = append(s.Candidates, candidate)
+	}
+}
+
+func attachTruncatedCandidates(compositions []ComposedActionPath, truncated map[string]*compositionTruncationState) {
 	if len(compositions) == 0 || len(truncated) == 0 {
 		return
 	}
@@ -509,12 +796,19 @@ func attachTruncatedCandidates(compositions []ComposedActionPath, truncated map[
 			firstByPattern[patternID] = idx
 		}
 	}
-	for patternID, candidates := range truncated {
+	for patternID, state := range truncated {
 		idx, ok := firstByPattern[strings.TrimSpace(patternID)]
-		if !ok || len(candidates) == 0 {
+		if !ok || state == nil || state.OmittedCandidates == 0 {
 			continue
 		}
-		compositions[idx].TruncatedCandidates = dedupeSortedStrings(append(compositions[idx].TruncatedCandidates, candidates...))
+		compositions[idx].TruncatedCandidates = dedupeSortedStrings(append(compositions[idx].TruncatedCandidates, state.Candidates...))
+		compositions[idx].Truncations = normalizeCompositionTruncations(append(compositions[idx].Truncations, CompositionTruncation{
+			PatternID:          strings.TrimSpace(patternID),
+			Reason:             CompositionTruncationCandidateCap,
+			Limit:              state.Limit,
+			ObservedCandidates: state.ObservedCandidates,
+			OmittedCandidates:  state.OmittedCandidates,
+		}))
 	}
 }
 
@@ -566,6 +860,11 @@ func dedupeCompositionStages(stages []CompositionStage) []CompositionStage {
 	}
 	out := make([]CompositionStage, 0, len(byKey))
 	for _, stage := range byKey {
+		stage.ActionClasses = boundedOutputEvidenceRefs(stage.ActionClasses)
+		stage.EvidenceRefs = boundedOutputEvidenceRefs(stage.EvidenceRefs)
+		stage.ProofRefs = boundedOutputEvidenceRefs(stage.ProofRefs)
+		stage.SourceDecisionRefs = boundedOutputEvidenceRefs(stage.SourceDecisionRefs)
+		stage.ReasonCodes = boundedOutputEvidenceRefs(stage.ReasonCodes)
 		out = append(out, stage)
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -1052,7 +1351,7 @@ func stringSetDeltaLabels(prefix string, parent, child []string) []string {
 			out = append(out, prefix+":removed:"+value)
 		}
 	}
-	return dedupeSortedStrings(out)
+	return boundedOutputEvidenceRefs(out)
 }
 
 func stringSet(values []string) map[string]struct{} {
@@ -1215,17 +1514,28 @@ func compositionTransitionDelegationKeys(transition CompositionTransition, stage
 }
 
 func mergeComposedActionPath(current, incoming ComposedActionPath) ComposedActionPath {
+	return mergeComposedActionPathWithContract(current, incoming, true)
+}
+
+func mergeComposedActionPathWithoutContract(current, incoming ComposedActionPath) ComposedActionPath {
+	return mergeComposedActionPathWithContract(current, incoming, false)
+}
+
+func mergeComposedActionPathWithContract(current, incoming ComposedActionPath, buildContract bool) ComposedActionPath {
 	if strings.TrimSpace(current.CompositionID) == "" {
+		if buildContract {
+			refreshCompositionContract(&incoming)
+		}
 		return incoming
 	}
 	merged := current
-	merged.PathIDs = dedupeSortedStrings(append(merged.PathIDs, incoming.PathIDs...))
-	merged.WorkflowChainRefs = dedupeSortedStrings(append(merged.WorkflowChainRefs, incoming.WorkflowChainRefs...))
-	merged.EvidenceRefs = dedupeSortedStrings(append(merged.EvidenceRefs, incoming.EvidenceRefs...))
-	merged.ProofRefs = dedupeSortedStrings(append(merged.ProofRefs, incoming.ProofRefs...))
-	merged.SourceDecisionRefs = dedupeSortedStrings(append(merged.SourceDecisionRefs, incoming.SourceDecisionRefs...))
-	merged.TruncatedCandidates = dedupeSortedStrings(append(merged.TruncatedCandidates, incoming.TruncatedCandidates...))
-	merged.ProposedActionContractRefs = dedupeSortedStrings(append(merged.ProposedActionContractRefs, incoming.ProposedActionContractRefs...))
+	merged.PathIDs = boundedOutputEvidenceRefs(append(merged.PathIDs, incoming.PathIDs...))
+	merged.WorkflowChainRefs = boundedOutputEvidenceRefs(append(merged.WorkflowChainRefs, incoming.WorkflowChainRefs...))
+	merged.EvidenceRefs = boundedOutputEvidenceRefs(append(merged.EvidenceRefs, incoming.EvidenceRefs...))
+	merged.ProofRefs = boundedOutputEvidenceRefs(append(merged.ProofRefs, incoming.ProofRefs...))
+	merged.SourceDecisionRefs = boundedOutputEvidenceRefs(append(merged.SourceDecisionRefs, incoming.SourceDecisionRefs...))
+	merged.TruncatedCandidates = boundedOutputEvidenceRefs(append(merged.TruncatedCandidates, incoming.TruncatedCandidates...))
+	merged.ProposedActionContractRefs = boundedOutputEvidenceRefs(append(merged.ProposedActionContractRefs, incoming.ProposedActionContractRefs...))
 	merged.Stages = dedupeCompositionStages(append(append([]CompositionStage(nil), merged.Stages...), incoming.Stages...))
 	merged.Transitions = buildCompositionTransitions(merged.CompositionID, merged.Stages)
 	mergeCompositionTransitionDelegation(&merged,
@@ -1242,21 +1552,36 @@ func mergeComposedActionPath(current, incoming ComposedActionPath) ComposedActio
 	merged.RuntimeEvidenceAbsenceStatus = compositionRuntimeAbsence(merged.RuntimeEvidenceAbsenceStatus, incoming.RuntimeEvidenceAbsenceStatus)
 	merged.RiskTier = compositionRiskTierFromValues(merged.RiskTier, incoming.RiskTier)
 	merged.RecommendedControl = compositionRecommendedControlFromValues(merged.RecommendedControl, incoming.RecommendedControl)
-	merged.RecommendedControlReasons = dedupeSortedStrings(append(merged.RecommendedControlReasons, incoming.RecommendedControlReasons...))
-	merged.EscalatingTransitionRefs = dedupeSortedStrings(append(merged.EscalatingTransitionRefs, incoming.EscalatingTransitionRefs...))
+	merged.RecommendedControlReasons = boundedOutputEvidenceRefs(append(merged.RecommendedControlReasons, incoming.RecommendedControlReasons...))
+	merged.EscalatingTransitionRefs = boundedOutputEvidenceRefs(append(merged.EscalatingTransitionRefs, incoming.EscalatingTransitionRefs...))
 	if strings.TrimSpace(merged.MostRestrictiveSource) == "" {
 		merged.MostRestrictiveSource = strings.TrimSpace(incoming.MostRestrictiveSource)
 	}
 	merged.ClaimState = compositionClaimState(merged.EvidenceState, merged.PolicyCoverageStatus, merged.FreshnessState, merged.GaitCoverage, merged.Stages, nil)
 	hydrateCompositionTransitions(&merged)
 	refreshCompositionEscalatingTransitionRefs(&merged)
-	merged.ProposedActionContract = BuildProposedActionContract(merged)
-	if merged.ProposedActionContract != nil {
-		merged.ProposedActionContractRefs = []string{merged.ProposedActionContract.ContractID}
-	} else {
-		merged.ProposedActionContractRefs = nil
+	if buildContract {
+		refreshCompositionContract(&merged)
 	}
 	return merged
+}
+
+func refreshCompositionContracts(compositions []ComposedActionPath) {
+	for index := range compositions {
+		refreshCompositionContract(&compositions[index])
+	}
+}
+
+func refreshCompositionContract(composition *ComposedActionPath) {
+	if composition == nil {
+		return
+	}
+	composition.ProposedActionContract = BuildProposedActionContract(*composition)
+	if composition.ProposedActionContract != nil {
+		composition.ProposedActionContractRefs = []string{composition.ProposedActionContract.ContractID}
+		return
+	}
+	composition.ProposedActionContractRefs = nil
 }
 
 func hydrateCompositionTransitions(composition *ComposedActionPath) {
@@ -1713,7 +2038,7 @@ func compositionStageRoles(stages []CompositionStage) []string {
 	for _, stage := range stages {
 		out = append(out, strings.TrimSpace(stage.Role))
 	}
-	return dedupeSortedStrings(out)
+	return boundedOutputEvidenceRefs(out)
 }
 
 func compositionMemberKey(path ActionPath) string {
@@ -1740,7 +2065,7 @@ func compositionPathIDs(paths []ActionPath) []string {
 	for _, path := range paths {
 		out = append(out, strings.TrimSpace(path.PathID))
 	}
-	return dedupeSortedStrings(out)
+	return boundedOutputEvidenceRefs(out)
 }
 
 func compositionWorkflowRefs(paths []ActionPath, refsByPath map[string][]string) []string {
@@ -1854,7 +2179,7 @@ func compositionEvidenceRefs(paths []ActionPath) []string {
 			out = append(out, "credential:shared")
 		}
 	}
-	return dedupeSortedStrings(out)
+	return boundedOutputEvidenceRefs(out)
 }
 
 func compositionProofRefs(paths []ActionPath) []string {
@@ -1863,7 +2188,7 @@ func compositionProofRefs(paths []ActionPath) []string {
 		out = append(out, path.DecisionTraceRefs...)
 		out = append(out, path.WorkflowChainRefs...)
 	}
-	return dedupeSortedStrings(out)
+	return boundedOutputEvidenceRefs(out)
 }
 
 func compositionSourceDecisionRefs(paths []ActionPath) []string {
@@ -1873,7 +2198,7 @@ func compositionSourceDecisionRefs(paths []ActionPath) []string {
 			out = append(out, decisionEvidenceRefs(decision)...)
 		}
 	}
-	return dedupeSortedStrings(out)
+	return boundedOutputEvidenceRefs(out)
 }
 
 func compositionContradictions(paths []ActionPath) []evidencepolicy.Contradiction {

--- a/core/risk/composition.go
+++ b/core/risk/composition.go
@@ -692,49 +692,28 @@ func compositionCandidateTargetIdentity(source, sink compositionCandidate) strin
 }
 
 func compositionCandidateFallbackTargetIdentity(sourceTargetClass, sourceOrgRepo, sinkTargetClass, sinkOrgRepo string) string {
-	values := [4]string{
+	values := []string{
 		sourceTargetClass,
 		sourceOrgRepo,
 		sinkTargetClass,
 		sinkOrgRepo,
 	}
-	count := 0
+	nonEmpty := make([]string, 0, len(values))
 	for _, value := range values {
 		if strings.TrimSpace(value) == "" {
 			continue
 		}
-		values[count] = value
-		count++
+		nonEmpty = append(nonEmpty, value)
 	}
-	for index := 1; index < count; index++ {
-		for previous := index; previous > 0 && values[previous] < values[previous-1]; previous-- {
-			values[previous], values[previous-1] = values[previous-1], values[previous]
-		}
-	}
-	length := 0
-	unique := 0
-	for index := 0; index < count; index++ {
-		if index > 0 && values[index] == values[index-1] {
+	sort.Strings(nonEmpty)
+	unique := nonEmpty[:0]
+	for _, value := range nonEmpty {
+		if len(unique) > 0 && value == unique[len(unique)-1] {
 			continue
 		}
-		length += len(values[index])
-		if unique > 0 {
-			length++
-		}
-		unique++
+		unique = append(unique, value)
 	}
-	var out strings.Builder
-	out.Grow(length)
-	for index := 0; index < count; index++ {
-		if index > 0 && values[index] == values[index-1] {
-			continue
-		}
-		if out.Len() > 0 {
-			out.WriteByte('+')
-		}
-		out.WriteString(values[index])
-	}
-	return out.String()
+	return strings.Join(unique, "+")
 }
 
 func compositionCandidateTargetClass(source, sink compositionCandidate) string {

--- a/core/risk/composition.go
+++ b/core/risk/composition.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"sort"
 	"strings"
 
@@ -258,6 +259,20 @@ type compositionCandidate struct {
 	targetClass               string
 	environment               string
 	hasExplicitTargetIdentity bool
+	workflowChainRefs         []string
+	governanceIdentity        string
+}
+
+type compositionCandidateGovernanceProjection struct {
+	Stage                     CompositionStage
+	Authority                 compositionAuthorityProfile
+	WorkflowChainRefs         []string
+	RuntimeEvidenceState      string
+	RiskTier                  string
+	RecommendedControl        string
+	RecommendedControlReasons []string
+	ClosureRequirements       []ClosureRequirement
+	EvidenceCompleteness      *EvidenceCompleteness
 }
 
 func BuildComposedActionPaths(paths []ActionPath, workflowChains *agentresolver.WorkflowChainArtifact) ([]ComposedActionPath, *ComposedActionPathToControlFirst) {
@@ -280,14 +295,20 @@ func BuildComposedActionPathsContext(ctx context.Context, paths []ActionPath, wo
 	if err != nil {
 		return nil, nil, err
 	}
+	chainRefsByPath := agentresolver.WorkflowChainRefsByPath(workflowChains)
 	candidateMetadata := make([]compositionCandidate, len(projected))
 	for index := range projected {
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
 		}
-		candidateMetadata[index] = newCompositionCandidate(projected[index])
+		candidate := newCompositionCandidate(projected[index])
+		candidate.workflowChainRefs = dedupeSortedStrings(append(
+			append([]string(nil), projected[index].WorkflowChainRefs...),
+			chainRefsByPath[strings.TrimSpace(projected[index].PathID)]...,
+		))
+		candidate.governanceIdentity = compositionCandidateGovernanceIdentity(candidate)
+		candidateMetadata[index] = candidate
 	}
-	chainRefsByPath := agentresolver.WorkflowChainRefsByPath(workflowChains)
 	specs := compositionPatternSpecs()
 	compositionsByKey := map[string]ComposedActionPath{}
 	truncated := map[string]*compositionTruncationState{}
@@ -536,10 +557,15 @@ func groupCompositionCandidates(candidates []compositionCandidate) ([]compositio
 }
 
 func compositionCandidateMembershipKey(candidate compositionCandidate) string {
+	governanceIdentity := strings.TrimSpace(candidate.governanceIdentity)
+	if governanceIdentity == "" {
+		governanceIdentity = compositionCandidateGovernanceIdentity(candidate)
+	}
 	return strings.Join([]string{
 		candidate.scope,
 		candidate.memberKey,
 		compositionCandidateOutcomeIdentity(candidate),
+		governanceIdentity,
 	}, "\x1e")
 }
 
@@ -560,6 +586,35 @@ func compositionCandidateOutcomeIdentity(candidate compositionCandidate) string 
 		"environment=" + candidate.environment,
 		"endpoint_semantics=" + strings.Join(dedupeSortedStrings(endpointSemantics), "+"),
 	}, "|")
+}
+
+// compositionCandidateGovernanceIdentity prevents the bounded candidate pass
+// from pooling paths that would contribute different policy, credential, or
+// evidence outcomes to the same materialized composition. It intentionally
+// hashes only output-affecting governance data so dense scans retain duplicate
+// compaction without repeatedly serializing the full action-path payload.
+func compositionCandidateGovernanceIdentity(candidate compositionCandidate) string {
+	stage := buildCompositionStage("", candidate.path)
+	stage.PathID = ""
+	stage.StageID = ""
+	projection := compositionCandidateGovernanceProjection{
+		Stage:                     stage,
+		Authority:                 compositionAuthorityProfileForPath(candidate.path),
+		WorkflowChainRefs:         append([]string(nil), candidate.workflowChainRefs...),
+		RuntimeEvidenceState:      strings.TrimSpace(candidate.path.RuntimeEvidenceState),
+		RiskTier:                  strings.TrimSpace(candidate.path.RiskTier),
+		RecommendedControl:        strings.TrimSpace(candidate.path.RecommendedControl),
+		RecommendedControlReasons: dedupeSortedStrings(candidate.path.RecommendedControlReasons),
+		ClosureRequirements:       CloneClosureRequirements(candidate.path.ClosureRequirements),
+		EvidenceCompleteness:      CloneEvidenceCompleteness(candidate.path.EvidenceCompleteness),
+	}
+	payload, err := json.Marshal(projection)
+	if err != nil {
+		// Failing closed here preserves the candidate instead of allowing an
+		// unrepresentable governance state to share another path's contract.
+		return "unserializable:" + stableCompositionHash(strings.TrimSpace(candidate.path.PathID))
+	}
+	return stableCompositionHash(string(payload))
 }
 
 func indexCompositionCandidatesByScope(candidates []compositionCandidate) map[string][]compositionCandidate {
@@ -1506,13 +1561,9 @@ func mergeCompositionTransitionDelegationValue(current, incoming CompositionTran
 	if strings.TrimSpace(current.TransitionID) == "" {
 		current = incoming
 	}
-	if strings.TrimSpace(current.Relationship) == "" {
+	if compositionTransitionDelegationMoreRestrictive(incoming, current) {
 		current.Relationship = strings.TrimSpace(incoming.Relationship)
-	}
-	if strings.TrimSpace(current.ParentAuthorityRef) == "" {
 		current.ParentAuthorityRef = strings.TrimSpace(incoming.ParentAuthorityRef)
-	}
-	if strings.TrimSpace(current.ChildAuthorityRef) == "" {
 		current.ChildAuthorityRef = strings.TrimSpace(incoming.ChildAuthorityRef)
 	}
 	current.ScopeDelta = dedupeSortedStrings(append(current.ScopeDelta, incoming.ScopeDelta...))
@@ -1521,6 +1572,36 @@ func mergeCompositionTransitionDelegationValue(current, incoming CompositionTran
 	current.ExpiryDelta = dedupeSortedStrings(append(current.ExpiryDelta, incoming.ExpiryDelta...))
 	current.ReasonCodes = dedupeSortedStrings(append(current.ReasonCodes, incoming.ReasonCodes...))
 	return current
+}
+
+func compositionTransitionDelegationMoreRestrictive(incoming, current CompositionTransition) bool {
+	incomingRank := compositionDelegationRelationshipControlRank(incoming.Relationship)
+	currentRank := compositionDelegationRelationshipControlRank(current.Relationship)
+	if incomingRank != currentRank {
+		return incomingRank < currentRank
+	}
+	return compositionTransitionDelegationIdentity(incoming) < compositionTransitionDelegationIdentity(current)
+}
+
+func compositionDelegationRelationshipControlRank(relationship string) int {
+	switch strings.TrimSpace(relationship) {
+	case CompositionDelegationContradictory:
+		return recommendedControlRank(RecommendedControlBlock)
+	case CompositionDelegationBroadened:
+		return recommendedControlRank(RecommendedControlJITCredentialRequired)
+	case CompositionDelegationUnknown:
+		return recommendedControlRank(RecommendedControlSecurityReview)
+	default:
+		return recommendedControlRank(RecommendedControlAllow)
+	}
+}
+
+func compositionTransitionDelegationIdentity(transition CompositionTransition) string {
+	return strings.Join([]string{
+		strings.TrimSpace(transition.Relationship),
+		strings.TrimSpace(transition.ParentAuthorityRef),
+		strings.TrimSpace(transition.ChildAuthorityRef),
+	}, "\x1f")
 }
 
 func compositionTransitionDelegationKeys(transition CompositionTransition, stages []CompositionStage) []string {

--- a/core/risk/composition.go
+++ b/core/risk/composition.go
@@ -276,9 +276,15 @@ func BuildComposedActionPathsContext(ctx context.Context, paths []ActionPath, wo
 	if err := ctx.Err(); err != nil {
 		return nil, nil, err
 	}
-	projected := ProjectActionPaths(paths)
+	projected, err := ProjectActionPathsContext(ctx, paths)
+	if err != nil {
+		return nil, nil, err
+	}
 	candidateMetadata := make([]compositionCandidate, len(projected))
 	for index := range projected {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		candidateMetadata[index] = newCompositionCandidate(projected[index])
 	}
 	chainRefsByPath := agentresolver.WorkflowChainRefsByPath(workflowChains)
@@ -289,20 +295,18 @@ func BuildComposedActionPathsContext(ctx context.Context, paths []ActionPath, wo
 	for _, spec := range specs {
 		sources := filterCompositionCandidates(projected, candidateMetadata, spec.sourceOK)
 		sinks := filterCompositionCandidates(projected, candidateMetadata, spec.sinkOK)
+		sinksByScope := indexCompositionCandidatesByScope(sinks)
 		count := 0
 		evaluated := 0
 		truncatedPattern := false
 		for sourceIndex, source := range sources {
-			for sinkIndex, sink := range sinks {
+			for sinkIndex, sink := range sinksByScope[source.scope] {
 				if err := ctx.Err(); err != nil {
 					return nil, nil, err
 				}
-				if !compositionCandidatesCompatibleCandidate(source, sink) {
-					continue
-				}
 				if evaluated >= maxComposedActionPathCandidateEvaluations {
 					state := truncationStateForPattern(truncated, spec.id, maxComposedActionPathCandidateEvaluations)
-					state.recordBatch(source.memberKey+"->"+sink.memberKey, evaluated, remainingCompatibleCompositionCandidates(sources, sinks, sourceIndex, sinkIndex))
+					state.recordBatch(source.memberKey+"->"+sink.memberKey, evaluated, remainingCompatibleCompositionCandidates(sources, sinksByScope, sourceIndex, sinkIndex))
 					truncatedPattern = true
 					break
 				}
@@ -311,7 +315,7 @@ func BuildComposedActionPathsContext(ctx context.Context, paths []ActionPath, wo
 				current, seen := compositionsByKey[compositionID]
 				if !seen && count >= maxComposedActionPathCandidates {
 					state := truncationStateForPattern(truncated, spec.id, maxComposedActionPathCandidates)
-					state.recordBatch(source.memberKey+"->"+sink.memberKey, evaluated-1, remainingCompatibleCompositionCandidates(sources, sinks, sourceIndex, sinkIndex))
+					state.recordBatch(source.memberKey+"->"+sink.memberKey, evaluated-1, remainingCompatibleCompositionCandidates(sources, sinksByScope, sourceIndex, sinkIndex))
 					truncatedPattern = true
 					break
 				}
@@ -508,26 +512,25 @@ func filterCompositionCandidates(paths []ActionPath, candidates []compositionCan
 	return out
 }
 
-func compositionCandidatesCompatibleCandidate(source, sink compositionCandidate) bool {
-	return source.scope == sink.scope
+func indexCompositionCandidatesByScope(candidates []compositionCandidate) map[string][]compositionCandidate {
+	byScope := make(map[string][]compositionCandidate, len(candidates))
+	for _, candidate := range candidates {
+		byScope[candidate.scope] = append(byScope[candidate.scope], candidate)
+	}
+	return byScope
 }
 
-func remainingCompatibleCompositionCandidates(sources, sinks []compositionCandidate, sourceIndex, sinkIndex int) int {
-	if sourceIndex < 0 || sourceIndex >= len(sources) || sinkIndex < 0 || sinkIndex >= len(sinks) {
+func remainingCompatibleCompositionCandidates(sources []compositionCandidate, sinksByScope map[string][]compositionCandidate, sourceIndex, sinkIndex int) int {
+	if sourceIndex < 0 || sourceIndex >= len(sources) {
 		return 0
 	}
-	remaining := 0
-	for index := sinkIndex; index < len(sinks); index++ {
-		if compositionCandidatesCompatibleCandidate(sources[sourceIndex], sinks[index]) {
-			remaining++
-		}
+	currentSinks := sinksByScope[sources[sourceIndex].scope]
+	if sinkIndex < 0 || sinkIndex >= len(currentSinks) {
+		return 0
 	}
-	sinksByScope := map[string]int{}
-	for _, sink := range sinks {
-		sinksByScope[sink.scope]++
-	}
+	remaining := len(currentSinks) - sinkIndex
 	for index := sourceIndex + 1; index < len(sources); index++ {
-		remaining += sinksByScope[sources[index].scope]
+		remaining += len(sinksByScope[sources[index].scope])
 	}
 	return remaining
 }

--- a/core/risk/composition_multistage.go
+++ b/core/risk/composition_multistage.go
@@ -1,6 +1,7 @@
 package risk
 
 import (
+	"context"
 	"sort"
 	"strconv"
 	"strings"
@@ -55,11 +56,58 @@ type multiStageCompositionBuildState struct {
 	truncations         []CompositionTruncation
 }
 
+func (s *multiStageCompositionBuildState) recordTruncatedCandidate(candidate string) {
+	if s == nil || len(s.truncatedCandidates) >= maxComposedActionPathTruncatedCandidates {
+		return
+	}
+	s.truncatedCandidates = append(s.truncatedCandidates, candidate)
+}
+
 func buildMultiStageComposedActionPaths(paths []ActionPath, workflowChains *agentresolver.WorkflowChainArtifact) []ComposedActionPath {
+	compositions, _ := buildMultiStageComposedActionPathsContext(context.Background(), paths, workflowChains)
+	return compositions
+}
+
+func buildMultiStageComposedActionPathsContext(ctx context.Context, paths []ActionPath, workflowChains *agentresolver.WorkflowChainArtifact) ([]ComposedActionPath, error) {
 	if len(paths) < minMultiStageCompositionDepth {
-		return nil
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 	chainRefsByPath := agentresolver.WorkflowChainRefsByPath(workflowChains)
+	correlationRefsByMember := map[string][]string{}
+	strongRefMembers := map[string]map[string]struct{}{}
+	hasEvidenceBackedJoin := false
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		memberKey := compositionMemberKey(path)
+		refs := multiStageCorrelationRefs(path, chainRefsByPath)
+		correlationRefsByMember[memberKey] = dedupeSortedStrings(append(correlationRefsByMember[memberKey], refs...))
+		for _, ref := range refs {
+			if !strongMultiStageCorrelationRef(ref) {
+				continue
+			}
+			members := strongRefMembers[ref]
+			if members == nil {
+				members = map[string]struct{}{}
+				strongRefMembers[ref] = members
+			}
+			members[memberKey] = struct{}{}
+			if len(members) > 1 {
+				hasEvidenceBackedJoin = true
+			}
+		}
+	}
+	if !hasEvidenceBackedJoin {
+		return nil, nil
+	}
+
 	ordered := append([]ActionPath(nil), paths...)
 	sort.Slice(ordered, func(i, j int) bool {
 		leftClass := multiStageSystemClass(ordered[i])
@@ -73,25 +121,24 @@ func buildMultiStageComposedActionPaths(paths []ActionPath, workflowChains *agen
 		return strings.TrimSpace(ordered[i].PathID) < strings.TrimSpace(ordered[j].PathID)
 	})
 
-	correlationRefsByMember := map[string][]string{}
-	for _, path := range ordered {
-		memberKey := compositionMemberKey(path)
-		correlationRefsByMember[memberKey] = dedupeSortedStrings(append(
-			correlationRefsByMember[memberKey],
-			multiStageCorrelationRefs(path, chainRefsByPath)...,
-		))
-	}
-
 	byID := map[string]ComposedActionPath{}
 	for _, spec := range multiStageCompositionPatternSpecs() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		state := &multiStageCompositionBuildState{}
 		for _, source := range ordered {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			sourceClass := multiStageSystemClass(source)
 			if !IsActionPathEligible(source) || !spec.sourceOK(source) || !stringInSet(sourceClass, spec.sourceSystems) || !knownMultiStageTrustBoundary(source, sourceClass) {
 				continue
 			}
 			visited := map[string]struct{}{compositionMemberKey(source): {}}
-			walkMultiStageComposition(spec, ordered, correlationRefsByMember, []ActionPath{source}, nil, visited, byID, state)
+			if err := walkMultiStageComposition(ctx, spec, ordered, correlationRefsByMember, []ActionPath{source}, nil, visited, byID, state); err != nil {
+				return nil, err
+			}
 			if state.candidateCount >= maxMultiStageCompositionCandidatesPerPattern || state.emittedCount >= maxMultiStageCompositionPathsPerPattern {
 				break
 			}
@@ -101,6 +148,9 @@ func buildMultiStageComposedActionPaths(paths []ActionPath, workflowChains *agen
 
 	out := make([]ComposedActionPath, 0, len(byID))
 	for _, composition := range byID {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		out = append(out, composition)
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -109,10 +159,11 @@ func buildMultiStageComposedActionPaths(paths []ActionPath, workflowChains *agen
 		}
 		return out[i].CompositionID < out[j].CompositionID
 	})
-	return out
+	return out, nil
 }
 
 func walkMultiStageComposition(
+	ctx context.Context,
 	spec multiStageCompositionPatternSpec,
 	candidates []ActionPath,
 	correlationRefsByMember map[string][]string,
@@ -121,9 +172,12 @@ func walkMultiStageComposition(
 	visited map[string]struct{},
 	byID map[string]ComposedActionPath,
 	state *multiStageCompositionBuildState,
-) {
+) error {
 	if state == nil || state.candidateCount >= maxMultiStageCompositionCandidatesPerPattern || state.emittedCount >= maxMultiStageCompositionPathsPerPattern {
-		return
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	last := current[len(current)-1]
 	lastMember := compositionMemberKey(last)
@@ -136,6 +190,9 @@ func walkMultiStageComposition(
 	}
 	next := make([]nextCandidate, 0)
 	for _, candidate := range candidates {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		memberKey := compositionMemberKey(candidate)
 		if _, seen := visited[memberKey]; seen || !IsActionPathEligible(candidate) {
 			continue
@@ -166,7 +223,7 @@ func walkMultiStageComposition(
 	if len(next) > maxMultiStageCompositionNeighborsPerStage {
 		omitted := next[maxMultiStageCompositionNeighborsPerStage:]
 		for _, candidate := range omitted {
-			state.truncatedCandidates = append(state.truncatedCandidates, compositionCandidateKey(candidate.path))
+			state.recordTruncatedCandidate(compositionCandidateKey(candidate.path))
 		}
 		state.truncations = append(state.truncations, CompositionTruncation{
 			PatternID:          spec.id,
@@ -179,6 +236,9 @@ func walkMultiStageComposition(
 	}
 
 	for _, candidate := range next {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if state.candidateCount >= maxMultiStageCompositionCandidatesPerPattern {
 			state.truncations = append(state.truncations, CompositionTruncation{
 				PatternID:          spec.id,
@@ -187,7 +247,7 @@ func walkMultiStageComposition(
 				ObservedCandidates: state.candidateCount + 1,
 				OmittedCandidates:  1,
 			})
-			return
+			return nil
 		}
 		state.candidateCount++
 		route := append(append([]ActionPath(nil), current...), candidate.path)
@@ -211,7 +271,7 @@ func walkMultiStageComposition(
 					ObservedCandidates: state.emittedCount + 1,
 					OmittedCandidates:  1,
 				})
-				return
+				return nil
 			}
 			composition := buildMultiStageComposedActionPath(spec, route, routeEdgeRefs)
 			if strings.TrimSpace(composition.CompositionID) != "" {
@@ -238,9 +298,12 @@ func walkMultiStageComposition(
 		}
 		memberKey := compositionMemberKey(candidate.path)
 		visited[memberKey] = struct{}{}
-		walkMultiStageComposition(spec, candidates, correlationRefsByMember, route, routeEdgeRefs, visited, byID, state)
+		if err := walkMultiStageComposition(ctx, spec, candidates, correlationRefsByMember, route, routeEdgeRefs, visited, byID, state); err != nil {
+			return err
+		}
 		delete(visited, memberKey)
 	}
+	return nil
 }
 
 func buildMultiStageComposedActionPath(spec multiStageCompositionPatternSpec, paths []ActionPath, edgeCorrelationRefs [][]string) ComposedActionPath {

--- a/core/risk/composition_multistage.go
+++ b/core/risk/composition_multistage.go
@@ -385,6 +385,7 @@ func buildMultiStageComposedActionPath(spec multiStageCompositionPatternSpec, pa
 		Pattern:                      multiStagePublicPattern(spec, stages),
 		ResolutionKey:                multiStageCompositionResolutionKey(paths),
 		PathIDs:                      compositionPathIDs(paths),
+		memberPathIDs:                compositionMembershipPathIDs(paths),
 		WorkflowChainRefs:            compositionWorkflowRefs(paths, nil),
 		Stages:                       stages,
 		Transitions:                  transitions,
@@ -859,7 +860,8 @@ func mergeMultiStageComposedActionPath(current, incoming ComposedActionPath) Com
 		return incoming
 	}
 	merged := current
-	merged.PathIDs = dedupeSortedStrings(append(merged.PathIDs, incoming.PathIDs...))
+	merged.PathIDs = boundedOutputEvidenceRefs(append(merged.PathIDs, incoming.PathIDs...))
+	merged.memberPathIDs = dedupeSortedStrings(append(compositionMemberPathIDs(current), compositionMemberPathIDs(incoming)...))
 	merged.WorkflowChainRefs = dedupeSortedStrings(append(merged.WorkflowChainRefs, incoming.WorkflowChainRefs...))
 	merged.EvidenceRefs = dedupeSortedStrings(append(merged.EvidenceRefs, incoming.EvidenceRefs...))
 	merged.ProofRefs = dedupeSortedStrings(append(merged.ProofRefs, incoming.ProofRefs...))

--- a/core/risk/composition_test.go
+++ b/core/risk/composition_test.go
@@ -250,12 +250,13 @@ func TestBuildComposedActionPathsPreservesGroupedDuplicateMembershipBeyondEvalua
 	composition := findCompositionByID(compositions, expectedCompositionID)
 	if composition == nil {
 		t.Fatalf("expected %s composition %s", CompositionPatternSensitiveReadToEgress, expectedCompositionID)
-	}
-	if got, want := len(composition.memberPathIDs), duplicateCount+1; got != want {
-		t.Fatalf("internal membership path ids = %d, want %d", got, want)
-	}
-	if len(composition.PathIDs) > maxOutputEvidenceRefs {
-		t.Fatalf("serialized path ids = %d, want <= %d", len(composition.PathIDs), maxOutputEvidenceRefs)
+	} else {
+		if got, want := len(composition.memberPathIDs), duplicateCount+1; got != want {
+			t.Fatalf("internal membership path ids = %d, want %d", got, want)
+		}
+		if len(composition.PathIDs) > maxOutputEvidenceRefs {
+			t.Fatalf("serialized path ids = %d, want <= %d", len(composition.PathIDs), maxOutputEvidenceRefs)
+		}
 	}
 
 	decorated, err := DecorateActionPathCompositionRefsContext(context.Background(), paths, compositions)
@@ -315,8 +316,7 @@ func TestBuildComposedActionPathsKeepsOutcomeDistinctCandidatesSeparate(t *testi
 		composition := byProductionTarget[target]
 		if composition == nil {
 			t.Fatalf("missing composition for %s: %+v", target, compositions)
-		}
-		if !containsAnyPathClass(composition.memberPathIDs, pathID) {
+		} else if !containsAnyPathClass(composition.memberPathIDs, pathID) {
 			t.Fatalf("composition for %s did not retain %s: %+v", target, pathID, composition)
 		}
 	}
@@ -338,8 +338,7 @@ func TestBuildComposedActionPathsKeepsOutcomeDistinctCandidatesSeparate(t *testi
 		}
 		if path == nil {
 			t.Fatalf("missing decorated path %s", pathID)
-		}
-		if !containsAnyPathClass(path.CompositionIDs, byProductionTarget[target].CompositionID) {
+		} else if !containsAnyPathClass(path.CompositionIDs, byProductionTarget[target].CompositionID) {
 			t.Fatalf("path %s has wrong composition target: %+v", pathID, path)
 		}
 	}
@@ -403,13 +402,14 @@ func TestBuildComposedActionPathsKeepsGovernanceDistinctCandidatesSeparate(t *te
 	composition := findCompositionByPattern(compositions, CompositionPatternSensitiveReadToEgress)
 	if composition == nil {
 		t.Fatalf("expected sensitive-read composition, got %+v", compositions)
-	}
-	if composition.PolicyCoverageStatus != PolicyCoverageStatusDeclared {
-		t.Fatalf("governance state was not merged conservatively: %+v", composition)
-	}
-	if !containsAnyPathClass(composition.memberPathIDs, governedRead.PathID, weakerRead.PathID) ||
-		!containsAnyPathClass(composition.EvidenceRefs, "evidence:weaker-read") {
-		t.Fatalf("expected governance evidence from both candidates, got %+v", composition)
+	} else {
+		if composition.PolicyCoverageStatus != PolicyCoverageStatusDeclared {
+			t.Fatalf("governance state was not merged conservatively: %+v", composition)
+		}
+		if !containsAnyPathClass(composition.memberPathIDs, governedRead.PathID, weakerRead.PathID) ||
+			!containsAnyPathClass(composition.EvidenceRefs, "evidence:weaker-read") {
+			t.Fatalf("expected governance evidence from both candidates, got %+v", composition)
+		}
 	}
 }
 

--- a/core/risk/composition_test.go
+++ b/core/risk/composition_test.go
@@ -199,7 +199,7 @@ func TestBuildComposedActionPathsBoundsSuppressedCandidateEvidence(t *testing.T)
 func TestBuildComposedActionPathsBoundsDuplicateCandidateEvaluation(t *testing.T) {
 	paths := make([]ActionPath, 0, maxComposedActionPathCandidateEvaluations+2)
 	for index := 0; index < maxComposedActionPathCandidateEvaluations+1; index++ {
-		source := compositionTestPath(fmt.Sprintf("apc-read-%04d", index), "rk-read-shared", []string{"read"}, TargetClassCustomerDataAdjacent)
+		source := compositionTestPath(fmt.Sprintf("apc-read-%04d", index), fmt.Sprintf("rk-read-%04d", index), []string{"read"}, TargetClassCustomerDataAdjacent)
 		source.Repo = "checkout"
 		paths = append(paths, source)
 	}
@@ -216,20 +216,59 @@ func TestBuildComposedActionPathsBoundsDuplicateCandidateEvaluation(t *testing.T
 	var receipt *CompositionTruncation
 	for index := range composition.Truncations {
 		candidate := composition.Truncations[index]
-		if candidate.Reason == CompositionTruncationCandidateCap && candidate.Limit == maxComposedActionPathCandidateEvaluations {
+		if candidate.Reason == CompositionTruncationCandidateCap && candidate.Limit == maxComposedActionPathCandidates {
 			receipt = &candidate
 			break
 		}
 	}
 	if receipt == nil || receipt.OmittedCandidates == 0 {
-		t.Fatalf("expected duplicate candidate evaluation receipt, got %+v", composition.Truncations)
+		t.Fatalf("expected candidate cap receipt, got %+v", composition.Truncations)
 		return
 	}
-	if receipt.ObservedCandidates != maxComposedActionPathCandidateEvaluations+receipt.OmittedCandidates {
-		t.Fatalf("observed candidates = %d, want evaluated %d plus omitted %d", receipt.ObservedCandidates, maxComposedActionPathCandidateEvaluations, receipt.OmittedCandidates)
+	if receipt.ObservedCandidates != maxComposedActionPathCandidates+receipt.OmittedCandidates {
+		t.Fatalf("observed candidates = %d, want emitted %d plus omitted %d", receipt.ObservedCandidates, maxComposedActionPathCandidates, receipt.OmittedCandidates)
 	}
 	if len(composition.PathIDs) > maxOutputEvidenceRefs {
 		t.Fatalf("path ids = %d, want <= %d", len(composition.PathIDs), maxOutputEvidenceRefs)
+	}
+}
+
+func TestBuildComposedActionPathsPreservesGroupedDuplicateMembershipBeyondEvaluationCap(t *testing.T) {
+	duplicateCount := maxComposedActionPathCandidateEvaluations + 1
+	paths := make([]ActionPath, 0, duplicateCount+1)
+	for index := 0; index < duplicateCount; index++ {
+		source := compositionTestPath(fmt.Sprintf("apc-read-%04d", index), "rk-read-shared", []string{"read"}, TargetClassCustomerDataAdjacent)
+		source.Repo = "checkout"
+		paths = append(paths, source)
+	}
+	sink := compositionTestPath("apc-egress", "rk-egress", []string{"egress"}, TargetClassUnknown)
+	sink.Repo = "checkout"
+	paths = append(paths, sink)
+
+	compositions, _ := BuildComposedActionPaths(paths, nil)
+	expectedCompositionID := buildComposedActionPath(compositionPatternSpecs()[0], paths[0], sink, nil).CompositionID
+	composition := findCompositionByID(compositions, expectedCompositionID)
+	if composition == nil {
+		t.Fatalf("expected %s composition %s", CompositionPatternSensitiveReadToEgress, expectedCompositionID)
+	}
+	if got, want := len(composition.memberPathIDs), duplicateCount+1; got != want {
+		t.Fatalf("internal membership path ids = %d, want %d", got, want)
+	}
+	if len(composition.PathIDs) > maxOutputEvidenceRefs {
+		t.Fatalf("serialized path ids = %d, want <= %d", len(composition.PathIDs), maxOutputEvidenceRefs)
+	}
+
+	decorated, err := DecorateActionPathCompositionRefsContext(context.Background(), paths, compositions)
+	if err != nil {
+		t.Fatalf("DecorateActionPathCompositionRefsContext() error = %v", err)
+	}
+	for _, path := range decorated {
+		if !containsAnyPathClass(path.CompositionIDs, composition.CompositionID) {
+			t.Fatalf("path %s is missing composition membership: %+v", path.PathID, path)
+		}
+		if len(path.ProposedActionContractRefs) == 0 {
+			t.Fatalf("path %s is missing proposed action contract membership: %+v", path.PathID, path)
+		}
 	}
 }
 
@@ -1310,6 +1349,15 @@ func findCompositionByPattern(paths []ComposedActionPath, patternID string) *Com
 	for idx := range paths {
 		if paths[idx].PatternID == patternID {
 			return &paths[idx]
+		}
+	}
+	return nil
+}
+
+func findCompositionByID(paths []ComposedActionPath, compositionID string) *ComposedActionPath {
+	for index := range paths {
+		if paths[index].CompositionID == compositionID {
+			return &paths[index]
 		}
 	}
 	return nil

--- a/core/risk/composition_test.go
+++ b/core/risk/composition_test.go
@@ -33,6 +33,38 @@ func TestBuildComposedActionPathsStableIDIgnoresPathIDChurn(t *testing.T) {
 	}
 }
 
+func TestCompositionCandidateFallbackTargetIdentityNormalizesValues(t *testing.T) {
+	tests := []struct {
+		name                             string
+		sourceTargetClass, sourceOrgRepo string
+		sinkTargetClass, sinkOrgRepo     string
+		want                             string
+	}{
+		{
+			name:              "sorts and deduplicates",
+			sourceTargetClass: "cloud",
+			sourceOrgRepo:     "acme/payments",
+			sinkTargetClass:   "cloud",
+			sinkOrgRepo:       "acme/payments",
+			want:              "acme/payments+cloud",
+		},
+		{
+			name:            "skips empty values",
+			sourceOrgRepo:   "acme/payments",
+			sinkTargetClass: "production",
+			want:            "acme/payments+production",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := compositionCandidateFallbackTargetIdentity(test.sourceTargetClass, test.sourceOrgRepo, test.sinkTargetClass, test.sinkOrgRepo)
+			if got != test.want {
+				t.Fatalf("compositionCandidateFallbackTargetIdentity() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestBuildComposedActionPathsSensitiveReadToEgress(t *testing.T) {
 	paths := []ActionPath{
 		compositionTestPath("apc-read", "rk-read", []string{"read"}, TargetClassCustomerDataAdjacent),

--- a/core/risk/composition_test.go
+++ b/core/risk/composition_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/Clyra-AI/wrkr/core/aggregate/agentresolver"
@@ -106,6 +107,54 @@ func TestBuildComposedActionPathsContextStopsBeforeAnalysis(t *testing.T) {
 	}, nil)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected canceled composition build, got %v", err)
+	}
+}
+
+func TestBuildComposedActionPathsContextSkipsCrossScopeCandidatePairs(t *testing.T) {
+	const candidatesPerSide = 24
+	paths := make([]ActionPath, 0, candidatesPerSide*2)
+	for index := 0; index < candidatesPerSide; index++ {
+		source := compositionTestPath(fmt.Sprintf("apc-read-%02d", index), fmt.Sprintf("rk-read-%02d", index), []string{"read"}, TargetClassCustomerDataAdjacent)
+		source.Repo = fmt.Sprintf("read-repo-%02d", index)
+		paths = append(paths, source)
+
+		sink := compositionTestPath(fmt.Sprintf("apc-egress-%02d", index), fmt.Sprintf("rk-egress-%02d", index), []string{"egress"}, TargetClassUnknown)
+		sink.Repo = fmt.Sprintf("egress-repo-%02d", index)
+		paths = append(paths, sink)
+	}
+
+	ctx := &deadlineAfterCallsContext{Context: context.Background(), allowedCalls: 700}
+	compositions, choice, err := BuildComposedActionPathsContext(ctx, paths, nil)
+	if err != nil {
+		t.Fatalf("BuildComposedActionPathsContext() error = %v", err)
+	}
+	if len(compositions) == 0 || choice == nil {
+		t.Fatalf("expected same-scope egress self-compositions, got compositions=%+v choice=%+v", compositions, choice)
+	}
+	for _, composition := range compositions {
+		for _, pathID := range composition.PathIDs {
+			if strings.HasPrefix(pathID, "apc-read-") {
+				t.Fatalf("cross-scope read candidate was composed: %+v", composition)
+			}
+		}
+	}
+}
+
+func TestProjectActionPathsContextHonorsCancellationDuringProjectionAndSort(t *testing.T) {
+	paths := []ActionPath{
+		compositionTestPath("apc-read", "rk-read", []string{"read"}, TargetClassCustomerDataAdjacent),
+		compositionTestPath("apc-egress", "rk-egress", []string{"egress"}, TargetClassUnknown),
+		compositionTestPath("apc-write", "rk-write", []string{"write"}, TargetClassReleaseAdjacent),
+	}
+
+	projectionCtx := &deadlineAfterCallsContext{Context: context.Background(), allowedCalls: 1}
+	if _, err := ProjectActionPathsContext(projectionCtx, paths); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("projection cancellation error = %v, want deadline exceeded", err)
+	}
+
+	sortCtx := &deadlineAfterCallsContext{Context: context.Background(), allowedCalls: len(paths) + 2}
+	if _, err := ProjectActionPathsContext(sortCtx, paths); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("sort cancellation error = %v, want deadline exceeded", err)
 	}
 }
 
@@ -1223,6 +1272,20 @@ func compositionTestPath(pathID, resolutionKey string, actionClasses []string, t
 			Surface:  "api",
 		}},
 	})
+}
+
+type deadlineAfterCallsContext struct {
+	context.Context
+	allowedCalls int
+	calls        int
+}
+
+func (c *deadlineAfterCallsContext) Err() error {
+	c.calls++
+	if c.calls > c.allowedCalls {
+		return context.DeadlineExceeded
+	}
+	return nil
 }
 
 func semanticForAction(actionClasses []string) string {

--- a/core/risk/composition_test.go
+++ b/core/risk/composition_test.go
@@ -1,6 +1,9 @@
 package risk
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -58,6 +61,120 @@ func TestBuildComposedActionPathsSensitiveReadToEgress(t *testing.T) {
 	}
 	if choice == nil || choice.Summary.TotalCompositions == 0 {
 		t.Fatalf("expected control-first composition choice, got %+v", choice)
+	}
+}
+
+func TestBuildComposedActionPathsContextStopsBeforeAnalysis(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := BuildComposedActionPathsContext(ctx, []ActionPath{
+		compositionTestPath("apc-read", "rk-read", []string{"read"}, TargetClassCustomerDataAdjacent),
+		compositionTestPath("apc-egress", "rk-egress", []string{"egress"}, TargetClassUnknown),
+	}, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled composition build, got %v", err)
+	}
+}
+
+func TestBuildComposedActionPathsBoundsSuppressedCandidateEvidence(t *testing.T) {
+	paths := make([]ActionPath, 0, 40)
+	for index := 0; index < 20; index++ {
+		paths = append(paths,
+			compositionTestPath(fmt.Sprintf("apc-read-%02d", index), fmt.Sprintf("rk-read-%02d", index), []string{"read"}, TargetClassCustomerDataAdjacent),
+			compositionTestPath(fmt.Sprintf("apc-egress-%02d", index), fmt.Sprintf("rk-egress-%02d", index), []string{"egress"}, TargetClassUnknown),
+		)
+	}
+
+	compositions, _ := BuildComposedActionPaths(paths, nil)
+	if len(compositions) != maxComposedActionPathCandidates {
+		t.Fatalf("expected %d retained compositions, got %d", maxComposedActionPathCandidates, len(compositions))
+	}
+	composition := findCompositionByPattern(compositions, CompositionPatternSensitiveReadToEgress)
+	if composition == nil {
+		t.Fatalf("expected %s composition", CompositionPatternSensitiveReadToEgress)
+	}
+	if len(composition.TruncatedCandidates) > maxComposedActionPathTruncatedCandidates {
+		t.Fatalf("truncated candidate examples = %d, want <= %d", len(composition.TruncatedCandidates), maxComposedActionPathTruncatedCandidates)
+	}
+	var receipt *CompositionTruncation
+	for index := range composition.Truncations {
+		candidate := composition.Truncations[index]
+		if candidate.Reason == CompositionTruncationCandidateCap && candidate.Limit == maxComposedActionPathCandidates {
+			receipt = &candidate
+			break
+		}
+	}
+	if receipt == nil {
+		t.Fatalf("expected candidate cap receipt, got %+v", composition.Truncations)
+	}
+	if receipt.ObservedCandidates <= maxComposedActionPathCandidates || receipt.OmittedCandidates != receipt.ObservedCandidates-maxComposedActionPathCandidates {
+		t.Fatalf("unexpected suppression receipt %+v", receipt)
+	}
+}
+
+func TestBuildComposedActionPathsBoundsDuplicateCandidateEvaluation(t *testing.T) {
+	paths := make([]ActionPath, 0, maxComposedActionPathCandidateEvaluations+2)
+	for index := 0; index < maxComposedActionPathCandidateEvaluations+1; index++ {
+		source := compositionTestPath(fmt.Sprintf("apc-read-%04d", index), "rk-read-shared", []string{"read"}, TargetClassCustomerDataAdjacent)
+		source.Repo = "checkout"
+		paths = append(paths, source)
+	}
+	sink := compositionTestPath("apc-egress", "rk-egress", []string{"egress"}, TargetClassUnknown)
+	sink.Repo = "checkout"
+	paths = append(paths, sink)
+
+	compositions, _ := BuildComposedActionPaths(paths, nil)
+	composition := findCompositionByPattern(compositions, CompositionPatternSensitiveReadToEgress)
+	if composition == nil {
+		t.Fatalf("expected %s composition", CompositionPatternSensitiveReadToEgress)
+	}
+	var receipt *CompositionTruncation
+	for index := range composition.Truncations {
+		candidate := composition.Truncations[index]
+		if candidate.Reason == CompositionTruncationCandidateCap && candidate.Limit == maxComposedActionPathCandidateEvaluations {
+			receipt = &candidate
+			break
+		}
+	}
+	if receipt == nil || receipt.OmittedCandidates == 0 {
+		t.Fatalf("expected duplicate candidate evaluation receipt, got %+v", composition.Truncations)
+	}
+	if receipt.ObservedCandidates != maxComposedActionPathCandidateEvaluations+receipt.OmittedCandidates {
+		t.Fatalf("observed candidates = %d, want evaluated %d plus omitted %d", receipt.ObservedCandidates, maxComposedActionPathCandidateEvaluations, receipt.OmittedCandidates)
+	}
+	if len(composition.PathIDs) > maxOutputEvidenceRefs {
+		t.Fatalf("path ids = %d, want <= %d", len(composition.PathIDs), maxOutputEvidenceRefs)
+	}
+}
+
+func TestCompositionCandidateIDMatchesMaterializedComposition(t *testing.T) {
+	spec := compositionPatternSpecs()[0]
+	for name, paths := range map[string][]ActionPath{
+		"fallback target identity": {
+			compositionTestPath("apc-read", "rk-read", []string{"read"}, TargetClassCustomerDataAdjacent),
+			compositionTestPath("apc-egress", "rk-egress", []string{"egress"}, TargetClassUnknown),
+		},
+		"endpoint target identity": {
+			func() ActionPath {
+				path := compositionTestPath("apc-read", "rk-read", []string{"read"}, TargetClassCustomerDataAdjacent)
+				path.EndpointRefGroupID = "group-customers"
+				return path
+			}(),
+			func() ActionPath {
+				path := compositionTestPath("apc-egress", "rk-egress", []string{"egress"}, TargetClassUnknown)
+				path.MutableEndpointSemantics = []agginventory.MutableEndpointSemantic{{Surface: "openapi", Operation: "POST /v1/export"}}
+				return path
+			}(),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := compositionCandidateID(spec, paths[0], paths[1])
+			want := buildComposedActionPath(spec, paths[0], paths[1], nil).CompositionID
+			if got != want {
+				t.Fatalf("candidate identity = %q, want %q", got, want)
+			}
+		})
 	}
 }
 

--- a/core/risk/composition_test.go
+++ b/core/risk/composition_test.go
@@ -272,6 +272,79 @@ func TestBuildComposedActionPathsPreservesGroupedDuplicateMembershipBeyondEvalua
 	}
 }
 
+func TestBuildComposedActionPathsKeepsOutcomeDistinctCandidatesSeparate(t *testing.T) {
+	paymentRead := compositionTestPath("apc-payment-read", "rk-read-shared", []string{"read"}, TargetClassCustomerDataAdjacent)
+	paymentRead.MatchedProductionTargets = []string{"production:payments"}
+	paymentRead.EndpointRefGroupID = "payments-api"
+	paymentRead.MutableEndpointSemantics = []agginventory.MutableEndpointSemantic{{
+		Semantic:  agginventory.EndpointSemanticRead,
+		Surface:   "openapi",
+		Operation: "GET /payments",
+	}}
+	billingRead := compositionTestPath("apc-billing-read", "rk-read-shared", []string{"read"}, TargetClassCustomerDataAdjacent)
+	billingRead.MatchedProductionTargets = []string{"production:billing"}
+	billingRead.EndpointRefGroupID = "billing-api"
+	billingRead.MutableEndpointSemantics = []agginventory.MutableEndpointSemantic{{
+		Semantic:  agginventory.EndpointSemanticRead,
+		Surface:   "openapi",
+		Operation: "GET /billing",
+	}}
+	egress := compositionTestPath("apc-egress", "rk-egress", []string{"egress"}, TargetClassUnknown)
+
+	paths := []ActionPath{paymentRead, billingRead, egress}
+	compositions, _ := BuildComposedActionPaths(paths, nil)
+	byProductionTarget := map[string]*ComposedActionPath{}
+	for index := range compositions {
+		composition := &compositions[index]
+		if composition.PatternID != CompositionPatternSensitiveReadToEgress {
+			continue
+		}
+		for _, target := range []string{"production:payments", "production:billing"} {
+			if strings.Contains(composition.TargetIdentity, target) {
+				byProductionTarget[target] = composition
+			}
+		}
+	}
+	if got, want := len(byProductionTarget), 2; got != want {
+		t.Fatalf("sensitive-read compositions = %d, want %d: %+v", got, want, compositions)
+	}
+	for target, pathID := range map[string]string{
+		"production:payments": paymentRead.PathID,
+		"production:billing":  billingRead.PathID,
+	} {
+		composition := byProductionTarget[target]
+		if composition == nil {
+			t.Fatalf("missing composition for %s: %+v", target, compositions)
+		}
+		if !containsAnyPathClass(composition.memberPathIDs, pathID) {
+			t.Fatalf("composition for %s did not retain %s: %+v", target, pathID, composition)
+		}
+	}
+
+	decorated, err := DecorateActionPathCompositionRefsContext(context.Background(), paths, compositions)
+	if err != nil {
+		t.Fatalf("DecorateActionPathCompositionRefsContext() error = %v", err)
+	}
+	for pathID, target := range map[string]string{
+		paymentRead.PathID: "production:payments",
+		billingRead.PathID: "production:billing",
+	} {
+		var path *ActionPath
+		for index := range decorated {
+			if decorated[index].PathID == pathID {
+				path = &decorated[index]
+				break
+			}
+		}
+		if path == nil {
+			t.Fatalf("missing decorated path %s", pathID)
+		}
+		if !containsAnyPathClass(path.CompositionIDs, byProductionTarget[target].CompositionID) {
+			t.Fatalf("path %s has wrong composition target: %+v", pathID, path)
+		}
+	}
+}
+
 func TestCompositionCandidateIDMatchesMaterializedComposition(t *testing.T) {
 	spec := compositionPatternSpecs()[0]
 	for name, paths := range map[string][]ActionPath{

--- a/core/risk/composition_test.go
+++ b/core/risk/composition_test.go
@@ -125,6 +125,7 @@ func TestBuildComposedActionPathsBoundsSuppressedCandidateEvidence(t *testing.T)
 	composition := findCompositionByPattern(compositions, CompositionPatternSensitiveReadToEgress)
 	if composition == nil {
 		t.Fatalf("expected %s composition", CompositionPatternSensitiveReadToEgress)
+		return
 	}
 	if len(composition.TruncatedCandidates) > maxComposedActionPathTruncatedCandidates {
 		t.Fatalf("truncated candidate examples = %d, want <= %d", len(composition.TruncatedCandidates), maxComposedActionPathTruncatedCandidates)
@@ -139,6 +140,7 @@ func TestBuildComposedActionPathsBoundsSuppressedCandidateEvidence(t *testing.T)
 	}
 	if receipt == nil {
 		t.Fatalf("expected candidate cap receipt, got %+v", composition.Truncations)
+		return
 	}
 	if receipt.ObservedCandidates <= maxComposedActionPathCandidates || receipt.OmittedCandidates != receipt.ObservedCandidates-maxComposedActionPathCandidates {
 		t.Fatalf("unexpected suppression receipt %+v", receipt)
@@ -160,6 +162,7 @@ func TestBuildComposedActionPathsBoundsDuplicateCandidateEvaluation(t *testing.T
 	composition := findCompositionByPattern(compositions, CompositionPatternSensitiveReadToEgress)
 	if composition == nil {
 		t.Fatalf("expected %s composition", CompositionPatternSensitiveReadToEgress)
+		return
 	}
 	var receipt *CompositionTruncation
 	for index := range composition.Truncations {
@@ -171,6 +174,7 @@ func TestBuildComposedActionPathsBoundsDuplicateCandidateEvaluation(t *testing.T
 	}
 	if receipt == nil || receipt.OmittedCandidates == 0 {
 		t.Fatalf("expected duplicate candidate evaluation receipt, got %+v", composition.Truncations)
+		return
 	}
 	if receipt.ObservedCandidates != maxComposedActionPathCandidateEvaluations+receipt.OmittedCandidates {
 		t.Fatalf("observed candidates = %d, want evaluated %d plus omitted %d", receipt.ObservedCandidates, maxComposedActionPathCandidateEvaluations, receipt.OmittedCandidates)
@@ -489,6 +493,45 @@ func TestDecorateActionPathCompositionRefs(t *testing.T) {
 	for _, path := range decorated {
 		if len(path.CompositionIDs) == 0 {
 			t.Fatalf("expected composition refs on %s: %+v", path.PathID, decorated)
+		}
+	}
+}
+
+func TestDecorateActionPathCompositionRefsRetainsUnboundedMembership(t *testing.T) {
+	paths := make([]ActionPath, 0, maxOutputEvidenceRefs+2)
+	for index := 0; index <= maxOutputEvidenceRefs; index++ {
+		source := compositionTestPath(fmt.Sprintf("apc-read-%03d", index), "rk-read-shared", []string{"read"}, TargetClassCustomerDataAdjacent)
+		source.Repo = "checkout"
+		paths = append(paths, source)
+	}
+	sink := compositionTestPath("apc-egress", "rk-egress", []string{"egress"}, TargetClassUnknown)
+	sink.Repo = "checkout"
+	paths = append(paths, sink)
+
+	compositions, _ := BuildComposedActionPaths(paths, nil)
+	var composition *ComposedActionPath
+	for index := range compositions {
+		candidate := &compositions[index]
+		if len(candidate.memberPathIDs) > maxOutputEvidenceRefs {
+			composition = candidate
+			break
+		}
+	}
+	if composition == nil {
+		t.Fatalf("expected a collapsed composition with unbounded internal membership, got %+v", compositions)
+		return
+	}
+	if len(composition.PathIDs) != maxOutputEvidenceRefs {
+		t.Fatalf("serialized path ids = %d, want cap %d", len(composition.PathIDs), maxOutputEvidenceRefs)
+	}
+
+	decorated := DecorateActionPathCompositionRefs(paths, compositions)
+	for _, path := range decorated {
+		if !containsAnyPathClass(path.CompositionIDs, composition.CompositionID) {
+			t.Fatalf("path %s lost composition membership: %+v", path.PathID, path)
+		}
+		if !containsAnyPathClass(path.ProposedActionContractRefs, composition.ProposedActionContractRefs[0]) {
+			t.Fatalf("path %s lost proposed action contract membership: %+v", path.PathID, path)
 		}
 	}
 }

--- a/core/risk/composition_test.go
+++ b/core/risk/composition_test.go
@@ -345,6 +345,74 @@ func TestBuildComposedActionPathsKeepsOutcomeDistinctCandidatesSeparate(t *testi
 	}
 }
 
+func TestBuildComposedActionPathsKeepsGovernanceDistinctCandidatesSeparate(t *testing.T) {
+	governedRead := compositionTestPath("apc-governed-read", "rk-read-shared", []string{"read"}, TargetClassCustomerDataAdjacent)
+	governedRead.PolicyCoverageStatus = PolicyCoverageStatusMatched
+	governedRead.ControlEvidenceRefs = []string{"evidence:governed-read"}
+	governedRead.CredentialAuthorityRef = "authority:read"
+	governedRead.CredentialAuthority = &agginventory.CredentialAuthority{
+		CredentialPresent: true,
+		AccessType:        agginventory.AuthorityAccessRead,
+		LikelyScope:       "customer-data:read",
+	}
+
+	weakerRead := governedRead
+	weakerRead.PathID = "apc-weaker-read"
+	weakerRead.PolicyCoverageStatus = PolicyCoverageStatusDeclared
+	weakerRead.ControlEvidenceRefs = []string{"evidence:weaker-read"}
+	weakerRead.CredentialAuthorityRef = "authority:read-weaker"
+	weakerRead.CredentialAuthority = &agginventory.CredentialAuthority{
+		CredentialPresent: true,
+		AccessType:        agginventory.AuthorityAccessRead,
+		LikelyScope:       "customer-data:read",
+		ReasonCodes:       []string{"authority:weaker"},
+	}
+	contradictoryCandidate := governedRead
+	contradictoryCandidate.PathID = "apc-contradictory-read"
+	contradictoryCandidate.Contradictions = []evidencepolicy.Contradiction{{
+		Class:             "credential_policy_conflict",
+		ReasonCodes:       []string{"policy:conflicting_credential_authority"},
+		EvidenceRefs:      []string{"evidence:credential-conflict"},
+		RecommendedAction: RecommendedControlBlock,
+	}}
+
+	egress := compositionTestPath("apc-egress", "rk-egress", []string{"egress"}, TargetClassUnknown)
+	egress.CredentialAuthorityRef = "authority:egress"
+	egress.CredentialAuthority = &agginventory.CredentialAuthority{
+		CredentialPresent: true,
+		AccessType:        agginventory.AuthorityAccessRead,
+		LikelyScope:       "network:egress",
+	}
+
+	grouped, memberships := groupCompositionCandidates([]compositionCandidate{
+		newCompositionCandidate(governedRead),
+		newCompositionCandidate(weakerRead),
+	})
+	if got, want := len(grouped), 2; got != want || len(memberships) != want {
+		t.Fatalf("governance-distinct candidates were grouped: grouped=%+v memberships=%+v", grouped, memberships)
+	}
+	contradictionGroups, _ := groupCompositionCandidates([]compositionCandidate{
+		newCompositionCandidate(governedRead),
+		newCompositionCandidate(contradictoryCandidate),
+	})
+	if got, want := len(contradictionGroups), 2; got != want {
+		t.Fatalf("contradictory candidate was grouped with an otherwise identical path: %+v", contradictionGroups)
+	}
+
+	compositions, _ := BuildComposedActionPaths([]ActionPath{governedRead, weakerRead, egress}, nil)
+	composition := findCompositionByPattern(compositions, CompositionPatternSensitiveReadToEgress)
+	if composition == nil {
+		t.Fatalf("expected sensitive-read composition, got %+v", compositions)
+	}
+	if composition.PolicyCoverageStatus != PolicyCoverageStatusDeclared {
+		t.Fatalf("governance state was not merged conservatively: %+v", composition)
+	}
+	if !containsAnyPathClass(composition.memberPathIDs, governedRead.PathID, weakerRead.PathID) ||
+		!containsAnyPathClass(composition.EvidenceRefs, "evidence:weaker-read") {
+		t.Fatalf("expected governance evidence from both candidates, got %+v", composition)
+	}
+}
+
 func TestCompositionCandidateIDMatchesMaterializedComposition(t *testing.T) {
 	spec := compositionPatternSpecs()[0]
 	for name, paths := range map[string][]ActionPath{
@@ -883,6 +951,53 @@ func TestMergeComposedActionPathPreservesDelegationMetadataAfterStageRebuild(t *
 	}
 	if !containsAnyPathClass(merged.EscalatingTransitionRefs, transition.TransitionID) || merged.MostRestrictiveSource != "transition:"+transition.TransitionID {
 		t.Fatalf("expected rebuilt transition refs to point at merged transition ids, got refs=%v source=%q transition=%+v", merged.EscalatingTransitionRefs, merged.MostRestrictiveSource, transition)
+	}
+}
+
+func TestMergeComposedActionPathPrefersMostRestrictiveDelegationRelationship(t *testing.T) {
+	base := ComposedActionPath{
+		CompositionID: "cap-restrictive-transition",
+		Stages: []CompositionStage{
+			{
+				StageID:       compositionStageID(CompositionStageRoleSource, "rk-source", TargetClassReleaseAdjacent, EvidenceStateDeclared),
+				Role:          CompositionStageRoleSource,
+				ResolutionKey: "rk-source",
+				TargetClass:   TargetClassReleaseAdjacent,
+				EvidenceState: EvidenceStateDeclared,
+			},
+			{
+				StageID:       compositionStageID(CompositionStageRolePrivilegedSink, "rk-sink", TargetClassProductionImpacting, EvidenceStateDeclared),
+				Role:          CompositionStageRolePrivilegedSink,
+				ResolutionKey: "rk-sink",
+				TargetClass:   TargetClassProductionImpacting,
+				EvidenceState: EvidenceStateDeclared,
+			},
+		},
+		EvidenceState:        EvidenceStateDeclared,
+		PolicyCoverageStatus: PolicyCoverageStatusDeclared,
+	}
+	base.Transitions = buildCompositionTransitions(base.CompositionID, base.Stages)
+	base.Transitions[0].Relationship = CompositionDelegationEqual
+	base.Transitions[0].ParentAuthorityRef = "authority:repo-read"
+	base.Transitions[0].ChildAuthorityRef = "authority:prod-read"
+
+	incoming := base
+	incoming.Transitions = append([]CompositionTransition(nil), base.Transitions...)
+	incoming.Transitions[0].Relationship = CompositionDelegationContradictory
+	incoming.Transitions[0].ParentAuthorityRef = "authority:repo-conflicted"
+	incoming.Transitions[0].ChildAuthorityRef = "authority:prod-conflicted"
+	incoming.Transitions[0].ReasonCodes = []string{"delegation_relationship:contradictory_evidence"}
+
+	merged := mergeComposedActionPath(base, incoming)
+	if len(merged.Transitions) != 1 {
+		t.Fatalf("expected one merged transition, got %+v", merged.Transitions)
+	}
+	transition := merged.Transitions[0]
+	if transition.Relationship != CompositionDelegationContradictory ||
+		transition.ParentAuthorityRef != "authority:repo-conflicted" ||
+		transition.ChildAuthorityRef != "authority:prod-conflicted" ||
+		!containsAnyPathClass(transition.ReasonCodes, "delegation_relationship:contradictory_evidence") {
+		t.Fatalf("expected most restrictive delegation to survive merge, got %+v", transition)
 	}
 }
 

--- a/core/risk/govern_first_model.go
+++ b/core/risk/govern_first_model.go
@@ -306,46 +306,47 @@ func pathHasHighImpactDeliveryEvidence(path ActionPath) bool {
 	return false
 }
 
-func compareActionPaths(left, right ActionPath) bool {
+// compareProjectedActionPaths orders paths after their buyer-facing fields have
+// been derived. Re-projecting inside a sort comparator repeats expensive endpoint
+// normalization for every comparison on large organizations.
+func compareProjectedActionPaths(left, right ActionPath) bool {
 	leftModel := deriveGovernFirstModel(left)
 	rightModel := deriveGovernFirstModel(right)
-	leftProjection := ProjectBuyerFacingActionPath(left)
-	rightProjection := ProjectBuyerFacingActionPath(right)
 	if leftModel.controlPriorityRank != rightModel.controlPriorityRank {
 		return leftModel.controlPriorityRank < rightModel.controlPriorityRank
 	}
-	if IsActionPathEligible(leftProjection) != IsActionPathEligible(rightProjection) {
-		return IsActionPathEligible(leftProjection)
+	if IsActionPathEligible(left) != IsActionPathEligible(right) {
+		return IsActionPathEligible(left)
 	}
-	if actionBindingRank(leftProjection.ActionBindingState) != actionBindingRank(rightProjection.ActionBindingState) {
-		return actionBindingRank(leftProjection.ActionBindingState) < actionBindingRank(rightProjection.ActionBindingState)
+	if actionBindingRank(left.ActionBindingState) != actionBindingRank(right.ActionBindingState) {
+		return actionBindingRank(left.ActionBindingState) < actionBindingRank(right.ActionBindingState)
 	}
-	if autonomyTierRank(leftProjection.AutonomyTier) != autonomyTierRank(rightProjection.AutonomyTier) {
-		return autonomyTierRank(leftProjection.AutonomyTier) < autonomyTierRank(rightProjection.AutonomyTier)
+	if autonomyTierRank(left.AutonomyTier) != autonomyTierRank(right.AutonomyTier) {
+		return autonomyTierRank(left.AutonomyTier) < autonomyTierRank(right.AutonomyTier)
 	}
-	if delegationReadinessRank(leftProjection.DelegationReadinessState) != delegationReadinessRank(rightProjection.DelegationReadinessState) {
-		return delegationReadinessRank(leftProjection.DelegationReadinessState) < delegationReadinessRank(rightProjection.DelegationReadinessState)
+	if delegationReadinessRank(left.DelegationReadinessState) != delegationReadinessRank(right.DelegationReadinessState) {
+		return delegationReadinessRank(left.DelegationReadinessState) < delegationReadinessRank(right.DelegationReadinessState)
 	}
-	if highStakesPresetScore(leftProjection) != highStakesPresetScore(rightProjection) {
-		return highStakesPresetScore(leftProjection) > highStakesPresetScore(rightProjection)
+	if highStakesPresetScore(left) != highStakesPresetScore(right) {
+		return highStakesPresetScore(left) > highStakesPresetScore(right)
 	}
-	if agenticDeliverySystemChangeRank(leftProjection.AgenticDeliverySystemChange) != agenticDeliverySystemChangeRank(rightProjection.AgenticDeliverySystemChange) {
-		return agenticDeliverySystemChangeRank(leftProjection.AgenticDeliverySystemChange) > agenticDeliverySystemChangeRank(rightProjection.AgenticDeliverySystemChange)
+	if agenticDeliverySystemChangeRank(left.AgenticDeliverySystemChange) != agenticDeliverySystemChangeRank(right.AgenticDeliverySystemChange) {
+		return agenticDeliverySystemChangeRank(left.AgenticDeliverySystemChange) > agenticDeliverySystemChangeRank(right.AgenticDeliverySystemChange)
 	}
 	if leftModel.riskTierRank != rightModel.riskTierRank {
 		return leftModel.riskTierRank < rightModel.riskTierRank
 	}
-	if targetClassRank(leftProjection.TargetClass) != targetClassRank(rightProjection.TargetClass) {
-		return targetClassRank(leftProjection.TargetClass) < targetClassRank(rightProjection.TargetClass)
+	if targetClassRank(left.TargetClass) != targetClassRank(right.TargetClass) {
+		return targetClassRank(left.TargetClass) < targetClassRank(right.TargetClass)
 	}
-	if actionPathTypeRank(leftProjection.ActionPathType) != actionPathTypeRank(rightProjection.ActionPathType) {
-		return actionPathTypeRank(leftProjection.ActionPathType) < actionPathTypeRank(rightProjection.ActionPathType)
+	if actionPathTypeRank(left.ActionPathType) != actionPathTypeRank(right.ActionPathType) {
+		return actionPathTypeRank(left.ActionPathType) < actionPathTypeRank(right.ActionPathType)
 	}
-	if confidenceLaneRank(leftProjection.ConfidenceLane) != confidenceLaneRank(rightProjection.ConfidenceLane) {
-		return confidenceLaneRank(leftProjection.ConfidenceLane) < confidenceLaneRank(rightProjection.ConfidenceLane)
+	if confidenceLaneRank(left.ConfidenceLane) != confidenceLaneRank(right.ConfidenceLane) {
+		return confidenceLaneRank(left.ConfidenceLane) < confidenceLaneRank(right.ConfidenceLane)
 	}
-	if reviewBurdenRank(leftProjection.ReviewBurden) != reviewBurdenRank(rightProjection.ReviewBurden) {
-		return reviewBurdenRank(leftProjection.ReviewBurden) < reviewBurdenRank(rightProjection.ReviewBurden)
+	if reviewBurdenRank(left.ReviewBurden) != reviewBurdenRank(right.ReviewBurden) {
+		return reviewBurdenRank(left.ReviewBurden) < reviewBurdenRank(right.ReviewBurden)
 	}
 	if leftModel.sourceSignalRank != rightModel.sourceSignalRank {
 		return leftModel.sourceSignalRank > rightModel.sourceSignalRank

--- a/core/risk/review_lifecycle.go
+++ b/core/risk/review_lifecycle.go
@@ -54,7 +54,7 @@ func ProjectReviewLifecycleTransitionsContext(ctx context.Context, current []Act
 	}
 
 	sort.Slice(out, func(i, j int) bool {
-		return compareActionPaths(out[i], out[j])
+		return compareProjectedActionPaths(out[i], out[j])
 	})
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/core/risk/review_lifecycle.go
+++ b/core/risk/review_lifecycle.go
@@ -1,19 +1,32 @@
 package risk
 
 import (
+	"context"
 	"sort"
 	"strings"
 )
 
 func ProjectReviewLifecycleTransitions(current []ActionPath, previous []ActionPath) []ActionPath {
+	projected, _ := ProjectReviewLifecycleTransitionsContext(context.Background(), current, previous)
+	return projected
+}
+
+// ProjectReviewLifecycleTransitionsContext projects review state while honoring cancellation.
+func ProjectReviewLifecycleTransitionsContext(ctx context.Context, current []ActionPath, previous []ActionPath) ([]ActionPath, error) {
 	if len(current) == 0 {
-		return nil
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	previousByPathID := map[string]ActionPath{}
 	previousByResolutionKey := map[string]ActionPath{}
 	previousByRepoLocation := map[string]ActionPath{}
 	for _, raw := range previous {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		path := ProjectActionPath(raw)
 		if pathID := strings.TrimSpace(path.PathID); pathID != "" {
 			previousByPathID[pathID] = path
@@ -28,6 +41,9 @@ func ProjectReviewLifecycleTransitions(current []ActionPath, previous []ActionPa
 
 	out := make([]ActionPath, 0, len(current))
 	for _, raw := range current {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		path := ProjectActionPath(raw)
 		if previousPath, ok := matchPreviousReviewLifecyclePath(path, previousByPathID, previousByResolutionKey, previousByRepoLocation); ok {
 			path = applyReviewLifecycleTransition(path, previousPath)
@@ -40,7 +56,10 @@ func ProjectReviewLifecycleTransitions(current []ActionPath, previous []ActionPa
 	sort.Slice(out, func(i, j int) bool {
 		return compareActionPaths(out[i], out[j])
 	})
-	return out
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func applyCurrentReviewLifecycleProjection(path ActionPath) ActionPath {

--- a/core/risk/risk_bench_test.go
+++ b/core/risk/risk_bench_test.go
@@ -47,3 +47,19 @@ func BenchmarkBuildComposedActionPathsMultiStageBounded(b *testing.B) {
 		_, _ = BuildComposedActionPaths(paths, chains)
 	}
 }
+
+func BenchmarkBuildComposedActionPathsDenseCandidateCap(b *testing.B) {
+	paths := make([]ActionPath, 0, 384)
+	for index := 0; index < 192; index++ {
+		paths = append(paths,
+			compositionTestPath(fmt.Sprintf("apc-read-%03d", index), fmt.Sprintf("rk-read-%03d", index), []string{"read"}, TargetClassCustomerDataAdjacent),
+			compositionTestPath(fmt.Sprintf("apc-egress-%03d", index), fmt.Sprintf("rk-egress-%03d", index), []string{"egress"}, TargetClassUnknown),
+		)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for index := 0; index < b.N; index++ {
+		_, _ = BuildComposedActionPaths(paths, nil)
+	}
+}

--- a/core/risk/workflow_chain.go
+++ b/core/risk/workflow_chain.go
@@ -103,11 +103,6 @@ type workflowChainGraphRefs struct {
 	EdgeIDs []string
 }
 
-func workflowChainGraphRefsByPath(graph *aggattack.ControlPathGraph) map[string]workflowChainGraphRefs {
-	refs, _ := workflowChainGraphRefsByPathContext(context.Background(), graph)
-	return refs
-}
-
 func workflowChainGraphRefsByPathContext(ctx context.Context, graph *aggattack.ControlPathGraph) (map[string]workflowChainGraphRefs, error) {
 	byPath := map[string]workflowChainGraphRefs{}
 	if graph == nil {

--- a/core/risk/workflow_chain.go
+++ b/core/risk/workflow_chain.go
@@ -1,6 +1,7 @@
 package risk
 
 import (
+	"context"
 	"strings"
 
 	"github.com/Clyra-AI/wrkr/core/aggregate/agentresolver"
@@ -10,13 +11,28 @@ import (
 )
 
 func BuildWorkflowChains(paths []ActionPath, graph *aggattack.ControlPathGraph) *agentresolver.WorkflowChainArtifact {
+	artifact, _ := BuildWorkflowChainsContext(context.Background(), paths, graph)
+	return artifact
+}
+
+// BuildWorkflowChainsContext builds bounded workflow-chain evidence while honoring scan cancellation.
+func BuildWorkflowChainsContext(ctx context.Context, paths []ActionPath, graph *aggattack.ControlPathGraph) (*agentresolver.WorkflowChainArtifact, error) {
 	if len(paths) == 0 {
-		return nil
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
-	graphRefsByPath := workflowChainGraphRefsByPath(graph)
+	graphRefsByPath, err := workflowChainGraphRefsByPathContext(ctx, graph)
+	if err != nil {
+		return nil, err
+	}
 	inputs := make([]agentresolver.WorkflowChainInput, 0, len(paths))
 	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		refs := graphRefsByPath[strings.TrimSpace(path.PathID)]
 		inputs = append(inputs, agentresolver.WorkflowChainInput{
 			PathID:                    strings.TrimSpace(path.PathID),
@@ -49,26 +65,37 @@ func BuildWorkflowChains(paths []ActionPath, graph *aggattack.ControlPathGraph) 
 			EvidenceCompletenessLabel: evidenceCompletenessProjectionLabel(path.EvidenceCompleteness),
 			GraphNodeRefs:             refs.NodeIDs,
 			GraphEdgeRefs:             refs.EdgeIDs,
-			ProofRefs:                 dedupeSortedStrings(path.PolicyEvidenceRefs),
+			ProofRefs:                 boundedOutputEvidenceRefs(path.PolicyEvidenceRefs),
 			EvidenceRefs:              workflowChainEvidenceRefs(path),
-			SourceFindingKeys:         dedupeSortedStrings(path.SourceFindingKeys),
+			SourceFindingKeys:         boundedOutputEvidenceRefs(path.SourceFindingKeys),
 		})
 	}
-	return agentresolver.BuildWorkflowChains(inputs)
+	return agentresolver.BuildWorkflowChainsContext(ctx, inputs)
 }
 
 func DecorateWorkflowChainRefs(paths []ActionPath, artifact *agentresolver.WorkflowChainArtifact) []ActionPath {
+	decorated, _ := DecorateWorkflowChainRefsContext(context.Background(), paths, artifact)
+	return decorated
+}
+
+func DecorateWorkflowChainRefsContext(ctx context.Context, paths []ActionPath, artifact *agentresolver.WorkflowChainArtifact) ([]ActionPath, error) {
 	if len(paths) == 0 {
-		return nil
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	refsByPath := agentresolver.WorkflowChainRefsByPath(artifact)
 	out := make([]ActionPath, 0, len(paths))
 	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		copyPath := path
 		copyPath.WorkflowChainRefs = dedupeSortedStrings(refsByPath[strings.TrimSpace(path.PathID)])
 		out = append(out, copyPath)
 	}
-	return out
+	return out, nil
 }
 
 type workflowChainGraphRefs struct {
@@ -77,29 +104,51 @@ type workflowChainGraphRefs struct {
 }
 
 func workflowChainGraphRefsByPath(graph *aggattack.ControlPathGraph) map[string]workflowChainGraphRefs {
+	refs, _ := workflowChainGraphRefsByPathContext(context.Background(), graph)
+	return refs
+}
+
+func workflowChainGraphRefsByPathContext(ctx context.Context, graph *aggattack.ControlPathGraph) (map[string]workflowChainGraphRefs, error) {
 	byPath := map[string]workflowChainGraphRefs{}
 	if graph == nil {
-		return byPath
+		return byPath, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	for _, node := range graph.Nodes {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		pathID := strings.TrimSpace(node.PathID)
 		if pathID == "" {
 			continue
 		}
 		current := byPath[pathID]
-		current.NodeIDs = dedupeSortedStrings(append(current.NodeIDs, strings.TrimSpace(node.NodeID)))
+		current.NodeIDs = append(current.NodeIDs, strings.TrimSpace(node.NodeID))
 		byPath[pathID] = current
 	}
 	for _, edge := range graph.Edges {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		pathID := strings.TrimSpace(edge.PathID)
 		if pathID == "" {
 			continue
 		}
 		current := byPath[pathID]
-		current.EdgeIDs = dedupeSortedStrings(append(current.EdgeIDs, strings.TrimSpace(edge.EdgeID)))
+		current.EdgeIDs = append(current.EdgeIDs, strings.TrimSpace(edge.EdgeID))
 		byPath[pathID] = current
 	}
-	return byPath
+	for pathID, refs := range byPath {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		refs.NodeIDs = dedupeSortedStrings(refs.NodeIDs)
+		refs.EdgeIDs = dedupeSortedStrings(refs.EdgeIDs)
+		byPath[pathID] = refs
+	}
+	return byPath, nil
 }
 
 func workflowChainEvidenceRefs(path ActionPath) []string {
@@ -109,5 +158,5 @@ func workflowChainEvidenceRefs(path ActionPath) []string {
 	if path.IntroducedBy != nil {
 		values = append(values, attribution.EvidenceRefs(path.IntroducedBy)...)
 	}
-	return dedupeSortedStrings(values)
+	return boundedOutputEvidenceRefs(values)
 }

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -12,7 +12,7 @@
         "gray-matter": "^4.0.3",
         "highlight.js": "^11.11.1",
         "marked": "^17.0.1",
-        "mermaid": "^11.14.0",
+        "mermaid": "^11.16.1",
         "next": "^16.2.11",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -775,9 +775,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -793,9 +790,6 @@
       "integrity": "sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -813,9 +807,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -831,9 +822,6 @@
       "integrity": "sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -851,9 +839,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -870,9 +855,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -888,9 +870,6 @@
       "integrity": "sha512-VVlpEWwizEFIOom0zdoeKuO5nuTswzVE5uHcBNvHzmeHUpNFajY3HFfbQ+zIH4E2kVaZ/yVxmsShW56TtEy4uA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -914,9 +893,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -938,9 +914,6 @@
       "integrity": "sha512-N3hzbEpUTJC8pWpPVJvgzGxM+so/MAXc8O2s/53B0LL9ZGpfXpME7Wizkc5d/8fRBlBtkDjzoZGDCqqNDHqLEw==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -964,9 +937,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -989,9 +959,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1013,9 +980,6 @@
       "integrity": "sha512-TYaItB5oj1ioXjhyn2xrR208vf+YuIIcHptQWRRaBmFhvIvL9D72DXN8w75xup0KXA8UdEAhQ9Qb2S49FD/9Cw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1164,12 +1128,12 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/types": "~11.1.1"
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1270,9 +1234,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1288,9 +1249,6 @@
       "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1308,9 +1266,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1326,9 +1281,6 @@
       "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1973,9 +1925,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2729,9 +2681,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3024,9 +2976,9 @@
       "license": "MIT"
     },
     "node_modules/cytoscape": {
-      "version": "3.33.1",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
-      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -3584,9 +3536,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.19",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
-      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3697,9 +3649,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4855,9 +4807,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -5551,10 +5503,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5614,9 +5576,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.28",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.28.tgz",
-      "integrity": "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==",
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -5796,26 +5758,26 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
+        "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.1",
+        "@mermaid-js/parser": "^1.2.0",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.1",
+        "cytoscape": "^3.33.3",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.25",
+        "katex": "^0.16.45",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -7034,9 +6996,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -7053,9 +7012,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -7071,9 +7027,6 @@
       "integrity": "sha512-DSTb6ijQzqe6DdAaOBVqJ/SYf1vO8EW5bK6X6LRXufEBebf2722VCdvBUtZ3rtV0x2ApfPNDy/p7LrrjaWjiyQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -7096,9 +7049,6 @@
       "integrity": "sha512-K7ykQ+26Rt6+4BTU80AuGgTPIYX86UxiAKT4rcXX/WNTo7k1ZxpKz+TguHnwVpCqQK3B5PK0vZ0ZBe6nz/ib1w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -15,7 +15,7 @@
     "gray-matter": "^4.0.3",
     "highlight.js": "^11.11.1",
     "marked": "^17.0.1",
-    "mermaid": "^11.14.0",
+    "mermaid": "^11.16.1",
     "next": "^16.2.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -35,7 +35,15 @@
     "typescript": "^5.0.0"
   },
   "overrides": {
-    "dompurify": "3.4.11",
+    "dompurify": "3.4.13",
+    "brace-expansion@^1.1.7": "1.1.18",
+    "brace-expansion@^2.0.2": "2.1.4",
+    "eslint": {
+      "js-yaml": "4.3.1"
+    },
+    "gray-matter": {
+      "js-yaml": "3.15.1"
+    },
     "lodash-es": "4.18.1",
     "postcss": "$postcss",
     "sharp": "0.35.0"

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	golang.org/x/mod v0.37.0
 	golang.org/x/net v0.56.0
+	golang.org/x/sys v0.46.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -18,6 +19,5 @@ require (
 	github.com/gowebpki/jcs v1.0.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 )

--- a/internal/acceptance/sprint0_size_signal_acceptance_test.go
+++ b/internal/acceptance/sprint0_size_signal_acceptance_test.go
@@ -21,8 +21,9 @@ const (
 	sprint0AcceptanceMarkdownLineCap = 1500
 	sprint0AcceptanceLeadLineCap     = 45
 	sprint0AcceptanceLeadSectionCap  = 5
-	sprint0EndpointDenseRepoCount    = 4
+	sprint0EndpointDenseRepoCount    = 1
 	sprint0EndpointDenseStateBudget  = 24 << 20
+	sprint0EndpointDenseMinimumRefs  = enterprisepressure.DefaultDenseOpenAPIOperations * 4
 )
 
 func TestSprint0AgentActionBOMArtifactsStayBoundedAndRedacted(t *testing.T) {
@@ -163,7 +164,7 @@ func TestSprint0EndpointDenseArtifactsUseGroupedEndpointProjection(t *testing.T)
 		path := requireObjectItem(t, raw)
 		count, _ := path["endpoint_ref_count"].(float64)
 		refs := requireOptionalArrayLength(path["mutable_endpoint_semantic_refs"])
-		if int(count) > refs && int(count) >= 1000 {
+		if int(count) > refs && int(count) >= sprint0EndpointDenseMinimumRefs {
 			groupedPathFound = true
 		}
 	}
@@ -186,7 +187,7 @@ func TestSprint0EndpointDenseArtifactsUseGroupedEndpointProjection(t *testing.T)
 		item := requireObjectItem(t, raw)
 		count, _ := item["endpoint_ref_count"].(float64)
 		refs := requireOptionalArrayLength(item["mutable_endpoint_semantic_refs"])
-		if int(count) > refs && int(count) >= 1000 {
+		if int(count) > refs && int(count) >= sprint0EndpointDenseMinimumRefs {
 			groupedItemFound = true
 			if refs > 8 {
 				t.Fatalf("expected bounded endpoint ref samples, got %d in %v", refs, item)

--- a/internal/scenarios/scan_analysis_reliability_scenario_test.go
+++ b/internal/scenarios/scan_analysis_reliability_scenario_test.go
@@ -1,0 +1,82 @@
+//go:build scenario
+
+package scenarios
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Clyra-AI/wrkr/internal/enterprisepressure"
+)
+
+const scanAnalysisReliabilityRepoCount = 384
+const scanAnalysisReliabilityMaxDuration = 45 * time.Second
+
+func TestScenarioScanAnalysisReliabilityAtEnterpriseScale(t *testing.T) {
+	tmp := t.TempDir()
+	reposRoot := filepath.Join(tmp, "repos")
+	if err := enterprisepressure.MaterializeEndpointDense(
+		reposRoot,
+		scanAnalysisReliabilityRepoCount,
+		enterprisepressure.DefaultDenseOpenAPIOperations,
+	); err != nil {
+		t.Fatalf("materialize enterprise reliability fixture: %v", err)
+	}
+
+	firstStarted := time.Now()
+	first := runScenarioCommandJSONRaw(t, []string{
+		"scan", "--path", reposRoot, "--state", filepath.Join(tmp, "first-state.json"), "--quiet", "--json",
+	})
+	if elapsed := time.Since(firstStarted); elapsed > scanAnalysisReliabilityMaxDuration {
+		t.Fatalf("first enterprise-scale scan took %s, want <= %s", elapsed.Round(time.Millisecond), scanAnalysisReliabilityMaxDuration)
+	}
+
+	secondStarted := time.Now()
+	second := runScenarioCommandJSONRaw(t, []string{
+		"scan", "--path", reposRoot, "--state", filepath.Join(tmp, "second-state.json"), "--quiet", "--json",
+	})
+	if elapsed := time.Since(secondStarted); elapsed > scanAnalysisReliabilityMaxDuration {
+		t.Fatalf("second enterprise-scale scan took %s, want <= %s", elapsed.Round(time.Millisecond), scanAnalysisReliabilityMaxDuration)
+	}
+
+	assertEnterpriseReliabilityShape(t, first)
+	if !bytes.Equal(scanAnalysisReliabilityFingerprint(t, first), scanAnalysisReliabilityFingerprint(t, second)) {
+		t.Fatal("enterprise-scale scan output changed between identical fixture runs")
+	}
+}
+
+func assertEnterpriseReliabilityShape(t *testing.T, payload map[string]any) {
+	t.Helper()
+	manifest := requireScenarioObject(t, payload, "source_manifest")
+	repos := requireScenarioArrayFromObject(t, manifest, "repos")
+	if got := len(repos); got != scanAnalysisReliabilityRepoCount {
+		t.Fatalf("fixture repositories = %d, want %d", got, scanAnalysisReliabilityRepoCount)
+	}
+	if paths := requireScenarioArrayFromObject(t, payload, "action_paths"); len(paths) == 0 {
+		t.Fatal("expected workflow and endpoint fixture to produce action paths")
+	}
+	if compositions := requireScenarioArrayFromObject(t, payload, "composed_action_paths"); len(compositions) == 0 {
+		t.Fatal("expected workflow and endpoint fixture to produce composed action paths")
+	}
+}
+
+func scanAnalysisReliabilityFingerprint(t *testing.T, payload map[string]any) []byte {
+	t.Helper()
+	stable := map[string]any{
+		"action_path_summary":                   payload["action_path_summary"],
+		"action_path_to_control_first":          payload["action_path_to_control_first"],
+		"action_paths":                          payload["action_paths"],
+		"composed_action_path_to_control_first": payload["composed_action_path_to_control_first"],
+		"composed_action_paths":                 payload["composed_action_paths"],
+		"finding_counts":                        payload["finding_counts"],
+		"source_manifest":                       payload["source_manifest"],
+	}
+	encoded, err := json.Marshal(stable)
+	if err != nil {
+		t.Fatalf("marshal stable enterprise scan output: %v", err)
+	}
+	return encoded
+}

--- a/internal/scenarios/wave42_enterprise_pressure_scenario_test.go
+++ b/internal/scenarios/wave42_enterprise_pressure_scenario_test.go
@@ -210,7 +210,7 @@ func TestScenarioWave42EndpointDenseProjectionBoundaries(t *testing.T) {
 	}
 
 	statePath := filepath.Join(tmp, "endpoint-dense-state.json")
-	scanPayload := runScenarioCommandJSONRaw(t, []string{"scan", "--path", root, "--state", statePath, "--quiet", "--json"})
+	runScenarioCommandJSONRaw(t, []string{"scan", "--path", root, "--state", statePath, "--quiet", "--json"})
 	reportPath := filepath.Join(tmp, "endpoint-dense-evidence.json")
 	reportPayload := runScenarioCommandJSON(t, []string{
 		"report",
@@ -224,67 +224,14 @@ func TestScenarioWave42EndpointDenseProjectionBoundaries(t *testing.T) {
 	})
 	evidencePayload := readScenarioJSONFile(t, reportPath)
 
-	actionPaths := requireScenarioArrayFromObject(t, scanPayload, "action_paths")
-	groupedActionPathFound := false
-	for _, raw := range actionPaths {
-		path := requireScenarioMapForRepo(raw)
-		count := objectInt(path["endpoint_ref_count"])
-		refs := arrayLength(path["mutable_endpoint_semantic_refs"])
-		if count > refs && count >= 1000 {
-			groupedActionPathFound = true
-			if strings.TrimSpace(stringValue(path["endpoint_ref_group_id"])) == "" {
-				t.Fatalf("expected grouped action path to expose endpoint_ref_group_id, got %v", path)
-			}
-			if arrayLength(path["endpoint_ref_samples"]) == 0 {
-				t.Fatalf("expected grouped action path to expose endpoint_ref_samples, got %v", path)
-			}
-		}
-	}
-	if !groupedActionPathFound {
-		t.Fatalf("expected at least one grouped endpoint-dense action path, got %v", actionPaths)
-	}
-
 	bom := requireScenarioObject(t, reportPayload, "agent_action_bom")
 	items := requireScenarioArrayFromObject(t, bom, "items")
-	groupedBOMFound := false
-	for _, raw := range items {
-		item := requireScenarioMapForRepo(raw)
-		count := objectInt(item["endpoint_ref_count"])
-		refs := arrayLength(item["mutable_endpoint_semantic_refs"])
-		if count > refs && count >= 1000 {
-			groupedBOMFound = true
-			if refs > 8 {
-				t.Fatalf("expected BOM endpoint refs to stay bounded, got %d in %v", refs, item)
-			}
-			if arrayLength(item["endpoint_route_groups"]) == 0 {
-				t.Fatalf("expected BOM endpoint_route_groups, got %v", item)
-			}
-			if arrayLength(item["endpoint_operation_counts"]) == 0 {
-				t.Fatalf("expected BOM endpoint_operation_counts, got %v", item)
-			}
-		}
-	}
-	if !groupedBOMFound {
-		t.Fatalf("expected grouped endpoint-dense BOM item, got %v", items)
-	}
+	const expectedDenseEndpointSemanticRefs = enterprisepressure.DefaultDenseOpenAPIOperations * 5
+	assertScenarioGroupedEndpointProjection(t, "BOM items", items, expectedDenseEndpointSemanticRefs, true)
 
 	graph := requireScenarioObject(t, evidencePayload, "control_path_graph")
 	nodes := requireScenarioArrayFromObject(t, graph, "nodes")
-	groupedNodeFound := false
-	for _, raw := range nodes {
-		node := requireScenarioMapForRepo(raw)
-		count := objectInt(node["endpoint_ref_count"])
-		refs := arrayLength(node["mutable_endpoint_semantic_refs"])
-		if count > refs && count >= 1000 {
-			groupedNodeFound = true
-			if refs > 8 {
-				t.Fatalf("expected graph node endpoint refs to stay bounded, got %d in %v", refs, node)
-			}
-		}
-	}
-	if !groupedNodeFound {
-		t.Fatalf("expected grouped endpoint-dense graph node, got %v", nodes)
-	}
+	assertScenarioGroupedEndpointProjection(t, "graph nodes", nodes, expectedDenseEndpointSemanticRefs, false)
 
 	stateBytes, err := os.ReadFile(statePath)
 	if err != nil {
@@ -292,6 +239,49 @@ func TestScenarioWave42EndpointDenseProjectionBoundaries(t *testing.T) {
 	}
 	if len(stateBytes) > 24<<20 {
 		t.Fatalf("expected endpoint-dense saved state under 24MiB, got %d", len(stateBytes))
+	}
+}
+
+func scenarioEndpointProjectionSummary(rows []any) []map[string]any {
+	summary := make([]map[string]any, 0, len(rows))
+	for _, raw := range rows {
+		row := requireScenarioMapForRepo(raw)
+		summary = append(summary, map[string]any{
+			"path_id":              stringValue(row["path_id"]),
+			"repo":                 stringValue(row["repo"]),
+			"location":             stringValue(row["location"]),
+			"tool_type":            stringValue(row["tool_type"]),
+			"occurrence_count":     objectInt(row["occurrence_count"]),
+			"endpoint_ref_count":   objectInt(row["endpoint_ref_count"]),
+			"endpoint_ref_samples": arrayLength(row["endpoint_ref_samples"]),
+		})
+	}
+	return summary
+}
+
+func assertScenarioGroupedEndpointProjection(t *testing.T, surface string, rows []any, wantRefCount int, requireOccurrences bool) {
+	t.Helper()
+	found := false
+	for _, raw := range rows {
+		row := requireScenarioMapForRepo(raw)
+		count := objectInt(row["endpoint_ref_count"])
+		refs := arrayLength(row["mutable_endpoint_semantic_refs"])
+		if count != wantRefCount || count <= refs {
+			continue
+		}
+		found = true
+		if requireOccurrences && objectInt(row["occurrence_count"]) != enterprisepressure.DefaultDenseOpenAPIOperations {
+			t.Fatalf("expected %d grouped OpenAPI occurrences on %s, got %v", enterprisepressure.DefaultDenseOpenAPIOperations, surface, row)
+		}
+		if strings.TrimSpace(stringValue(row["endpoint_ref_group_id"])) == "" {
+			t.Fatalf("expected %s to expose endpoint_ref_group_id, got %v", surface, row)
+		}
+		if refs > 8 || arrayLength(row["endpoint_ref_samples"]) == 0 {
+			t.Fatalf("expected bounded endpoint samples on %s, got %v", surface, row)
+		}
+	}
+	if !found {
+		t.Fatalf("expected grouped endpoint projection on %s, got %v", surface, scenarioEndpointProjectionSummary(rows))
 	}
 }
 

--- a/internal/statelock/metadata_unix.go
+++ b/internal/statelock/metadata_unix.go
@@ -1,0 +1,47 @@
+//go:build !windows
+
+package statelock
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func openOwnerMetadataForWrite(path string) (*os.File, error) {
+	return openOwnerMetadataFile(path, unix.O_WRONLY|unix.O_CREAT, true)
+}
+
+func openOwnerMetadataForRead(path string) (*os.File, error) {
+	return openOwnerMetadataFile(path, unix.O_RDONLY, false)
+}
+
+func openOwnerMetadataFile(path string, flags int, truncate bool) (*os.File, error) {
+	// #nosec G304 -- metadata path is derived from the caller-selected managed state directory.
+	fd, err := unix.Open(path, flags|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open owner metadata without following links: %w", err)
+	}
+	var info unix.Stat_t
+	if err := unix.Fstat(fd, &info); err != nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("stat owner metadata: %w", err)
+	}
+	if info.Mode&unix.S_IFMT != unix.S_IFREG || info.Nlink != 1 {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("owner metadata must be a single-link regular file: %s", path)
+	}
+	file := os.NewFile(uintptr(fd), path)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("open owner metadata file: %s", path)
+	}
+	if truncate {
+		if err := file.Truncate(0); err != nil {
+			_ = file.Close()
+			return nil, fmt.Errorf("truncate owner metadata: %w", err)
+		}
+	}
+	return file, nil
+}

--- a/internal/statelock/metadata_unix.go
+++ b/internal/statelock/metadata_unix.go
@@ -32,7 +32,11 @@ func openOwnerMetadataFile(path string, flags int, truncate bool) (*os.File, err
 		_ = unix.Close(fd)
 		return nil, fmt.Errorf("owner metadata must be a single-link regular file: %s", path)
 	}
-	file := os.NewFile(uintptr(fd), path)
+	file, err := ownerMetadataFileFromDescriptor(fd, path)
+	if err != nil {
+		_ = unix.Close(fd)
+		return nil, err
+	}
 	if file == nil {
 		_ = unix.Close(fd)
 		return nil, fmt.Errorf("open owner metadata file: %s", path)
@@ -44,4 +48,11 @@ func openOwnerMetadataFile(path string, flags int, truncate bool) (*os.File, err
 		}
 	}
 	return file, nil
+}
+
+func ownerMetadataFileFromDescriptor(fd int, path string) (*os.File, error) {
+	if fd < 0 {
+		return nil, fmt.Errorf("open owner metadata file: invalid descriptor")
+	}
+	return os.NewFile(uintptr(fd), path), nil
 }

--- a/internal/statelock/metadata_unix_test.go
+++ b/internal/statelock/metadata_unix_test.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package statelock
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOwnerMetadataFileRejectsNegativeDescriptor(t *testing.T) {
+	file, err := ownerMetadataFileFromDescriptor(-1, "owner.json")
+	if err == nil {
+		if file != nil {
+			_ = file.Close()
+		}
+		t.Fatal("ownerMetadataFileFromDescriptor() error = nil, want invalid descriptor rejection")
+	}
+	if file != nil {
+		t.Fatalf("ownerMetadataFileFromDescriptor() file = %v, want nil", file)
+	}
+	if !strings.Contains(err.Error(), "invalid descriptor") {
+		t.Fatalf("ownerMetadataFileFromDescriptor() error = %v, want invalid descriptor", err)
+	}
+}

--- a/internal/statelock/metadata_windows.go
+++ b/internal/statelock/metadata_windows.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package statelock
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func openOwnerMetadataForWrite(path string) (*os.File, error) {
+	return openOwnerMetadataFile(path, windows.GENERIC_WRITE, windows.OPEN_ALWAYS, true)
+}
+
+func openOwnerMetadataForRead(path string) (*os.File, error) {
+	return openOwnerMetadataFile(path, windows.GENERIC_READ, windows.OPEN_EXISTING, false)
+}
+
+func openOwnerMetadataFile(path string, access uint32, createMode uint32, truncate bool) (*os.File, error) {
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, fmt.Errorf("encode owner metadata path: %w", err)
+	}
+	handle, err := windows.CreateFile(
+		name,
+		access,
+		0,
+		nil,
+		createMode,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open owner metadata without following links: %w", err)
+	}
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("stat owner metadata: %w", err)
+	}
+	if info.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 || info.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0 || info.NumberOfLinks != 1 {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("owner metadata must be a single-link regular file: %s", path)
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("open owner metadata file: %s", path)
+	}
+	if truncate {
+		if err := file.Truncate(0); err != nil {
+			_ = file.Close()
+			return nil, fmt.Errorf("truncate owner metadata: %w", err)
+		}
+	}
+	return file, nil
+}

--- a/internal/statelock/statelock.go
+++ b/internal/statelock/statelock.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,7 +106,7 @@ func (l *Lease) writeOwnerMetadata() error {
 	if l == nil || strings.TrimSpace(l.metadataPath) == "" {
 		return nil
 	}
-	file, err := os.OpenFile(l.metadataPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	file, err := openOwnerMetadataForWrite(l.metadataPath)
 	if err != nil {
 		return fmt.Errorf("write managed artifact lock metadata: %w", err)
 	}
@@ -143,10 +144,17 @@ func busyError(statePath, metadataPath string) error {
 }
 
 func readOwnerMetadata(lockPath string) (ownerMetadata, error) {
-	// #nosec G304 -- lockPath is derived from the caller-selected managed state directory.
-	payload, err := os.ReadFile(lockPath)
+	file, err := openOwnerMetadataForRead(lockPath)
 	if err != nil {
 		return ownerMetadata{}, err
+	}
+	payload, readErr := io.ReadAll(file)
+	closeErr := file.Close()
+	if readErr != nil {
+		return ownerMetadata{}, readErr
+	}
+	if closeErr != nil {
+		return ownerMetadata{}, closeErr
 	}
 	var metadata ownerMetadata
 	if err := json.Unmarshal(payload, &metadata); err != nil {

--- a/internal/statelock/statelock.go
+++ b/internal/statelock/statelock.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	fileName       = ".wrkr-managed.lock"
+	metadataName   = ".wrkr-managed.lock.owner.json"
 	defaultTimeout = 10 * time.Minute
 	retryDelay     = 25 * time.Millisecond
 )
@@ -24,8 +25,9 @@ var ErrBusy = errors.New("managed artifact state is busy")
 
 // Lease is an exclusive, cross-process lock for a managed artifact directory.
 type Lease struct {
-	lock     *flock.Flock
-	lockPath string
+	lock         *flock.Flock
+	lockPath     string
+	metadataPath string
 }
 
 type ownerMetadata struct {
@@ -53,6 +55,7 @@ func Acquire(ctx context.Context, statePath string) (*Lease, error) {
 	defer cancel()
 
 	lockPath := filepath.Join(dir, fileName)
+	metadataPath := filepath.Join(dir, metadataName)
 	lock := flock.New(lockPath)
 	locked, err := lock.TryLockContext(lockCtx, retryDelay)
 	if err != nil {
@@ -60,7 +63,7 @@ func Acquire(ctx context.Context, statePath string) (*Lease, error) {
 			if ctx.Err() != nil {
 				return nil, fmt.Errorf("acquire managed artifact lock: %w", ctx.Err())
 			}
-			return nil, busyError(statePath, lockPath)
+			return nil, busyError(statePath, metadataPath)
 		}
 		return nil, fmt.Errorf("acquire managed artifact lock: %w", err)
 	}
@@ -68,9 +71,13 @@ func Acquire(ctx context.Context, statePath string) (*Lease, error) {
 		if ctx.Err() != nil {
 			return nil, fmt.Errorf("acquire managed artifact lock: %w", ctx.Err())
 		}
-		return nil, busyError(statePath, lockPath)
+		return nil, busyError(statePath, metadataPath)
 	}
-	lease := &Lease{lock: lock, lockPath: lockPath}
+	lease := &Lease{
+		lock:         lock,
+		lockPath:     lockPath,
+		metadataPath: metadataPath,
+	}
 	if err := lease.writeOwnerMetadata(); err != nil {
 		_ = lease.Release()
 		return nil, err
@@ -82,19 +89,23 @@ func (l *Lease) Release() error {
 	if l == nil || l.lock == nil {
 		return nil
 	}
+	metadataErr := l.removeOwnerMetadata()
 	err := l.lock.Unlock()
 	l.lock = nil
 	if err != nil {
 		return fmt.Errorf("release managed artifact lock: %w", err)
 	}
+	if metadataErr != nil {
+		return metadataErr
+	}
 	return nil
 }
 
 func (l *Lease) writeOwnerMetadata() error {
-	if l == nil || strings.TrimSpace(l.lockPath) == "" {
+	if l == nil || strings.TrimSpace(l.metadataPath) == "" {
 		return nil
 	}
-	file, err := os.OpenFile(l.lockPath, os.O_WRONLY|os.O_TRUNC, 0)
+	file, err := os.OpenFile(l.metadataPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("write managed artifact lock metadata: %w", err)
 	}
@@ -109,10 +120,20 @@ func (l *Lease) writeOwnerMetadata() error {
 	return nil
 }
 
-func busyError(statePath, lockPath string) error {
+func (l *Lease) removeOwnerMetadata() error {
+	if l == nil || strings.TrimSpace(l.metadataPath) == "" {
+		return nil
+	}
+	if err := os.Remove(l.metadataPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove managed artifact lock metadata: %w", err)
+	}
+	return nil
+}
+
+func busyError(statePath, metadataPath string) error {
 	stateLabel := filepath.Clean(strings.TrimSpace(statePath))
 	message := fmt.Sprintf("state %s is locked by another wrkr scan; wait for it to finish or use a separate --state path", stateLabel)
-	if metadata, err := readOwnerMetadata(lockPath); err == nil && metadata.PID > 0 {
+	if metadata, err := readOwnerMetadata(metadataPath); err == nil && metadata.PID > 0 {
 		message += fmt.Sprintf(" (lock metadata pid=%d started_at=%s)", metadata.PID, metadata.StartedAt)
 	}
 	return fmt.Errorf("%w: %s", ErrBusy, message)

--- a/internal/statelock/statelock.go
+++ b/internal/statelock/statelock.go
@@ -3,6 +3,7 @@ package statelock
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -23,7 +24,13 @@ var ErrBusy = errors.New("managed artifact state is busy")
 
 // Lease is an exclusive, cross-process lock for a managed artifact directory.
 type Lease struct {
-	lock *flock.Flock
+	lock     *flock.Flock
+	lockPath string
+}
+
+type ownerMetadata struct {
+	PID       int    `json:"pid"`
+	StartedAt string `json:"started_at"`
 }
 
 func Acquire(ctx context.Context, statePath string) (*Lease, error) {
@@ -45,14 +52,15 @@ func Acquire(ctx context.Context, statePath string) (*Lease, error) {
 	}
 	defer cancel()
 
-	lock := flock.New(filepath.Join(dir, fileName))
+	lockPath := filepath.Join(dir, fileName)
+	lock := flock.New(lockPath)
 	locked, err := lock.TryLockContext(lockCtx, retryDelay)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 			if ctx.Err() != nil {
 				return nil, fmt.Errorf("acquire managed artifact lock: %w", ctx.Err())
 			}
-			return nil, ErrBusy
+			return nil, busyError(statePath, lockPath)
 		}
 		return nil, fmt.Errorf("acquire managed artifact lock: %w", err)
 	}
@@ -60,9 +68,14 @@ func Acquire(ctx context.Context, statePath string) (*Lease, error) {
 		if ctx.Err() != nil {
 			return nil, fmt.Errorf("acquire managed artifact lock: %w", ctx.Err())
 		}
-		return nil, ErrBusy
+		return nil, busyError(statePath, lockPath)
 	}
-	return &Lease{lock: lock}, nil
+	lease := &Lease{lock: lock, lockPath: lockPath}
+	if err := lease.writeOwnerMetadata(); err != nil {
+		_ = lease.Release()
+		return nil, err
+	}
+	return lease, nil
 }
 
 func (l *Lease) Release() error {
@@ -75,4 +88,44 @@ func (l *Lease) Release() error {
 		return fmt.Errorf("release managed artifact lock: %w", err)
 	}
 	return nil
+}
+
+func (l *Lease) writeOwnerMetadata() error {
+	if l == nil || strings.TrimSpace(l.lockPath) == "" {
+		return nil
+	}
+	file, err := os.OpenFile(l.lockPath, os.O_WRONLY|os.O_TRUNC, 0)
+	if err != nil {
+		return fmt.Errorf("write managed artifact lock metadata: %w", err)
+	}
+	defer file.Close()
+	metadata := ownerMetadata{
+		PID:       os.Getpid(),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := json.NewEncoder(file).Encode(metadata); err != nil {
+		return fmt.Errorf("write managed artifact lock metadata: %w", err)
+	}
+	return nil
+}
+
+func busyError(statePath, lockPath string) error {
+	stateLabel := filepath.Clean(strings.TrimSpace(statePath))
+	message := fmt.Sprintf("state %s is locked by another wrkr scan; wait for it to finish or use a separate --state path", stateLabel)
+	if metadata, err := readOwnerMetadata(lockPath); err == nil && metadata.PID > 0 {
+		message += fmt.Sprintf(" (lock metadata pid=%d started_at=%s)", metadata.PID, metadata.StartedAt)
+	}
+	return fmt.Errorf("%w: %s", ErrBusy, message)
+}
+
+func readOwnerMetadata(lockPath string) (ownerMetadata, error) {
+	payload, err := os.ReadFile(lockPath)
+	if err != nil {
+		return ownerMetadata{}, err
+	}
+	var metadata ownerMetadata
+	if err := json.Unmarshal(payload, &metadata); err != nil {
+		return ownerMetadata{}, err
+	}
+	return metadata, nil
 }

--- a/internal/statelock/statelock.go
+++ b/internal/statelock/statelock.go
@@ -109,13 +109,16 @@ func (l *Lease) writeOwnerMetadata() error {
 	if err != nil {
 		return fmt.Errorf("write managed artifact lock metadata: %w", err)
 	}
-	defer file.Close()
 	metadata := ownerMetadata{
 		PID:       os.Getpid(),
 		StartedAt: time.Now().UTC().Format(time.RFC3339),
 	}
 	if err := json.NewEncoder(file).Encode(metadata); err != nil {
+		_ = file.Close()
 		return fmt.Errorf("write managed artifact lock metadata: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close managed artifact lock metadata: %w", err)
 	}
 	return nil
 }

--- a/internal/statelock/statelock.go
+++ b/internal/statelock/statelock.go
@@ -140,6 +140,7 @@ func busyError(statePath, metadataPath string) error {
 }
 
 func readOwnerMetadata(lockPath string) (ownerMetadata, error) {
+	// #nosec G304 -- lockPath is derived from the caller-selected managed state directory.
 	payload, err := os.ReadFile(lockPath)
 	if err != nil {
 		return ownerMetadata{}, err

--- a/internal/statelock/statelock_test.go
+++ b/internal/statelock/statelock_test.go
@@ -122,19 +122,3 @@ func TestOwnerMetadataRejectsSymlink(t *testing.T) {
 		t.Fatalf("victim metadata = %q, want %q", payload, want)
 	}
 }
-
-func TestOwnerMetadataFileRejectsNegativeDescriptor(t *testing.T) {
-	file, err := ownerMetadataFileFromDescriptor(-1, "owner.json")
-	if err == nil {
-		if file != nil {
-			_ = file.Close()
-		}
-		t.Fatal("ownerMetadataFileFromDescriptor() error = nil, want invalid descriptor rejection")
-	}
-	if file != nil {
-		t.Fatalf("ownerMetadataFileFromDescriptor() file = %v, want nil", file)
-	}
-	if !strings.Contains(err.Error(), "invalid descriptor") {
-		t.Fatalf("ownerMetadataFileFromDescriptor() error = %v, want invalid descriptor", err)
-	}
-}

--- a/internal/statelock/statelock_test.go
+++ b/internal/statelock/statelock_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -33,5 +34,32 @@ func TestAcquireBlocksOtherProcessLeaseUntilRelease(t *testing.T) {
 	}
 	if err := third.Release(); err != nil {
 		t.Fatalf("Release(third) error = %v", err)
+	}
+}
+
+func TestBusyErrorIncludesStateAndOwnerMetadata(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	lease, err := Acquire(context.Background(), statePath)
+	if err != nil {
+		t.Fatalf("Acquire() error = %v", err)
+	}
+	defer func() { _ = lease.Release() }()
+
+	metadata, err := readOwnerMetadata(lease.lockPath)
+	if err != nil {
+		t.Fatalf("readOwnerMetadata() error = %v", err)
+	}
+	if metadata.PID <= 0 || metadata.StartedAt == "" {
+		t.Fatalf("unexpected owner metadata: %+v", metadata)
+	}
+
+	busy := busyError(statePath, lease.lockPath)
+	if !errors.Is(busy, ErrBusy) {
+		t.Fatalf("busyError() = %v, want ErrBusy", busy)
+	}
+	for _, want := range []string{filepath.Clean(statePath), "pid=", "separate --state path"} {
+		if !strings.Contains(busy.Error(), want) {
+			t.Fatalf("busyError() missing %q: %v", want, busy)
+		}
 	}
 }

--- a/internal/statelock/statelock_test.go
+++ b/internal/statelock/statelock_test.go
@@ -95,3 +95,30 @@ func TestLeaseMetadataHelpersHandleAbsentOrMalformedMetadata(t *testing.T) {
 		t.Fatal("readOwnerMetadata(malformed) error = nil, want error")
 	}
 }
+
+func TestOwnerMetadataRejectsSymlink(t *testing.T) {
+	root := t.TempDir()
+	victimPath := filepath.Join(root, "victim.json")
+	if err := os.WriteFile(victimPath, []byte("preserve this payload"), 0o600); err != nil {
+		t.Fatalf("write victim metadata: %v", err)
+	}
+	metadataPath := filepath.Join(root, metadataName)
+	if err := os.Symlink(victimPath, metadataPath); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	lease := &Lease{metadataPath: metadataPath}
+	if err := lease.writeOwnerMetadata(); err == nil {
+		t.Fatal("writeOwnerMetadata() error = nil, want symlink rejection")
+	}
+	if _, err := readOwnerMetadata(metadataPath); err == nil {
+		t.Fatal("readOwnerMetadata() error = nil, want symlink rejection")
+	}
+	payload, err := os.ReadFile(victimPath)
+	if err != nil {
+		t.Fatalf("read victim metadata: %v", err)
+	}
+	if want := "preserve this payload"; string(payload) != want {
+		t.Fatalf("victim metadata = %q, want %q", payload, want)
+	}
+}

--- a/internal/statelock/statelock_test.go
+++ b/internal/statelock/statelock_test.go
@@ -68,3 +68,30 @@ func TestBusyErrorIncludesStateAndOwnerMetadata(t *testing.T) {
 		}
 	}
 }
+
+func TestLeaseMetadataHelpersHandleAbsentOrMalformedMetadata(t *testing.T) {
+	var nilLease *Lease
+	if err := nilLease.writeOwnerMetadata(); err != nil {
+		t.Fatalf("nil writeOwnerMetadata() error = %v", err)
+	}
+	if err := nilLease.removeOwnerMetadata(); err != nil {
+		t.Fatalf("nil removeOwnerMetadata() error = %v", err)
+	}
+	if err := (&Lease{}).writeOwnerMetadata(); err != nil {
+		t.Fatalf("empty writeOwnerMetadata() error = %v", err)
+	}
+	if err := (&Lease{}).removeOwnerMetadata(); err != nil {
+		t.Fatalf("empty removeOwnerMetadata() error = %v", err)
+	}
+
+	metadataPath := filepath.Join(t.TempDir(), "owner.json")
+	if _, err := readOwnerMetadata(metadataPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("readOwnerMetadata(missing) error = %v, want not exist", err)
+	}
+	if err := os.WriteFile(metadataPath, []byte("not json"), 0o600); err != nil {
+		t.Fatalf("write malformed owner metadata: %v", err)
+	}
+	if _, err := readOwnerMetadata(metadataPath); err == nil {
+		t.Fatal("readOwnerMetadata(malformed) error = nil, want error")
+	}
+}

--- a/internal/statelock/statelock_test.go
+++ b/internal/statelock/statelock_test.go
@@ -122,3 +122,19 @@ func TestOwnerMetadataRejectsSymlink(t *testing.T) {
 		t.Fatalf("victim metadata = %q, want %q", payload, want)
 	}
 }
+
+func TestOwnerMetadataFileRejectsNegativeDescriptor(t *testing.T) {
+	file, err := ownerMetadataFileFromDescriptor(-1, "owner.json")
+	if err == nil {
+		if file != nil {
+			_ = file.Close()
+		}
+		t.Fatal("ownerMetadataFileFromDescriptor() error = nil, want invalid descriptor rejection")
+	}
+	if file != nil {
+		t.Fatalf("ownerMetadataFileFromDescriptor() file = %v, want nil", file)
+	}
+	if !strings.Contains(err.Error(), "invalid descriptor") {
+		t.Fatalf("ownerMetadataFileFromDescriptor() error = %v, want invalid descriptor", err)
+	}
+}

--- a/internal/statelock/statelock_test.go
+++ b/internal/statelock/statelock_test.go
@@ -3,6 +3,7 @@ package statelock
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -16,6 +17,7 @@ func TestAcquireBlocksOtherProcessLeaseUntilRelease(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Acquire(first) error = %v", err)
 	}
+	metadataPath := first.metadataPath
 	defer func() { _ = first.Release() }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
@@ -28,6 +30,9 @@ func TestAcquireBlocksOtherProcessLeaseUntilRelease(t *testing.T) {
 		t.Fatalf("Release() error = %v", err)
 	}
 	first = nil
+	if _, err := os.Stat(metadataPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("owner metadata remains after Release: %v", err)
+	}
 	third, err := Acquire(context.Background(), statePath)
 	if err != nil {
 		t.Fatalf("Acquire(after release) error = %v", err)
@@ -45,7 +50,7 @@ func TestBusyErrorIncludesStateAndOwnerMetadata(t *testing.T) {
 	}
 	defer func() { _ = lease.Release() }()
 
-	metadata, err := readOwnerMetadata(lease.lockPath)
+	metadata, err := readOwnerMetadata(lease.metadataPath)
 	if err != nil {
 		t.Fatalf("readOwnerMetadata() error = %v", err)
 	}
@@ -53,7 +58,7 @@ func TestBusyErrorIncludesStateAndOwnerMetadata(t *testing.T) {
 		t.Fatalf("unexpected owner metadata: %+v", metadata)
 	}
 
-	busy := busyError(statePath, lease.lockPath)
+	busy := busyError(statePath, lease.metadataPath)
 	if !errors.Is(busy, ErrBusy) {
 		t.Fatalf("busyError() = %v, want ErrBusy", busy)
 	}

--- a/perf/bench_baseline.json
+++ b/perf/bench_baseline.json
@@ -18,6 +18,12 @@
       "unit": "ns/op",
       "median": 250000000,
       "max_regression_factor": 1.5
+    },
+    {
+      "name": "BenchmarkBuildComposedActionPathsDenseCandidateCap",
+      "unit": "ns/op",
+      "median": 260000000,
+      "max_regression_factor": 1.5
     }
   ]
 }

--- a/scenarios/wrkr/buyer-action-registry-hardening/expected/design-partner-lines.txt
+++ b/scenarios/wrkr/buyer-action-registry-hardening/expected/design-partner-lines.txt
@@ -52,7 +52,7 @@ Mutable endpoint: 5 grouped endpoint semantics; 2 route groups; data_export x1, 
 Production context: status=correlated, surface=label-a5534a43, credential=no credential evidence, target=production_impacting, deployment=unknown, operations=label-0315367e,label-d66e2561
 Owner: owner-ab37caea
 Purpose: exportCustomers
-Lineage: label-a5534a43 -> label-a5534a43 -> label-844ed1a9 -> label-d236d5a6 -> label-9614be72 -> label-6dd0f3ed -> label-6dd0f3ed -> label-6955e514 -> label-eef5b827 -> credential (missing) -> label-eb24c1ad -> label-ab37caea -> label-05227691 (missing) -> label-a6769766 -> label-eb24c1ad -> label-dcf46005 -> label-2575fc52 (missing) -> label-3ebe56d9
+Lineage: label-a5534a43 -> label-a5534a43 -> label-844ed1a9 -> label-d236d5a6 -> label-9614be72 -> label-6dd0f3ed -> label-6dd0f3ed -> label-837b932d -> label-eef5b827 -> credential (missing) -> label-eb24c1ad -> label-ab37caea -> label-05227691 (missing) -> label-a6769766 -> label-eb24c1ad -> label-dcf46005 -> label-2575fc52 (missing) -> label-3ebe56d9
 
 4. repo-d236d5 in loc-d5d3368a
 Problem: The path reaches declared mutable actions that need tighter approval, proof, or scope.

--- a/scenarios/wrkr/buyer-action-registry-hardening/expected/design-partner-lines.txt
+++ b/scenarios/wrkr/buyer-action-registry-hardening/expected/design-partner-lines.txt
@@ -14,15 +14,15 @@ Problem: The path reaches declared mutable actions that need tighter approval, p
 Evidence class: inferred relationship
 Inferred relationship: config=loc-dd191250
 Unresolved context: proof=path-specific proof not found, policy=none, runtime=runtime evidence not collected, approval=approval evidence not found
-Threat: risk_zone=production_data, risk_tier=critical, production_target_status=builtin_inferred, mutable_endpoint=production_mutation x6,refund x4,write x3
+Threat: risk_zone=production_data, risk_tier=critical, production_target_status=builtin_inferred, mutable_endpoint=production_mutation x2,delete x1,refund x1
 Recommended control: Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.
 Credential authority: no credential authority was linked to this path
 High-stakes: mutable_endpoint (mutable_endpoint:present); payment_flow (payment_surface:detected); production_path (production_path:detected); regulated_customer_workflow (customer_or_regulated_surface:detected)
-Mutable endpoint: 20 grouped endpoint semantics; 4 route groups; production_mutation x6, refund x4, write x3, data_export x2; samples=endpoint-8be61507 | endpoint-dc74895a | endpoint-d66e2561 | endpoint-c43f7237 | endpoint-0d2751ad | endpoint-0315367e | endpoint-412970ad
-Production context: status=correlated, surface=label-dd191250, credential=no credential evidence, target=production_impacting, deployment=unknown, operations=label-0315367e,label-0d2751ad,label-412970ad,label-8be61507,label-c43f7237,label-d66e2561,label-dc74895a
+Mutable endpoint: 6 grouped endpoint semantics; 2 route groups; production_mutation x2, delete x1, refund x1, user_admin x1; samples=endpoint-dc74895a | endpoint-0d2751ad
+Production context: status=correlated, surface=label-dd191250, credential=no credential evidence, target=production_impacting, deployment=unknown, operations=label-0d2751ad,label-dc74895a
 Owner: owner-c6dd827f
 Purpose: purpose not confirmed
-Lineage: label-9431ef09 -> label-119136f6 -> label-844ed1a9 -> label-d236d5a6 -> label-9614be72 -> label-dd191250 -> label-dd191250 -> label-880ec2e1 -> label-190c1a6b -> label-b23a6a84 (missing) -> label-eb24c1ad -> label-c6dd827f -> label-05227691 (missing) -> label-a6769766 -> label-eb24c1ad -> label-dcf46005 -> label-2575fc52 (missing) -> label-78aef3a3
+Lineage: label-9431ef09 -> label-119136f6 -> label-844ed1a9 -> label-d236d5a6 -> label-9614be72 -> label-dd191250 -> label-dd191250 -> label-880ec2e1 -> label-1447feaa -> label-b23a6a84 (missing) -> label-eb24c1ad -> label-c6dd827f -> label-05227691 (missing) -> label-a6769766 -> label-eb24c1ad -> label-dcf46005 -> label-2575fc52 (missing) -> label-78aef3a3
 
 2. repo-d236d5 in loc-d5d3368a
 Problem: The path reaches declared mutable actions that need tighter approval, proof, or scope.
@@ -44,32 +44,17 @@ Problem: The path reaches declared mutable actions that need tighter approval, p
 Evidence class: inferred relationship
 Inferred relationship: purpose=exportCustomers, purpose_source=symbol, config=loc-6dd0f3ed
 Unresolved context: proof=path-specific proof not found, policy=none, runtime=runtime evidence not collected, approval=approval evidence not found
-Threat: risk_zone=production_data, risk_tier=critical, production_target_status=builtin_inferred, mutable_endpoint=production_mutation x5,refund x4,data_export x3
+Threat: risk_zone=production_data, risk_tier=critical, production_target_status=builtin_inferred, mutable_endpoint=data_export x1,production_mutation x1,read x1
 Recommended control: Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.
 Credential authority: no credential authority was linked to this path
 High-stakes: external_egress (external_egress:detected); mutable_endpoint (mutable_endpoint:present); payment_flow (payment_surface:detected); production_path (production_path:detected); regulated_customer_workflow (customer_or_regulated_surface:detected)
-Mutable endpoint: 19 grouped endpoint semantics; 4 route groups; production_mutation x5, refund x4, data_export x3, write x3; samples=endpoint-dc74895a | endpoint-73437816 | endpoint-d66e2561 | endpoint-0d2751ad | endpoint-fed73031 | endpoint-0315367e | endpoint-412970ad
-Production context: status=correlated, surface=label-a5534a43, credential=no credential evidence, target=production_impacting, deployment=unknown, operations=label-0315367e,label-0d2751ad,label-412970ad,label-73437816,label-d66e2561,label-dc74895a,label-fed73031
+Mutable endpoint: 5 grouped endpoint semantics; 2 route groups; data_export x1, production_mutation x1, read x1, refund x1; samples=endpoint-d66e2561 | endpoint-0315367e
+Production context: status=correlated, surface=label-a5534a43, credential=no credential evidence, target=production_impacting, deployment=unknown, operations=label-0315367e,label-d66e2561
 Owner: owner-ab37caea
 Purpose: exportCustomers
-Lineage: label-a5534a43 -> label-a5534a43 -> label-844ed1a9 -> label-d236d5a6 -> label-9614be72 -> label-6dd0f3ed -> label-6dd0f3ed -> label-6955e514 -> label-44b4c4e4 -> credential (missing) -> label-eb24c1ad -> label-ab37caea -> label-05227691 (missing) -> label-a6769766 -> label-eb24c1ad -> label-dcf46005 -> label-2575fc52 (missing) -> label-3ebe56d9
+Lineage: label-a5534a43 -> label-a5534a43 -> label-844ed1a9 -> label-d236d5a6 -> label-9614be72 -> label-6dd0f3ed -> label-6dd0f3ed -> label-6955e514 -> label-eef5b827 -> credential (missing) -> label-eb24c1ad -> label-ab37caea -> label-05227691 (missing) -> label-a6769766 -> label-eb24c1ad -> label-dcf46005 -> label-2575fc52 (missing) -> label-3ebe56d9
 
-4. repo-d236d5 in loc-6dd0f3ed
-Problem: The path reaches declared mutable actions that need tighter approval, proof, or scope.
-Evidence class: inferred relationship
-Inferred relationship: purpose=refundPayment, purpose_source=symbol, config=loc-6dd0f3ed
-Unresolved context: proof=path-specific proof not found, policy=none, runtime=runtime evidence not collected, approval=approval evidence not found
-Threat: risk_zone=production_data, risk_tier=critical, production_target_status=builtin_inferred, mutable_endpoint=production_mutation x5,refund x4,data_export x3
-Recommended control: Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.
-Credential authority: no credential authority was linked to this path
-High-stakes: mutable_endpoint (mutable_endpoint:present); payment_flow (payment_surface:detected); production_path (production_path:detected); regulated_customer_workflow (customer_or_regulated_surface:detected)
-Mutable endpoint: 19 grouped endpoint semantics; 4 route groups; production_mutation x5, refund x4, data_export x3, write x3; samples=endpoint-dc74895a | endpoint-73437816 | endpoint-d66e2561 | endpoint-0d2751ad | endpoint-fed73031 | endpoint-0315367e | endpoint-412970ad
-Production context: status=correlated, surface=label-2f716b0a, credential=no credential evidence, target=production_impacting, deployment=unknown, operations=label-0315367e,label-0d2751ad,label-412970ad,label-73437816,label-d66e2561,label-dc74895a,label-fed73031
-Owner: owner-ab37caea
-Purpose: refundPayment
-Lineage: label-2f716b0a -> label-2f716b0a -> label-844ed1a9 -> label-d236d5a6 -> label-9614be72 -> label-6dd0f3ed -> label-6dd0f3ed -> label-b5efc3fa -> label-190c1a6b -> credential (missing) -> label-eb24c1ad -> label-ab37caea -> label-05227691 (missing) -> label-a6769766 -> label-eb24c1ad -> label-dcf46005 -> label-2575fc52 (missing) -> label-3ebe56d9
-
-5. repo-d236d5 in loc-d5d3368a
+4. repo-d236d5 in loc-d5d3368a
 Problem: The path reaches declared mutable actions that need tighter approval, proof, or scope.
 Evidence class: inferred relationship
 Inferred relationship: purpose=mcp integration, purpose_source=location_heuristic, config=loc-d5d3368a
@@ -84,7 +69,7 @@ Owner: owner-f9ae3305
 Purpose: mcp integration
 Lineage: label-625a4c05 -> label-625a4c05 -> label-844ed1a9 -> label-d236d5a6 -> label-9614be72 -> label-d5d3368a -> label-d5d3368a -> label-b29c45ca -> label-eef5b827 -> label-b23a6a84 (missing) -> label-5a824d8e -> label-f9ae3305 -> label-05227691 (missing) -> label-a6769766 -> label-5a824d8e -> label-dcf46005 -> label-2575fc52 (missing) -> label-78aef3a3
 
-6. repo-d236d5 in loc-cd78127f
+5. repo-d236d5 in loc-cd78127f
 Problem: A standing credential can drive this path without enough compensating proof or gating.
 Evidence class: confirmed path
 Inferred relationship: purpose=refund agent, purpose_source=workflow_name, config=loc-cd78127f
@@ -99,7 +84,7 @@ Owner: owner-920a23be
 Purpose: refund agent
 Lineage: label-9132aafa -> label-9132aafa -> label-844ed1a9 -> label-d236d5a6 -> label-9614be72 -> label-cd78127f -> label-cd78127f -> label-89dcc80b -> label-bab06f2c -> label-f82078a0 -> target (missing) -> label-920a23be -> label-05227691 (missing) -> label-a6769766 -> label-77fcb75d (missing) -> label-dcf46005 -> label-2575fc52 (missing) -> label-78aef3a3
 
-7. repo-d236d5 in loc-a54ff182
+6. repo-d236d5 in loc-a54ff182
 Problem: The path is operationally meaningful, but approval evidence is not yet linked or complete.
 Evidence class: inferred relationship
 Inferred relationship: config=loc-a54ff182
@@ -119,8 +104,8 @@ Lineage: label-9431ef09 -> label-119136f6 -> label-844ed1a9 -> label-d236d5a6 ->
 - label-8a84e406 surface=route_file owner=owner-c6dd827f purpose=purpose not confirmed confidence=likely_action_path remediation=Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.
 - label-625a4c05 surface=server owner=owner-f9ae3305 purpose=mcp integration confidence=likely_action_path remediation=Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.
 - label-a5534a43 surface=api_schema owner=owner-ab37caea purpose=exportCustomers confidence=likely_action_path remediation=Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.
-- label-2f716b0a surface=api_schema owner=owner-ab37caea purpose=refundPayment confidence=likely_action_path remediation=Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.
 - label-625a4c05 surface=surface owner=owner-f9ae3305 purpose=mcp integration confidence=likely_action_path remediation=Review the declared mutable endpoint scope, require owner approval and proof for the exact action path, tighten token scope where possible, and rescan before treating this mutation surface as governed.
+- label-9132aafa surface=workflow owner=owner-920a23be purpose=refund agent confidence=confirmed_action_path remediation=Replace the standing credential with brokered or JIT access where possible, attach rotation evidence, and rescan to confirm the reduced blast radius.
 
 ## Known Limits
 

--- a/scenarios/wrkr/buyer-action-registry-hardening/expected/evidence-design-partner-summary.json
+++ b/scenarios/wrkr/buyer-action-registry-hardening/expected/evidence-design-partner-summary.json
@@ -1,5 +1,5 @@
 {
-  "bom_count": 8,
+  "bom_count": 7,
   "first_bom": {
     "confidence_lane": "likely_action_path",
     "location": "loc-dd191250",
@@ -37,7 +37,7 @@
       "repos"
     ]
   },
-  "registry_count": 8,
+  "registry_count": 7,
   "share_profile": "design-partner",
   "template": "design-partner-summary"
 }

--- a/scenarios/wrkr/buyer-action-registry-hardening/expected/report-customer-redacted-summary.json
+++ b/scenarios/wrkr/buyer-action-registry-hardening/expected/report-customer-redacted-summary.json
@@ -12,7 +12,7 @@
     "location": "loc-dd191250",
     "owner": "owner-c6dd827f",
     "proof_refs": [
-      "proof-1b388508"
+      "proof-a230a8c7"
     ],
     "repo": "repo-d236d5"
   },

--- a/scenarios/wrkr/buyer-action-registry-hardening/expected/report-internal-summary.json
+++ b/scenarios/wrkr/buyer-action-registry-hardening/expected/report-internal-summary.json
@@ -1,5 +1,5 @@
 {
-  "bom_count": 8,
+  "bom_count": 7,
   "confirmed_item": {
     "credential_authority_ref": "cred-d3b8675b6f0d",
     "lineage_statuses": [
@@ -85,10 +85,10 @@
   "lane_counts": {
     "confirmed_action_path": 1,
     "context_only": 1,
-    "likely_action_path": 5,
+    "likely_action_path": 4,
     "semantic_review_candidate": 1
   },
-  "registry_count": 8,
+  "registry_count": 7,
   "registry_surface_types": [
     "agent_config",
     "api_schema",

--- a/scenarios/wrkr/buyer-action-registry-hardening/expected/scan-summary.json
+++ b/scenarios/wrkr/buyer-action-registry-hardening/expected/scan-summary.json
@@ -1,5 +1,5 @@
 {
-  "action_path_count": 8,
+  "action_path_count": 7,
   "confirmed_path": {
     "confidence_lane": "confirmed_action_path",
     "location": ".github/workflows/refund-agent.yml",
@@ -8,7 +8,7 @@
   "lane_counts": {
     "confirmed_action_path": 1,
     "context_only": 1,
-    "likely_action_path": 5,
+    "likely_action_path": 4,
     "semantic_review_candidate": 1
   },
   "mutable_surface_path": {
@@ -37,25 +37,11 @@
     "location": "server/refund_routes.js",
     "repo": "payments-private",
     "semantics": [
-      "data_export",
-      "data_export",
-      "delete",
       "delete",
       "production_mutation",
       "production_mutation",
-      "production_mutation",
-      "production_mutation",
-      "production_mutation",
-      "production_mutation",
-      "read",
-      "refund",
-      "refund",
-      "refund",
       "refund",
       "user_admin",
-      "user_admin",
-      "write",
-      "write",
       "write"
     ]
   }

--- a/scripts/test_perf_budgets.sh
+++ b/scripts/test_perf_budgets.sh
@@ -20,7 +20,7 @@ fi
 bench_output="$(mktemp)"
 trap 'rm -f "$bench_output"' EXIT
 
-GOMAXPROCS=1 go test -run '^$' -bench 'Benchmark(ScoreComputeDeterministic|RiskScoreDeterministic|BuildComposedActionPathsMultiStageBounded)$' -benchmem -count=5 ./core/score ./core/risk | tee "$bench_output"
+GOMAXPROCS=1 go test -run '^$' -bench 'Benchmark(ScoreComputeDeterministic|RiskScoreDeterministic|BuildComposedActionPathsMultiStageBounded|BuildComposedActionPathsDenseCandidateCap)$' -benchmem -count=5 ./core/score ./core/risk | tee "$bench_output"
 
 python3 - "$bench_output" <<'PY'
 import json

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,6 +1,6 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "4e4e6e06a872d12fc275c79d5cdf7c40f2e4e1d36090b7ae4673d3f54b5ea3fc",
+  "validated_content_sha256": "776e9a3d1b71ab938e2f6b4b32b9f3f3423f07aed03ce4b6951f70f31a48b362",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,10 +1,12 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "c6c060c4d548ac194d253e1f85f3f95a94e194ea82934703c9865a12694f6e67",
+  "validated_content_sha256": "eddfcc590c29437e5c453d5e50876726765910f759f5622da976e8233a4e4dbc",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",
     "README.md",
+    "core/aggregate/attackpath",
+    "core/aggregate/privilegebudget",
     "core/cli",
     "core/evidence",
     "core/export/actioncontracts",
@@ -15,6 +17,7 @@
     "docs/commands/scan.md",
     "docs/examples/site-assets",
     "internal/acceptance",
+    "internal/enterprisepressure",
     "internal/e2e/diff",
     "internal/scenarios",
     "scenarios/cross-product/action-contract-interop",
@@ -40,10 +43,10 @@
     "action_contract_conformance_fixture_v1",
     "bounded_multi_stage_composed_action_contracts"
   ],
-  "validated_on": "2026-08-06",
+  "validated_on": "2026-08-07",
   "fixture_names": [
     "internal/enterprisepressure.VariantBaseline:96-repos",
-    "internal/enterprisepressure.EndpointDense:4-repos",
+    "internal/enterprisepressure.EndpointDense:1-repo",
     "scenarios/wrkr/first-offer-noise-pack",
     "scenarios/wrkr/scan-diff-no-noise",
     "core/export/actioncontracts.TestBuildActionContractArtifactsIsDeterministicAndSensitiveToContent",
@@ -90,11 +93,11 @@
     },
     {
       "artifact": "endpoint-dense-scan.json",
-      "fixture": "internal/enterprisepressure.EndpointDense:4-repos",
-      "measured_bytes": 23747901,
+      "fixture": "internal/enterprisepressure.EndpointDense:1-repo",
+      "measured_bytes": 2479780,
       "baseline_bytes": 0,
       "budget_bytes": 25165824,
-      "delta_bytes": 23747901,
+      "delta_bytes": 2479780,
       "measurement_source": "internal/acceptance.TestSprint0EndpointDenseArtifactsUseGroupedEndpointProjection"
     },
     {
@@ -222,7 +225,7 @@
       ],
       "fixture_names": [
         "internal/enterprisepressure.VariantBaseline:96-repos",
-        "internal/enterprisepressure.EndpointDense:4-repos",
+        "internal/enterprisepressure.EndpointDense:1-repo",
         "core/report.actionContractPacketTestInput",
         "internal/scenarios.TestScenarioActionContractPacketPaidAssessment",
         "core/report.actionContractPacketTestInput:three-stage",
@@ -293,7 +296,7 @@
       ],
       "fixture_names": [
         "internal/enterprisepressure.VariantBaseline:96-repos",
-        "internal/enterprisepressure.EndpointDense:4-repos",
+        "internal/enterprisepressure.EndpointDense:1-repo",
         "core/report.actionContractPacketTestInput",
         "core/report.actionContractPacketTestInput:three-stage"
       ],
@@ -349,6 +352,25 @@
         "scenarios/cross-product/action-contract-interop/expected/fixture-manifest.json"
       ],
       "evidence": "All nine internal artifact and packet fixtures are produced by the real Wrkr pipeline, schema/digest verified, and regenerated to temporary storage for exact-byte comparison. External Gait/Axym receipts remain a separate Tier 12 release dependency."
+    },
+    {
+      "name": "scan_analysis_reliability",
+      "status": "pass",
+      "commands": [
+        "go test ./core/cli -run 'TestScan(TimeoutAfterStateWriteRollsBackManagedArtifacts|ConcurrentScanProcessesWithSeparateArtifactsDoNotCollide|ConcurrentScanProcessesPreserveCompleteProofChain)$' -count=1 -timeout=5m",
+        "go test ./core/aggregate/privilegebudget -run TestBuildKeepsOpenAPIEndpointSemanticsInstanceScoped -count=1",
+        "go test ./core/risk -run TestBuildActionPathsGroupsEndpointOperationsBySpecification -count=1",
+        "go test ./internal/scenarios -run TestScenarioWave42EndpointDenseProjectionBoundaries -tags=scenario -count=1 -timeout=5m",
+        "go test ./internal/scenarios -run TestScenarioScanAnalysisReliabilityAtEnterpriseScale -tags=scenario -count=1 -timeout=5m"
+      ],
+      "fixture_names": [
+        "core/cli.process-isolation-and-timeout",
+        "core/aggregate/privilegebudget.open-api-instance-scope",
+        "core/risk.open-api-specification-roll-up",
+        "internal/enterprisepressure.EndpointDense:4-repos",
+        "internal/enterprisepressure.EndpointDense:384-repos"
+      ],
+      "evidence": "Endpoint-dense fixtures retain exact operation evidence, expose bounded specification roll-ups in buyer BOM and control-graph artifacts, and a 384-repository scan stays deterministic under a 512 MiB Go memory limit; timeout or concurrent isolated scans leave reusable managed state."
     }
   ],
   "public_surface_decision": "composition public surface may be exposed only when this receipt is present, status is green, and every validation listed here is pass"

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,6 +1,6 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "236cab28906c9d6e2089cc019901a86cb77ce220f95dff024d3df3aee5cf37cb",
+  "validated_content_sha256": "0590346ebf5f52131f7b39996ccd53c5555e55f1785b740d4c8a3eafe31d7c8d",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,6 +1,6 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "7121632cfa15c7a3d4f3cbd61615010527fe61e6f300ce68c6f9e41bb5ef038a",
+  "validated_content_sha256": "341a22fe25ff1503536478c54b2a6e5f85a5480102260b227e6fbaac53f66265",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",
@@ -43,7 +43,8 @@
     "action_contract_conformance_fixture_v1",
     "bounded_multi_stage_composed_action_contracts",
     "control_path_graph_timeout_cancellation",
-    "bounded_serialized_action_path_occurrence_refs"
+    "bounded_serialized_action_path_occurrence_refs",
+    "endpoint_specification_identity"
   ],
   "validated_on": "2026-08-07",
   "fixture_names": [
@@ -68,6 +69,7 @@
     "core/risk.TestBuildComposedActionPathsBoundsDuplicateCandidateEvaluation",
     "core/risk.TestBuildComposedActionPathsKeepsOutcomeDistinctCandidatesSeparate",
     "core/risk.TestBuildActionPathsBoundsSerializedOccurrenceRefs",
+    "core/risk.TestBuildActionPathsGroupsEndpointOperationsBySpecification",
     "core/report.TestBuildActionContractPacketPreservesOrderedMultiStageReachability",
     "core/report.TestBuildSummaryMultiStageDefaultOutputSizeDeltaBudget",
     "core/report.TestSanitizeComposedActionPathsPublicRedactsMultiStageBoundaryAndCorrelationRefs",
@@ -226,6 +228,7 @@
         "go test ./core/report -run TestBuildActionContractPacketPreservesOrderedMultiStageReachability -count=1",
         "go test ./core/risk -run TestBuildComposedActionPathsMultiStageDefaultProjectionSizeAndNoiseBudget -count=1",
         "go test ./core/risk -run TestBuildActionPathsBoundsSerializedOccurrenceRefs -count=1",
+        "go test ./core/risk -run TestBuildActionPathsGroupsEndpointOperationsBySpecification -count=1",
         "go test ./core/report -run TestBuildSummaryMultiStageDefaultOutputSizeDeltaBudget -count=1"
       ],
       "fixture_names": [
@@ -238,7 +241,7 @@
         "core/risk.endpoint-specification-rollup:320-operations",
         "core/report.multiStageReportPath:20-paths"
       ],
-      "evidence": "Saved state, evidence JSON, endpoint-dense state, and the multi-stage Action Contract packet remain under committed byte budgets; serialized action-path occurrence references are capped while exact occurrence counts are retained."
+      "evidence": "Saved state, evidence JSON, endpoint-dense state, and the multi-stage Action Contract packet remain under committed byte budgets; serialized action-path occurrence references are capped while exact occurrence counts are retained, and endpoint roll-ups carry deterministic specification-level identities."
     },
     {
       "name": "composition_generation_bounds",

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,6 +1,6 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "341a22fe25ff1503536478c54b2a6e5f85a5480102260b227e6fbaac53f66265",
+  "validated_content_sha256": "236cab28906c9d6e2089cc019901a86cb77ce220f95dff024d3df3aee5cf37cb",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,6 +1,6 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "dda38f99504504ab9876a778f229064cf78e05d822a7fce2e24e7b2f08841dcd",
+  "validated_content_sha256": "4e4e6e06a872d12fc275c79d5cdf7c40f2e4e1d36090b7ae4673d3f54b5ea3fc",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",
@@ -40,7 +40,7 @@
     "action_contract_conformance_fixture_v1",
     "bounded_multi_stage_composed_action_contracts"
   ],
-  "validated_on": "2026-08-05",
+  "validated_on": "2026-08-06",
   "fixture_names": [
     "internal/enterprisepressure.VariantBaseline:96-repos",
     "internal/enterprisepressure.EndpointDense:4-repos",
@@ -60,6 +60,7 @@
     "core/risk.TestBuildComposedActionPathsMultiStageSupportsThreeToFiveStages",
     "core/risk.TestBuildComposedActionPathsMultiStageRejectsUnknownTrustBoundaryAndWeakRefs",
     "core/risk.TestBuildComposedActionPathsMultiStageDefaultProjectionSizeAndNoiseBudget",
+    "core/risk.TestBuildComposedActionPathsBoundsDuplicateCandidateEvaluation",
     "core/report.TestBuildActionContractPacketPreservesOrderedMultiStageReachability",
     "core/report.TestBuildSummaryMultiStageDefaultOutputSizeDeltaBudget",
     "core/report.TestSanitizeComposedActionPathsPublicRedactsMultiStageBoundaryAndCorrelationRefs",
@@ -229,6 +230,20 @@
         "core/report.multiStageReportPath:20-paths"
       ],
       "evidence": "Saved state, evidence JSON, endpoint-dense state, and the multi-stage Action Contract packet remain under committed byte budgets."
+    },
+    {
+      "name": "composition_generation_bounds",
+      "status": "pass",
+      "commands": [
+        "go test ./core/risk -run 'TestBuildComposedActionPaths(BoundsDuplicateCandidateEvaluation|BoundsSuppressedCandidateEvidence|MultiStageDefaultProjectionSizeAndNoiseBudget)$' -count=1"
+      ],
+      "fixture_names": [
+        "core/risk.TestBuildComposedActionPathsBoundsDuplicateCandidateEvaluation",
+        "core/risk.TestBuildComposedActionPathsBoundsSuppressedCandidateEvidence",
+        "core/risk.high-fanout-multi-stage:38-paths",
+        "core/risk.BenchmarkBuildComposedActionPathsDenseCandidateCap"
+      ],
+      "evidence": "Pairwise and duplicate candidate generation has deterministic evaluation and output-reference caps, with explicit truncation receipts."
     },
     {
       "name": "redaction",

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,6 +1,6 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "eddfcc590c29437e5c453d5e50876726765910f759f5622da976e8233a4e4dbc",
+  "validated_content_sha256": "b1a054bc6bee756847292a185d6f4530e977ab8438432382f4ffdad1bd5022f3",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",
@@ -64,6 +64,7 @@
     "core/risk.TestBuildComposedActionPathsMultiStageRejectsUnknownTrustBoundaryAndWeakRefs",
     "core/risk.TestBuildComposedActionPathsMultiStageDefaultProjectionSizeAndNoiseBudget",
     "core/risk.TestBuildComposedActionPathsBoundsDuplicateCandidateEvaluation",
+    "core/risk.TestBuildComposedActionPathsKeepsOutcomeDistinctCandidatesSeparate",
     "core/report.TestBuildActionContractPacketPreservesOrderedMultiStageReachability",
     "core/report.TestBuildSummaryMultiStageDefaultOutputSizeDeltaBudget",
     "core/report.TestSanitizeComposedActionPathsPublicRedactsMultiStageBoundaryAndCorrelationRefs",
@@ -238,15 +239,16 @@
       "name": "composition_generation_bounds",
       "status": "pass",
       "commands": [
-        "go test ./core/risk -run 'TestBuildComposedActionPaths(BoundsDuplicateCandidateEvaluation|BoundsSuppressedCandidateEvidence|MultiStageDefaultProjectionSizeAndNoiseBudget)$' -count=1"
+        "go test ./core/risk -run 'TestBuildComposedActionPaths(BoundsDuplicateCandidateEvaluation|BoundsSuppressedCandidateEvidence|KeepsOutcomeDistinctCandidatesSeparate|MultiStageDefaultProjectionSizeAndNoiseBudget)$' -count=1"
       ],
       "fixture_names": [
         "core/risk.TestBuildComposedActionPathsBoundsDuplicateCandidateEvaluation",
         "core/risk.TestBuildComposedActionPathsBoundsSuppressedCandidateEvidence",
+        "core/risk.TestBuildComposedActionPathsKeepsOutcomeDistinctCandidatesSeparate",
         "core/risk.high-fanout-multi-stage:38-paths",
         "core/risk.BenchmarkBuildComposedActionPathsDenseCandidateCap"
       ],
-      "evidence": "Pairwise and duplicate candidate generation has deterministic evaluation and output-reference caps, with explicit truncation receipts."
+      "evidence": "Pairwise and duplicate candidate generation has deterministic evaluation and output-reference caps, preserves distinct production-target and endpoint outcomes, and records explicit truncation receipts."
     },
     {
       "name": "redaction",

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,6 +1,6 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "b1a054bc6bee756847292a185d6f4530e977ab8438432382f4ffdad1bd5022f3",
+  "validated_content_sha256": "531712b307a222a8c88e74ece217843336f91ecc27727959b1bca394a9499eb1",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",
@@ -41,7 +41,8 @@
     "proposed_action_contract_artifact",
     "action_contract_packet_v1",
     "action_contract_conformance_fixture_v1",
-    "bounded_multi_stage_composed_action_contracts"
+    "bounded_multi_stage_composed_action_contracts",
+    "control_path_graph_timeout_cancellation"
   ],
   "validated_on": "2026-08-07",
   "fixture_names": [
@@ -239,16 +240,19 @@
       "name": "composition_generation_bounds",
       "status": "pass",
       "commands": [
-        "go test ./core/risk -run 'TestBuildComposedActionPaths(BoundsDuplicateCandidateEvaluation|BoundsSuppressedCandidateEvidence|KeepsOutcomeDistinctCandidatesSeparate|MultiStageDefaultProjectionSizeAndNoiseBudget)$' -count=1"
+        "go test ./core/risk -run 'TestBuildComposedActionPaths(BoundsDuplicateCandidateEvaluation|BoundsSuppressedCandidateEvidence|KeepsGovernanceDistinctCandidatesSeparate|KeepsOutcomeDistinctCandidatesSeparate|MultiStageDefaultProjectionSizeAndNoiseBudget)$' -count=1",
+        "go test ./core/aggregate/attackpath -run TestControlPathGraphSortsHonorCancellation -count=1"
       ],
       "fixture_names": [
         "core/risk.TestBuildComposedActionPathsBoundsDuplicateCandidateEvaluation",
         "core/risk.TestBuildComposedActionPathsBoundsSuppressedCandidateEvidence",
+        "core/risk.TestBuildComposedActionPathsKeepsGovernanceDistinctCandidatesSeparate",
         "core/risk.TestBuildComposedActionPathsKeepsOutcomeDistinctCandidatesSeparate",
+        "core/aggregate/attackpath.TestControlPathGraphSortsHonorCancellation",
         "core/risk.high-fanout-multi-stage:38-paths",
         "core/risk.BenchmarkBuildComposedActionPathsDenseCandidateCap"
       ],
-      "evidence": "Pairwise and duplicate candidate generation has deterministic evaluation and output-reference caps, preserves distinct production-target and endpoint outcomes, and records explicit truncation receipts."
+      "evidence": "Pairwise and duplicate candidate generation has deterministic evaluation and output-reference caps, preserves distinct production-target, endpoint, and governance outcomes, records explicit truncation receipts, and observes cancellation during control-graph sorting."
     },
     {
       "name": "redaction",

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,6 +1,6 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "776e9a3d1b71ab938e2f6b4b32b9f3f3423f07aed03ce4b6951f70f31a48b362",
+  "validated_content_sha256": "96ae8eb68472a507ee57d5e7c06a1260840bcc0977e0f65fe16e947faaaefa8c",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,6 +1,6 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "96ae8eb68472a507ee57d5e7c06a1260840bcc0977e0f65fe16e947faaaefa8c",
+  "validated_content_sha256": "67c179b3a3c856bdf350706f47a8c0cebf1b64de1780e0f0311e02d065c289a9",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,6 +1,6 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "67c179b3a3c856bdf350706f47a8c0cebf1b64de1780e0f0311e02d065c289a9",
+  "validated_content_sha256": "c6c060c4d548ac194d253e1f85f3f95a94e194ea82934703c9865a12694f6e67",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,6 +1,6 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "531712b307a222a8c88e74ece217843336f91ecc27727959b1bca394a9499eb1",
+  "validated_content_sha256": "7121632cfa15c7a3d4f3cbd61615010527fe61e6f300ce68c6f9e41bb5ef038a",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",
@@ -42,7 +42,8 @@
     "action_contract_packet_v1",
     "action_contract_conformance_fixture_v1",
     "bounded_multi_stage_composed_action_contracts",
-    "control_path_graph_timeout_cancellation"
+    "control_path_graph_timeout_cancellation",
+    "bounded_serialized_action_path_occurrence_refs"
   ],
   "validated_on": "2026-08-07",
   "fixture_names": [
@@ -66,6 +67,7 @@
     "core/risk.TestBuildComposedActionPathsMultiStageDefaultProjectionSizeAndNoiseBudget",
     "core/risk.TestBuildComposedActionPathsBoundsDuplicateCandidateEvaluation",
     "core/risk.TestBuildComposedActionPathsKeepsOutcomeDistinctCandidatesSeparate",
+    "core/risk.TestBuildActionPathsBoundsSerializedOccurrenceRefs",
     "core/report.TestBuildActionContractPacketPreservesOrderedMultiStageReachability",
     "core/report.TestBuildSummaryMultiStageDefaultOutputSizeDeltaBudget",
     "core/report.TestSanitizeComposedActionPathsPublicRedactsMultiStageBoundaryAndCorrelationRefs",
@@ -223,6 +225,7 @@
         "go test ./internal/scenarios -run TestScenarioActionContractPacketPaidAssessment -tags=scenario -count=1",
         "go test ./core/report -run TestBuildActionContractPacketPreservesOrderedMultiStageReachability -count=1",
         "go test ./core/risk -run TestBuildComposedActionPathsMultiStageDefaultProjectionSizeAndNoiseBudget -count=1",
+        "go test ./core/risk -run TestBuildActionPathsBoundsSerializedOccurrenceRefs -count=1",
         "go test ./core/report -run TestBuildSummaryMultiStageDefaultOutputSizeDeltaBudget -count=1"
       ],
       "fixture_names": [
@@ -232,9 +235,10 @@
         "internal/scenarios.TestScenarioActionContractPacketPaidAssessment",
         "core/report.actionContractPacketTestInput:three-stage",
         "core/risk.high-fanout-multi-stage:38-paths",
+        "core/risk.endpoint-specification-rollup:320-operations",
         "core/report.multiStageReportPath:20-paths"
       ],
-      "evidence": "Saved state, evidence JSON, endpoint-dense state, and the multi-stage Action Contract packet remain under committed byte budgets."
+      "evidence": "Saved state, evidence JSON, endpoint-dense state, and the multi-stage Action Contract packet remain under committed byte budgets; serialized action-path occurrence references are capped while exact occurrence counts are retained."
     },
     {
       "name": "composition_generation_bounds",

--- a/testinfra/contracts/story0_contracts_test.go
+++ b/testinfra/contracts/story0_contracts_test.go
@@ -221,6 +221,29 @@ func TestPRWorkflowPathFilterContract(t *testing.T) {
 			t.Fatalf("pr workflow missing required path-filter fragment %q", fragment)
 		}
 	}
+	for _, filter := range []struct {
+		name string
+		next string
+	}{
+		{name: "core", next: "dependencies"},
+		{name: "scan_contract", next: "security"},
+	} {
+		start := strings.Index(text, "            "+filter.name+":\n")
+		end := strings.Index(text, "            "+filter.next+":\n")
+		if start < 0 || end <= start {
+			t.Fatalf("could not locate %s path filter", filter.name)
+		}
+		section := text[start:end]
+		for _, input := range []string{
+			"- 'schemas/**'",
+			"- '.goreleaser.yaml'",
+			"- '.github/coverage-exceptions.json'",
+		} {
+			if !strings.Contains(section, input) {
+				t.Fatalf("%s path filter must include %q", filter.name, input)
+			}
+		}
+	}
 }
 
 func TestWorkflowTriggerContracts(t *testing.T) {

--- a/testinfra/contracts/story0_contracts_test.go
+++ b/testinfra/contracts/story0_contracts_test.go
@@ -209,7 +209,7 @@ func TestPRWorkflowPathFilterContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read .github/workflows/pr.yml: %v", err)
 	}
-	text := string(content)
+	text := strings.ReplaceAll(string(content), "\r\n", "\n")
 	for _, fragment := range []string{
 		"dorny/paths-filter@v4.0.1",
 		"security:",


### PR DESCRIPTION
## Summary
- Bound endpoint-dense analysis without losing exact operation attribution, and cover cancellation/state-isolation regressions.
- Refresh buyer-report fixtures and freeze-gate receipts for the deterministic grouped evidence model.
- Resolve docs-site npm advisories by updating Mermaid and pinning js-yaml, brace-expansion, and DOMPurify overrides.
- Reject invalid Unix lock metadata descriptors before conversion; this clears the current GoSec failure with a focused regression test.

## Validation
- `make prepush-full`
- exact pinned GoSec scan across 283 first-party Go files (0 findings)
- `npm --prefix docs-site audit --json` (0 vulnerabilities)
- `npm --prefix docs-site run lint`
- `npm --prefix docs-site test`
- `npm --prefix docs-site run build`
