### PR TITLE
chore: finalize changelog for v1.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- [semver:patch] Kept endpoint-dense scans bounded by reusing canonical endpoint evidence during analysis, preserving per-operation attribution, and isolating concurrent scan artifacts.
+- (none yet)
 
 ### Security
 
@@ -38,6 +38,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 4. Keep entries concise and operator-facing: what changed, why it matters, and any migration/action notes.
 5. Link release notes and tag artifacts to the finalized changelog section.
 6. The Sprint 0 v1.7.3 clarification workflow item must record measured artifact-size deltas, redaction test names, and fixture coverage before release notes claim size, privacy, redaction, customer-safe, or readability hardening.
+
+## [v1.12.2] - 2026-08-07
+<!-- release-semver: patch -->
+
+### Fixed
+
+- Kept endpoint-dense scans bounded by reusing canonical endpoint evidence during analysis, preserving per-operation attribution, and isolating concurrent scan artifacts.
 
 ## [v1.12.1] - 2026-07-27
 <!-- release-semver: patch -->


### PR DESCRIPTION
## Release prep

Finalizes the changelog for `v1.12.2` from the validated `Unreleased` patch entry.

## Validation

- `python3 factory/scripts/resolve_release_version.py --repo-root . --release-version v1.12.2 --json`
- `python3 factory/scripts/finalize_release_changelog.py --repo-root . --release-version v1.12.2 --json`
- `python3 factory/scripts/validate_release_changelog.py --repo-root . --release-version v1.12.2 --json`

## Risk

Changelog-only change. The tag will be cut only after this PR merges and release preflight succeeds on `main`.
