### PR TITLE
fix: update x/mod for release security gate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/dop251/goja v0.0.0-20260219130522-0ba9a5494a59
 	github.com/gofrs/flock v0.13.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
-	golang.org/x/mod v0.37.0
+	golang.org/x/mod v0.40.0
 	golang.org/x/net v0.56.0
 	golang.org/x/sys v0.46.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
-golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+golang.org/x/mod v0.40.0 h1:hUv+3cXcdRHz08UmSiOob7sadHig73uo5bkXxQ/tvUs=
+golang.org/x/mod v0.40.0/go.mod h1:0/weTWkPWGBikyTWAX3dkjVztMmBA5hM0DH6BElSupE=
 golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
 golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,6 +1,6 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "3caafddf7a8e67f80863be7b28b7f5a55390cd955a64a60c284a35fc03aac75e",
+  "validated_content_sha256": "2bfd2db0b4dcfd9a20dbc2fd7a168b5b5b7fe9d139aebd8a0ed06f4911c75df2",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",


### PR DESCRIPTION
## Summary

- upgrade `golang.org/x/mod` from `v0.37.0` to fixed `v0.40.0`
- refresh the freeze-gate content receipt after the merged v1.15.0 changelog/docs finalization

The immutable `v1.15.0` tag remains unchanged. This hotfix addresses the release Grype findings `GO-2026-6179` and `GO-2026-6180`, both reported against `golang.org/x/mod v0.37.0` and fixed by `v0.40.0`.

## Validation

- exact release SBOM rebuilt locally with `syft`; Grype reports zero high/critical matches
- focused conformance `gosec` and `govulncheck ./...`
- `go test ./... -count=1`
- `python3 scripts/run_freeze_gate.py --metadata-only`
- `scripts/generate_action_contract_conformance.sh --check`
- `make test-freeze-gate` (40 commands; digest `2bfd2db0b4dcfd9a20dbc2fd7a168b5b5b7fe9d139aebd8a0ed06f4911c75df2`)
