### PR TITLE
chore: finalize changelog for v1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 5. Link release notes and tag artifacts to the finalized changelog section.
 6. The Sprint 0 v1.7.3 clarification workflow item must record measured artifact-size deltas, redaction test names, and fixture coverage before release notes claim size, privacy, redaction, customer-safe, or readability hardening.
 
+## [v1.15.1] - 2026-08-19
+<!-- release-semver: patch -->
+
+### Security
+
+- Upgraded `golang.org/x/mod` to `v0.40.0` to remediate Grype advisories `GO-2026-6179` and `GO-2026-6180` identified in the v1.15.0 release SBOM.
+
 ## [v1.15.0] - 2026-08-19
 <!-- release-semver: minor -->
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ brew install Clyra-AI/tap/wrkr
 ### Go install (Pinned/reproducible)
 
 ```bash
-WRKR_VERSION="v1.15.0"
+WRKR_VERSION="v1.15.1"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 

--- a/docs-site/public/llm/quickstart.md
+++ b/docs-site/public/llm/quickstart.md
@@ -4,7 +4,7 @@ Install with Homebrew or the pinned Go path first, then verify the installed CLI
 
 ```bash
 brew install Clyra-AI/tap/wrkr
-WRKR_VERSION="v1.15.0"
+WRKR_VERSION="v1.15.1"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 wrkr version --json
 

--- a/docs/commands/action.md
+++ b/docs/commands/action.md
@@ -21,7 +21,7 @@ Any packaged GitHub Action surface must wrap these CLI contracts rather than dup
 Wrkr now ships a repo-root `action.yml` composite action that wraps the same CLI contracts through `scripts/action_entrypoint.sh`.
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.15.0
+- uses: Clyra-AI/wrkr@v1.15.1
   with:
     mode: scheduled
     remediation_mode: summary_only
@@ -65,7 +65,7 @@ wrkr action pr-comment --changed-paths ".codex/config.toml" --risk-delta 2.8 --c
 ```
 
 ```yaml
-- uses: Clyra-AI/wrkr@v1.15.0
+- uses: Clyra-AI/wrkr@v1.15.1
   with:
     mode: scheduled
     target_mode: repo

--- a/docs/install/minimal-dependencies.md
+++ b/docs/install/minimal-dependencies.md
@@ -7,7 +7,7 @@ The main README landing page surfaces Homebrew, the pinned Go install path below
 ## Go-only pinned install
 
 ```bash
-WRKR_VERSION="v1.15.0"
+WRKR_VERSION="v1.15.1"
 go install github.com/Clyra-AI/wrkr/cmd/wrkr@"${WRKR_VERSION}"
 ```
 
@@ -56,6 +56,6 @@ Install commands above are validated by release UAT together with the public `wr
 
 ```bash
 scripts/test_uat_local.sh --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.15.0 --skip-global-gates
-scripts/test_uat_local.sh --release-version v1.15.0 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.15.1 --skip-global-gates
+scripts/test_uat_local.sh --release-version v1.15.1 --brew-formula Clyra-AI/tap/wrkr --skip-global-gates
 ```

--- a/docs/trust/release-integrity.md
+++ b/docs/trust/release-integrity.md
@@ -98,7 +98,7 @@ scripts/test_uat_local.sh
 scripts/test_uat_local.sh --skip-global-gates
 
 # Validate exact public install commands (brew + pinned go install) for a published tag
-scripts/test_uat_local.sh --release-version v1.15.0 --brew-formula Clyra-AI/tap/wrkr
+scripts/test_uat_local.sh --release-version v1.15.1 --brew-formula Clyra-AI/tap/wrkr
 ```
 
 ## Changelog finalization

--- a/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
+++ b/testinfra/contracts/fixtures/freeze-gate/story-0.1-receipt.json
@@ -1,6 +1,6 @@
 {
   "validation_contract_version": 2,
-  "validated_content_sha256": "2bfd2db0b4dcfd9a20dbc2fd7a168b5b5b7fe9d139aebd8a0ed06f4911c75df2",
+  "validated_content_sha256": "f2b3ee49de5c82329db4566073c69167060ccf69d452a2f7ecf751ce6066f026",
   "validation_scope_paths": [
     ".github/workflows",
     "Makefile",


### PR DESCRIPTION
## Summary

- finalize the dated `v1.15.1` patch section documenting the x/mod security fix
- record Grype advisories `GO-2026-6179` and `GO-2026-6180` and the fixed `v0.40.0` dependency
- update current supported-release install, Action, and release-smoke documentation references to `v1.15.1`

This release-prep change contains no product-code or fixture-byte changes. The nine Action Contract v3 artifacts, packets, schemas, canonical digests, and consumer entrypoints remain unchanged.

## Validation

- `python3 scripts/resolve_release_version.py --json`
- `python3 scripts/resolve_release_version.py --release-version v1.15.1 --json`
- `python3 scripts/finalize_release_changelog.py --release-version v1.15.1 --release-date 2026-08-19 --json`
- `python3 scripts/validate_release_changelog.py --release-version v1.15.1 --json`
- `scripts/generate_action_contract_conformance.sh --check`
- `make test-freeze-gate` (40 commands; digest `f2b3ee49de5c82329db4566073c69167060ccf69d452a2f7ecf751ce6066f026`)
- `scripts/check_docs_consistency.sh`
- focused hygiene/contracts tests
- `go test ./... -count=1`
