### PR TITLE
docs: align install references with v1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ brew install Clyra-AI/tap/wrkr
 ### Go install (Pinned/reproducible)
 
 ```bash
-WRKR_VERSION="v1.12.2"
+WRKR_VERSION="v1.13.0"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -4,7 +4,7 @@ Install with Homebrew or the pinned Go path first, then verify the installed CLI
 
 ```bash
 brew install Clyra-AI/tap/wrkr
-WRKR_VERSION="v1.12.2"
+WRKR_VERSION="v1.13.0"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 wrkr version --json
 

--- a/docs/commands/action.md
+++ b/docs/commands/action.md
@@ -21,7 +21,7 @@ Any packaged GitHub Action surface must wrap these CLI contracts rather than dup
 Wrkr now ships a repo-root `action.yml` composite action that wraps the same CLI contracts through `scripts/action_entrypoint.sh`.
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.12.2
+- uses: Clyra-AI/wrkr@v1.13.0
   with:
     mode: scheduled
     remediation_mode: summary_only
@@ -65,7 +65,7 @@ wrkr action pr-comment --changed-paths ".codex/config.toml" --risk-delta 2.8 --c
 ```
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.12.2
+- uses: Clyra-AI/wrkr@v1.13.0
   with:
     mode: scheduled
     target_mode: repo

--- a/docs/install/minimal-dependencies.md
+++ b/docs/install/minimal-dependencies.md
@@ -7,7 +7,7 @@ The main README landing page surfaces Homebrew, the pinned Go install path below
 ## Go-only pinned install
 
 ```bash
-WRKR_VERSION="v1.12.2"
+WRKR_VERSION="v1.13.0"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 
@@ -56,6 +56,6 @@ Install commands above are validated by release UAT together with the public `wr
 
 ```bash
 scripts/test_uat_local.sh --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.12.2 --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.12.2 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.13.0 --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.13.0 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
 ```

--- a/docs/trust/release-integrity.md
+++ b/docs/trust/release-integrity.md
@@ -97,7 +97,7 @@ scripts/test_uat_local.sh
 scripts/test_uat_local.sh --skip-global-gates
 
 # Validate exact public install commands (brew + pinned go install) for a published tag
-scripts/test_uat_local.sh --release-version v1.12.2 --brew-formula Clyra-AI/tap/wrkr
+scripts/test_uat_local.sh --release-version v1.13.0 --brew-formula Clyra-AI/tap/wrkr
 ```
 
 ## Changelog finalization


### PR DESCRIPTION
## Release-prep follow-up

Aligns all published pinned-install, GitHub Action, release-smoke, and LLM quickstart examples with the finalized `v1.13.0` changelog section.

## Root cause

The changelog finalizer correctly promoted `v1.13.0`, while the release documentation contract still referenced `v1.12.2`. Release preflight caught the mismatch before tagging.

## Validation

- `go test ./testinfra/hygiene -run 'TestInstallDocsPinnedVersionSupportsCurrentReadmeCommands|TestMinimalDependenciesReleaseSmokeVersionIsCurrent' -count=1`
- `make test-docs-consistency`
