### PR TITLE
Adopt Proof v0.5.0 evidence-set frameworks

### DIFF
--- a/core/compliance/compliance.go
+++ b/core/compliance/compliance.go
@@ -149,7 +149,7 @@ func evaluateLegacyControl(frameworkID string, control framework.Control, record
 }
 
 func evaluateEvidenceSetControl(frameworkID string, control framework.Control, evidenceCoverage framework.ControlCoverage, records []proof.Record, matchedRuleIDs map[string]struct{}) ControlCheck {
-	selected, ok := selectEvidenceSetCoverage(evidenceCoverage.EvidenceSets)
+	selected, ok := selectEvidenceSetCoverage(evidenceCoverage.EvidenceSets, records)
 	mappedRules := mappedRuleIDs(frameworkID, control.ID, matchedRuleIDs)
 	if !ok {
 		return ControlCheck{
@@ -179,42 +179,51 @@ func evaluateEvidenceSetControl(frameworkID string, control framework.Control, e
 	}
 }
 
-func selectEvidenceSetCoverage(sets []framework.EvidenceSetCoverage) (framework.EvidenceSetCoverage, bool) {
+func selectEvidenceSetCoverage(sets []framework.EvidenceSetCoverage, records []proof.Record) (framework.EvidenceSetCoverage, bool) {
 	if len(sets) == 0 {
 		return framework.EvidenceSetCoverage{}, false
 	}
-	ordered := make([]framework.EvidenceSetCoverage, 0, len(sets))
+	type candidate struct {
+		coverage           framework.EvidenceSetCoverage
+		missingRecordTypes int
+		missingFields      int
+		key                string
+	}
+	ordered := make([]candidate, 0, len(sets))
 	for _, set := range sets {
-		if evidenceSetAppliesToWrkr(set.SourceProducts) {
-			ordered = append(ordered, set)
+		if !evidenceSetAppliesToWrkr(set.SourceProducts) {
+			continue
 		}
+		missingRecordTypes, missingFields := evidenceSetGaps(set, records)
+		ordered = append(ordered, candidate{
+			coverage:           set,
+			missingRecordTypes: len(missingRecordTypes),
+			missingFields:      len(missingFields),
+			key: strings.Join([]string{
+				strings.TrimSpace(set.ID),
+				strings.Join(uniqueSortedStrings(set.SourceProducts), ","),
+				strings.Join(uniqueSortedStrings(set.RequiredRecordTypes), ","),
+				strings.Join(uniqueSortedStrings(set.RequiredFields), ","),
+			}, "|"),
+		})
 	}
 	if len(ordered) == 0 {
 		return framework.EvidenceSetCoverage{}, false
 	}
 	sort.Slice(ordered, func(i, j int) bool {
 		left, right := ordered[i], ordered[j]
-		if left.Covered != right.Covered {
-			return left.Covered
+		if left.coverage.Covered != right.coverage.Covered {
+			return left.coverage.Covered
 		}
-		if len(left.MissingRecordTypes) != len(right.MissingRecordTypes) {
-			return len(left.MissingRecordTypes) < len(right.MissingRecordTypes)
+		if left.missingRecordTypes != right.missingRecordTypes {
+			return left.missingRecordTypes < right.missingRecordTypes
 		}
-		leftKey := strings.Join([]string{
-			strings.TrimSpace(left.ID),
-			strings.Join(uniqueSortedStrings(left.SourceProducts), ","),
-			strings.Join(uniqueSortedStrings(left.RequiredRecordTypes), ","),
-			strings.Join(uniqueSortedStrings(left.RequiredFields), ","),
-		}, "|")
-		rightKey := strings.Join([]string{
-			strings.TrimSpace(right.ID),
-			strings.Join(uniqueSortedStrings(right.SourceProducts), ","),
-			strings.Join(uniqueSortedStrings(right.RequiredRecordTypes), ","),
-			strings.Join(uniqueSortedStrings(right.RequiredFields), ","),
-		}, "|")
-		return leftKey < rightKey
+		if left.missingFields != right.missingFields {
+			return left.missingFields < right.missingFields
+		}
+		return left.key < right.key
 	})
-	return ordered[0], true
+	return ordered[0].coverage, true
 }
 
 func evidenceSetGaps(set framework.EvidenceSetCoverage, records []proof.Record) ([]string, []string) {

--- a/core/compliance/compliance.go
+++ b/core/compliance/compliance.go
@@ -45,12 +45,30 @@ func Evaluate(in Input) (Result, error) {
 		return Result{}, fmt.Errorf("chain is required")
 	}
 	controls := flatten(in.Framework.Controls)
+	var coverageControls []framework.ControlCoverage
+	if controlsUseEvidenceSets(controls) {
+		evidenceCoverage, err := framework.EvaluateCoverage(in.Framework, in.Chain.Records)
+		if err != nil {
+			return Result{}, fmt.Errorf("evaluate framework evidence sets: %w", err)
+		}
+		coverageControls = flattenCoverage(evidenceCoverage.Controls)
+		if len(coverageControls) != len(controls) {
+			return Result{}, fmt.Errorf("framework control coverage mismatch: controls=%d coverage=%d", len(controls), len(coverageControls))
+		}
+	}
 	matchedRuleIDs := collectRuleIDs(in.Chain.Records)
 	checks := make([]ControlCheck, 0, len(controls))
 	gaps := make([]ControlCheck, 0)
 	covered := 0
-	for _, control := range controls {
-		check := evaluateControl(in.Framework.Framework.ID, control, in.Chain.Records, matchedRuleIDs)
+	for index, control := range controls {
+		var coverageControl framework.ControlCoverage
+		if len(control.EvidenceSets) > 0 {
+			coverageControl = coverageControls[index]
+			if coverageControl.ID != control.ID {
+				return Result{}, fmt.Errorf("framework control coverage order mismatch: control=%q coverage=%q", control.ID, coverageControl.ID)
+			}
+		}
+		check := evaluateControl(in.Framework.Framework.ID, control, coverageControl, in.Chain.Records, matchedRuleIDs)
 		checks = append(checks, check)
 		if check.Status == "covered" {
 			covered++
@@ -74,7 +92,14 @@ func Evaluate(in Input) (Result, error) {
 	}, nil
 }
 
-func evaluateControl(frameworkID string, control framework.Control, records []proof.Record, matchedRuleIDs map[string]struct{}) ControlCheck {
+func evaluateControl(frameworkID string, control framework.Control, evidenceCoverage framework.ControlCoverage, records []proof.Record, matchedRuleIDs map[string]struct{}) ControlCheck {
+	if len(control.EvidenceSets) > 0 {
+		return evaluateEvidenceSetControl(frameworkID, control, evidenceCoverage, matchedRuleIDs)
+	}
+	return evaluateLegacyControl(frameworkID, control, records, matchedRuleIDs)
+}
+
+func evaluateLegacyControl(frameworkID string, control framework.Control, records []proof.Record, matchedRuleIDs map[string]struct{}) ControlCheck {
 	requiredTypes := uniqueSortedStrings(control.RequiredRecordTypes)
 	requiredFields := uniqueSortedStrings(control.RequiredFields)
 	missingTypes := make([]string, 0)
@@ -120,6 +145,85 @@ func evaluateControl(frameworkID string, control framework.Control, records []pr
 		RequiredRecordTypes: requiredTypes,
 		RequiredFields:      requiredFields,
 	}
+}
+
+func evaluateEvidenceSetControl(frameworkID string, control framework.Control, evidenceCoverage framework.ControlCoverage, matchedRuleIDs map[string]struct{}) ControlCheck {
+	selected, ok := selectEvidenceSetCoverage(evidenceCoverage.EvidenceSets)
+	mappedRules := mappedRuleIDs(frameworkID, control.ID, matchedRuleIDs)
+	if !ok {
+		return ControlCheck{
+			ID:             control.ID,
+			Title:          control.Title,
+			Status:         "gap",
+			MappedRuleIDs:  mappedRules,
+			MatchedRecords: len(mappedRules),
+		}
+	}
+
+	status := "gap"
+	if selected.Covered {
+		status = "covered"
+	}
+	return ControlCheck{
+		ID:                  control.ID,
+		Title:               control.Title,
+		Status:              status,
+		MatchedRecords:      len(selected.MatchingRecordIDs) + len(mappedRules),
+		MappedRuleIDs:       mappedRules,
+		MissingRecordTypes:  uniqueSortedStrings(selected.MissingRecordTypes),
+		RequiredRecordTypes: uniqueSortedStrings(selected.RequiredRecordTypes),
+		RequiredFields:      uniqueSortedStrings(selected.RequiredFields),
+	}
+}
+
+func selectEvidenceSetCoverage(sets []framework.EvidenceSetCoverage) (framework.EvidenceSetCoverage, bool) {
+	if len(sets) == 0 {
+		return framework.EvidenceSetCoverage{}, false
+	}
+	ordered := make([]framework.EvidenceSetCoverage, 0, len(sets))
+	for _, set := range sets {
+		if evidenceSetAppliesToWrkr(set.SourceProducts) {
+			ordered = append(ordered, set)
+		}
+	}
+	if len(ordered) == 0 {
+		ordered = append(ordered, sets...)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		left, right := ordered[i], ordered[j]
+		if left.Covered != right.Covered {
+			return left.Covered
+		}
+		if len(left.MissingRecordTypes) != len(right.MissingRecordTypes) {
+			return len(left.MissingRecordTypes) < len(right.MissingRecordTypes)
+		}
+		leftKey := strings.Join([]string{
+			strings.TrimSpace(left.ID),
+			strings.Join(uniqueSortedStrings(left.SourceProducts), ","),
+			strings.Join(uniqueSortedStrings(left.RequiredRecordTypes), ","),
+			strings.Join(uniqueSortedStrings(left.RequiredFields), ","),
+		}, "|")
+		rightKey := strings.Join([]string{
+			strings.TrimSpace(right.ID),
+			strings.Join(uniqueSortedStrings(right.SourceProducts), ","),
+			strings.Join(uniqueSortedStrings(right.RequiredRecordTypes), ","),
+			strings.Join(uniqueSortedStrings(right.RequiredFields), ","),
+		}, "|")
+		return leftKey < rightKey
+	})
+	return ordered[0], true
+}
+
+func evidenceSetAppliesToWrkr(sourceProducts []string) bool {
+	if len(sourceProducts) == 0 {
+		return true
+	}
+	for _, sourceProduct := range sourceProducts {
+		if strings.EqualFold(strings.TrimSpace(sourceProduct), "wrkr") {
+			return true
+		}
+	}
+	return false
 }
 
 func fieldCovered(requiredField string, matchedByType map[string][]proof.Record) bool {
@@ -184,6 +288,31 @@ func flatten(controls []framework.Control) []framework.Control {
 		return out[i].ID < out[j].ID
 	})
 	return out
+}
+
+func flattenCoverage(controls []framework.ControlCoverage) []framework.ControlCoverage {
+	out := make([]framework.ControlCoverage, 0)
+	for _, control := range controls {
+		out = append(out, control)
+		children := flattenCoverage(control.Children)
+		out = append(out, children...)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ID == out[j].ID {
+			return out[i].Title < out[j].Title
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+func controlsUseEvidenceSets(controls []framework.Control) bool {
+	for _, control := range controls {
+		if len(control.EvidenceSets) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func uniqueSortedStrings(values []string) []string {
@@ -255,11 +384,7 @@ func eventRuleID(event map[string]any) string {
 }
 
 func mappedRuleIDs(frameworkID, controlID string, matchedRuleIDs map[string]struct{}) []string {
-	controls := frameworkControlRuleMap[strings.TrimSpace(frameworkID)]
-	if len(controls) == 0 {
-		return nil
-	}
-	ruleIDs := controls[strings.TrimSpace(controlID)]
+	ruleIDs := configuredControlRuleIDs(strings.TrimSpace(frameworkID), strings.TrimSpace(controlID))
 	if len(ruleIDs) == 0 {
 		return nil
 	}

--- a/core/compliance/compliance.go
+++ b/core/compliance/compliance.go
@@ -185,6 +185,7 @@ func selectEvidenceSetCoverage(sets []framework.EvidenceSetCoverage, records []p
 	}
 	type candidate struct {
 		coverage           framework.EvidenceSetCoverage
+		wrkrMatched        bool
 		missingRecordTypes int
 		missingFields      int
 		key                string
@@ -195,8 +196,12 @@ func selectEvidenceSetCoverage(sets []framework.EvidenceSetCoverage, records []p
 			continue
 		}
 		missingRecordTypes, missingFields := evidenceSetGaps(set, records)
+		wrkrMatched := evidenceSetHasMatchingWrkrRecord(set, records)
+		projectedCoverage := set
+		projectedCoverage.Covered = set.Covered && wrkrMatched
 		ordered = append(ordered, candidate{
-			coverage:           set,
+			coverage:           projectedCoverage,
+			wrkrMatched:        wrkrMatched,
 			missingRecordTypes: len(missingRecordTypes),
 			missingFields:      len(missingFields),
 			key: strings.Join([]string{
@@ -215,6 +220,9 @@ func selectEvidenceSetCoverage(sets []framework.EvidenceSetCoverage, records []p
 		if left.coverage.Covered != right.coverage.Covered {
 			return left.coverage.Covered
 		}
+		if left.wrkrMatched != right.wrkrMatched {
+			return left.wrkrMatched
+		}
 		if left.missingRecordTypes != right.missingRecordTypes {
 			return left.missingRecordTypes < right.missingRecordTypes
 		}
@@ -224,6 +232,23 @@ func selectEvidenceSetCoverage(sets []framework.EvidenceSetCoverage, records []p
 		return left.key < right.key
 	})
 	return ordered[0].coverage, true
+}
+
+func evidenceSetHasMatchingWrkrRecord(set framework.EvidenceSetCoverage, records []proof.Record) bool {
+	for _, requiredType := range uniqueSortedStrings(set.RequiredRecordTypes) {
+		for _, record := range records {
+			if !strings.EqualFold(strings.TrimSpace(record.SourceProduct), "wrkr") {
+				continue
+			}
+			if strings.TrimSpace(record.RecordType) != requiredType {
+				continue
+			}
+			if len(missingEvidenceFields(record, set.RequiredFields)) == 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func evidenceSetGaps(set framework.EvidenceSetCoverage, records []proof.Record) ([]string, []string) {

--- a/core/compliance/compliance.go
+++ b/core/compliance/compliance.go
@@ -1,6 +1,7 @@
 package compliance
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -94,7 +95,7 @@ func Evaluate(in Input) (Result, error) {
 
 func evaluateControl(frameworkID string, control framework.Control, evidenceCoverage framework.ControlCoverage, records []proof.Record, matchedRuleIDs map[string]struct{}) ControlCheck {
 	if len(control.EvidenceSets) > 0 {
-		return evaluateEvidenceSetControl(frameworkID, control, evidenceCoverage, matchedRuleIDs)
+		return evaluateEvidenceSetControl(frameworkID, control, evidenceCoverage, records, matchedRuleIDs)
 	}
 	return evaluateLegacyControl(frameworkID, control, records, matchedRuleIDs)
 }
@@ -147,7 +148,7 @@ func evaluateLegacyControl(frameworkID string, control framework.Control, record
 	}
 }
 
-func evaluateEvidenceSetControl(frameworkID string, control framework.Control, evidenceCoverage framework.ControlCoverage, matchedRuleIDs map[string]struct{}) ControlCheck {
+func evaluateEvidenceSetControl(frameworkID string, control framework.Control, evidenceCoverage framework.ControlCoverage, records []proof.Record, matchedRuleIDs map[string]struct{}) ControlCheck {
 	selected, ok := selectEvidenceSetCoverage(evidenceCoverage.EvidenceSets)
 	mappedRules := mappedRuleIDs(frameworkID, control.ID, matchedRuleIDs)
 	if !ok {
@@ -164,13 +165,15 @@ func evaluateEvidenceSetControl(frameworkID string, control framework.Control, e
 	if selected.Covered {
 		status = "covered"
 	}
+	missingRecordTypes, missingFields := evidenceSetGaps(selected, records)
 	return ControlCheck{
 		ID:                  control.ID,
 		Title:               control.Title,
 		Status:              status,
 		MatchedRecords:      len(selected.MatchingRecordIDs) + len(mappedRules),
 		MappedRuleIDs:       mappedRules,
-		MissingRecordTypes:  uniqueSortedStrings(selected.MissingRecordTypes),
+		MissingRecordTypes:  missingRecordTypes,
+		MissingFields:       missingFields,
 		RequiredRecordTypes: uniqueSortedStrings(selected.RequiredRecordTypes),
 		RequiredFields:      uniqueSortedStrings(selected.RequiredFields),
 	}
@@ -187,7 +190,7 @@ func selectEvidenceSetCoverage(sets []framework.EvidenceSetCoverage) (framework.
 		}
 	}
 	if len(ordered) == 0 {
-		ordered = append(ordered, sets...)
+		return framework.EvidenceSetCoverage{}, false
 	}
 	sort.Slice(ordered, func(i, j int) bool {
 		left, right := ordered[i], ordered[j]
@@ -212,6 +215,133 @@ func selectEvidenceSetCoverage(sets []framework.EvidenceSetCoverage) (framework.
 		return leftKey < rightKey
 	})
 	return ordered[0], true
+}
+
+func evidenceSetGaps(set framework.EvidenceSetCoverage, records []proof.Record) ([]string, []string) {
+	missingRecordTypes := make([]string, 0)
+	missingFields := make([]string, 0)
+	for _, requiredType := range uniqueSortedStrings(set.RequiredRecordTypes) {
+		candidates := evidenceSetCandidates(requiredType, set.SourceProducts, records)
+		if len(candidates) == 0 {
+			missingRecordTypes = append(missingRecordTypes, requiredType)
+			continue
+		}
+
+		bestMissing := missingEvidenceFields(candidates[0], set.RequiredFields)
+		bestKey := evidenceRecordKey(candidates[0])
+		for _, candidate := range candidates[1:] {
+			candidateMissing := missingEvidenceFields(candidate, set.RequiredFields)
+			candidateKey := evidenceRecordKey(candidate)
+			if len(candidateMissing) < len(bestMissing) || (len(candidateMissing) == len(bestMissing) && candidateKey < bestKey) {
+				bestMissing = candidateMissing
+				bestKey = candidateKey
+			}
+		}
+		missingFields = append(missingFields, bestMissing...)
+	}
+	return uniqueSortedStrings(missingRecordTypes), uniqueSortedStrings(missingFields)
+}
+
+func evidenceSetCandidates(requiredType string, sourceProducts []string, records []proof.Record) []proof.Record {
+	out := make([]proof.Record, 0)
+	for _, record := range records {
+		if strings.TrimSpace(record.RecordType) != strings.TrimSpace(requiredType) {
+			continue
+		}
+		if !evidenceSourceProductAllowed(record.SourceProduct, sourceProducts) {
+			continue
+		}
+		out = append(out, record)
+	}
+	return out
+}
+
+func evidenceSourceProductAllowed(sourceProduct string, allowed []string) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	for _, candidate := range allowed {
+		if strings.EqualFold(strings.TrimSpace(sourceProduct), strings.TrimSpace(candidate)) {
+			return true
+		}
+	}
+	return false
+}
+
+func missingEvidenceFields(record proof.Record, requiredFields []string) []string {
+	root, ok := evidenceRecordObject(record)
+	if !ok {
+		return uniqueSortedStrings(requiredFields)
+	}
+	missing := make([]string, 0)
+	for _, requiredField := range uniqueSortedStrings(requiredFields) {
+		if !evidenceFieldPresent(root, requiredField) {
+			missing = append(missing, requiredField)
+		}
+	}
+	return missing
+}
+
+func evidenceRecordObject(record proof.Record) (map[string]any, bool) {
+	raw, err := json.Marshal(record)
+	if err != nil {
+		return nil, false
+	}
+	var root map[string]any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return nil, false
+	}
+	return root, true
+}
+
+func evidenceFieldPresent(root map[string]any, field string) bool {
+	value, ok := nestedEvidenceField(root, field)
+	return ok && evidenceValuePresent(value)
+}
+
+func nestedEvidenceField(root map[string]any, field string) (any, bool) {
+	current := any(root)
+	for _, part := range strings.Split(field, ".") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, false
+		}
+		object, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		next, exists := object[part]
+		if !exists {
+			return nil, false
+		}
+		current = next
+	}
+	return current, true
+}
+
+func evidenceValuePresent(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return false
+	case string:
+		return strings.TrimSpace(typed) != ""
+	case []any:
+		return len(typed) > 0
+	case map[string]any:
+		return len(typed) > 0
+	default:
+		return true
+	}
+}
+
+func evidenceRecordKey(record proof.Record) string {
+	return strings.Join([]string{
+		strings.TrimSpace(record.RecordID),
+		strings.TrimSpace(record.SourceProduct),
+		strings.TrimSpace(record.Source),
+		strings.TrimSpace(record.RecordType),
+		strings.TrimSpace(record.Integrity.RecordHash),
+	}, "|")
 }
 
 func evidenceSetAppliesToWrkr(sourceProducts []string) bool {

--- a/core/compliance/compliance_test.go
+++ b/core/compliance/compliance_test.go
@@ -168,6 +168,49 @@ func TestEvaluateEvidenceSetCoverageReportsMissingFields(t *testing.T) {
 	}
 }
 
+func TestEvaluateEvidenceSetCoverageSelectsClosestFieldGap(t *testing.T) {
+	t.Parallel()
+
+	frameworkDef := &proof.Framework{}
+	frameworkDef.Framework.ID = "closest-gap-framework"
+	frameworkDef.Framework.Version = "1"
+	frameworkDef.Framework.Title = "Closest Gap Framework"
+	frameworkDef.Controls = []framework.Control{{
+		ID:    "closest-gap-control",
+		Title: "Closest Gap Control",
+		EvidenceSets: []framework.EvidenceSet{
+			{
+				ID:                  "a-farther-path",
+				SourceProducts:      []string{"wrkr"},
+				RequiredRecordTypes: []string{"scan_finding"},
+				RequiredFields:      []string{"record_id", "event.alpha", "event.beta"},
+				MinimumFrequency:    "continuous",
+			},
+			{
+				ID:                  "z-closer-path",
+				SourceProducts:      []string{"wrkr"},
+				RequiredRecordTypes: []string{"scan_finding"},
+				RequiredFields:      []string{"record_id", "event.near"},
+				MinimumFrequency:    "continuous",
+			},
+		},
+	}}
+	chain := proof.NewChain("wrkr-proof")
+	appendRecord(t, chain, "scan_finding")
+
+	result, err := Evaluate(Input{Framework: frameworkDef, Chain: chain})
+	if err != nil {
+		t.Fatalf("evaluate closest evidence gap: %v", err)
+	}
+	check := result.Controls[0]
+	if !reflect.DeepEqual(check.RequiredFields, []string{"event.near", "record_id"}) {
+		t.Fatalf("expected closest field-gap path despite lexical set order: %+v", check)
+	}
+	if !reflect.DeepEqual(check.MissingFields, []string{"event.near"}) {
+		t.Fatalf("expected remediation for closest field-gap path: %+v", check)
+	}
+}
+
 func TestEvaluateEvidenceSetCoverageDoesNotProjectExternalOnlyAlternativeAsWrkrCoverage(t *testing.T) {
 	t.Parallel()
 

--- a/core/compliance/compliance_test.go
+++ b/core/compliance/compliance_test.go
@@ -1,12 +1,179 @@
 package compliance
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
 	proof "github.com/Clyra-AI/proof"
 	"github.com/Clyra-AI/proof/core/framework"
 )
+
+func TestFlattenPreservesLegacyControlRequirements(t *testing.T) {
+	t.Parallel()
+
+	legacy := framework.Control{
+		ID:                  "legacy-control",
+		Title:               "Legacy Control",
+		RequiredRecordTypes: []string{"approval", "permission_check"},
+		RequiredFields:      []string{"record_id", "event"},
+		MinimumFrequency:    "continuous",
+	}
+
+	got := flatten([]framework.Control{legacy})
+	if len(got) != 1 {
+		t.Fatalf("expected one flattened control, got %d", len(got))
+	}
+	if !reflect.DeepEqual(got[0], legacy) {
+		t.Fatalf("legacy control changed during flattening\nwant=%+v\ngot=%+v", legacy, got[0])
+	}
+}
+
+func TestEvaluateEvidenceSetCoverageSelectsSatisfiedWrkrAlternativeDeterministically(t *testing.T) {
+	t.Parallel()
+
+	evidenceSets := []framework.EvidenceSet{
+		{
+			ID:                  "runtime-control",
+			SourceProducts:      []string{"gait"},
+			RequiredRecordTypes: []string{"permission_check", "policy_enforcement"},
+			RequiredFields:      []string{"record_id", "source_product", "event"},
+			MinimumFrequency:    "continuous",
+		},
+		{
+			ID:                  "wrkr-discovery",
+			SourceProducts:      []string{"wrkr"},
+			RequiredRecordTypes: []string{"scan_finding"},
+			RequiredFields:      []string{"record_id", "source_product", "event"},
+			MinimumFrequency:    "continuous",
+		},
+	}
+	evaluate := func(sets []framework.EvidenceSet) ControlCheck {
+		frameworkDef := &proof.Framework{}
+		frameworkDef.Framework.ID = "evidence-set-framework"
+		frameworkDef.Framework.Version = "1"
+		frameworkDef.Framework.Title = "Evidence Set Framework"
+		frameworkDef.Controls = []framework.Control{{
+			ID:           "evidence-set-control",
+			Title:        "Evidence Set Control",
+			EvidenceSets: sets,
+		}}
+		chain := proof.NewChain("wrkr-proof")
+		appendRecord(t, chain, "scan_finding")
+		result, err := Evaluate(Input{Framework: frameworkDef, Chain: chain})
+		if err != nil {
+			t.Fatalf("evaluate evidence-set control: %v", err)
+		}
+		if len(result.Controls) != 1 {
+			t.Fatalf("expected one control, got %d", len(result.Controls))
+		}
+		return result.Controls[0]
+	}
+
+	first := evaluate(evidenceSets)
+	reversed := append([]framework.EvidenceSet(nil), evidenceSets...)
+	reversed[0], reversed[1] = reversed[1], reversed[0]
+	second := evaluate(reversed)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("evidence-set evaluation changed with input order\nfirst=%+v\nsecond=%+v", first, second)
+	}
+	if first.Status != "covered" {
+		t.Fatalf("expected wrkr evidence path to be covered, got %+v", first)
+	}
+	wantTypes := []string{"scan_finding"}
+	if !reflect.DeepEqual(first.RequiredRecordTypes, wantTypes) {
+		t.Fatalf("required record types mismatch: want=%v got=%v", wantTypes, first.RequiredRecordTypes)
+	}
+	if len(first.MissingRecordTypes) != 0 {
+		t.Fatalf("covered evidence path reported missing types: %+v", first)
+	}
+}
+
+func TestEvaluateEvidenceSetCoverageRequiresEveryTypeInSelectedSet(t *testing.T) {
+	t.Parallel()
+
+	frameworkDef := &proof.Framework{}
+	frameworkDef.Framework.ID = "combined-evidence-framework"
+	frameworkDef.Framework.Version = "1"
+	frameworkDef.Framework.Title = "Combined Evidence Framework"
+	frameworkDef.Controls = []framework.Control{{
+		ID:    "evidence-set-control",
+		Title: "Evidence Set Control",
+		EvidenceSets: []framework.EvidenceSet{{
+			ID:                  "combined",
+			SourceProducts:      []string{"wrkr", "gait"},
+			RequiredRecordTypes: []string{"scan_finding", "permission_check"},
+			RequiredFields:      []string{"record_id", "source_product", "event"},
+			MinimumFrequency:    "continuous",
+		}},
+	}}
+	chain := proof.NewChain("wrkr-proof")
+	appendRecord(t, chain, "scan_finding")
+
+	result, err := Evaluate(Input{Framework: frameworkDef, Chain: chain})
+	if err != nil {
+		t.Fatalf("evaluate combined evidence set: %v", err)
+	}
+	if len(result.Controls) != 1 {
+		t.Fatalf("expected one control, got %d", len(result.Controls))
+	}
+	check := result.Controls[0]
+	if check.Status != "gap" {
+		t.Fatalf("single record type must not cover a multi-type evidence set: %+v", check)
+	}
+	wantTypes := []string{"permission_check", "scan_finding"}
+	if !reflect.DeepEqual(check.RequiredRecordTypes, wantTypes) {
+		t.Fatalf("required record types mismatch: want=%v got=%v", wantTypes, check.RequiredRecordTypes)
+	}
+	wantMissing := []string{"permission_check"}
+	if !reflect.DeepEqual(check.MissingRecordTypes, wantMissing) {
+		t.Fatalf("missing record types mismatch: want=%v got=%v", wantMissing, check.MissingRecordTypes)
+	}
+}
+
+func TestEvaluateEvidenceSetCoverageDoesNotProjectExternalOnlyAlternativeAsWrkrCoverage(t *testing.T) {
+	t.Parallel()
+
+	frameworkDef := &proof.Framework{}
+	frameworkDef.Framework.ID = "source-scoped-framework"
+	frameworkDef.Framework.Version = "1"
+	frameworkDef.Framework.Title = "Source Scoped Framework"
+	frameworkDef.Controls = []framework.Control{{
+		ID:    "source-scoped-control",
+		Title: "Source Scoped Control",
+		EvidenceSets: []framework.EvidenceSet{
+			{
+				ID:                  "wrkr-discovery",
+				SourceProducts:      []string{"wrkr"},
+				RequiredRecordTypes: []string{"scan_finding"},
+				RequiredFields:      []string{"record_id", "source_product", "event"},
+				MinimumFrequency:    "continuous",
+			},
+			{
+				ID:                  "runtime-control",
+				SourceProducts:      []string{"gait"},
+				RequiredRecordTypes: []string{"permission_check"},
+				RequiredFields:      []string{"record_id", "source_product", "event"},
+				MinimumFrequency:    "continuous",
+			},
+		},
+	}}
+	chain := proof.NewChain("wrkr-proof")
+	appendRecordForProduct(t, chain, "gait", "permission_check")
+
+	result, err := Evaluate(Input{Framework: frameworkDef, Chain: chain})
+	if err != nil {
+		t.Fatalf("evaluate source-scoped evidence sets: %v", err)
+	}
+	check := result.Controls[0]
+	if check.Status != "gap" {
+		t.Fatalf("external-only evidence path must not overclaim wrkr coverage: %+v", check)
+	}
+	if !reflect.DeepEqual(check.RequiredRecordTypes, []string{"scan_finding"}) ||
+		!reflect.DeepEqual(check.MissingRecordTypes, []string{"scan_finding"}) {
+		t.Fatalf("expected the wrkr evidence path to remain selected and incomplete: %+v", check)
+	}
+}
 
 func TestEvaluateFrameworkCoverage(t *testing.T) {
 	t.Parallel()
@@ -75,7 +242,7 @@ func TestEvaluateFrameworkGapWhenMissingRecordType(t *testing.T) {
 func TestComplianceMapping_WRKRAControlsCovered(t *testing.T) {
 	t.Parallel()
 
-	frameworkIDs := []string{"eu-ai-act", "soc2", "pci-dss"}
+	frameworkIDs := []string{"eu-ai-act", "soc2"}
 	for _, frameworkID := range frameworkIDs {
 		frameworkDef, err := proof.LoadFramework(frameworkID)
 		if err != nil {
@@ -124,6 +291,20 @@ func TestComplianceMapping_WRKRAControlsCovered(t *testing.T) {
 		if !coveredByRules {
 			t.Fatalf("expected mapped WRKR-A rule coverage for %s, got %+v", frameworkID, result.Controls)
 		}
+	}
+}
+
+func TestConfiguredControlRuleIDsUsesOnlyExplicitCompatibilityAliases(t *testing.T) {
+	t.Parallel()
+
+	if got := configuredControlRuleIDs("soc2", "cc6.1"); !reflect.DeepEqual(got, frameworkControlRuleMap["soc2"]["cc6"]) {
+		t.Fatalf("expected explicit cc6.1 compatibility mapping, got %v", got)
+	}
+	if got := configuredControlRuleIDs("soc2", "cc6.3"); len(got) != 0 {
+		t.Fatalf("cc6.3 must not inherit cc6 rules without an explicit equivalence, got %v", got)
+	}
+	if got := configuredControlRuleIDs("pci-dss", "req-6.5"); len(got) != 0 {
+		t.Fatalf("unrelated PCI control must not inherit the legacy req-10 mapping, got %v", got)
 	}
 }
 
@@ -192,10 +373,15 @@ func TestComplianceMapping_DoesNotMaskMissingRecords(t *testing.T) {
 
 func appendRecord(t *testing.T, chain *proof.Chain, recordType string) {
 	t.Helper()
+	appendRecordForProduct(t, chain, "wrkr", recordType)
+}
+
+func appendRecordForProduct(t *testing.T, chain *proof.Chain, sourceProduct, recordType string) {
+	t.Helper()
 	record, err := proof.NewRecord(proof.RecordOpts{
 		Timestamp:     time.Date(2026, 2, 20, 12, 0, 0, 0, time.UTC),
-		Source:        "wrkr",
-		SourceProduct: "wrkr",
+		Source:        sourceProduct,
+		SourceProduct: sourceProduct,
 		Type:          recordType,
 		Event:         map[string]any{"ok": true},
 		Controls:      proof.Controls{PermissionsEnforced: true},

--- a/core/compliance/compliance_test.go
+++ b/core/compliance/compliance_test.go
@@ -131,6 +131,43 @@ func TestEvaluateEvidenceSetCoverageRequiresEveryTypeInSelectedSet(t *testing.T)
 	}
 }
 
+func TestEvaluateEvidenceSetCoverageReportsMissingFields(t *testing.T) {
+	t.Parallel()
+
+	frameworkDef := &proof.Framework{}
+	frameworkDef.Framework.ID = "field-scoped-framework"
+	frameworkDef.Framework.Version = "1"
+	frameworkDef.Framework.Title = "Field Scoped Framework"
+	frameworkDef.Controls = []framework.Control{{
+		ID:    "field-scoped-control",
+		Title: "Field Scoped Control",
+		EvidenceSets: []framework.EvidenceSet{{
+			ID:                  "wrkr-discovery",
+			SourceProducts:      []string{"wrkr"},
+			RequiredRecordTypes: []string{"scan_finding"},
+			RequiredFields:      []string{"record_id", "event.required_value"},
+			MinimumFrequency:    "continuous",
+		}},
+	}}
+	chain := proof.NewChain("wrkr-proof")
+	appendRecord(t, chain, "scan_finding")
+
+	result, err := Evaluate(Input{Framework: frameworkDef, Chain: chain})
+	if err != nil {
+		t.Fatalf("evaluate field-scoped evidence set: %v", err)
+	}
+	check := result.Controls[0]
+	if check.Status != "gap" {
+		t.Fatalf("missing required field must keep the evidence set uncovered: %+v", check)
+	}
+	if len(check.MissingRecordTypes) != 0 {
+		t.Fatalf("present record type must not be reported missing when only a field is absent: %+v", check)
+	}
+	if !reflect.DeepEqual(check.MissingFields, []string{"event.required_value"}) {
+		t.Fatalf("missing fields mismatch: %+v", check)
+	}
+}
+
 func TestEvaluateEvidenceSetCoverageDoesNotProjectExternalOnlyAlternativeAsWrkrCoverage(t *testing.T) {
 	t.Parallel()
 
@@ -172,6 +209,40 @@ func TestEvaluateEvidenceSetCoverageDoesNotProjectExternalOnlyAlternativeAsWrkrC
 	if !reflect.DeepEqual(check.RequiredRecordTypes, []string{"scan_finding"}) ||
 		!reflect.DeepEqual(check.MissingRecordTypes, []string{"scan_finding"}) {
 		t.Fatalf("expected the wrkr evidence path to remain selected and incomplete: %+v", check)
+	}
+}
+
+func TestEvaluateEvidenceSetCoverageRejectsAllExternalAlternatives(t *testing.T) {
+	t.Parallel()
+
+	frameworkDef := &proof.Framework{}
+	frameworkDef.Framework.ID = "external-framework"
+	frameworkDef.Framework.Version = "1"
+	frameworkDef.Framework.Title = "External Framework"
+	frameworkDef.Controls = []framework.Control{{
+		ID:    "external-control",
+		Title: "External Control",
+		EvidenceSets: []framework.EvidenceSet{{
+			ID:                  "runtime-control",
+			SourceProducts:      []string{"gait"},
+			RequiredRecordTypes: []string{"permission_check"},
+			RequiredFields:      []string{"record_id", "source_product", "event"},
+			MinimumFrequency:    "continuous",
+		}},
+	}}
+	chain := proof.NewChain("wrkr-proof")
+	appendRecordForProduct(t, chain, "gait", "permission_check")
+
+	result, err := Evaluate(Input{Framework: frameworkDef, Chain: chain})
+	if err != nil {
+		t.Fatalf("evaluate external-only evidence set: %v", err)
+	}
+	check := result.Controls[0]
+	if check.Status != "gap" || check.MatchedRecords != 0 {
+		t.Fatalf("external-only evidence must not satisfy the wrkr projection: %+v", check)
+	}
+	if len(check.RequiredRecordTypes) != 0 || len(check.MissingRecordTypes) != 0 {
+		t.Fatalf("external-only requirements must not be projected as wrkr requirements: %+v", check)
 	}
 }
 

--- a/core/compliance/compliance_test.go
+++ b/core/compliance/compliance_test.go
@@ -289,6 +289,45 @@ func TestEvaluateEvidenceSetCoverageRejectsAllExternalAlternatives(t *testing.T)
 	}
 }
 
+func TestEvaluateEvidenceSetCoverageRequiresWrkrContributionForMixedSet(t *testing.T) {
+	t.Parallel()
+
+	frameworkDef := &proof.Framework{}
+	frameworkDef.Framework.ID = "mixed-source-framework"
+	frameworkDef.Framework.Version = "1"
+	frameworkDef.Framework.Title = "Mixed Source Framework"
+	frameworkDef.Controls = []framework.Control{{
+		ID:    "mixed-source-control",
+		Title: "Mixed Source Control",
+		EvidenceSets: []framework.EvidenceSet{{
+			ID:                  "combined",
+			SourceProducts:      []string{"wrkr", "gait"},
+			RequiredRecordTypes: []string{"permission_check"},
+			RequiredFields:      []string{"record_id", "source_product", "event"},
+			MinimumFrequency:    "continuous",
+		}},
+	}}
+	chain := proof.NewChain("wrkr-proof")
+	appendRecordForProduct(t, chain, "gait", "permission_check")
+
+	gaitOnly, err := Evaluate(Input{Framework: frameworkDef, Chain: chain})
+	if err != nil {
+		t.Fatalf("evaluate gait-only mixed evidence set: %v", err)
+	}
+	if gaitOnly.Controls[0].Status != "gap" {
+		t.Fatalf("gait-only evidence must not cover the wrkr projection: %+v", gaitOnly.Controls[0])
+	}
+
+	appendRecordForProduct(t, chain, "wrkr", "permission_check")
+	withWrkr, err := Evaluate(Input{Framework: frameworkDef, Chain: chain})
+	if err != nil {
+		t.Fatalf("evaluate mixed evidence set with wrkr contribution: %v", err)
+	}
+	if withWrkr.Controls[0].Status != "covered" {
+		t.Fatalf("matching wrkr contribution should allow mixed-set coverage: %+v", withWrkr.Controls[0])
+	}
+}
+
 func TestEvaluateFrameworkCoverage(t *testing.T) {
 	t.Parallel()
 	frameworkDef := &proof.Framework{}

--- a/core/compliance/rulemap.go
+++ b/core/compliance/rulemap.go
@@ -15,3 +15,30 @@ var frameworkControlRuleMap = map[string]map[string][]string{
 		"req-10": {"WRKR-A001", "WRKR-A003", "WRKR-A004", "WRKR-A006", "WRKR-A009", "WRKR-A010"},
 	},
 }
+
+// frameworkControlCompatibilityAliases preserves the one-to-one SOC 2 control
+// identities that Proof made more precise in v0.5.0. It is intentionally
+// explicit: controls without an established predecessor must not inherit a
+// mapping through prefix or fuzzy matching.
+var frameworkControlCompatibilityAliases = map[string]map[string]string{
+	"soc2": {
+		"cc6.1": "cc6",
+		"cc7.1": "cc7",
+		"cc8.1": "cc8",
+	},
+}
+
+func configuredControlRuleIDs(frameworkID, controlID string) []string {
+	controls := frameworkControlRuleMap[frameworkID]
+	if len(controls) == 0 {
+		return nil
+	}
+	if ruleIDs := controls[controlID]; len(ruleIDs) > 0 {
+		return append([]string(nil), ruleIDs...)
+	}
+	alias := frameworkControlCompatibilityAliases[frameworkID][controlID]
+	if alias == "" {
+		return nil
+	}
+	return append([]string(nil), controls[alias]...)
+}

--- a/core/compliance/summary.go
+++ b/core/compliance/summary.go
@@ -181,11 +181,7 @@ func buildRuleFindingIndex(findings []model.Finding) map[string]map[string]struc
 }
 
 func controlRuleIDs(frameworkID, controlID string) []string {
-	controls := frameworkControlRuleMap[strings.TrimSpace(frameworkID)]
-	if len(controls) == 0 {
-		return nil
-	}
-	return uniqueSortedStrings(controls[strings.TrimSpace(controlID)])
+	return uniqueSortedStrings(configuredControlRuleIDs(strings.TrimSpace(frameworkID), strings.TrimSpace(controlID)))
 }
 
 func mappedFindingKeys(frameworkID, controlID string, ruleFindingIndex map[string]map[string]struct{}) []string {

--- a/core/compliance/summary_test.go
+++ b/core/compliance/summary_test.go
@@ -78,7 +78,7 @@ func TestBuildRollupSummaryDeterministic(t *testing.T) {
 	for _, control := range soc2.Controls {
 		counts[control.ControlID] = control.FindingCount
 	}
-	if counts["cc6"] != 1 || counts["cc7"] != 1 || counts["cc8"] != 2 {
+	if counts["cc6.1"] != 1 || counts["cc7.1"] != 1 || counts["cc8.1"] != 2 {
 		t.Fatalf("unexpected soc2 control finding counts: %+v", counts)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.6
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/Clyra-AI/proof v0.4.6
+	github.com/Clyra-AI/proof v0.5.0
 	github.com/dop251/goja v0.0.0-20260219130522-0ba9a5494a59
 	github.com/gofrs/flock v0.13.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/Clyra-AI/proof v0.4.6 h1:k7WMrpOvuS9IZWj+5smbOFEXla8A5CXoOsGtNQ/xqQ4=
-github.com/Clyra-AI/proof v0.4.6/go.mod h1:EDff6buidj222E+EYyqQXXj1rtPgSFlYOxl2JFfWKFs=
+github.com/Clyra-AI/proof v0.5.0 h1:Kat5kQqNQTDE8v22yLHx9fpHi77CNYgQYDqOL4ZdsJg=
+github.com/Clyra-AI/proof v0.5.0/go.mod h1:6q8D3hGzpd9dAsEanrKfPEQbG2yncnNXugb7Svl3W34=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
## Summary

- pin `github.com/Clyra-AI/proof` exactly to `v0.5.0` and refresh module checksums
- adapt Wrkr's flat compliance projection to Proof v0.5 evidence-set controls without changing legacy-control behavior
- preserve evidence-set semantics: OR across alternative sets, AND within a set, including source-product and required-field scoping
- add explicit one-to-one SOC 2 compatibility aliases for the legacy Wrkr rule map; do not fuzzy-map unrelated controls
- keep checked-in website demo assets byte-identical

## Root cause

Proof v0.5 moves several built-in framework controls from legacy top-level `required_record_types` fields to nested alternative `evidence_sets`. Wrkr's adapter only read the legacy fields, so it projected empty requirements, false covered controls, and zero mapped SOC 2 findings.

## Compatibility and safety

Wrkr now delegates evidence-set evaluation to Proof's canonical evaluator, then deterministically projects the satisfied or closest Wrkr-applicable evidence path into its existing flat `ControlCheck` contract. A single record type cannot satisfy a multi-type evidence set, and external-only evidence cannot overclaim Wrkr coverage. Legacy-only programmatic frameworks continue through the unchanged legacy evaluator.

The only control-ID aliases are explicit one-to-one SOC 2 transitions:

- `cc6.1 -> cc6`
- `cc7.1 -> cc7`
- `cc8.1 -> cc8`

New or unrelated controls, including PCI-DSS replacements and SOC 2 `cc6.3`, do not inherit mappings.

## Validation

- `go test ./core/compliance -count=1`
- `go test ./internal/siteassets -count=1`
- `make test-contracts`
- `go mod verify`
- `git diff --check`
- `make prepush` (exact final tree; run twice)

No toolchain, `record_version`, Action Contract fixture, site-asset, or unrelated dependency changes are included.