### PR TITLE
chore: finalize changelog for v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed
 
-- Pinned the nine Action Contract v3 interoperability fixtures to the released `v1.14.0` producer identity, preserving exact artifact bytes and canonical digests while making release conformance reject `devel` or untagged producer metadata.
+- (none yet)
 
 ### Deprecated
 
@@ -28,7 +28,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Security
 
-- Raised the pinned Go toolchain from `1.26.5` to `1.26.6` across `go.mod`, `.tool-versions`, the Wrkr pin-enforcement fixtures, and the authoritative Factory profile snapshot path so the vulnerability and strict pin-alignment gates clear on Go `1.26.6`.
+- (none yet)
 
 ## Changelog maintenance process
 
@@ -38,6 +38,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 4. Keep entries concise and operator-facing: what changed, why it matters, and any migration/action notes.
 5. Link release notes and tag artifacts to the finalized changelog section.
 6. The Sprint 0 v1.7.3 clarification workflow item must record measured artifact-size deltas, redaction test names, and fixture coverage before release notes claim size, privacy, redaction, customer-safe, or readability hardening.
+
+## [v1.15.0] - 2026-08-19
+<!-- release-semver: minor -->
+
+### Changed
+
+- Pinned the nine Action Contract v3 interoperability fixtures to the released `v1.14.0` producer identity, preserving exact artifact bytes and canonical digests while making release conformance reject `devel` or untagged producer metadata.
+
+### Security
+
+- Raised the pinned Go toolchain from `1.26.5` to `1.26.6` across `go.mod`, `.tool-versions`, the Wrkr pin-enforcement fixtures, and the authoritative Factory profile snapshot path so the vulnerability and strict pin-alignment gates clear on Go `1.26.6`.
 
 ## [v1.14.0] - 2026-08-12
 <!-- release-semver: minor -->

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ brew install Clyra-AI/tap/wrkr
 ### Go install (Pinned/reproducible)
 
 ```bash
-WRKR_VERSION="v1.14.0"
+WRKR_VERSION="v1.15.0"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -4,7 +4,7 @@ Install with Homebrew or the pinned Go path first, then verify the installed CLI
 
 ```bash
 brew install Clyra-AI/tap/wrkr
-WRKR_VERSION="v1.14.0"
+WRKR_VERSION="v1.15.0"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 wrkr version --json
 

--- a/docs/commands/action.md
+++ b/docs/commands/action.md
@@ -21,7 +21,7 @@ Any packaged GitHub Action surface must wrap these CLI contracts rather than dup
 Wrkr now ships a repo-root `action.yml` composite action that wraps the same CLI contracts through `scripts/action_entrypoint.sh`.
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.14.0
+- uses: Clyra-AI/wrkr@v1.15.0
   with:
     mode: scheduled
     remediation_mode: summary_only
@@ -65,7 +65,7 @@ wrkr action pr-comment --changed-paths ".codex/config.toml" --risk-delta 2.8 --c
 ```
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.14.0
+- uses: Clyra-AI/wrkr@v1.15.0
   with:
     mode: scheduled
     target_mode: repo

--- a/docs/install/minimal-dependencies.md
+++ b/docs/install/minimal-dependencies.md
@@ -7,7 +7,7 @@ The main README landing page surfaces Homebrew, the pinned Go install path below
 ## Go-only pinned install
 
 ```bash
-WRKR_VERSION="v1.14.0"
+WRKR_VERSION="v1.15.0"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 
@@ -56,6 +56,6 @@ Install commands above are validated by release UAT together with the public `wr
 
 ```bash
 scripts/test_uat_local.sh --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.14.0 --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.14.0 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.15.0 --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.15.0 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
 ```

--- a/docs/trust/release-integrity.md
+++ b/docs/trust/release-integrity.md
@@ -98,7 +98,7 @@ scripts/test_uat_local.sh
 scripts/test_uat_local.sh --skip-global-gates
 
 # Validate exact public install commands (brew + pinned go install) for a published tag
-scripts/test_uat_local.sh --release-version v1.14.0 --brew-formula Clyra-AI/tap/wrkr
+scripts/test_uat_local.sh --release-version v1.15.0 --brew-formula Clyra-AI/tap/wrkr
 ```
 
 ## Changelog finalization


### PR DESCRIPTION
## Summary

- finalize the accumulated Action Contract v3 fixture-freeze entry as the dated `v1.15.0` changelog section
- mark the release as the required minor bump from `v1.14.0`
- update current supported-release install, Action, and release-smoke documentation references to `v1.15.0`

This release-prep change is documentation-only. It does not change Wrkr product code, the nine exact fixture artifacts, packet bytes, schemas, canonical digests, or consumer entrypoints.

## Validation

- `python3 scripts/resolve_release_version.py --json`
- `python3 scripts/resolve_release_version.py --release-version v1.15.0 --json`
- `python3 scripts/finalize_release_changelog.py --release-version v1.15.0 --release-date 2026-08-19 --json`
- `python3 scripts/validate_release_changelog.py --release-version v1.15.0 --json`
- `scripts/generate_action_contract_conformance.sh --check`
- `make test-freeze-gate` (40 commands; unchanged fixture digest `3caafddf7a8e67f80863be7b28b7f5a55390cd955a64a60c284a35fc03aac75e`)
- `go test ./testinfra/hygiene -run 'Test.*Release|Test.*Changelog' -count=1`
- `go test ./testinfra/contracts -run 'Test.*Release|TestActionContractConformance' -count=1`
- `scripts/check_docs_consistency.sh`
- `go test ./... -count=1`
